### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* DataDog/apm-dotnet


### PR DESCRIPTION
Add `CODEOWNERS` file to make `DataDog/apm-dotnet` team the default owner of every file in the repo. That team will be automatically added as a reviewer in new PRs.