### PR TITLE
C++ Profiler: support generic classes, improve logging

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -57,14 +57,15 @@ WSTRING GetAssemblyName(const ComPtr<IMetaDataAssemblyImport>& assembly_import,
 FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                              const mdToken& token) {
   mdToken parent_token = mdTokenNil;
-  WCHAR function_name[kNameMaxSize];
+  WCHAR function_name[kNameMaxSize]{};
   DWORD function_name_len = 0;
 
   PCCOR_SIGNATURE raw_signature;
   ULONG raw_signature_len;
 
   HRESULT hr = E_FAIL;
-  switch (TypeFromToken(token)) {
+  const auto token_type = TypeFromToken(token);
+  switch (token_type) {
     case mdtMemberRef:
       hr = metadata_import->GetMemberRefProps(
           token, &parent_token, function_name, kNameMaxSize, &function_name_len,
@@ -89,7 +90,7 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
     } break;
     default:
       Warn("[trace::GetFunctionInfo] unknown token type: {}",
-           TypeFromToken(token));
+           token_type);
   }
   if (FAILED(hr) || function_name_len == 0) {
     return {};
@@ -101,15 +102,15 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
   }
 
   // parent_token could be: TypeDef, TypeRef, TypeSpec, ModuleRef, MethodDef
+  const auto type_info = GetTypeInfo(metadata_import, parent_token);
 
-  return {token, WSTRING(function_name),
-          GetTypeInfo(metadata_import, parent_token),
+  return {token, WSTRING(function_name), type_info,
           MethodSignature(signature_data)};
 }
 
 ModuleInfo GetModuleInfo(ICorProfilerInfo3* info, const ModuleID& module_id) {
   const DWORD module_path_size = 260;
-  WCHAR module_path[module_path_size];
+  WCHAR module_path[module_path_size]{};
   DWORD module_path_len = 0;
   LPCBYTE base_load_address;
   AssemblyID assembly_id = 0;
@@ -127,7 +128,7 @@ ModuleInfo GetModuleInfo(ICorProfilerInfo3* info, const ModuleID& module_id) {
 TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                      const mdToken& token) {
   mdToken parent_token = mdTokenNil;
-  WCHAR type_name[kNameMaxSize];
+  WCHAR type_name[kNameMaxSize]{};
   DWORD type_name_len = 0;
 
   HRESULT hr = E_FAIL;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -24,9 +24,9 @@ CorProfiler::CorProfiler() : integrations_(LoadIntegrationsFromEnvironment()) {
 HRESULT STDMETHODCALLTYPE
 CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   is_attached_ = FALSE;
+  Info("CorProfiler::Initialize");
 
   const auto process_name = GetCurrentProcessName();
-  Info("Initialize() called for", process_name);
 
   if (integrations_.empty()) {
     Warn("Profiler disabled: ", kIntegrationsEnvironmentName,
@@ -48,8 +48,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
 
     if (std::find(allowed_process_names.begin(), allowed_process_names.end(),
                   process_name) == allowed_process_names.end()) {
-      Info("Profiler disabled: module name ", process_name, " does not match ",
-           kProcessesEnvironmentName, " environment variable");
+      Info("Profiler disabled: ", process_name, " not found in ", kProcessesEnvironmentName, ".");
       return E_FAIL;
     }
   }
@@ -57,7 +56,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo3>(
       &this->info_);
   if (FAILED(hr)) {
-    Warn("Profiler disabled: interface ICorProfilerInfo3 or higher not found.");
+    Warn("Failed to attach profiler: interface ICorProfilerInfo3 not found.");
   }
 
   hr = this->info_->SetEventMask(kEventMask);
@@ -66,7 +65,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   }
 
   // we're in!
-  Info("Profiler attached to process", process_name);
+  Info("Profiler attached.");
   this->info_->AddRef();
   is_attached_ = true;
   profiler = this;
@@ -89,8 +88,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
     // We cannot obtain writable metadata interfaces on Windows Runtime modules
     // or instrument their IL. We must never try to add assembly references to
     // mscorlib or netstandard.
-    Info("ModuleLoadFinished() called for ", module_info.assembly.name,
-         ". Skipping instrumentation.");
+    Info("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,
+         ". Skipping (known module).");
     return S_OK;
   }
 
@@ -98,9 +97,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
       FilterIntegrationsByCaller(integrations_, module_info.assembly.name);
   if (enabled_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
-    Info("ModuleLoadFinished() called for ", module_info.assembly.name,
-         ". FilterIntegrationsByCaller() returned empty list. Nothing to "
-         "instrument here.");
+    Info("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,
+         ". Skipping (filtered by caller).");
     return S_OK;
   }
 
@@ -111,7 +109,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
                                            metadata_interfaces.GetAddressOf());
 
   if (FAILED(hr)) {
-    Warn("failed to get metadata interface");
+    Warn("Failed to get metadata interface");
+    return S_OK;
   }
 
   const auto metadata_import =
@@ -127,19 +126,16 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
       FilterIntegrationsByTarget(enabled_integrations, assembly_import);
   if (enabled_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
-    Info("ModuleLoadFinished() called for ", module_info.assembly.name,
-         ". FilterIntegrationsByTarget() returned empty list. Nothing to "
-         "instrument here.");
+    Info("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,
+         ". Skipping (filtered by target).");
     return S_OK;
   }
-
-  Info("ModuleLoadFinished() will try to emit instrumentation metadata for ",
-       module_info.assembly.name, ".");
 
   mdModule module;
   hr = metadata_import->GetModuleFromScope(&module);
   if (FAILED(hr)) {
-    Warn("ModuleLoadFinished() failed to get module token.");
+    Warn("CorProfiler::ModuleLoadFinished: failed to get module token.");
+    return S_OK;
   }
 
   ModuleMetadata* module_metadata =
@@ -170,14 +166,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
     module_id_to_info_map_[module_id] = module_metadata;
   }
 
-  Info("ModuleLoadFinished() emitted instrumentation metadata for",
+  Info("CorProfiler::ModuleLoadFinished: emitted instrumentation metadata for ",
        module_info.assembly.name);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadFinished(ModuleID module_id,
                                                             HRESULT hrStatus) {
-  Info("CorProfiler::ModuleUnloadFinished", uint64_t(module_id));
+  Info("CorProfiler::ModuleUnloadFinished ", uint64_t(module_id));
   {
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
     if (module_id_to_info_map_.count(module_id) > 0) {
@@ -300,7 +296,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
 
       modified = true;
 
-      Info("JITCompilationStarted() replaced calls from ", caller.type.name,
+      Info("CorProfiler::JITCompilationStarted() replaced calls from ", caller.type.name,
            ".", caller.name, "() to ",
            method_replacement.target_method.type_name, ".",
            method_replacement.target_method.method_name, "() ",

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -26,6 +26,13 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   is_attached_ = FALSE;
   Info("CorProfiler::Initialize");
 
+  Info(kIntegrationsEnvironmentName, " ",
+       GetEnvironmentValue(kIntegrationsEnvironmentName));
+  Info("DD_AGENT_HOST"_W, GetEnvironmentValue("DD_AGENT_HOST"_W));
+  Info("DD_TRACE_AGENT_PORT"_W, GetEnvironmentValue("DD_TRACE_AGENT_PORT"_W));
+  Info("DD_ENV"_W, GetEnvironmentValue("DD_ENV"_W));
+  Info("DD_SERVICE_NAME"_W, GetEnvironmentValue("DD_SERVICE_NAME"_W));
+
   const auto process_name = GetCurrentProcessName();
 
   if (integrations_.empty()) {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -13,7 +13,7 @@ using json = nlohmann::json;
 std::vector<Integration> LoadIntegrationsFromEnvironment() {
   std::vector<Integration> integrations;
   for (const auto f : GetEnvironmentValues(kIntegrationsEnvironmentName)) {
-    Info("loading integrations from", f);
+    Info("Loading integrations from file: ", f);
     auto is = LoadIntegrationsFromFile(f);
     for (auto& i : is) {
       integrations.push_back(i);
@@ -37,7 +37,7 @@ std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path) {
         std::rethrow_exception(ex);
       }
     } catch (const std::exception& ex) {
-      Warn("failed to load integrations", ex.what());
+      Warn("Failed to load integrations: ", ex.what());
     }
   }
 
@@ -59,11 +59,11 @@ std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream) {
       }
     }
 
-    Info("loaded integrations:", j.dump());
+    Info("Loaded integrations: ", j.dump());
   } catch (const json::parse_error& e) {
-    Warn("invalid integrations:", e.what());
+    Warn("Invalid integrations:", e.what());
   } catch (const json::type_error& e) {
-    Warn("invalid integrations:", e.what());
+    Warn("Invalid integrations:", e.what());
   } catch (...) {
     auto ex = std::current_exception();
     try {
@@ -71,7 +71,7 @@ std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream) {
         std::rethrow_exception(ex);
       }
     } catch (const std::exception& ex) {
-      Warn("failed to load integrations", ex.what());
+      Warn("Failed to load integrations: ", ex.what());
     }
   }
 
@@ -88,7 +88,7 @@ std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src) {
   // first get the name, which is required
   auto name = ToWSTRING(src.value("name", ""));
   if (name.empty()) {
-    Warn("integration name is missing for integration:", src.dump());
+    Warn("Integration name is missing for integration: ", src.dump());
     return std::make_pair<Integration, bool>({}, false);
   }
 
@@ -111,9 +111,9 @@ std::pair<MethodReplacement, bool> MethodReplacementFromJson(
     return std::make_pair<MethodReplacement, bool>({}, false);
   }
 
-  auto caller = MethodReferenceFromJson(src.value("caller", json::object()));
-  auto target = MethodReferenceFromJson(src.value("target", json::object()));
-  auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()));
+  const auto caller = MethodReferenceFromJson(src.value("caller", json::object()));
+  const auto target = MethodReferenceFromJson(src.value("target", json::object()));
+  const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()));
   return std::make_pair<MethodReplacement, bool>({caller, target, wrapper},
                                                  true);
 }
@@ -123,9 +123,9 @@ MethodReference MethodReferenceFromJson(const json::value_type& src) {
     return {};
   }
 
-  auto assembly = ToWSTRING(src.value("assembly", ""));
-  auto type = ToWSTRING(src.value("type", ""));
-  auto method = ToWSTRING(src.value("method", ""));
+  const auto assembly = ToWSTRING(src.value("assembly", ""));
+  const auto type = ToWSTRING(src.value("type", ""));
+  const auto method = ToWSTRING(src.value("method", ""));
   auto raw_signature = src.value("signature", json::array());
   std::vector<BYTE> signature;
   if (raw_signature.is_array()) {


### PR DESCRIPTION
Generics:
- decode `mdTypeSpec` to obtain type name
  - we already supported interception of `Class.Method<T>()`, but not `Class<T>.Method()`
  - required for MongoDB integration

Logging:
- include supported environment variables, useful when troubleshooting with users
- clean up logging (more missing whitespace, consistent capitalization, redundant process name, etc)
