### PR TITLE
fix method documentation

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvc5Integration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <summary>
         /// Initializes a new instance of the <see cref="AspNetMvc5Integration"/> class.
         /// </summary>
-        /// <param name="controllerContextObj">An array with all the arguments that were passed into the instrumented method. If it is an instance method, the first arguments is <c>this</c>.</param>
+        /// <param name="controllerContextObj">The System.Web.Mvc.ControllerContext that was passed as an argument to the instrumented method.</param>
         public AspNetMvc5Integration(object controllerContextObj)
         {
             if (controllerContextObj == null || ContollerContextType == null)


### PR DESCRIPTION
Argument was changed from a `object[]` containing all arguemtns to a single `ControllerContext`, but xml-doc comments were _stale_.

Reported by @gshackles on public Slack.