### PR TITLE
Tracer configuration clean-up

### DIFF
--- a/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Configuration
         /// Sources are queried in the order in which they were added.
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
-        /// <returns>The value of the setting, or null if not found.</returns>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public string GetString(string key)
         {
             return _sources.Select(source => source.GetString(key))
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Configuration
         /// Sources are queried in the order in which they were added.
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
-        /// <returns>The value of the setting, or null if not found.</returns>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public int? GetInt32(string key)
         {
             return _sources.Select(source => source.GetInt32(key))
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Configuration
         /// Sources are queried in the order in which they were added.
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
-        /// <returns>The value of the setting, or null if not found.</returns>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         public bool? GetBool(string key)
         {
             return _sources.Select(source => source.GetBool(key))

--- a/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
@@ -62,6 +62,19 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <summary>
+        /// Gets the <see cref="double"/> value of the first setting found with
+        /// the specified key from the current list of configuration sources.
+        /// Sources are queried in the order in which they were added.
+        /// </summary>
+        /// <param name="key">The key that identifies the setting.</param>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        public double? GetDouble(string key)
+        {
+            return _sources.Select(source => source.GetDouble(key))
+                           .FirstOrDefault(value => value != null);
+        }
+
+        /// <summary>
         /// Gets the <see cref="bool"/> value of the first setting found with
         /// the specified key from the current list of configuration sources.
         /// Sources are queried in the order in which they were added.

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -7,13 +7,15 @@ namespace Datadog.Trace.Configuration
     {
         /// <summary>
         /// Configuration key for the path to the configuration file.
-        /// Can only be set with an environment variable.
+        /// Can only be set with an environment variable
+        /// or in the <c>app.config</c>/<c>web.config</c> file.
         /// </summary>
         public const string ConfigurationFileName = "DD_DOTNET_TRACER_CONFIG_FILE";
 
         /// <summary>
         /// Configuration key for the application's environment. Sets the "env" tag on every <see cref="Span"/>.
         /// </summary>
+        /// <seealso cref="TracerSettings.Environment"/>
         public const string Environment = "DD_ENV";
 
         /// <summary>
@@ -21,18 +23,21 @@ namespace Datadog.Trace.Configuration
         /// Used as the service name for top-level spans,
         /// and used to determine service name of some child spans.
         /// </summary>
+        /// <seealso cref="TracerSettings.ServiceName"/>
         public const string ServiceName = "DD_SERVICE_NAME";
 
         /// <summary>
         /// Configuration key for enabling or disabling the Tracer.
-        /// Default is enabled.
+        /// Default is value is true (enabled).
         /// </summary>
+        /// <seealso cref="TracerSettings.TraceEnabled"/>
         public const string TraceEnabled = "DD_TRACE_ENABLED";
 
         /// <summary>
         /// Configuration key for enabling or disabling the Tracer's debug mode.
-        /// Default is disabled.
+        /// Default is value is false (disabled).
         /// </summary>
+        /// <seealso cref="TracerSettings.DebugEnabled"/>
         public const string DebugEnabled = "DD_TRACE_DEBUG";
 
         /// <summary>
@@ -40,24 +45,30 @@ namespace Datadog.Trace.Configuration
         /// Default is empty (all integrations are enabled).
         /// Supports multiple values separated with semi-colons.
         /// </summary>
+        /// <seealso cref="TracerSettings.DisabledIntegrationNames"/>
         public const string DisabledIntegrations = "DD_DISABLED_INTEGRATIONS";
 
         /// <summary>
         /// Configuration key for the Agent host where the Tracer can send traces.
-        /// Default is "localhost".
+        /// Overriden by <see cref="AgentUri"/> if present.
+        /// Default value is "localhost".
         /// </summary>
+        /// <seealso cref="TracerSettings.AgentUri"/>
         public const string AgentHost = "DD_AGENT_HOST";
 
         /// <summary>
         /// Configuration key for the Agent port where the Tracer can send traces.
-        /// Default is 8126.
+        /// Default value is 8126.
         /// </summary>
+        /// <seealso cref="TracerSettings.AgentUri"/>
         public const string AgentPort = "DD_TRACE_AGENT_PORT";
 
         /// <summary>
         /// Configuration key for the Agent URL where the Tracer can send traces.
-        /// Default is "http://localhost:8126".
+        /// Overrides values in <see cref="AgentHost"/> and <see cref="AgentPort"/> if present.
+        /// Default value is "http://localhost:8126".
         /// </summary>
+        /// <seealso cref="TracerSettings.AgentUri"/>
         public const string AgentUri = "DD_TRACE_AGENT_URL";
     }
 }

--- a/src/Datadog.Trace/Configuration/IConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/IConfigurationSource.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Datadog.Trace.Configuration
 {
     /// <summary>
@@ -22,6 +20,14 @@ namespace Datadog.Trace.Configuration
         /// <param name="key">The key that identifies the setting.</param>
         /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         int? GetInt32(string key);
+
+        /// <summary>
+        /// Gets the <see cref="double"/> value of
+        /// the setting with the specified key.
+        /// </summary>
+        /// <param name="key">The key that identifies the setting.</param>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
+        double? GetDouble(string key);
 
         /// <summary>
         /// Gets the <see cref="bool"/> value of

--- a/src/Datadog.Trace/Configuration/IConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/IConfigurationSource.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Configuration
         /// the setting with the specified key.
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
-        /// <returns>The value of the setting, or null if not found.</returns>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         string GetString(string key);
 
         /// <summary>
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Configuration
         /// the setting with the specified key.
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
-        /// <returns>The value of the setting, or null if not found.</returns>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         int? GetInt32(string key);
 
         /// <summary>
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Configuration
         /// the setting with the specified key.
         /// </summary>
         /// <param name="key">The key that identifies the setting.</param>
-        /// <returns>The value of the setting, or null if not found.</returns>
+        /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
         bool? GetBool(string key);
     }
 }

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -59,6 +59,18 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <summary>
+        /// Gets the <see cref="double"/> value of
+        /// the setting with the specified key.
+        /// Supports JPath.
+        /// </summary>
+        /// <param name="key">The key that identifies the setting.</param>
+        /// <returns>The value of the setting, or null if not found.</returns>
+        double? IConfigurationSource.GetDouble(string key)
+        {
+            return GetValue<double?>(key);
+        }
+
+        /// <summary>
         /// Gets the <see cref="bool"/> value of
         /// the setting with the specified key.
         /// Supports JPath.
@@ -70,7 +82,14 @@ namespace Datadog.Trace.Configuration
             return GetValue<bool?>(key);
         }
 
-        private T GetValue<T>(string key)
+        /// <summary>
+        /// Gets the value of the setting with the specified key and converts it into type <typeparamref name="T"/>.
+        /// Supports JPath.
+        /// </summary>
+        /// <typeparam name="T">The type to convert the setting value into.</typeparam>
+        /// <param name="key">The key that identifies the setting.</param>
+        /// <returns>The value of the setting, or the default value of T if not found.</returns>
+        public T GetValue<T>(string key)
         {
             JToken token = _configuration.SelectToken(key, errorWhenNoMatch: false);
             return token == null ? default(T) : token.Value<T>();

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -92,7 +94,10 @@ namespace Datadog.Trace.Configuration
         public T GetValue<T>(string key)
         {
             JToken token = _configuration.SelectToken(key, errorWhenNoMatch: false);
-            return token == null ? default(T) : token.Value<T>();
+
+            return token == null
+                       ? default
+                       : token.Value<T>();
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="filename">A JSON file that contains configuration values.</param>
         /// <returns>The newly created configuration source.</returns>
-        public static JsonConfigurationSource LoadFile(string filename)
+        public static JsonConfigurationSource FromFile(string filename)
         {
             string json = File.ReadAllText(filename);
             return new JsonConfigurationSource(json);

--- a/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
@@ -14,9 +14,19 @@ namespace Datadog.Trace.Configuration
         {
             string value = GetString(key);
 
-            return int.TryParse(value, out int result1)
-                       ? result1
+            return int.TryParse(value, out int result)
+                       ? result
                        : (int?)null;
+        }
+
+        /// <inheritdoc />
+        public double? GetDouble(string key)
+        {
+            string value = GetString(key);
+
+            return double.TryParse(value, out double result)
+                       ? result
+                       : (double?)null;
         }
 
         /// <inheritdoc />

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -4,8 +4,7 @@ using System.IO;
 namespace Datadog.Trace.Configuration
 {
     /// <summary>
-    /// Wraps a <see cref="IConfigurationSource"/> with strongly-typed
-    /// properties for standard Datadog configuration values.
+    /// Contains Tracer settings.
     /// </summary>
     public class TracerSettings
     {
@@ -70,34 +69,42 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets or sets the default environment name applied to all spans.
         /// </summary>
+        /// <seealso cref="ConfigurationKeys.Environment"/>
         public string Environment { get; set; }
 
         /// <summary>
         /// Gets or sets the service name applied to top-level spans and used to build derived service names.
         /// </summary>
+        /// <seealso cref="ConfigurationKeys.ServiceName"/>
         public string ServiceName { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether tracing is enabled.
         /// Default is <c>true</c>.
         /// </summary>
+        /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
         public bool TraceEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether debug mode is enabled.
         /// Default is <c>false</c>.
         /// </summary>
+        /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
         public bool DebugEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets the names of disabled integrations.
         /// </summary>
+        /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
         public string[] DisabledIntegrationNames { get; set; }
 
         /// <summary>
         /// Gets or sets the Uri where the Tracer can connect to the Agent.
         /// Default is <c>"http://localhost:8126"</c>.
         /// </summary>
+        /// <seealso cref="ConfigurationKeys.AgentUri"/>
+        /// <seealso cref="ConfigurationKeys.AgentHost"/>
+        /// <seealso cref="ConfigurationKeys.AgentPort"/>
         public Uri AgentUri { get; set; }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Configuration
             if (Path.GetExtension(configurationFileName).ToUpperInvariant() == ".JSON" &&
                 File.Exists(configurationFileName))
             {
-                configurationSource.Add(JsonConfigurationSource.LoadFile(configurationFileName));
+                configurationSource.Add(JsonConfigurationSource.FromFile(configurationFileName));
             }
 
             return configurationSource;

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -33,34 +33,39 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         public TracerSettings(IConfigurationSource source)
         {
-            Environment = source?.GetString(ConfigurationKeys.Environment);
+            if (source == null)
+            {
+                return;
+            }
 
-            ServiceName = source?.GetString(ConfigurationKeys.ServiceName);
+            Environment = source.GetString(ConfigurationKeys.Environment);
 
-            TraceEnabled = source?.GetBool(ConfigurationKeys.DebugEnabled) ??
+            ServiceName = source.GetString(ConfigurationKeys.ServiceName);
+
+            TraceEnabled = source.GetBool(ConfigurationKeys.DebugEnabled) ??
                            // default value
                            false;
 
-            DebugEnabled = source?.GetBool(ConfigurationKeys.DebugEnabled) ??
+            DebugEnabled = source.GetBool(ConfigurationKeys.DebugEnabled) ??
                            // default value
                            false;
 
-            DisabledIntegrationNames = source?.GetString(ConfigurationKeys.DisabledIntegrations)
+            DisabledIntegrationNames = source.GetString(ConfigurationKeys.DisabledIntegrations)
                                              ?.Split(';')
                                     ?? new string[0];
 
-            var agentHost = source?.GetString(ConfigurationKeys.AgentHost) ??
+            var agentHost = source.GetString(ConfigurationKeys.AgentHost) ??
                             // backwards compatibility for names used in the past
-                            source?.GetString("DD_TRACE_AGENT_HOSTNAME") ??
-                            source?.GetString("DATADOG_TRACE_AGENT_HOSTNAME") ??
+                            source.GetString("DD_TRACE_AGENT_HOSTNAME") ??
+                            source.GetString("DATADOG_TRACE_AGENT_HOSTNAME") ??
                             DefaultAgentHost;
 
-            var agentPort = source?.GetInt32(ConfigurationKeys.AgentPort) ??
+            var agentPort = source.GetInt32(ConfigurationKeys.AgentPort) ??
                             // backwards compatibility for names used in the past
-                            source?.GetInt32("DATADOG_TRACE_AGENT_PORT") ??
+                            source.GetInt32("DATADOG_TRACE_AGENT_PORT") ??
                             DefaultAgentPort;
 
-            var agentUri = source?.GetString(ConfigurationKeys.AgentUri) ??
+            var agentUri = source.GetString(ConfigurationKeys.AgentUri) ??
                            $"http://{agentHost}:{agentPort}";
 
             AgentUri = new Uri(agentUri);

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Datadog.Trace.Configuration
 {
@@ -50,9 +52,11 @@ namespace Datadog.Trace.Configuration
                            // default value
                            false;
 
-            DisabledIntegrationNames = source.GetString(ConfigurationKeys.DisabledIntegrations)
-                                             ?.Split(';')
-                                    ?? new string[0];
+            var disabledIntegrationNames = source.GetString(ConfigurationKeys.DisabledIntegrations)
+                                                ?.Split(';') ??
+                                           Enumerable.Empty<string>();
+
+            DisabledIntegrationNames = new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase);
 
             var agentHost = source.GetString(ConfigurationKeys.AgentHost) ??
                             // backwards compatibility for names used in the past
@@ -101,7 +105,7 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets the names of disabled integrations.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
-        public string[] DisabledIntegrationNames { get; set; }
+        public HashSet<string> DisabledIntegrationNames { get; set; }
 
         /// <summary>
         /// Gets or sets the Uri where the Tracer can connect to the Agent.


### PR DESCRIPTION
Follow-up to #289, which hasn't been released yet.

While working on #299, I did some clean up to the recently added Tracer configuration code. I broke those changes into this separate PR.

- add `IConfigurationSource.GetDouble()`
- make `Tracer.Settings` public so users can change settings after the `Tracer` is created
- tweaked a lot of xml doc comments
- other small clean up like code reformatting or null checks