### PR TITLE
set "env" tag from DD_DEV environment variable

### DIFF
--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -6,6 +6,11 @@ namespace Datadog.Trace
     public static class Tags
     {
         /// <summary>
+        /// The environment of the profiled service.
+        /// </summary>
+        public const string Env = "env";
+
+        /// <summary>
         /// The URL of an HTTP request
         /// </summary>
         public const string HttpUrl = "http.url";

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -150,7 +150,7 @@ namespace Datadog.Trace
 
             var env = Environment.GetEnvironmentVariable(EnvVariableName);
 
-            // automatically the "env" tag if environment variable is defined
+            // automatically add the "env" tag if environment variable is defined
             if (!string.IsNullOrWhiteSpace(env))
             {
                 span.SetTag(Tags.Env, env);

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace
         private const string UnknownServiceName = "UnknownService";
         private const string DefaultTraceAgentHost = "localhost";
         private const string DefaultTraceAgentPort = "8126";
+        private const string EnvVariableName = "DD_ENV";
 
         private static readonly string[] TraceAgentHostEnvironmentVariableNames =
         {
@@ -146,6 +147,15 @@ namespace Datadog.Trace
             }
 
             var span = new Span(this, childOf, operationName, serviceName, startTime);
+
+            var env = Environment.GetEnvironmentVariable(EnvVariableName);
+
+            // automatically the "env" tag if environment variable is defined
+            if (!string.IsNullOrWhiteSpace(env))
+            {
+                span.SetTag("env", env);
+            }
+
             span.TraceContext.AddSpan(span);
             return span;
         }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -153,7 +153,7 @@ namespace Datadog.Trace
             // automatically the "env" tag if environment variable is defined
             if (!string.IsNullOrWhiteSpace(env))
             {
-                span.SetTag("env", env);
+                span.SetTag(Tags.Env, env);
             }
 
             span.TraceContext.AddSpan(span);

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -290,7 +290,7 @@ namespace Datadog.Trace.Tests
 
             Assert.Equal(env, span.GetTag(Tags.Env));
 
-            // reset the environment variable to its original values (if any) when done
+            // reset the environment variable to its original value (if any) when done
             Environment.SetEnvironmentVariable(name, originalEnv);
         }
     }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -276,5 +276,22 @@ namespace Datadog.Trace.Tests
             Environment.SetEnvironmentVariable("DD_AGENT_HOST", originalHost);
             Environment.SetEnvironmentVariable("DD_TRACE_AGENT_PORT", originalPort);
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("test")]
+        public void SetEnvEnvironmentVariable(string env)
+        {
+            var name = "DD_ENV";
+            string originalEnv = Environment.GetEnvironmentVariable(name);
+
+            Environment.SetEnvironmentVariable(name, env);
+            Span span = Tracer.Instance.StartSpan("operation");
+
+            Assert.Equal(env, span.GetTag(Tags.Env));
+
+            // reset the environment variable to its original values (if any) when done
+            Environment.SetEnvironmentVariable(name, originalEnv);
+        }
     }
 }


### PR DESCRIPTION
If the `DD_ENV` environment variable is set when a `Span` is created, automatically add the `env` tag to the span with the variable's value.