### PR TITLE
Add license url in csproj

### DIFF
--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -10,6 +10,7 @@
     <PackageReleaseNotes>Alpha release</PackageReleaseNotes>
     <Copyright>Datadog, Inc. 2017</Copyright>
     <PackageTags></PackageTags>
+    <!-- Use the python license's url while the project's github is not public -->
     <PackageLicenseUrl>https://github.com/DataDog/dd-trace-py/blob/master/LICENSE</PackageLicenseUrl>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeOpentracingLib</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>


### PR DESCRIPTION
This metadata is used to populate the package page on nuget.org.