### PR TITLE
Wait for traces flush on process exit

### DIFF
--- a/src/Datadog.Trace/IAgentWriter.cs
+++ b/src/Datadog.Trace/IAgentWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace
 {
@@ -7,5 +8,7 @@ namespace Datadog.Trace
         void WriteTrace(List<Span> trace);
 
         void WriteServiceInfo(ServiceInfo serviceInfo);
+
+        Task FlushAndCloseAsync();
     }
 }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -33,6 +33,10 @@ namespace Datadog.Trace
             {
                 _agentWriter.WriteServiceInfo(service);
             }
+            // Register callbacks to make sure we flush the traces before exiting
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            Console.CancelKeyPress += Console_CancelKeyPress;
         }
 
         private string GetAppDomainFriendlyName()
@@ -76,6 +80,20 @@ namespace Datadog.Trace
                 _currentContext.Set(new TraceContext(this));
             }
             return _currentContext.Get();
+        }
+        private void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        {
+            _agentWriter.FlushAndCloseAsync().Wait();
+        }
+
+        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            _agentWriter.FlushAndCloseAsync().Wait();
+        }
+
+        private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            _agentWriter.FlushAndCloseAsync().Wait();
         }
 
         void IDatadogTracer.CloseCurrentTraceContext()


### PR DESCRIPTION
This makes sure that we flush traces before the process exit either by normal termination, unhandled exception or ctrl+c. The process will terminate anyway if flushing traces takes more than 2 seconds.