### PR TITLE
Config: disable individual integrations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -153,6 +153,7 @@
     <ClInclude Include="com_ptr.h" />
     <ClInclude Include="cor_profiler.h" />
     <ClInclude Include="cor_profiler_base.h" />
+    <ClInclude Include="environment_variables.h" />
     <ClInclude Include="il_rewriter.h" />
     <ClInclude Include="il_rewriter_wrapper.h" />
     <ClInclude Include="integration.h" />

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -194,12 +194,15 @@ std::vector<Integration> FilterIntegrationsByName(
 
   for (auto& i : integrations) {
     bool disabled = false;
+
     for (auto& disabled_integration : integration_names) {
       if (i.integration_name == disabled_integration) {
+        // this integration is disabled, skip it
         disabled = true;
         break;
       }
     }
+
     if (!disabled) {
       enabled.push_back(i);
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -142,21 +142,21 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                                             kNameMaxSize, &type_name_len);
       break;
     case mdtTypeSpec: {
-        PCCOR_SIGNATURE signature{};
-        ULONG signature_length{};
+      PCCOR_SIGNATURE signature{};
+      ULONG signature_length{};
 
-        hr = metadata_import->GetTypeSpecFromToken(token, &signature,
-                                                   &signature_length);
+      hr = metadata_import->GetTypeSpecFromToken(token, &signature,
+                                                 &signature_length);
 
-        if (FAILED(hr) || signature_length < 3) {
-          return {};
-        }
+      if (FAILED(hr) || signature_length < 3) {
+        return {};
+      }
 
-        if (signature[0] & ELEMENT_TYPE_GENERICINST) {
-          mdToken type_token;
-          CorSigUncompressToken(&signature[2], &type_token);
-          return GetTypeInfo(metadata_import, type_token);
-        }
+      if (signature[0] & ELEMENT_TYPE_GENERICINST) {
+        mdToken type_token;
+        CorSigUncompressToken(&signature[2], &type_token);
+        return GetTypeInfo(metadata_import, type_token);
+      }
     } break;
     case mdtModuleRef:
       metadata_import->GetModuleRefProps(token, type_name, kNameMaxSize,
@@ -185,6 +185,27 @@ mdAssemblyRef FindAssemblyRef(
     }
   }
   return mdAssemblyRefNil;
+}
+
+std::vector<Integration> FilterEnabledIntegrations(
+    const std::vector<Integration>& integrations,
+    const std::vector<WSTRING> disabled_integrations) {
+  std::vector<Integration> enabled;
+
+  for (auto& i : integrations) {
+    bool disabled = false;
+    for (auto& disabled_integration : disabled_integrations) {
+      if (i.integration_name == disabled_integration) {
+        disabled = true;
+        break;
+      }
+    }
+    if (!disabled) {
+      enabled.push_back(i);
+    }
+  }
+
+  return enabled;
 }
 
 std::vector<Integration> FilterIntegrationsByCaller(

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -187,14 +187,14 @@ mdAssemblyRef FindAssemblyRef(
   return mdAssemblyRefNil;
 }
 
-std::vector<Integration> FilterEnabledIntegrations(
+std::vector<Integration> FilterIntegrationsByName(
     const std::vector<Integration>& integrations,
-    const std::vector<WSTRING> disabled_integrations) {
+    const std::vector<WSTRING> integration_names) {
   std::vector<Integration> enabled;
 
   for (auto& i : integrations) {
     bool disabled = false;
-    for (auto& disabled_integration : disabled_integrations) {
+    for (auto& disabled_integration : integration_names) {
       if (i.integration_name == disabled_integration) {
         disabled = true;
         break;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -89,8 +89,7 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
       function_name_len = (DWORD)(generic_info.name.length() + 1);
     } break;
     default:
-      Warn("[trace::GetFunctionInfo] unknown token type: {}",
-           token_type);
+      Warn("[trace::GetFunctionInfo] unknown token type: {}", token_type);
   }
   if (FAILED(hr) || function_name_len == 0) {
     return {};
@@ -142,8 +141,7 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
       hr = metadata_import->GetTypeRefProps(token, &parent_token, type_name,
                                             kNameMaxSize, &type_name_len);
       break;
-    case mdtTypeSpec:
-      {
+    case mdtTypeSpec: {
         PCCOR_SIGNATURE signature{};
         ULONG signature_length{};
 
@@ -159,8 +157,7 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
           CorSigUncompressToken(&signature[2], &type_token);
           return GetTypeInfo(metadata_import, type_token);
         }
-      }
-      break;
+    } break;
     case mdtModuleRef:
       metadata_import->GetModuleRefProps(token, type_name, kNameMaxSize,
                                          &type_name_len);

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -237,11 +237,11 @@ mdAssemblyRef FindAssemblyRef(
     const ComPtr<IMetaDataAssemblyImport>& assembly_import,
     const WSTRING& assembly_name);
 
-// FilterEnabledIntegrations removes any integrations that are disabled via
-// configuration
-std::vector<Integration> FilterEnabledIntegrations(
+// FilterIntegrationsByName removes integrations whose names are specified in
+// disabled_integration_names
+std::vector<Integration> FilterIntegrationsByName(
     const std::vector<Integration>& integrations,
-    std::vector<WSTRING> disabled_integrations);
+    std::vector<WSTRING> integration_names);
 
 // FilterIntegrationsByCaller removes any integrations which have a caller and
 // its not set to the module

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -237,6 +237,12 @@ mdAssemblyRef FindAssemblyRef(
     const ComPtr<IMetaDataAssemblyImport>& assembly_import,
     const WSTRING& assembly_name);
 
+// FilterEnabledIntegrations removes any integrations that are disabled via
+// configuration
+std::vector<Integration> FilterEnabledIntegrations(
+    const std::vector<Integration>& integrations,
+    std::vector<WSTRING> disabled_integrations);
+
 // FilterIntegrationsByCaller removes any integrations which have a caller and
 // its not set to the module
 std::vector<Integration> FilterIntegrationsByCaller(

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -128,7 +128,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
                                            metadata_interfaces.GetAddressOf());
 
   if (FAILED(hr)) {
-    Warn("Failed to get metadata interface");
+    Warn("CorProfiler::ModuleLoadFinished: Failed to get metadata interface");
     return S_OK;
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -26,7 +26,9 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   Info("CorProfiler::Initialize");
   Info("Environment variables:");
 
-  WSTRING env_vars[] = {environment::integrations_path,
+  WSTRING env_vars[] = {environment::tracing_enabled,
+                        environment::debug_enabled,
+                        environment::integrations_path,
                         environment::process_names,
                         environment::agent_host,
                         environment::agent_port,
@@ -36,6 +38,14 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
 
   for (auto&& env_var : env_vars) {
     Info("  ", env_var, "=", GetEnvironmentValue(env_var));
+  }
+
+  const WSTRING tracing_enabled =
+      GetEnvironmentValue(environment::tracing_enabled);
+
+  if (tracing_enabled == "0"_W || tracing_enabled == "false"_W) {
+    Info("Profiler disabled in ", environment::tracing_enabled);
+    return E_FAIL;
   }
 
   const auto allowed_process_names =

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -112,7 +112,18 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
     return S_OK;
   }
 
+  const std::vector<std::basic_string<wchar_t>> disabled_integration_names =
+      GetEnvironmentValues(environment::disabled_integrations);
   std::vector<Integration> enabled_integrations =
+      FilterEnabledIntegrations(integrations_, disabled_integration_names);
+  if (enabled_integrations.empty()) {
+    // we don't need to instrument anything in this module, skip it
+    Info("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,
+         ". Skipping (no enabled integrations).");
+    return S_OK;
+  }
+
+  enabled_integrations =
       FilterIntegrationsByCaller(integrations_, module_info.assembly.name);
   if (enabled_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -112,7 +112,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
     return S_OK;
   }
 
-  const std::vector<std::basic_string<wchar_t>> disabled_integration_names =
+  const std::vector<WSTRING> disabled_integration_names =
       GetEnvironmentValues(environment::disabled_integrations);
   std::vector<Integration> enabled_integrations =
       FilterIntegrationsByName(integrations_, disabled_integration_names);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -115,7 +115,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   const std::vector<std::basic_string<wchar_t>> disabled_integration_names =
       GetEnvironmentValues(environment::disabled_integrations);
   std::vector<Integration> enabled_integrations =
-      FilterEnabledIntegrations(integrations_, disabled_integration_names);
+      FilterIntegrationsByName(integrations_, disabled_integration_names);
   if (enabled_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
     Info("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -41,13 +41,14 @@ class CorProfiler : public CorProfilerBase {
 
   bool IsAttached() const;
 
-  HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk) override;
+  HRESULT STDMETHODCALLTYPE
+  Initialize(IUnknown* cor_profiler_info_unknown) override;
   HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID module_id,
                                                HRESULT hrStatus) override;
   HRESULT STDMETHODCALLTYPE ModuleUnloadFinished(ModuleID module_id,
                                                  HRESULT hrStatus) override;
-  HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID functionId,
-                                                  BOOL fIsSafeToBlock) override;
+  HRESULT STDMETHODCALLTYPE
+  JITCompilationStarted(FunctionID function_id, BOOL is_safe_to_block) override;
 };
 
 // Note: Generally you should not have a single, global callback implementation,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -31,7 +31,7 @@ const DWORD kEventMask =
 class CorProfiler : public CorProfilerBase {
  private:
   bool is_attached_ = false;
-  const std::vector<Integration> integrations_;
+  std::vector<Integration> integrations_;
 
   std::mutex module_id_to_info_map_lock_;
   std::unordered_map<ModuleID, ModuleMetadata*> module_id_to_info_map_;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -14,8 +14,6 @@
 
 namespace trace {
 
-const WSTRING kProcessesEnvironmentName = "DD_PROFILER_PROCESSES"_W;
-
 const DWORD kEventMask =
     COR_PRF_MONITOR_JIT_COMPILATION |
     COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST | /* helps the case

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -9,8 +9,10 @@ const WSTRING tracing_enabled = "DD_TRACE_ENABLED"_W;
 
 const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
 
+// supports multiple values
 const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
 
+// supports multiple values
 const WSTRING process_names = "DD_PROFILER_PROCESSES"_W;
 
 const WSTRING agent_host = "DD_AGENT_HOST"_W;
@@ -21,6 +23,7 @@ const WSTRING env = "DD_ENV"_W;
 
 const WSTRING service_name = "DD_SERVICE_NAME"_W;
 
+// supports multiple values
 const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
 
 }  // namespace trace::environment

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -6,27 +6,48 @@
 namespace trace {
 namespace environment {
 
+// Sets whether the profiler is enabled. Detault is true.
+// Setting this to false disabled the profiler entirely.
 const WSTRING tracing_enabled = "DD_TRACE_ENABLED"_W;
 
+// Sets whether debug mode is enabled. Default is false.
 const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
 
-// supports multiple values
+// Sets the paths to integration definition JSON files.
+// Supports multiple values separated with semi-colons, for example:
+// "C:\Program Files\Datadog .NET tracer\integrations.json;D:\temp\test_integrations.json"
 const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
 
-// supports multiple values
+// Sets the filename of executables the profiler will attach to.
+// If not defined (default), the profiler will attach to any process.
+// Supports multiple values separated with semi-colons, for example:
+// "MyApp.exe;dotnet.exe"
 const WSTRING process_names = "DD_PROFILER_PROCESSES"_W;
 
+// Sets the Agent's host. Default is localhost.
 const WSTRING agent_host = "DD_AGENT_HOST"_W;
 
+// Sets the Agent's port. Default is 8126.
 const WSTRING agent_port = "DD_TRACE_AGENT_PORT"_W;
 
+// Sets the "env" tag for every span.
 const WSTRING env = "DD_ENV"_W;
 
+// Sets the default service name for every span.
+// If not set, Tracer will try to determine service name automatically
+// from application name (e.g. entry assembly or IIS application name).
 const WSTRING service_name = "DD_SERVICE_NAME"_W;
 
-// supports multiple values
+// Sets a list of integrations to disable. All other integrations will remain enabled.
+// If not set (default), all integrations are enabled.
+// Supports multiple values separated with semi-colons, for example:
+// "ElastichsearchNet;AspNetWebApi2"
 const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
 
+// Sets the path for the profiler's log file.
+// If not set, default is
+// "%ProgramData%"\Datadog .NET Tracer\logs\dotnet-profiler.log" on Windows or
+// "/var/log/datadog/dotnet-profiler.log" on Linux.
 const WSTRING log_path = "DD_TRACE_LOG_PATH"_W;
 
 }  // namespace environment

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -27,6 +27,8 @@ const WSTRING service_name = "DD_SERVICE_NAME"_W;
 // supports multiple values
 const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
 
+const WSTRING log_path = "DD_TRACE_LOG_PATH"_W;
+
 }  // namespace environment
 }  // namespace trace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -3,7 +3,8 @@
 
 #include "string.h"  // NOLINT
 
-namespace trace::environment {
+namespace trace {
+namespace environment {
 
 const WSTRING tracing_enabled = "DD_TRACE_ENABLED"_W;
 
@@ -26,6 +27,7 @@ const WSTRING service_name = "DD_SERVICE_NAME"_W;
 // supports multiple values
 const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
 
-}  // namespace trace::environment
+}  // namespace environment
+}  // namespace trace
 
 #endif

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -1,0 +1,28 @@
+#ifndef DD_CLR_PROFILER_ENVIRONMENT_VARIABLES_H_
+#define DD_CLR_PROFILER_ENVIRONMENT_VARIABLES_H_
+
+#include "string.h"  // NOLINT
+
+namespace trace::environment {
+
+const WSTRING tracing_enabled = "DD_TRACE_ENABLED"_W;
+
+const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
+
+const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
+
+const WSTRING process_names = "DD_PROFILER_PROCESSES"_W;
+
+const WSTRING agent_host = "DD_AGENT_HOST"_W;
+
+const WSTRING agent_port = "DD_TRACE_AGENT_PORT"_W;
+
+const WSTRING env = "DD_ENV"_W;
+
+const WSTRING service_name = "DD_SERVICE_NAME"_W;
+
+const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
+
+}  // namespace trace::environment
+
+#endif

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -5,6 +5,7 @@
 
 #include "logging.h"
 #include "util.h"
+#include "environment_variables.h"
 
 namespace trace {
 
@@ -12,7 +13,7 @@ using json = nlohmann::json;
 
 std::vector<Integration> LoadIntegrationsFromEnvironment() {
   std::vector<Integration> integrations;
-  for (const auto f : GetEnvironmentValues(kIntegrationsEnvironmentName)) {
+  for (const auto f : GetEnvironmentValues(environment::integrations_path)) {
     Info("Loading integrations from file: ", f);
     auto is = LoadIntegrationsFromFile(f);
     for (auto& i : is) {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
@@ -12,8 +12,6 @@
 
 namespace trace {
 
-const WSTRING kIntegrationsEnvironmentName = "DD_INTEGRATIONS"_W;
-
 using json = nlohmann::json;
 
 // LoadIntegrationsFromEnvironment loads integrations from any files specified

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -1,7 +1,7 @@
 #ifndef DD_CLR_PROFILER_LOGGING_H_
 #define DD_CLR_PROFILER_LOGGING_H_
 
-#include "string.h"
+#include "string.h"  // NOLINT
 
 namespace trace {
 

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -14,17 +14,26 @@
 
 #endif
 
-#include "string.h"
+#include "environment_variables.h"
+#include "string.h"  // NOLINT
+#include "util.h"
 
 namespace trace {
 
 inline WSTRING DatadogLogFilePath() {
+  WSTRING path = GetEnvironmentValue(environment::log_path);
+
+  if (path.length() > 0) {
+    return path;
+  }
+
 #ifdef _WIN32
   std::string programdata(getenv("PROGRAMDATA"));
   if (programdata.empty()) {
     programdata = "C:\\ProgramData";
   }
-  return ToWSTRING(programdata + "\\Datadog .NET Tracer\\logs\\dotnet-profiler.log");
+  return ToWSTRING(programdata +
+                   "\\Datadog .NET Tracer\\logs\\dotnet-profiler.log");
 #else
   return ToWSTRING("/var/log/datadog/dotnet-profiler.log");
 #endif

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -95,7 +95,7 @@ TEST_F(DISABLED_CLRHelperTest, FiltersEnabledIntegrations) {
   std::vector<Integration> expected = {i1, i3};
   std::vector<WSTRING> disabled_integrations = {"integration-2"_W};
   std::vector<Integration> actual =
-      FilterEnabledIntegrations(all, disabled_integrations);
+      FilterIntegrationsByName(all, disabled_integrations);
   EXPECT_EQ(expected, actual);
 }
 

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -82,6 +82,23 @@ TEST_F(DISABLED_CLRHelperTest, EnumeratesAssemblyRefs) {
   EXPECT_EQ(expected_assemblies, actual_assemblies);
 }
 
+TEST_F(DISABLED_CLRHelperTest, FiltersEnabledIntegrations) {
+  Integration i1 = {
+      L"integration-1",
+      {{{}, {L"Samples.ExampleLibrary", L"SomeType", L"SomeMethod", {}}, {}}}};
+  Integration i2 = {
+      L"integration-2",
+      {{{}, {L"Assembly.Two", L"SomeType", L"SomeMethod", {}}, {}}}};
+  Integration i3 = {L"integration-3",
+                    {{{}, {L"System.Runtime", L"", L"", {}}, {}}}};
+  std::vector<Integration> all = {i1, i2, i3};
+  std::vector<Integration> expected = {i1, i3};
+  std::vector<WSTRING> disabled_integrations = {"integration-2"_W};
+  std::vector<Integration> actual =
+      FilterEnabledIntegrations(all, disabled_integrations);
+  EXPECT_EQ(expected, actual);
+}
+
 TEST_F(DISABLED_CLRHelperTest, FiltersIntegrationsByCaller) {
   Integration i1 = {
       L"integration-1",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
@@ -8,6 +8,7 @@
 #include <string>
 
 #include "../../src/Datadog.Trace.ClrProfiler.Native/integration_loader.h"
+#include "../../src/Datadog.Trace.ClrProfiler.Native/environment_variables.h"
 
 using namespace trace;
 
@@ -68,13 +69,13 @@ TEST(IntegrationLoaderTest,
 
 TEST(IntegrationLoaderTest, HandlesSingleIntegrationWithMethodReplacements) {
   std::stringstream str(R"TEXT(
-        [{ 
-            "name": "test-integration", 
+        [{
+            "name": "test-integration",
             "method_replacements": [{
                 "caller": { },
                 "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One" },
                 "wrapper": { "assembly": "Assembly.Two", "type": "Type.Two", "method": "Method.Two", "signature": [0, 1, 1, 28] }
-            }] 
+            }]
         }]
     )TEXT");
 
@@ -99,12 +100,12 @@ TEST(IntegrationLoaderTest, HandlesSingleIntegrationWithMethodReplacements) {
 
 TEST(IntegrationLoaderTest, HandlesSingleIntegrationWithMissingCaller) {
   std::stringstream str(R"TEXT(
-        [{ 
-            "name": "test-integration", 
+        [{
+            "name": "test-integration",
             "method_replacements": [{
                 "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One" },
                 "wrapper": { "assembly": "Assembly.Two", "type": "Type.Two", "method": "Method.Two", "signature": [0, 1, 1, 28] }
-            }] 
+            }]
         }]
     )TEXT");
 
@@ -129,12 +130,12 @@ TEST(IntegrationLoaderTest, HandlesSingleIntegrationWithMissingCaller) {
 
 TEST(IntegrationLoaderTest, HandlesSingleIntegrationWithInvalidTarget) {
   std::stringstream str(R"TEXT(
-        [{ 
-            "name": "test-integration", 
+        [{
+            "name": "test-integration",
             "method_replacements": [{
                 "target": 1234,
                 "wrapper": { "assembly": "Assembly.Two", "type": "Type.Two", "method": "Method.Two" }
-            }] 
+            }]
         }]
     )TEXT");
 
@@ -166,7 +167,7 @@ TEST(IntegrationLoaderTest, LoadsFromEnvironment) {
 
   auto name = tmpname1.wstring() + L";" + tmpname2.wstring();
 
-  SetEnvironmentVariableW(kIntegrationsEnvironmentName.data(), name.data());
+  SetEnvironmentVariableW(trace::environment::integrations_path.data(), name.data());
 
   std::vector<std::wstring> expected_names = {L"test-integration-1",
                                               L"test-integration-2"};


### PR DESCRIPTION
Refactor handling environment variables in the profiler code (C++) to ease configuration.

- move all supported environment variable names into a single file
- add support for new environment variables:
  - `DD_TRACE_ENABLED` completely disable attaching the profiler
  - `DD_TRACE_DEBUG` enable debug mode (doesn't do anything yet, coming soon)
  - `DD_DISABLED_INTEGRATIONS` disable individual integrations by name
  -  `DD_TRACE_LOG_PATH` override default log file path
- move initialization from the `CorProfiler` constructor to `CorProfiler::Initialize()` as expected by the Profiling API
- reorder initialization to exit early when possible (e.g. don't try to load `integrations.json` if profiling is disabled)
