### PR TITLE
don't inject AspNetHttpModule automatically

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -61,25 +61,6 @@
     ]
   },
   {
-    "name": "AspNet",
-    "method_replacements": [
-      {
-        "caller": {},
-        "target": {
-          "assembly": "System.Web",
-          "type": "System.Web.HttpApplication",
-          "method": "Init"
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=0.8.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetIntegration",
-          "method": "Init",
-          "signature": "00 01 01 1C"
-        }
-      }
-    ]
-  },
-  {
     "name": "AspNetCoreMvc2",
     "method_replacements": [
       {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetIntegration.cs
@@ -19,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         ///     Calls the underlying Init() For an HttpApplication and traces the request.
         /// </summary>
         /// <param name="thisObj">The HttpApplication instance ref.</param>
-        [InterceptMethod(
-            TargetAssembly = "System.Web",
-            TargetType = "System.Web.HttpApplication")]
+        // [InterceptMethod(
+        //    TargetAssembly = "System.Web",
+        //    TargetType = "System.Web.HttpApplication")]
         [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1119:StatementMustNotUseUnnecessaryParenthesis", Justification = "Actually Needed")]
         public static void Init(object thisObj)
         {


### PR DESCRIPTION
Temporarily disable the AspNet integration that injects `AspNetHttpModule`. Users can add it manually for testing.