### PR TITLE
set service name from DD_SERVICE_NAME env var

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace
         private const string UnknownServiceName = "UnknownService";
         private const string DefaultTraceAgentHost = "localhost";
         private const string DefaultTraceAgentPort = "8126";
+        private const string ServiceNameVariableName = "DD_SERVICE_NAME";
 
         private static readonly string[] TraceAgentHostEnvironmentVariableNames =
         {
@@ -189,6 +190,14 @@ namespace Datadog.Trace
         {
             try
             {
+                // allow users to override this with an environment variable
+                var serviceName = Environment.GetEnvironmentVariable(ServiceNameVariableName);
+
+                if (!string.IsNullOrWhiteSpace(serviceName))
+                {
+                    return serviceName;
+                }
+
 #if !NETSTANDARD2_0
                 if (System.Web.Hosting.HostingEnvironment.IsHosted)
                 {

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -186,6 +186,11 @@ namespace Datadog.Trace
             return new Uri($"http://{host}:{port}");
         }
 
+        /// <summary>
+        /// Determines the default service name for the executing application by looking at
+        /// environment variables, hosted app name (.NET Framework on IIS only), assembly name, and process name.
+        /// </summary>
+        /// <returns>The default service name.</returns>
         private static string CreateDefaultServiceName()
         {
             try
@@ -199,6 +204,7 @@ namespace Datadog.Trace
                 }
 
 #if !NETSTANDARD2_0
+                // System.Web.dll is only available on .NET Framework
                 if (System.Web.Hosting.HostingEnvironment.IsHosted)
                 {
                     // if we are hosted as an ASP.NET application, return "SiteName/ApplicationVirtualPath".
@@ -206,6 +212,7 @@ namespace Datadog.Trace
                     return (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
                 }
 #endif
+
                 return Assembly.GetEntryAssembly()?.GetName().Name ??
                        Process.GetCurrentProcess().ProcessName;
             }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -277,10 +277,16 @@ namespace Datadog.Trace.Tests
         }
 
         [Theory]
+        // if no service name is specified, fallback to a best guess (e.g. assembly name, process name)
         [InlineData(null, null, null, null)]
+        // if only one is set, use that one
         [InlineData("envService", null, null, "envService")]
         [InlineData(null, "tracerService", null, "tracerService")]
         [InlineData(null, null, "spanService", "spanService")]
+        // if more than one is set, follow precedence: span > tracer > env > default
+        [InlineData(null, "tracerService", "spanService", "spanService")]
+        [InlineData("envService", null, "spanService", "spanService")]
+        [InlineData("envService", "tracerService", null, "tracerService")]
         [InlineData("envService", "tracerService", "spanService", "spanService")]
         public void SetServiceName(string envServiceName, string tracerServiceName, string spanServiceName, string expectedServiceName)
         {


### PR DESCRIPTION
If the `DD_SERVICE_NAME` environment variable is set when a `Tracer` is created, use its value as the default service name.