### PR TITLE
Refactor C# integrations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace Datadog.Trace.ClrProfiler.Integrations
+{
+    /// <summary>
+    /// The ASP.NET MVC 5 integration.
+    /// </summary>
+    public sealed class AspNetMvc5Integration : Integration
+    {
+        private readonly dynamic _controllerContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AspNetMvc5Integration"/> class.
+        /// </summary>
+        /// <param name="args">An array with all the arguments that were passed into the instrumented method. If it is an instance method, the first arguments is <c>this</c>.</param>
+        public AspNetMvc5Integration(object[] args)
+        {
+            if (args.Length < 2 || args[1].GetType().FullName != "System.Web.Mvc.ControllerContext")
+            {
+                return;
+            }
+
+            // [System.Web.Mvc]System.Web.Mvc.ControllerContext
+            _controllerContext = args[1];
+
+            HttpContextBase httpContext = _controllerContext.HttpContext;
+            string httpMethod = httpContext.Request.HttpMethod.ToUpperInvariant();
+
+            string routeTemplate = _controllerContext.RouteData.Route.Url;
+            IDictionary<string, object> routeValues = _controllerContext.RouteData.Values;
+            var resourceName = new StringBuilder(routeTemplate);
+
+            // replace all route values except "id"
+            // TODO: make this filter configurable
+            foreach (var routeValue in routeValues.Where(p => !string.Equals(p.Key, "id", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                string key = $"{{{routeValue.Key.ToLowerInvariant()}}}";
+                string value = routeValue.Value.ToString().ToLowerInvariant();
+                resourceName.Replace(key, value);
+            }
+
+            // TODO: define constants elsewhere instead of using magic strings
+            Span span = Scope.Span;
+            span.Type = "web";
+            span.OperationName = "web.request";
+            span.ResourceName = string.Join(" ", httpMethod, resourceName.ToString());
+            span.SetTag("http.method", httpMethod);
+            span.SetTag("http.url", httpContext.Request.RawUrl.ToLowerInvariant());
+            span.SetTag("http.route", routeTemplate);
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                HttpContextBase httpContext = _controllerContext?.HttpContext;
+
+                if (httpContext != null)
+                {
+                    Scope.Span.SetTag("http.status_code", httpContext.Response.StatusCode.ToString());
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/CustomIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/CustomIntegration.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Datadog.Trace.ClrProfiler.Integrations
+{
+    /// <summary>
+    /// The custom integration which can instrument arbitrary method through configuration.
+    /// </summary>
+    public class CustomIntegration : Integration
+    {
+        private readonly string _operationName;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomIntegration"/> class.
+        /// </summary>
+        /// <param name="names">The names of the instrumented method, and its containing type and assembly.</param>
+        public CustomIntegration(MetadataNames names)
+        {
+            _operationName = $"[{names.ModuleName}]{names.TypeName}.{names.MethodName}";
+            Console.WriteLine($"Entering {_operationName}()");
+
+            Scope.Span.OperationName = _operationName;
+            Scope.Span.ResourceName = string.Empty;
+        }
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Console.WriteLine($"Exiting {_operationName}()");
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Integration.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace Datadog.Trace.ClrProfiler.Integrations
+{
+    /// <summary>
+    /// The base class inherited by all integrations.
+    /// </summary>
+    public abstract class Integration : IDisposable
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Integration"/> class.
+        /// </summary>
+        protected Integration()
+        {
+            // TODO: explicitly set upstream Scope as parent for this new Scope, but Span.Context is currently internal
+            Scope = Tracer.Instance.StartActive(string.Empty);
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this integration is enabled.
+        /// Defaults to <c>true</c> unless explicitly disabled.
+        /// </summary>
+        // TODO: read from configuration
+        public virtual bool IsEnabled { get; } = true;
+
+        /// <summary>
+        /// Gets the <see cref="Scope"/> created by this integration instance.
+        /// </summary>
+        public Scope Scope { get; }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        // [System.Security.SecuritySafeCritical]
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> is called from <see cref="Dispose()"/>; <c>false</c> otherwise.</param>
+        // [System.Security.SecuritySafeCritical]
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                Scope?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Native/CustomIntegration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/CustomIntegration.cpp
@@ -1,0 +1,23 @@
+#include "CustomIntegration.h"
+#include "GlobalTypeReferences.h"
+
+CustomIntegration::CustomIntegration()
+{
+    // TODO: for CustomIntegration, load these from configuration
+    m_InstrumentedMethods = {
+        ConsoleApp_StaticMethods_DoStuff,
+        ConsoleApp_StaticMethods_DoStuffWithArguments,
+        ConsoleApp_StaticMethods_DoStuffAndReturnClass,
+        ConsoleApp_StaticMethods_DoStuffAndReturnValueType,
+        ConsoleApp_InstanceMethods_DoStuff,
+        ConsoleApp_InstanceMethods_DoStuffWithArguments,
+        ConsoleApp_InstanceMethods_DoStuffAndReturnClass,
+        ConsoleApp_InstanceMethods_DoStuffAndReturnValueType,
+    };
+}
+
+bool CustomIntegration::IsEnabled() const
+{
+    // TODO: read from configuration
+    return true;
+}

--- a/src/Datadog.Trace.ClrProfiler.Native/Integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/Integration.cpp
@@ -46,7 +46,8 @@ void Integration::InjectEntryProbe(const ILRewriterWrapper& pilr,
         pilr.EndLoadValueIntoArray();
     }
 
-    // note: the entry probe returns a Datadog.Trace.Scope instance,
+    // note: the entry probe returns a
+    // Datadog.Trace.ClrProfiler.Integrations.Integration instance,
     // which we will leave on the stack for the exit probe to pick up
     pilr.CallMember(entryProbe);
 }
@@ -62,8 +63,9 @@ void Integration::InjectExitProbe(const ILRewriterWrapper& pilr,
         pilr.Box(instrumentedMethod.ReturnType);
     }
 
-    // the entry probe returned a Datadog.Trace.Scope instance
-    // and we left if on the stack, the exit probe will pop it
+    // the entry probe returned a
+    // Datadog.Trace.ClrProfiler.Integrations.Integration instance
+    // earlier and we left if on the stack, the exit probe will pop it
     // and leave a balanced stack
     pilr.CallMember(exitProbe);
 
@@ -79,8 +81,8 @@ bool Integration::NeedsBoxing(const TypeReference& type)
 {
     return type.CorElementType != ELEMENT_TYPE_VOID &&
            type.CorElementType != ELEMENT_TYPE_CLASS &&
-           type.CorElementType != ELEMENT_TYPE_OBJECT &&
            type.CorElementType != ELEMENT_TYPE_STRING &&
-           type.CorElementType != ELEMENT_TYPE_ARRAY &&
-           type.CorElementType != ELEMENT_TYPE_SZARRAY;
+           type.CorElementType != ELEMENT_TYPE_OBJECT &&
+           type.CorElementType != ELEMENT_TYPE_SZARRAY &&
+           type.CorElementType != ELEMENT_TYPE_ARRAY;
 }


### PR DESCRIPTION
Refactor integrations in the C# code so each one inherits from a base `Integration` and defines how to handle construction and disposal.

(note: mostly superceded by https://github.com/DataDog/dd-trace-csharp/pull/51)