### PR TITLE
Improve profiler logging

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler
                 {
                     return NativeMethods.IsProfilerAttached();
                 }
-                catch
+                catch (DllNotFoundException)
                 {
                     return false;
                 }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -195,7 +195,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
       hr = metadata_builder.StoreWrapperMethodRef(method_replacement);
       if (FAILED(hr)) {
         Warn("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,
-             ". Failed to emit wrapper method ref.");
+             ". Failed to emit and store wrapper method ref.");
         return S_OK;
       }
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -103,7 +103,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
       module_info.assembly.name == "netstandard"_W ||
       module_info.assembly.name == "Datadog.Trace"_W ||
       module_info.assembly.name == "Datadog.Trace.ClrProfiler.Managed"_W ||
-      module_info.assembly.name == "Sigil.Emit.DynamicAssembly"_W) {
+      module_info.assembly.name == "Sigil.Emit.DynamicAssembly"_W ||
+      module_info.assembly.name ==
+          "Anonymously Hosted DynamicMethods Assembly"_W) {
     // We cannot obtain writable metadata interfaces on Windows Runtime modules
     // or instrument their IL. We must never try to add assembly references to
     // mscorlib or netstandard.

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -24,7 +24,7 @@ HRESULT MetadataBuilder::EmitAssemblyRef(
     assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
   }
 
-  Info("EmitAssemblyRef ", assembly_ref.str());
+  // Info("EmitAssemblyRef ", assembly_ref.str());
 
   DWORD public_key_size = 8;
   if (assembly_ref.public_key == trace::PublicKey()) {

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -24,8 +24,6 @@ HRESULT MetadataBuilder::EmitAssemblyRef(
     assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
   }
 
-  // Info("EmitAssemblyRef ", assembly_ref.str());
-
   DWORD public_key_size = 8;
   if (assembly_ref.public_key == trace::PublicKey()) {
     public_key_size = 0;


### PR DESCRIPTION
Improve messages logged from the native profiler:

- add missing log entries
- improve consistency between messages
- remove one noisy message (can be added back when we implement debug mode)

Bonus: in `Instrumentation.ProfilerAttached` getter, instead of capturing any exception, only fallback to `false` if native dll is not found (i.e. profiler is definitely not attached)