### PR TITLE
Add close method on Scope

### DIFF
--- a/src/Datadog.Trace.Tests/TracerTests.cs
+++ b/src/Datadog.Trace.Tests/TracerTests.cs
@@ -66,7 +66,19 @@ namespace Datadog.Trace.Tests
             var scope = _tracer.StartActive("Operation");
             Assert.False(scope.Span.IsFinished);
 
-            scope.Dispose();
+            scope.Close();
+
+            Assert.True(scope.Span.IsFinished);
+            Assert.Null(_tracer.ActiveScope);
+        }
+
+        [Fact]
+        public void StartActive_FinishOnClose_SpanIsFinishedWhenScopeIsDisposed()
+        {
+            Scope scope;
+            using(scope = _tracer.StartActive("Operation")){
+                Assert.False(scope.Span.IsFinished);
+            }
 
             Assert.True(scope.Span.IsFinished);
             Assert.Null(_tracer.ActiveScope);

--- a/src/Datadog.Trace/Implementations/Scope.cs
+++ b/src/Datadog.Trace/Implementations/Scope.cs
@@ -31,13 +31,21 @@ namespace Datadog.Trace
         /// <summary>
         /// Closes the current scope and makes its parent scope active
         /// </summary>
-        public void Dispose()
+        public void Close()
         {
             _scopeManager.Close(this);
             if (_finishOnClose)
             {
                 Span.Finish();
             }
+        }
+
+        /// <summary>
+        /// Closes the current scope and makes its parent scope active
+        /// </summary>
+        public void Dispose()
+        {
+            Close();
         }
     }
 }


### PR DESCRIPTION
Add the `Close` method on the Scope class to make it consistent with other languages.