### PR TITLE
Set smarter default service name

### DIFF
--- a/src/Datadog.Tracer.IntegrationTests/SendTracesToAgent.cs
+++ b/src/Datadog.Tracer.IntegrationTests/SendTracesToAgent.cs
@@ -50,18 +50,13 @@ namespace Datadog.Tracer.IntegrationTests
             span.Finish();
 
             // Check that the HTTP calls went as expected
-            await _httpRecorder.WaitForCompletion(2);
-            Assert.Equal(2, _httpRecorder.Requests.Count);
-            Assert.Equal(2, _httpRecorder.Responses.Count);
+            await _httpRecorder.WaitForCompletion(1);
+            Assert.Equal(1, _httpRecorder.Requests.Count);
+            Assert.Equal(1, _httpRecorder.Responses.Count);
             Assert.All(_httpRecorder.Responses, (x) => Assert.Equal(HttpStatusCode.OK, x.StatusCode));
 
             var trace = _httpRecorder.Traces.Single();
             AssertSpanEqual(span, trace.Single());
-
-            var serviceInfo = _httpRecorder.Services.Single().ServiceInfos().Single();
-            Assert.Equal("Datadog.Tracer", serviceInfo.ServiceName);
-            Assert.Equal(Constants.UnkownApp, serviceInfo.App);
-            Assert.Equal(Constants.WebAppType, serviceInfo.AppType);
         }
 
         [Fact]
@@ -81,17 +76,15 @@ namespace Datadog.Tracer.IntegrationTests
             span.Finish();
 
             // Check that the HTTP calls went as expected
-            await _httpRecorder.WaitForCompletion(3);
-            Assert.Equal(3, _httpRecorder.Requests.Count);
-            Assert.Equal(3, _httpRecorder.Responses.Count);
+            await _httpRecorder.WaitForCompletion(2);
+            Assert.Equal(2, _httpRecorder.Requests.Count);
+            Assert.Equal(2, _httpRecorder.Responses.Count);
             Assert.All(_httpRecorder.Responses, (x) => Assert.Equal(HttpStatusCode.OK, x.StatusCode));
 
             var trace = _httpRecorder.Traces.Single();
             AssertSpanEqual(span, trace.Single());
 
-            var serviceInfos = _httpRecorder.Services.Select(x => x.ServiceInfos().Single()).ToList();
-            Assert.Equal(2, serviceInfos.Count);
-            var serviceInfo = serviceInfos.Single(x => x.ServiceName == ServiceName);
+            var serviceInfo = _httpRecorder.Services.Select(x => x.ServiceInfos().Single()).Single();
             Assert.Equal(ServiceName, serviceInfo.ServiceName);
             Assert.Equal(App, serviceInfo.App);
             Assert.Equal(AppType, serviceInfo.AppType);
@@ -108,9 +101,9 @@ namespace Datadog.Tracer.IntegrationTests
             span.Finish();
 
             // Check that the HTTP calls went as expected
-            await _httpRecorder.WaitForCompletion(2);
-            Assert.Equal(2, _httpRecorder.Requests.Count);
-            Assert.Equal(2, _httpRecorder.Responses.Count);
+            await _httpRecorder.WaitForCompletion(1);
+            Assert.Equal(1, _httpRecorder.Requests.Count);
+            Assert.Equal(1, _httpRecorder.Responses.Count);
             Assert.All(_httpRecorder.Responses, (x) => Assert.Equal(HttpStatusCode.OK, x.StatusCode));
 
             var trace = _httpRecorder.Traces.Single();

--- a/src/Datadog.Tracer.Tests/TracerTests.cs
+++ b/src/Datadog.Tracer.Tests/TracerTests.cs
@@ -12,13 +12,6 @@ namespace Datadog.Tracer.Tests
         private Mock<IAgentWriter> _agentWriter = new Mock<IAgentWriter>();
 
         [Fact]
-        public void Ctor_DefaultValues_ShouldSendDefaultServiceInfo()
-        {
-            var tracer = new Tracer(_agentWriter.Object);
-            _agentWriter.Verify(x => x.WriteServiceInfo(It.Is<ServiceInfo>(y => y.ServiceName == "Datadog.Tracer" && y.AppType == Constants.WebAppType && y.App == Constants.UnkownApp)), Times.Once);
-        }
-
-        [Fact]
         public void BuildSpan_NoParameter_DefaultParameters()
         {
             var tracer = new Tracer(_agentWriter.Object);

--- a/src/Datadog.Tracer/Tracer.cs
+++ b/src/Datadog.Tracer/Tracer.cs
@@ -19,17 +19,7 @@ namespace Datadog.Tracer
         public Tracer(IAgentWriter agentWriter, List<ServiceInfo> serviceInfo = null, string defaultServiceName = null)
         {
             _agentWriter = agentWriter;
-            _defaultServiceName = defaultServiceName;
-            if (_defaultServiceName == null)
-            {
-                _defaultServiceName = GetExecutingAssemblyName() ?? Constants.UnkownService;
-                _services[_defaultServiceName] = new ServiceInfo
-                {
-                    ServiceName = _defaultServiceName,
-                    App = Constants.UnkownApp,
-                    AppType = Constants.WebAppType,
-                };
-            }
+            _defaultServiceName = GetExecutingAssemblyName() ?? Constants.UnkownService;
             if (serviceInfo != null)
             {
                 foreach(var service in serviceInfo)


### PR DESCRIPTION
The Tracer now uses the name of the executing assembly as default service name if none is explicitly provided by the application.

Open question: What should be the default value of `App` ?