### PR TITLE
Add a global debug flag

### DIFF
--- a/src/Datadog.Trace.Tests/SpanTests.cs
+++ b/src/Datadog.Trace.Tests/SpanTests.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.Tests
             _tracerMock.Setup(x => x.GetTraceContext()).Returns(_traceContext);
             _tracerMock.Setup(x => x.CloseCurrentTraceContext());
             _tracerMock.Setup(x => x.DefaultServiceName).Returns("DefaultServiceName");
+            _tracerMock.Setup(x => x.IsDebugEnabled).Returns(true);
         }
 
         [Fact]

--- a/src/Datadog.Trace/IDatadogTracer.cs
+++ b/src/Datadog.Trace/IDatadogTracer.cs
@@ -12,5 +12,7 @@ namespace Datadog.Trace
         ITraceContext GetTraceContext();
 
         void CloseCurrentTraceContext();
+
+        bool IsDebugEnabled { get; }
     }
 }

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -61,11 +61,14 @@ namespace Datadog.Trace
                     if (_openSpans != 0)
                     {
                         _log.DebugFormat("Some child spans were not finished before the root. {NumberOfOpenSpans}", _openSpans);
-                        foreach(var s in _spans.Where(x => !x.IsFinished))
+                        if (_tracer.IsDebugEnabled)
                         {
-                            _log.DebugFormat("Span {UnfinishedSpan} was not finished before its root span", s);
+                            foreach (var s in _spans.Where(x => !x.IsFinished))
+                            {
+                                _log.DebugFormat("Span {UnfinishedSpan} was not finished before its root span", s);
+                            }
+                            // TODO:bertrand Instead detect if we are being garbage collected and warn at that point
                         }
-                        // TODO:bertrand Instead detect if we are being garbage collected and warn at that point
                     }
                     else
                     {

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -3,7 +3,6 @@ using OpenTracing;
 using OpenTracing.Propagation;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Datadog.Trace
 {
@@ -15,11 +14,15 @@ namespace Datadog.Trace
         private string _defaultServiceName;
         private Dictionary<string, ServiceInfo> _services = new Dictionary<string, ServiceInfo>();
         private IAgentWriter _agentWriter;
+        private bool _isDebugEnabled;
+
+        bool IDatadogTracer.IsDebugEnabled => _isDebugEnabled;
 
         string IDatadogTracer.DefaultServiceName => _defaultServiceName;
 
-        public Tracer(IAgentWriter agentWriter, List<ServiceInfo> serviceInfo = null, string defaultServiceName = null)
+        public Tracer(IAgentWriter agentWriter, List<ServiceInfo> serviceInfo = null, string defaultServiceName = null, bool isDebugEnabled = false)
         {
+            _isDebugEnabled = isDebugEnabled;
             _agentWriter = agentWriter;
             _defaultServiceName = GetAppDomainFriendlyName() ?? Constants.UnkownService;
             if (serviceInfo != null)

--- a/src/Datadog.Trace/TracerFactory.cs
+++ b/src/Datadog.Trace/TracerFactory.cs
@@ -15,18 +15,19 @@ namespace Datadog.Trace
         /// <param name="agentEndpoint">The agent endpoint where the traces will be sent (default is http://localhost:8126).</param>
         /// <param name="serviceInfoList">The service information list.</param>
         /// <param name="defaultServiceName">Default name of the service (default is the name of the executing assembly).</param>
+        /// <param name="isDebugEnabled">Turns on all debug logging (this may have an impact on application performance).</param>
         /// <returns></returns>
-        public static ITracer GetTracer(Uri agentEndpoint = null, List<ServiceInfo> serviceInfoList = null, string defaultServiceName = null)
+        public static ITracer GetTracer(Uri agentEndpoint = null, List<ServiceInfo> serviceInfoList = null, string defaultServiceName = null, bool isDebugEnabled = false)
         {
             agentEndpoint = agentEndpoint ?? _defaultUri;
-            return GetTracer(agentEndpoint, serviceInfoList, defaultServiceName, null);
+            return GetTracer(agentEndpoint, serviceInfoList, defaultServiceName, null, isDebugEnabled);
         }
 
-        internal static Tracer GetTracer(Uri agentEndpoint, List<ServiceInfo> serviceInfoList = null, string defaultServiceName = null, DelegatingHandler delegatingHandler = null)
+        internal static Tracer GetTracer(Uri agentEndpoint, List<ServiceInfo> serviceInfoList = null, string defaultServiceName = null, DelegatingHandler delegatingHandler = null, bool isDebugEnabled = false)
         {
             var api = new Api(agentEndpoint, delegatingHandler);
             var agentWriter = new AgentWriter(api);
-            var tracer = new Tracer(agentWriter, serviceInfoList, defaultServiceName);
+            var tracer = new Tracer(agentWriter, serviceInfoList, defaultServiceName, isDebugEnabled);
             return tracer;
         }
     }


### PR DESCRIPTION
This PR adds an optional debug argument to the tracer factory that is used to control logging operations that might be very verbose or have a significant impact on performance.