### PR TITLE
facilitate emitting IL to access type members

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
@@ -6,13 +6,13 @@ using System.Reflection;
 using System.Reflection.Emit;
 using Sigil;
 
-namespace Datadog.Trace.ClrProfiler
+namespace Datadog.Trace.ClrProfiler.Emit
 {
     /// <summary>
     /// Helper class to instances of <see cref="DynamicMethod"/> using <see cref="System.Reflection.Emit"/>.
     /// </summary>
     /// <typeparam name="TDelegate">The type of delegate</typeparam>
-    public static class DynamicMethodBuilder<TDelegate>
+    internal static class DynamicMethodBuilder<TDelegate>
         where TDelegate : Delegate
     {
         private static readonly ConcurrentDictionary<Key, TDelegate> _cached = new ConcurrentDictionary<Key, TDelegate>(new KeyComparer());

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MemberResult.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MemberResult.cs
@@ -1,0 +1,88 @@
+using System;
+
+namespace Datadog.Trace.ClrProfiler.Emit
+{
+    internal sealed class MemberResult<T>
+    {
+        /// <summary>
+        /// A static value used to represent a member that was not found.
+        /// </summary>
+        public static readonly MemberResult<T> NotFound = new MemberResult<T>();
+
+        private readonly T _value;
+
+        public MemberResult(T value)
+        {
+            _value = value;
+        }
+
+        private MemberResult()
+        {
+        }
+
+        public T Value =>
+            ReferenceEquals(this, NotFound)
+                ? throw new InvalidOperationException("Reflected member not found.")
+                : _value;
+
+        public T GetValueOrDefault()
+        {
+            return _value;
+        }
+
+        public MemberResult<TResult> GetProperty<TResult>(string propertyName)
+        {
+            if (ReferenceEquals(this, NotFound) || Value == null || !Value.TryGetPropertyValue(propertyName, out TResult result))
+            {
+                return MemberResult<TResult>.NotFound;
+            }
+
+            return new MemberResult<TResult>(result);
+        }
+
+        public MemberResult<object> GetProperty(string propertyName)
+        {
+            return GetProperty<object>(propertyName);
+        }
+
+        public MemberResult<TResult> GetField<TResult>(string fieldName)
+        {
+            if (ReferenceEquals(this, NotFound) || Value == null || !Value.TryGetFieldValue(fieldName, out TResult result))
+            {
+                return MemberResult<TResult>.NotFound;
+            }
+
+            return new MemberResult<TResult>(result);
+        }
+
+        public MemberResult<object> GetField(string fieldName)
+        {
+            return GetField<object>(fieldName);
+        }
+
+        public MemberResult<TResult> CallMethod<TArg1, TResult>(string methodName, TArg1 arg1)
+        {
+            if (ReferenceEquals(this, NotFound) || Value == null || !Value.TryCallMethod(methodName, arg1, out TResult result))
+            {
+                return MemberResult<TResult>.NotFound;
+            }
+
+            return new MemberResult<TResult>(result);
+        }
+
+        public MemberResult<object> CallMethod<TArg1>(string methodName, TArg1 arg1)
+        {
+            return CallMethod<TArg1, object>(methodName, arg1);
+        }
+
+        public override string ToString()
+        {
+            if (ReferenceEquals(this, NotFound) || Value == null)
+            {
+                return string.Empty;
+            }
+
+            return Value.ToString();
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -46,6 +46,18 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return false;
         }
 
+        public static MemberResult<TResult> CallMethod<TArg1, TResult>(this object source, string methodName, TArg1 arg1)
+        {
+            return source.TryCallMethod(methodName, arg1, out TResult result)
+                       ? new MemberResult<TResult>(result)
+                       : MemberResult<TResult>.NotFound;
+        }
+
+        public static MemberResult<object> CallMethod<TArg1>(this object source, string methodName, TArg1 arg1)
+        {
+            return CallMethod<TArg1, object>(source, methodName, arg1);
+        }
+
         /// <summary>
         /// Tries to get the value of an instance property with the specified name.
         /// </summary>
@@ -72,6 +84,18 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return false;
         }
 
+        public static MemberResult<TResult> GetProperty<TResult>(this object source, string propertyName)
+        {
+            return source.TryGetPropertyValue(propertyName, out TResult result)
+                       ? new MemberResult<TResult>(result)
+                       : MemberResult<TResult>.NotFound;
+        }
+
+        public static MemberResult<object> GetProperty(this object source, string propertyName)
+        {
+            return GetProperty<object>(source, propertyName);
+        }
+
         /// <summary>
         /// Tries to get the value of an instance field with the specified name.
         /// </summary>
@@ -96,6 +120,18 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             value = default;
             return false;
+        }
+
+        public static MemberResult<TResult> GetField<TResult>(this object source, string fieldName)
+        {
+            return source.TryGetFieldValue(fieldName, out TResult result)
+                       ? new MemberResult<TResult>(result)
+                       : MemberResult<TResult>.NotFound;
+        }
+
+        public static MemberResult<object> GetField(this object source, string fieldName)
+        {
+            return GetField<object>(source, fieldName);
         }
 
         private static Func<object, TResult> CreatePropertyDelegate<TResult>(Type containerType, string propertyName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -3,12 +3,12 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using Sigil;
 
-namespace Datadog.Trace.ClrProfiler
+namespace Datadog.Trace.ClrProfiler.Emit
 {
     /// <summary>
     /// Provides helper methods to access object members by emitting IL dynamically.
     /// </summary>
-    public static class MemberAccessor
+    internal static class ObjectExtensions
     {
         private static readonly ConcurrentDictionary<string, object> Cache = new ConcurrentDictionary<string, object>();
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetIntegration.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Web;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.ClrProfiler.Integrations

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
+using Datadog.Trace.ClrProfiler.Emit;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using Datadog.Trace.ClrProfiler.Emit;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.ServiceModel.Channels;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ClrProfiler.ExtensionMethods;
 using Datadog.Trace.ClrProfiler.Models;
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/MemberAccessorTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/MemberAccessorTests.cs
@@ -1,3 +1,4 @@
+using Datadog.Trace.ClrProfiler.Emit;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Tests


### PR DESCRIPTION
Quality-of-life improvements to make emitting IL dynamically easier to use.

- Move existing types to `Datadog.Trace.ClrProfiler.Emit` namespace
- add new type `MemberResult<T>` which wraps returned values and propagates "member not found" or null values
- add new extensions that return `MemberResult<T>` instead of using a `bool` return value and an `out` parameter: `GetProperty()`, `GetField()`, `CallMethod()`

Example usage:
```csharp
var value = myObject?.Foo?._bar?.Baz;

// can be written like this, not null checks required
var value = myObject.GetProperty("Foo")
                    .GetField("_bar")
                    .GetProperty("Baz")
                    .GetValueOrDefault();
```

TODO:
- migrate MongoDB and ASP.NET Core MVC integrations to use new methods
- remove old methods when no longer used