### PR TITLE
[OpenTracing] allow setting service name after span is created

### DIFF
--- a/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
@@ -116,21 +116,23 @@ namespace Datadog.Trace.OpenTracing
         public ISpan SetTag(string key, string value)
         {
             // TODO:bertrand do we want this behavior on the Span object too ?
-            if (key == DatadogTags.ResourceName)
+
+            switch (key)
             {
-                Span.ResourceName = value;
-                return this;
+                case DatadogTags.ResourceName:
+                    Span.ResourceName = value;
+                    return this;
+                case DatadogTags.SpanType:
+                    Span.Type = value;
+                    return this;
+                 case DatadogTags.ServiceName:
+                     Span.ServiceName = value;
+                     return this;
             }
 
             if (key == global::OpenTracing.Tag.Tags.Error.Key)
             {
                 Span.Error = value == bool.TrueString;
-                return this;
-            }
-
-            if (key == DatadogTags.SpanType)
-            {
-                Span.Type = value;
                 return this;
             }
 

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -60,7 +60,11 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the service name
         /// </summary>
-        public string ServiceName => _context.ServiceName;
+        public string ServiceName
+        {
+            get { return _context.ServiceName; }
+            internal set { _context.ServiceName = value; }
+        }
 
         /// <summary>
         /// Gets the trace's unique identifier.

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
@@ -73,7 +73,7 @@ namespace Datadog.Trace
         /// </summary>
         public ulong SpanId { get; }
 
-        internal string ServiceName { get; }
+        internal string ServiceName { get; set;  }
 
         // This may be null if SpanContext was extracted from another process context
         internal TraceContext TraceContext { get; }

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -173,8 +173,8 @@ namespace Datadog.Trace.OpenTracing.Tests
         public void StartActive_SetServiceName_ServiceNameIsSet()
         {
             var scope = _tracer.BuildSpan("Operation")
-                              .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
-                              .StartActive();
+                               .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
+                               .StartActive();
 
             var otSpan = (OpenTracingSpan)scope.Span;
             var ddSpan = otSpan.Span;
@@ -205,7 +205,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             ITracer tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
 
             var scope = tracer.BuildSpan("Operation")
-                               .StartActive();
+                              .StartActive();
 
             var otSpan = (OpenTracingSpan)scope.Span;
             var ddSpan = otSpan.Span;
@@ -234,12 +234,12 @@ namespace Datadog.Trace.OpenTracing.Tests
             ITracer tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
 
             var parentScope = tracer.BuildSpan("ParentOperation")
-                                     .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
-                                     .StartActive();
+                                    .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
+                                    .StartActive();
 
             var childScope = tracer.BuildSpan("ChildOperation")
-                                    .AsChildOf(parentScope.Span)
-                                    .StartActive();
+                                   .AsChildOf(parentScope.Span)
+                                   .StartActive();
 
             var otSpan = (OpenTracingSpan)childScope.Span;
             var ddSpan = otSpan.Span;

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -156,5 +156,95 @@ namespace Datadog.Trace.OpenTracing.Tests
             Assert.Equal(parentId, otSpanContext.Context.SpanId);
             Assert.Equal(traceId, otSpanContext.Context.TraceId);
         }
+
+        [Fact]
+        public void StartActive_NoServiceName_DefaultServiceName()
+        {
+            var scope = _tracer.BuildSpan("Operation")
+                               .StartActive();
+
+            var otSpan = (OpenTracingSpan)scope.Span;
+            var ddSpan = otSpan.Span;
+
+            Assert.Contains(ddSpan.ServiceName, TestRunners.ValidNames);
+        }
+
+        [Fact]
+        public void StartActive_SetServiceName_ServiceNameIsSet()
+        {
+            var scope = _tracer.BuildSpan("Operation")
+                              .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
+                              .StartActive();
+
+            var otSpan = (OpenTracingSpan)scope.Span;
+            var ddSpan = otSpan.Span;
+
+            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+        }
+
+        [Fact]
+        public void StartActive_SetParentServiceName_ChildServiceNameIsSet()
+        {
+            var parentScope = _tracer.BuildSpan("ParentOperation")
+                                     .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
+                                     .StartActive();
+
+            var childScope = _tracer.BuildSpan("ChildOperation")
+                                    .AsChildOf(parentScope.Span)
+                                    .StartActive();
+
+            var otSpan = (OpenTracingSpan)childScope.Span;
+            var ddSpan = otSpan.Span;
+
+            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+        }
+
+        [Fact]
+        public void StartActive_NoServiceName_DefaultServiceName_WithTracerDefault()
+        {
+            ITracer tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
+
+            var scope = tracer.BuildSpan("Operation")
+                               .StartActive();
+
+            var otSpan = (OpenTracingSpan)scope.Span;
+            var ddSpan = otSpan.Span;
+
+            Assert.Equal("DefaultServiceName", ddSpan.ServiceName);
+        }
+
+        [Fact]
+        public void StartActive_SetServiceName_ServiceNameIsSet_WithTracerDefault()
+        {
+            ITracer tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
+
+            var scope = tracer.BuildSpan("Operation")
+                              .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
+                              .StartActive();
+
+            var otSpan = (OpenTracingSpan)scope.Span;
+            var ddSpan = otSpan.Span;
+
+            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+        }
+
+        [Fact]
+        public void StartActive_SetParentServiceName_ChildServiceNameIsSet_WithTracerDefault()
+        {
+            ITracer tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
+
+            var parentScope = tracer.BuildSpan("ParentOperation")
+                                     .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
+                                     .StartActive();
+
+            var childScope = tracer.BuildSpan("ChildOperation")
+                                    .AsChildOf(parentScope.Span)
+                                    .StartActive();
+
+            var otSpan = (OpenTracingSpan)childScope.Span;
+            var ddSpan = otSpan.Span;
+
+            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+        }
     }
 }


### PR DESCRIPTION
Allow a span's service name to be changed with `ISpan.SetTag()` after the span is created. Setting the service name before a span is created was already supported with `ISpanBuilder.WithTag()`.
See #182.