### PR TITLE
Fix discrepancies in time measurements

### DIFF
--- a/src/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/src/Datadog.Trace.Tests/TraceContextTests.cs
@@ -1,0 +1,37 @@
+﻿using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class TraceContextTests
+    {
+        private Mock<IDatadogTracer> _tracerMock = new Mock<IDatadogTracer>();
+
+        [Fact]
+        public void UtcNow_GivesLegitTime()
+        {
+            var traceContext = new TraceContext(_tracerMock.Object);
+
+            var now = traceContext.UtcNow();
+            var expectedNow = DateTimeOffset.UtcNow;
+
+
+            Assert.True(expectedNow.Subtract(now) < TimeSpan.FromMilliseconds(30));
+        }
+
+        [Fact]
+        public void UtcNow_IsMonotonic()
+        {
+            var traceContext = new TraceContext(_tracerMock.Object);
+
+            var t1 = traceContext.UtcNow();
+            var t2 = traceContext.UtcNow();
+
+
+            Assert.True(t2.Subtract(t1) > TimeSpan.Zero);
+        }
+    }
+}

--- a/src/Datadog.Trace/ITraceContext.cs
+++ b/src/Datadog.Trace/ITraceContext.cs
@@ -1,4 +1,6 @@
-﻿namespace Datadog.Trace
+﻿using System;
+
+namespace Datadog.Trace
 {
     internal interface ITraceContext
     {
@@ -9,5 +11,7 @@
         void CloseSpan(Span span);
 
         SpanContext GetCurrentSpanContext();
+
+        DateTimeOffset UtcNow();
     }
 }

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -1,5 +1,7 @@
 ﻿using Datadog.Trace.Logging;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Datadog.Trace
@@ -13,12 +15,21 @@ namespace Datadog.Trace
         private List<Span> _spans = new List<Span>();
         private int _openSpans = 0;
         private AsyncLocalCompat<SpanContext> _currentSpanContext = new AsyncLocalCompat<SpanContext>("Datadog.Trace.TraceContext._currentSpanContext");
+        private DateTimeOffset _start;
+        private Stopwatch _sw;
 
         public bool Sampled { get; set; }
 
         public TraceContext(IDatadogTracer tracer)
         {
             _tracer = tracer;
+            _start = DateTimeOffset.UtcNow;
+            _sw = Stopwatch.StartNew();
+        }
+
+        public DateTimeOffset UtcNow()
+        {
+            return _start.Add(_sw.Elapsed);
         }
 
         public SpanContext GetCurrentSpanContext()


### PR DESCRIPTION
Previously inside a same trace we used two different sources for time. An absolute DateTimeOffset.UtcNow for the span start and a Stopwatch to measure the duration, however this made our time non-monotonic inside a single trace and made the flamegraphs unreadable. This PR makes sure that we use a single monotonic source of time inside a trace.