### PR TITLE
Web API integration: check for null argument

### DIFF
--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -11,3 +11,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:UsingDirectivesMustBePlacedWithinNamespace", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1512:Single-line comments must not be followed by blank line", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:Single-line comment must be preceded by blank line", Justification = "Reviewed.")]
+[assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1501:Statement must not be on a single line", Justification = "Reviewed.")]

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -25,7 +25,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <returns>A task with the result</returns>
         public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource)
         {
-            var cancellationToken = ((CancellationTokenSource)cancellationTokenSource).Token;
+            if (apiController == null) { throw new ArgumentNullException(nameof(apiController)); }
+
+            if (controllerContext == null) { throw new ArgumentNullException(nameof(controllerContext)); }
+
+            var tokenSource = cancellationTokenSource as CancellationTokenSource;
+            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
             return ExecuteAsyncInternal(apiController, controllerContext, cancellationToken);
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -27,8 +27,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             if (apiController == null) { throw new ArgumentNullException(nameof(apiController)); }
 
-            if (controllerContext == null) { throw new ArgumentNullException(nameof(controllerContext)); }
-
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
             return ExecuteAsyncInternal(apiController, controllerContext, cancellationToken);


### PR DESCRIPTION
We got a report of a `NullReferenceException` in `AspNetWebApi2Integration.ExecuteAsync()`. This PR adds a null check for argument `cancellationTokenSource` with a fallback to `CancellationToken.None`. Also, if argument `apiController ` is null (should never ever happen), throw `ArgumentNullException` with the name of the argument to make troubleshooting easier.