### PR TITLE
Mock tracer listening port, redux

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc4Tests.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             await AssertHttpSpan(
                 path,
-                _iisFixture.AgentPort,
+                _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
                 SpanTypes.Web,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc5Tests.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             await AssertHttpSpan(
                 path,
-                _iisFixture.AgentPort,
+                _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
                 SpanTypes.Web,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebApi2Tests.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             await AssertHttpSpan(
                 path,
-                _iisFixture.AgentPort,
+                _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
                 SpanTypes.Web,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebFormsTests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             await AssertHttpSpan(
                                  path,
-                                 _iisFixture.AgentPort,
+                                 _iisFixture.Agent,
                                  _iisFixture.HttpPort,
                                  HttpStatusCode.OK,
                                  SpanTypes.Web,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ElasticsearchTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ElasticsearchTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public void SubmitsTraces()
         {
             using (var agent = new MockTracerAgent(AgentPort))
-            using (var processResult = RunSampleAndWaitForExit(AgentPort))
+            using (var processResult = RunSampleAndWaitForExit(agent.Port))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int httpPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agentPort, $"HttpClient Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, $"HttpClient Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int httpPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agentPort, $"HttpClient TracingDisabled Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, $"HttpClient TracingDisabled Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -79,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int httpPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agentPort, $"WebClient Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, $"WebClient Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
@@ -110,7 +110,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int httpPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agentPort, $"WebClient TracingDisabled Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, $"WebClient TracingDisabled Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/IisFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/IisFixture.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private Process _iisExpress;
 
-        public int AgentPort { get; private set; }
+        public MockTracerAgent Agent { get; private set; }
 
         public int HttpPort { get; private set; }
 
@@ -19,11 +19,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 if (_iisExpress == null)
                 {
-                    AgentPort = TcpPortProvider.GetOpenPort();
+                    var initialAgentPort = TcpPortProvider.GetOpenPort();
+                    Agent = new MockTracerAgent(initialAgentPort);
+
                     HttpPort = TcpPortProvider.GetOpenPort();
 
                     // start IIS Express and give it a few seconds to boot up
-                    _iisExpress = helper.StartIISExpress(AgentPort, HttpPort);
+                    _iisExpress = helper.StartIISExpress(Agent.Port, HttpPort);
                     Thread.Sleep(TimeSpan.FromSeconds(3));
                 }
             }
@@ -31,6 +33,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public void Dispose()
         {
+            Agent?.Dispose();
+
             if (_iisExpress != null)
             {
                 if (!_iisExpress.HasExited)
@@ -43,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     _iisExpress.WaitForExit();
                 }
 
-                _iisExpress?.Dispose();
+                _iisExpress.Dispose();
             }
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var prefix = $"{BuildParameters.Configuration}.{BuildParameters.TargetFramework}.";
             using (var agent = new MockTracerAgent(agentPort))
-            using (var processResult = RunSampleAndWaitForExit(agentPort, arguments: $"ServiceStack {prefix}"))
+            using (var processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"ServiceStack {prefix}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SqlServerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SqlServerTests.cs
@@ -9,8 +9,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class SqlServerTests : TestHelper
     {
-        private const int AgentPort = 9002;
-
         public SqlServerTests(ITestOutputHelper output)
             : base("SqlServer", output)
         {
@@ -20,8 +18,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            using (var agent = new MockTracerAgent(AgentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(AgentPort))
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -19,11 +19,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            int agentPort = TcpPortProvider.GetOpenPort();
             var prefix = $"{BuildParameters.Configuration}.{BuildParameters.TargetFramework}.";
+            int agentPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (var processResult = RunSampleAndWaitForExit(agentPort, arguments: $"StackExchange {prefix}"))
+            using (var processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"StackExchange {prefix}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestHelper.cs
@@ -274,7 +274,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task AssertHttpSpan(
             string path,
-            int agentPort,
+            MockTracerAgent agent,
             int httpPort,
             HttpStatusCode expectedHttpStatusCode,
             string expectedSpanType,
@@ -283,7 +283,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             IImmutableList<MockTracerAgent.Span> spans;
 
-            using (var agent = new MockTracerAgent(agentPort))
             using (var httpClient = new HttpClient())
             {
                 // disable tracing for this HttpClient request

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -18,10 +18,9 @@ namespace Datadog.Trace.TestHelpers
         public MockTracerAgent(int port = 8126, int retries = 5)
         {
             _listener = new HttpListener();
-            bool listening = false;
 
             // try up to 5 consecutive ports before giving up
-            while (!listening)
+            while (true)
             {
                 _listener.Prefixes.Clear();
                 _listener.Prefixes.Add($"http://localhost:{port}/");
@@ -29,7 +28,7 @@ namespace Datadog.Trace.TestHelpers
                 try
                 {
                     _listener.Start();
-                    listening = true;
+                    break;
                 }
                 catch (HttpListenerException) when (retries > 0)
                 {
@@ -39,9 +38,18 @@ namespace Datadog.Trace.TestHelpers
                 }
             }
 
+            Port = port;
+
             _listenerThread = new Thread(HandleHttpRequests);
             _listenerThread.Start();
         }
+
+        /// <summary>
+        /// Gets the TCP port that this Agent is listening on.
+        /// Can be different from <see cref="MockTracerAgent(int, int)"/>'s <c>initialPort</c>
+        /// parameter if listening on that port fails.
+        /// </summary>
+        public int Port { get; }
 
         public IImmutableList<Span> Spans { get; private set; } = ImmutableList<Span>.Empty;
 

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -45,6 +45,8 @@ namespace Datadog.Trace.TestHelpers
                     retries--;
                 }
 
+                // always close listener if exception is thrown,
+                // whether it was caught or not
                 listener.Close();
             }
         }


### PR DESCRIPTION
Follow-up to #285.

- fix integration tests that use IIS so they use the TCP port where `MockTracerAgent` is listening on, since it can be different from the initial port passed into the ctor
- migrate the last tests still using hard-coded ports to use `TcpPortProvider`

