### PR TITLE
Create profiler log file directory

### DIFF
--- a/samples/Samples.SqlServer/Properties/launchSettings.json
+++ b/samples/Samples.SqlServer/Properties/launchSettings.json
@@ -12,7 +12,8 @@
         "CORECLR_PROFILER_PATH": "%UserProfile%\\source\\repos\\dd-trace-csharp\\src\\Datadog.Trace.ClrProfiler.Native\\bin\\Debug\\x64\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_INTEGRATIONS": "%UserProfile%\\source\\repos\\dd-trace-csharp\\integrations.json"
-      }
+      },
+      "nativeDebugging": true
     }
   }
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -6,7 +6,7 @@
 namespace trace {
 namespace environment {
 
-// Sets whether the profiler is enabled. Detault is true.
+// Sets whether the profiler is enabled. Default is true.
 // Setting this to false disabled the profiler entirely.
 const WSTRING tracing_enabled = "DD_TRACE_ENABLED"_W;
 
@@ -15,7 +15,7 @@ const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
 
 // Sets the paths to integration definition JSON files.
 // Supports multiple values separated with semi-colons, for example:
-// "C:\Program Files\Datadog .NET tracer\integrations.json;D:\temp\test_integrations.json"
+// "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
 const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
 
 // Sets the filename of executables the profiler will attach to.
@@ -41,7 +41,7 @@ const WSTRING service_name = "DD_SERVICE_NAME"_W;
 // Sets a list of integrations to disable. All other integrations will remain enabled.
 // If not set (default), all integrations are enabled.
 // Supports multiple values separated with semi-colons, for example:
-// "ElastichsearchNet;AspNetWebApi2"
+// "ElasticsearchNet;AspNetWebApi2"
 const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
 
 // Sets the path for the profiler's log file.

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -18,6 +18,10 @@ void Log(const std::string& str) {
 
   try {
     const auto path = ToString(DatadogLogFilePath());
+
+#ifdef _WIN32
+    // on VC++, use std::filesystem (C++ 17) to
+    // create directory if missing
     const auto log_path = std::filesystem::path(path);
 
     if (log_path.has_parent_path()) {
@@ -27,6 +31,7 @@ void Log(const std::string& str) {
         std::filesystem::create_directories(parent_path);
       }
     }
+#endif
 
     std::ofstream out(path, std::ios::app);
     out << line;

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -17,7 +17,18 @@ void Log(const std::string& str) {
   auto line = ss.str();
 
   try {
-    std::ofstream out(ToString(DatadogLogFilePath()), std::ios::app);
+    const auto path = ToString(DatadogLogFilePath());
+    const auto log_path = std::filesystem::path(path);
+
+    if (log_path.has_parent_path()) {
+      const auto parent_path = log_path.parent_path();
+
+      if (!std::filesystem::exists(parent_path)) {
+        std::filesystem::create_directories(parent_path);
+      }
+    }
+
+    std::ofstream out(path, std::ios::app);
     out << line;
   } catch (...) {
   }


### PR DESCRIPTION
Create profiler log file directory if missing.

We used to do this but it [was lost during refactoring](https://github.com/DataDog/dd-trace-dotnet/commit/da52be6d9346397f49d65121ac82efe7b8de58a3#diff-83443047dc9813b7bd4cefe58a91b330L37) when Linux support was added #171.
