### PR TITLE
Add continuous integration with circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
    build:
      docker:
-       - image: bemermet/dd-trace-csharp-ci
+       - image: datadog/docker-library:ddtrace_csharp_0_1_0
        - image: datadog/docker-dd-agent
          env:
            - DD_APM_ENABLED=true

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,9 +1,0 @@
-FROM microsoft/dotnet:latest
-
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-        && echo "deb http://download.mono-project.com/repo/debian stretch main" >> /etc/apt/sources.list.d/mono-official.list \
-        && apt-get update \
-        && apt-get install -y --no-install-recommends mono-devel msbuild libuv1-dev \
-        && rm -rf /var/lib/apt/lists/*
-
-ENV FrameworkPathOverride="/usr/lib/mono/4.5/"


### PR DESCRIPTION
This PR runs the build and tests in circle-ci on debian stretch with mono and dotnet core.