### PR TITLE
fix async calls in ADO.NET integration

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -83,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 try
                 {
-                    return await executeReader(command, behavior, cancellationToken);
+                    return await executeReader(command, behavior, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This PR adds a missing call to `Task<T>.ConfigureAwait(false)` which is causing deadlocks when async calls .