### PR TITLE
MSI installer: create directory for log file

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -46,6 +46,10 @@
     <Content Include="license.rtf" />
   </ItemGroup>
   <ItemGroup>
+    <WixExtension Include="WixUtilExtension">
+      <HintPath>$(WixExtDir)\WixUtilExtension.dll</HintPath>
+      <Name>WixUtilExtension</Name>
+    </WixExtension>
     <WixExtension Include="WixUIExtension">
       <HintPath>$(WixExtDir)\WixUIExtension.dll</HintPath>
       <Name>WixUIExtension</Name>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -108,8 +108,11 @@
 
     <ComponentGroup Id="EmptyFolders" Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
       <Component Id="EmptyFolders.Logs" Guid="0A9B510D-44F6-41A9-9EFE-E2CEB7314CF3">
+        <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer">
+          <!-- inherit permissions from parent, C:\ProgramData -->
+        </CreateFolder>
         <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
-          <Permission User="Everyone" GenericAll="yes" />
+          <util:PermissionEx User="Everyone" GenericAll="yes" />
         </CreateFolder>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <?include $(sys.CURRENTDIR)\Config.wxi?>
   <Product Id="*"
            Name="$(var.ProductName)"

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -46,8 +46,6 @@
       <Directory Id="$(var.PlatformProgramFilesFolder)">
         <Directory Id="ProgramFilesFolder.Datadog" Name="$(var.Company)">
           <Directory Id="INSTALLFOLDER" Name="$(var.BaseProductName)">
-            <Directory Id="INSTALLFOLDER_NET45" Name="net45"/>
-            <Directory Id="INSTALLFOLDER_NETCOREAPP20" Name="netcoreapp2.0"/>
           </Directory>
         </Directory>
       </Directory>
@@ -60,7 +58,8 @@
           <File Id="integrations.json" Source="..\..\integrations.json" />
       </Component>
     </ComponentGroup>
-    <ComponentGroup Id="Files.Managed.Net45" Directory="INSTALLFOLDER_NET45">
+
+    <ComponentGroup Id="Files.Managed.Net45" Directory="INSTALLFOLDER">
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.ClrProfiler.Managed.dll"
               Source="$(var.ManagedDllPath)\Datadog.Trace.ClrProfiler.Managed.dll"

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -37,7 +37,7 @@
       <ComponentGroupRef Id="Files.Managed.Net45"/>
       <ComponentGroupRef Id="Registry"/>
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
-      <ComponentGroupRef Id="EnvironmentVariables.User"/>
+      <ComponentGroupRef Id="EnvironmentVariables.IIS"/>
     </Feature>
   </Product>
 
@@ -114,7 +114,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="EnvironmentVariables.User" Directory="INSTALLFOLDER">
+    <ComponentGroup Id="EnvironmentVariables.IIS" Directory="INSTALLFOLDER">
       <Component Id="Registry.EnvironmentVariables.W3SVC" Guid="{702DB265-F33E-47F4-A6B0-E21FA0FC21C1}" Win64="$(var.Win64)">
         <CreateFolder/>
         <RegistryKey Root="HKLM"

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -112,7 +112,7 @@
           <!-- inherit permissions from parent, C:\ProgramData -->
         </CreateFolder>
         <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
-          <util:PermissionEx User="Everyone" GenericAll="yes" />
+          <util:PermissionEx User="Everyone" GenericWrite="yes" />
         </CreateFolder>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -35,6 +35,7 @@
       <ComponentGroupRef Id="Files"/>
       <ComponentGroupRef Id="Files.Native"/>
       <ComponentGroupRef Id="Files.Managed.Net45"/>
+      <ComponentGroupRef Id="EmptyFolders"/>
       <ComponentGroupRef Id="Registry"/>
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.IIS"/>
@@ -49,13 +50,20 @@
           </Directory>
         </Directory>
       </Directory>
+
+      <Directory Id="CommonAppDataFolder">
+        <Directory Id="CommonAppDataFolder.DatadogDotNetTracer" Name="Datadog .NET Tracer">
+          <Directory Id="CommonAppDataFolder.DatadogDotNetTracer.logs" Name="logs">
+          </Directory>
+        </Directory>
+      </Directory>
     </Directory>
   </Fragment>
 
   <Fragment>
     <ComponentGroup Id="Files" Directory="INSTALLFOLDER">
       <Component Win64="$(var.Win64)">
-          <File Id="integrations.json" Source="..\..\integrations.json" />
+        <File Id="integrations.json" Source="..\..\integrations.json" />
       </Component>
     </ComponentGroup>
 
@@ -94,6 +102,14 @@
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductName)"/>
         </File>
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="EmptyFolders" Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
+      <Component Id="EmptyFolders.Logs" Guid="0A9B510D-44F6-41A9-9EFE-E2CEB7314CF3">
+        <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
+          <Permission User="Everyone" GenericAll="yes" />
+        </CreateFolder>
       </Component>
     </ComponentGroup>
 

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -46,15 +46,21 @@
   <Fragment>
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="$(var.PlatformProgramFilesFolder)">
+        <!-- "C:\Program Files" or "C:\Program Files (x86)"-->
         <Directory Id="ProgramFilesFolder.Datadog" Name="$(var.Company)">
+          <!-- ".\Datadog" -->
           <Directory Id="INSTALLFOLDER" Name="$(var.BaseProductName)">
+            <!-- ".\.NET Tracer" -->
           </Directory>
         </Directory>
       </Directory>
 
       <Directory Id="CommonAppDataFolder">
+        <!-- "C:\ProgramData" -->
         <Directory Id="CommonAppDataFolder.DatadogDotNetTracer" Name="Datadog .NET Tracer">
+          <!-- ".\Datadog .NET Tracer" -->
           <Directory Id="CommonAppDataFolder.DatadogDotNetTracer.logs" Name="logs">
+            <!-- ".\logs" -->
           </Directory>
         </Directory>
       </Directory>
@@ -108,9 +114,7 @@
 
     <ComponentGroup Id="EmptyFolders" Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
       <Component Id="EmptyFolders.Logs" Guid="0A9B510D-44F6-41A9-9EFE-E2CEB7314CF3">
-        <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer">
-          <!-- inherit permissions from parent, C:\ProgramData -->
-        </CreateFolder>
+        <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer"/>
         <CreateFolder Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
           <util:PermissionEx User="Everyone" GenericWrite="yes" />
         </CreateFolder>


### PR DESCRIPTION
Follow-up to #254. Creates directory for log file while we have administrator access during installation.

Changes to MSI installer:
- create directory for log file (`%ProgramData%\Datadog .NET Tracer\logs`)
- let directory `Datadog .NET Tracer` inherit permission from parent
- let directory `logs` inherit permission from parent, and add write access to `Everyone`

Bonus clean up
- remove unused folders `INSTALLFOLDER_NET45` and `INSTALLFOLDER_NETCOREAPP20`
- rename `EnvironmentVariables.User` to `EnvironmentVariables.IIS` (environment variables are set per Windows Services, not per user)