### PR TITLE
Don't crash apps with multiple AppDomains

### DIFF
--- a/Datadog.Trace.sln.DotSettings
+++ b/Datadog.Trace.sln.DotSettings
@@ -16,6 +16,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTLINE_TYPE_PARAMETER_CONSTRAINS/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTLINE_TYPE_PARAMETER_LIST/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_TUPLE_COMPONENTS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INT_ALIGN_NESTED_TERNARY/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EMBEDDED_BLOCK_ARRANGEMENT/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/NESTED_TERNARY_STYLE/@EntryValue">COMPACT</s:String>
@@ -30,6 +31,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_TERNARY_EXPR_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CppUseAuto/AutoWasChosen/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/ShowEditorConfigStatusBarIndicator/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EncapsulateField/UpdateExternalUsagesOnly/@EntryValue">False</s:Boolean>
@@ -94,4 +96,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FPREFIX/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Datadog.Trace/AsyncLocalCompat.cs
+++ b/src/Datadog.Trace/AsyncLocalCompat.cs
@@ -26,11 +26,7 @@ namespace Datadog.Trace
 
     internal class AsyncLocalCompat<T>
     {
-        private AsyncLocal<T> _asyncLocal = new AsyncLocal<T>();
-
-        public AsyncLocalCompat()
-        {
-        }
+        private readonly AsyncLocal<T> _asyncLocal = new AsyncLocal<T>();
 
         public T Get()
         {

--- a/src/Datadog.Trace/AsyncLocalCompat.cs
+++ b/src/Datadog.Trace/AsyncLocalCompat.cs
@@ -12,7 +12,10 @@ namespace Datadog.Trace
         public T Get()
         {
             var handle = CallContext.LogicalGetData(_name) as ObjectHandle;
-            return handle == null ? default(T) : (T)handle.Unwrap();
+
+            return handle == null
+                       ? default(T)
+                       : (T)handle.Unwrap();
         }
 
         public void Set(T value)

--- a/src/Datadog.Trace/AsyncLocalCompat.cs
+++ b/src/Datadog.Trace/AsyncLocalCompat.cs
@@ -5,7 +5,6 @@ namespace Datadog.Trace
     using System.Runtime.Remoting;
     using System.Runtime.Remoting.Messaging;
 
-    // TODO:bertrand revisit this when we want to support multiple AppDomains
     internal class AsyncLocalCompat<T>
     {
         private readonly string _name = "__Datadog_Scope_Current__" + Guid.NewGuid();

--- a/src/Datadog.Trace/AsyncLocalCompat.cs
+++ b/src/Datadog.Trace/AsyncLocalCompat.cs
@@ -2,26 +2,23 @@ namespace Datadog.Trace
 {
 #if NET45
     using System;
+    using System.Runtime.Remoting;
     using System.Runtime.Remoting.Messaging;
 
     // TODO:bertrand revisit this when we want to support multiple AppDomains
     internal class AsyncLocalCompat<T>
     {
-        private string _name;
-
-        public AsyncLocalCompat()
-        {
-            _name = Guid.NewGuid().ToString();
-        }
+        private readonly string _name = "__Datadog_Scope_Current__" + Guid.NewGuid();
 
         public T Get()
         {
-            return (T)CallContext.LogicalGetData(_name);
+            var handle = CallContext.LogicalGetData(_name) as ObjectHandle;
+            return handle == null ? default(T) : (T)handle.Unwrap();
         }
 
         public void Set(T value)
         {
-            CallContext.LogicalSetData(_name, value);
+            CallContext.LogicalSetData(_name, new ObjectHandle(value));
         }
     }
 

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -1,12 +1,12 @@
-﻿using Datadog.Trace.Logging;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace
 {
     internal class AsyncLocalScopeManager
     {
-        private static ILog _log = LogProvider.For<AsyncLocalScopeManager>();
+        private static readonly ILog _log = LogProvider.For<AsyncLocalScopeManager>();
 
-        private AsyncLocalCompat<Scope> _currentSpan = new AsyncLocalCompat<Scope>();
+        private readonly AsyncLocalCompat<Scope> _currentSpan = new AsyncLocalCompat<Scope>();
 
         public Scope Active => _currentSpan.Get();
 

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -25,15 +25,15 @@ namespace Datadog.Trace
             if (current == null)
             {
                 _log.Error("Trying to close a null scope.");
+                return;
             }
-            else if (current != scope)
+
+            if (current != scope)
             {
                 _log.Warn("Specified scope is not the active scope.");
             }
-            else
-            {
-                _currentSpan.Set(current.Parent);
-            }
+
+            _currentSpan.Set(current.Parent);
         }
     }
 }

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -21,17 +21,19 @@ namespace Datadog.Trace
         public void Close(Scope scope)
         {
             var current = _currentSpan.Get();
+
             if (current == null)
             {
-                _log.Error("Trying to close a null scope");
+                _log.Error("Trying to close a null scope.");
             }
-
-            if (current != scope)
+            else if (current != scope)
             {
-                _log.Warn("Current span doesn't match deactivate span");
+                _log.Warn("Specified scope is not the active scope.");
             }
-
-            _currentSpan.Set(current.Parent);
+            else
+            {
+                _currentSpan.Set(current.Parent);
+            }
         }
     }
 }

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace
 
             if (current != scope)
             {
-                _log.Warn("Current span doesn't match desactivated span");
+                _log.Warn("Current span doesn't match deactivate span");
             }
 
             _currentSpan.Set(current.Parent);

--- a/src/Datadog.Trace/Scope.cs
+++ b/src/Datadog.Trace/Scope.cs
@@ -6,7 +6,7 @@ namespace Datadog.Trace
     /// A scope is a handle used to manage the concept of an active span.
     /// Meaning that at a given time at most one span is considered active and
     /// all newly created spans that are not created with the ignoreActiveSpan
-    /// parameter will be automically children of the active span.
+    /// parameter will be automatically children of the active span.
     /// </summary>
     public class Scope : IDisposable
     {

--- a/src/Datadog.Trace/Scope.cs
+++ b/src/Datadog.Trace/Scope.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Datadog.Trace
 {
@@ -11,7 +11,7 @@ namespace Datadog.Trace
     public class Scope : IDisposable
     {
         private readonly AsyncLocalScopeManager _scopeManager;
-        private bool _finishOnClose;
+        private readonly bool _finishOnClose;
 
         internal Scope(Scope parent, Span span,  AsyncLocalScopeManager scopeManager, bool finishOnClose)
         {


### PR DESCRIPTION
This PR implements a fix for applications using multiple AppDomains. Instead of letting the CLR use the default behavior of marshaling `Scope` by value (which requires making a copy by serializing and deserializing), we use [`ObjectHandle`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.remoting.objecthandle) to marshal the `Scope` by ref.

Should fix #238.