### PR TITLE
allow setting the service name after a span is created

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -58,12 +58,12 @@ namespace Datadog.Trace
         public bool Error { get; set; }
 
         /// <summary>
-        /// Gets the service name
+        /// Gets or sets the service name
         /// </summary>
         public string ServiceName
         {
-            get { return _context.ServiceName; }
-            internal set { _context.ServiceName = value; }
+            get => _context.ServiceName;
+            set => _context.ServiceName = value;
         }
 
         /// <summary>

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -73,7 +73,10 @@ namespace Datadog.Trace
         /// </summary>
         public ulong SpanId { get; }
 
-        internal string ServiceName { get; set;  }
+        /// <summary>
+        /// Gets or sets the service name
+        /// </summary>
+        public string ServiceName { get; set; }
 
         // This may be null if SpanContext was extracted from another process context
         internal TraceContext TraceContext { get; }

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -74,9 +74,9 @@ namespace Datadog.Trace
         public ulong SpanId { get; }
 
         /// <summary>
-        /// Gets or sets the service name
+        /// Gets the service name
         /// </summary>
-        public string ServiceName { get; set; }
+        public string ServiceName { get; internal set; }
 
         // This may be null if SpanContext was extracted from another process context
         internal TraceContext TraceContext { get; }


### PR DESCRIPTION
This PR allows setting the service name after a span is created. This is a follow-up of #229, where we added the ability to set the service name OpenTracing by setting a tag.