### PR TITLE
Integrations cleanup (dispose scope, exception filters, add logging)

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetHttpModule.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetHttpModule.cs
@@ -56,8 +56,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            var scopeActive = false;
-
             Scope scope = null;
 
             try
@@ -84,18 +82,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
 
                 scope = Tracer.Instance.StartActive(_operationName, propagatedContext);
-
-                scopeActive = true;
-
                 httpContext.Items[_httpContextDelegateKey] = HttpContextSpanIntegrationDelegate.CreateAndBegin(httpContext, scope);
             }
             catch (Exception ex)
             {
                 // Dispose here, as the scope won't be in context items and won't get disposed on request end in that case...
-                if (scopeActive)
-                {
-                    scope.Dispose();
-                }
+                scope?.Dispose();
 
                 Log.ErrorException("Datadog ASP.NET HttpModule instrumentation error", ex);
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     /// </summary>
     public static class AspNetMvcIntegration
     {
-        internal const string OperationName = "aspnet-mvc.request";
+        private const string OperationName = "aspnet-mvc.request";
         private const string HttpContextKey = "__Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration";
 
         private static readonly Type ControllerContextType = Type.GetType("System.Web.Mvc.ControllerContext, System.Web.Mvc", throwOnError: false);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     /// </summary>
     public static class AspNetWebApi2Integration
     {
-        internal const string OperationName = "aspnet-webapi.request";
+        private const string OperationName = "aspnet-webapi.request";
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(AspNetWebApi2Integration));
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -2,8 +2,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 {
     internal static class RedisHelper
     {
-        internal const string OperationName = "redis.command";
-        internal const string ServiceName = "redis";
+        private const string OperationName = "redis.command";
+        private const string ServiceName = "redis";
 
         internal static Scope CreateScope(string host, string port, string rawCommand)
         {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -1,3 +1,6 @@
+using System;
+using Datadog.Trace.Logging;
+
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
     internal static class RedisHelper
@@ -5,29 +8,39 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string OperationName = "redis.command";
         private const string ServiceName = "redis";
 
+        private static readonly ILog Log = LogProvider.GetLogger(typeof(RedisHelper));
+
         internal static Scope CreateScope(string host, string port, string rawCommand)
         {
             Tracer tracer = Tracer.Instance;
             string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+            Scope scope = null;
 
-            var scope = tracer.StartActive(OperationName, serviceName: serviceName);
-            int separatorIndex = rawCommand.IndexOf(' ');
-            string command;
-
-            if (separatorIndex >= 0)
+            try
             {
-                command = rawCommand.Substring(0, separatorIndex);
-            }
-            else
-            {
-                command = rawCommand;
-            }
+                scope = tracer.StartActive(OperationName, serviceName: serviceName);
+                int separatorIndex = rawCommand.IndexOf(' ');
+                string command;
 
-            scope.Span.Type = SpanTypes.Redis;
-            scope.Span.ResourceName = command;
-            scope.Span.SetTag(Tags.RedisRawCommand, rawCommand);
-            scope.Span.SetTag(Tags.OutHost, host);
-            scope.Span.SetTag(Tags.OutPort, port);
+                if (separatorIndex >= 0)
+                {
+                    command = rawCommand.Substring(0, separatorIndex);
+                }
+                else
+                {
+                    command = rawCommand;
+                }
+
+                scope.Span.Type = SpanTypes.Redis;
+                scope.Span.ResourceName = command;
+                scope.Span.SetTag(Tags.RedisRawCommand, rawCommand);
+                scope.Span.SetTag(Tags.OutHost, host);
+                scope.Span.SetTag(Tags.OutPort, port);
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException("Error creating or populating scope.", ex);
+            }
 
             return scope;
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -31,15 +31,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     "SendReceive",
                     methodGenericArguments: new[] { typeof(T) });
 
-            using (var scope = Integrations.RedisHelper.CreateScope(GetHost(redisNativeClient), GetPort(redisNativeClient), GetRawCommand(cmdWithBinaryArgs)))
+            using (var scope = RedisHelper.CreateScope(GetHost(redisNativeClient), GetPort(redisNativeClient), GetRawCommand(cmdWithBinaryArgs)))
             {
                 try
                 {
                     return originalMethod(redisNativeClient, cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
                 {
-                    scope.Span.SetException(ex);
+                    // unreachable code
                     throw;
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -49,9 +49,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 {
                     return originalMethod(multiplexer, message, processor, server);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
                 {
-                    scope.Span.SetException(ex);
+                    // unreachable code
                     throw;
                 }
             }
@@ -115,9 +115,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 {
                     return await originalMethod(multiplexer, message, processor, state, server).ConfigureAwait(false);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
                 {
-                    scope.Span.SetException(ex);
+                    // unreachable code
                     throw;
                 }
             }
@@ -129,7 +129,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(config);
             var rawCommand = StackExchangeRedisHelper.GetRawCommand(multiplexer, message);
 
-            return Integrations.RedisHelper.CreateScope(hostAndPort.Item1, hostAndPort.Item2, rawCommand);
+            return RedisHelper.CreateScope(hostAndPort.Item1, hostAndPort.Item2, rawCommand);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -67,9 +67,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                     {
                         return await originalMethod(redisBase, message, processor, server).ConfigureAwait(false);
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
                     {
-                        scope.Span.SetException(ex);
+                        // unreachable code
                         throw;
                     }
                 }
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(config);
             var cmd = StackExchangeRedisHelper.GetRawCommand(batch, message);
 
-            return Integrations.RedisHelper.CreateScope(hostAndPort.Item1, hostAndPort.Item2, cmd);
+            return RedisHelper.CreateScope(hostAndPort.Item1, hostAndPort.Item2, cmd);
         }
     }
 }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace
 
         internal ConcurrentDictionary<string, string> Tags { get; } = new ConcurrentDictionary<string, string>();
 
-        internal ConcurrentDictionary<string, int> Metrics { get; } = new ConcurrentDictionary<string, int>();
+        internal ConcurrentDictionary<string, double> Metrics { get; } = new ConcurrentDictionary<string, double>();
 
         internal bool IsFinished { get; private set; }
 
@@ -254,14 +254,14 @@ namespace Datadog.Trace
             return false;
         }
 
-        internal int? GetMetric(string key)
+        internal double? GetMetric(string key)
         {
-            return Metrics.TryGetValue(key, out int value)
+            return Metrics.TryGetValue(key, out double value)
                        ? value
                        : default;
         }
 
-        internal Span SetMetric(string key, int? value)
+        internal Span SetMetric(string key, double? value)
         {
             if (value == null)
             {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc4Tests.cs
@@ -31,8 +31,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.AgentPort,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
-                SpanTypes.Web,
-                Integrations.AspNetMvcIntegration.OperationName,
+                "web",
+                "aspnet-mvc.request",
                 expectedResourceName);
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc5Tests.cs
@@ -34,8 +34,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.AgentPort,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
-                SpanTypes.Web,
-                Integrations.AspNetMvcIntegration.OperationName,
+                "web",
+                "aspnet-mvc.request",
                 expectedResourceName);
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebApi2Tests.cs
@@ -34,8 +34,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.AgentPort,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
-                SpanTypes.Web,
-                Integrations.AspNetWebApi2Integration.OperationName,
+                "web",
+                "aspnet-webapi.request",
                 expectedResourceName);
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -37,8 +37,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    Assert.Equal(RedisHelper.OperationName, span.Name);
-                    Assert.Equal($"Samples.RedisCore-{RedisHelper.ServiceName}", span.Service);
+                    Assert.Equal("redis.command", span.Name);
+                    Assert.Equal("Samples.RedisCore-redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, span.Tags.GetValueOrDefault("out.host"));
                     Assert.Equal("6379", span.Tags.GetValueOrDefault("out.port"));

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -242,8 +242,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 foreach (var span in spans)
                 {
-                    Assert.Equal(RedisHelper.OperationName, span.Name);
-                    Assert.Equal($"Samples.RedisCore-{RedisHelper.ServiceName}", span.Service);
+                    Assert.Equal("redis.command", span.Name);
+                    Assert.Equal("Samples.RedisCore-redis", span.Service);
                     Assert.Equal(SpanTypes.Redis, span.Type);
                     Assert.Equal(host, span.Tags.Get<string>("out.host"));
                     Assert.Equal("6379", span.Tags.Get<string>("out.port"));


### PR DESCRIPTION
While working on #299, I cleaned up and updated some of the older integration to follow newer patterns. I broke those unrelated changes into this separate PR for easier review:

- change metrics value from `int` to `double`
- use explicit strings in unit tests so they break if we accidentally change the string
- integrations:
  - ensure scope is disposed even if exception is thrown
  - add missing logging for exceptions
  - use exception filters where possible