### PR TITLE
Make asynclocal compat consistent

### DIFF
--- a/src/Datadog.Trace/Internals/AsyncLocalCompat.cs
+++ b/src/Datadog.Trace/Internals/AsyncLocalCompat.cs
@@ -1,6 +1,7 @@
 ﻿namespace Datadog.Trace
 {
 #if NET45
+    using System;
     using System.Runtime.Remoting.Messaging;
 
     // TODO:bertrand revisit this when we want to support multiple AppDomains
@@ -8,9 +9,9 @@
     {
         private string _name;
 
-        public AsyncLocalCompat(string name)
+        public AsyncLocalCompat()
         {
-            _name = name;
+            _name = Guid.NewGuid().ToString();
         }
 
         public T Get()
@@ -31,7 +32,7 @@
     {
         private AsyncLocal<T> _asyncLocal = new AsyncLocal<T>();
 
-        public AsyncLocalCompat(string name)
+        public AsyncLocalCompat()
         {
         }
 

--- a/src/Datadog.Trace/Internals/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/Internals/AsyncLocalScopeManager.cs
@@ -6,7 +6,7 @@ namespace Datadog.Trace
     {
         private static ILog _log = LogProvider.For<AsyncLocalScopeManager>();
 
-        private AsyncLocalCompat<Scope> _currentSpan = new AsyncLocalCompat<Scope>("Datadog.Trace.AsyncLocalScopeManager._currentSpan");
+        private AsyncLocalCompat<Scope> _currentSpan = new AsyncLocalCompat<Scope>();
 
         public Scope Active => _currentSpan.Get();
 


### PR DESCRIPTION
This fix an inconsistency between the .Net 45 and other implementations.