### PR TITLE
OpenTracing: remove logging warnings in unsupported span methods

### DIFF
--- a/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Datadog.Trace.Logging;
 using OpenTracing;
 using OpenTracing.Tag;
 
@@ -9,8 +8,6 @@ namespace Datadog.Trace.OpenTracing
 {
     internal class OpenTracingSpan : ISpan
     {
-        private static ILog _log = LogProvider.For<OpenTracingSpan>();
-
         internal OpenTracingSpan(Span span)
         {
             Span = span;
@@ -31,41 +28,17 @@ namespace Datadog.Trace.OpenTracing
 
         internal TimeSpan Duration => Span.Duration;
 
-        public string GetBaggageItem(string key)
-        {
-            _log.Debug("ISpan.GetBaggageItem is not implemented by Datadog.Trace");
-            return null;
-        }
+        public string GetBaggageItem(string key) => null;
 
-        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            _log.Debug("ISpan.Log is not implemented by Datadog.Trace");
-            return this;
-        }
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields) => this;
 
-        public ISpan Log(string eventName)
-        {
-            _log.Debug("ISpan.Log is not implemented by Datadog.Trace");
-            return this;
-        }
+        public ISpan Log(string eventName) => this;
 
-        public ISpan Log(DateTimeOffset timestamp, string eventName)
-        {
-            _log.Debug("ISpan.Log is not implemented by Datadog.Trace");
-            return this;
-        }
+        public ISpan Log(DateTimeOffset timestamp, string eventName) => this;
 
-        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
-        {
-            _log.Debug("ISpan.Log is not implemented by Datadog.Trace");
-            return this;
-        }
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields) => this;
 
-        public ISpan SetBaggageItem(string key, string value)
-        {
-            _log.Debug("ISpan.SetBaggageItem is not implemented by Datadog.Trace");
-            return this;
-        }
+        public ISpan SetBaggageItem(string key, string value) => this;
 
         public ISpan SetOperationName(string operationName)
         {


### PR DESCRIPTION
This is based on the conversation in #269. I ended up just opting for removing the logging lines entirely instead of doing the log-once route since it felt like more trouble than it's probably worth given the different methods/log lines, and that it sounds like there's some rework planned around that anyway.

The build failures here seem to be related to a NuGet permissions error:

```
Response status code does not indicate success: 403 (Forbidden - User '5c1406b8-8200-43ed-91b3-d4366d690ab0' lacks permission to complete this action. You need to have 'ReadPackages'. (DevOps Activity ID: 2326F605-C2BE-4D40-995A-73086F328AC3)).)
```

Update: builds are now passing 😄 