### PR TITLE
remove breaking changes

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+
+namespace Datadog.Trace.ClrProfiler
+{
+    /// <summary>
+    /// Helper class to instances of <see cref="DynamicMethod"/> using <see cref="System.Reflection.Emit"/>.
+    /// </summary>
+    /// <typeparam name="TDelegate">The type of delegate</typeparam>
+    [Obsolete("This type will be removed in a future version of this library.")]
+    public static class DynamicMethodBuilder<TDelegate>
+        where TDelegate : Delegate
+    {
+        /// <summary>
+        /// Memoizes CreateMethodCallDelegate
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> that contains the method.</param>
+        /// <param name="methodName">The name of the method.</param>
+        /// <param name="returnType">The method's return type.</param>
+        /// <param name="methodParameterTypes">optional types for the method parameters</param>
+        /// <param name="methodGenericArguments">optional generic type arguments for a generic method</param>
+        /// <returns>A <see cref="Delegate"/> that can be used to execute the dynamic method.</returns>
+        public static TDelegate GetOrCreateMethodCallDelegate(
+            Type type,
+            string methodName,
+            Type returnType = null,
+            Type[] methodParameterTypes = null,
+            Type[] methodGenericArguments = null)
+        {
+            return Emit.DynamicMethodBuilder<TDelegate>.GetOrCreateMethodCallDelegate(
+                type,
+                methodName,
+                returnType,
+                methodParameterTypes,
+                methodGenericArguments);
+        }
+
+        /// <summary>
+        /// Creates a simple <see cref="DynamicMethod"/> using <see cref="System.Reflection.Emit"/> that
+        /// calls a method with the specified name and parameter types.
+        /// </summary>
+        /// <param name="type">The <see cref="Type"/> that contains the method to call when the returned delegate is executed..</param>
+        /// <param name="methodName">The name of the method to call when the returned delegate is executed.</param>
+        /// <param name="methodParameterTypes">If not null, use method overload that matches the specified parameters.</param>
+        /// <param name="methodGenericArguments">If not null, use method overload that has the same number of generic arguments.</param>
+        /// <returns>A <see cref="Delegate"/> that can be used to execute the dynamic method.</returns>
+        public static TDelegate CreateMethodCallDelegate(
+            Type type,
+            string methodName,
+            Type[] methodParameterTypes = null,
+            Type[] methodGenericArguments = null)
+        {
+            return Emit.DynamicMethodBuilder<TDelegate>.CreateMethodCallDelegate(type, methodName, methodParameterTypes, methodGenericArguments);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var command = (DbCommand)@this;
             var commandBehavior = (CommandBehavior)behavior;
 
-            var executeReader = DynamicMethodBuilder<Func<object, CommandBehavior, object>>
+            var executeReader = Emit.DynamicMethodBuilder<Func<object, CommandBehavior, object>>
                .GetOrCreateMethodCallDelegate(
                     command.GetType(),
                     "ExecuteDbDataReader");
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static async Task<object> ExecuteDbDataReaderAsyncInternal(DbCommand command, CommandBehavior behavior, CancellationToken cancellationToken)
         {
-            var executeReader = DynamicMethodBuilder<Func<object, CommandBehavior, CancellationToken, Task<object>>>
+            var executeReader = Emit.DynamicMethodBuilder<Func<object, CommandBehavior, CancellationToken, Task<object>>>
                .GetOrCreateMethodCallDelegate(
                     command.GetType(),
                     "ExecuteDbDataReaderAsync");

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     var assembly = actionDescriptor.GetType().GetTypeInfo().Assembly;
                     var type = assembly.GetType("Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions");
 
-                    _beforeAction = DynamicMethodBuilder<Action<object, object, object, object>>.CreateMethodCallDelegate(
+                    _beforeAction = Emit.DynamicMethodBuilder<Action<object, object, object, object>>.CreateMethodCallDelegate(
                         type,
                         "BeforeAction");
                 }
@@ -204,7 +204,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                     var type = actionDescriptor.GetType().Assembly.GetType("Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions");
 
-                    _afterAction = DynamicMethodBuilder<Action<object, object, object, object>>.CreateMethodCallDelegate(
+                    _afterAction = Emit.DynamicMethodBuilder<Action<object, object, object, object>>.CreateMethodCallDelegate(
                         type,
                         "AfterAction");
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetIntegration.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 if (!(thisObj is HttpApplication httpApplication))
                 {
-                    var initMethodAction = DynamicMethodBuilder<Action<object>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "Init");
+                    var initMethodAction = Emit.DynamicMethodBuilder<Action<object>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "Init");
 
                     initMethodAction(thisObj);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -53,9 +53,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             // in some cases, ExecuteAsync() is an explicit interface implementation,
             // which is not public and has a different name, so try both
             var executeAsyncFunc =
-                DynamicMethodBuilder<Func<object, object, CancellationToken, Task<HttpResponseMessage>>>
+                Emit.DynamicMethodBuilder<Func<object, object, CancellationToken, Task<HttpResponseMessage>>>
                    .GetOrCreateMethodCallDelegate(controllerType, "ExecuteAsync") ??
-                DynamicMethodBuilder<Func<object, object, CancellationToken, Task<HttpResponseMessage>>>
+                Emit.DynamicMethodBuilder<Func<object, object, CancellationToken, Task<HttpResponseMessage>>>
                    .GetOrCreateMethodCallDelegate(controllerType, "System.Web.Http.Controllers.IHttpController.ExecuteAsync");
 
             using (Scope scope = CreateScope(controllerContext))

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetIntegration.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "Elasticsearch.Net.IRequestPipeline")]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData)
         {
-            var originalMethod = DynamicMethodBuilder<Func<object, object, TResponse>>
+            var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, TResponse>>
                .GetOrCreateMethodCallDelegate(
                     pipeline.GetType(),
                     "CallElasticsearch",
@@ -94,7 +94,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 _requestDataType = requestData.GetType();
             }
 
-            var originalMethod = DynamicMethodBuilder<Func<object, object, CancellationToken, Task<TResponse>>>
+            var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, CancellationToken, Task<TResponse>>>
                .GetOrCreateMethodCallDelegate(
                     pipeline.GetType(),
                     "CallElasticsearchAsync",
@@ -120,7 +120,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             string requestName = null;
             try
             {
-                var requestParameters = DynamicMethodBuilder<Func<object, object>>
+                var requestParameters = Emit.DynamicMethodBuilder<Func<object, object>>
                    .GetOrCreateMethodCallDelegate(
                         pipeline.GetType(),
                         "get_RequestParameters")(pipeline);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var executeAsync = DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
+            var executeAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
                .GetOrCreateMethodCallDelegate(
                     handler.GetType(),
                     nameof(SendAsync));

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             // TResult MongoDB.Driver.Core.WireProtocol.IWireProtocol<TResult>.Execute(IConnection connection, CancellationToken cancellationToken)
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
-            var execute = DynamicMethodBuilder<Func<object, object, CancellationToken, object>>
+            var execute = Emit.DynamicMethodBuilder<Func<object, object, CancellationToken, object>>
                .GetOrCreateMethodCallDelegate(
                     wireProtocol.GetType(),
                     "Execute");
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
-            var executeAsync = DynamicMethodBuilder<Func<object, object, CancellationToken, Task<object>>>
+            var executeAsync = Emit.DynamicMethodBuilder<Func<object, object, CancellationToken, Task<object>>>
                .GetOrCreateMethodCallDelegate(
                     wireProtocol.GetType(),
                     "ExecuteAsync");

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "ServiceStack.Redis.RedisNativeClient")]
         public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead)
         {
-            var originalMethod = DynamicMethodBuilder<Func<object, byte[][], object, object, bool, T>>
+            var originalMethod = Emit.DynamicMethodBuilder<Func<object, byte[][], object, object, bool, T>>
                .GetOrCreateMethodCallDelegate(
                     redisNativeClient.GetType(),
                     "SendReceive",

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var processorType = asm.GetType("StackExchange.Redis.ResultProcessor`1").MakeGenericType(resultType);
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
-            var originalMethod = DynamicMethodBuilder<Func<object, object, object, object, T>>
+            var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, T>>
                .CreateMethodCallDelegate(
                     multiplexerType,
                     "ExecuteSyncImpl",
@@ -103,7 +103,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var stateType = typeof(object);
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
-            var originalMethod = DynamicMethodBuilder<Func<object, object, object, object, object, Task<T>>>
+            var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, object, Task<T>>>
                .CreateMethodCallDelegate(
                     multiplexerType,
                     "ExecuteAsyncImpl",

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var processorType = asm.GetType("StackExchange.Redis.ResultProcessor`1").MakeGenericType(genericType);
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
-            var originalMethod = DynamicMethodBuilder<Func<object, object, object, object, Task<T>>>
+            var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, Task<T>>>
                .CreateMethodCallDelegate(
                     thisType,
                     "ExecuteAsync",

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             {
                 if (_getConfigurationMethod == null)
                 {
-                    _getConfigurationMethod = DynamicMethodBuilder<Func<object, string>>.CreateMethodCallDelegate(multiplexer.GetType(), "get_Configuration");
+                    _getConfigurationMethod = Emit.DynamicMethodBuilder<Func<object, string>>.CreateMethodCallDelegate(multiplexer.GetType(), "get_Configuration");
                 }
 
                 return _getConfigurationMethod(multiplexer);
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 {
                     var asm = multiplexer.GetType().Assembly;
                     var messageType = asm.GetType("StackExchange.Redis.Message");
-                    _getCommandAndKeyMethod = DynamicMethodBuilder<Func<object, string>>.CreateMethodCallDelegate(messageType, "get_CommandAndKey");
+                    _getCommandAndKeyMethod = Emit.DynamicMethodBuilder<Func<object, string>>.CreateMethodCallDelegate(messageType, "get_CommandAndKey");
                 }
 
                 cmdAndKey = _getCommandAndKeyMethod(message);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1119:StatementMustNotUseUnnecessaryParenthesis", Justification = "Actually Needed")]
         public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext)
         {
-            var handleRequestDelegate = DynamicMethodBuilder<Func<object, object, object, bool>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "HandleRequest");
+            var handleRequestDelegate = Emit.DynamicMethodBuilder<Func<object, object, object, bool>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "HandleRequest");
 
             if (!(requestContext is RequestContext castRequestContext))
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/MemberAccessor.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/MemberAccessor.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace Datadog.Trace.ClrProfiler
+{
+    /// <summary>
+    /// Provides helper methods to access object members by emitting IL dynamically.
+    /// </summary>
+    [Obsolete("This type will be removed in a future version of this library.")]
+    public static class MemberAccessor
+    {
+        /// <summary>
+        /// Tries to call an instance method with the specified name, a single parameter, and a return value.
+        /// </summary>
+        /// <typeparam name="TArg1">The type of the method's single parameter.</typeparam>
+        /// <typeparam name="TResult">The type of the method's result value.</typeparam>
+        /// <param name="source">The object to call the method on.</param>
+        /// <param name="methodName">The name of the method to call.</param>
+        /// <param name="arg1">The value to pass as the method's single argument.</param>
+        /// <param name="value">The value returned by the method.</param>
+        /// <returns><c>true</c> if the method was found, <c>false</c> otherwise.</returns>
+        public static bool TryCallMethod<TArg1, TResult>(this object source, string methodName, TArg1 arg1, out TResult value)
+        {
+            return Emit.ObjectExtensions.TryCallMethod(source, methodName, arg1, out value);
+        }
+
+        /// <summary>
+        /// Tries to get the value of an instance property with the specified name.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the property.</typeparam>
+        /// <param name="source">The value that contains the property.</param>
+        /// <param name="propertyName">The name of the property.</param>
+        /// <param name="value">The value of the property, or <c>null</c> if the property is not found.</param>
+        /// <returns><c>true</c> if the property exists, otherwise <c>false</c>.</returns>
+        public static bool TryGetPropertyValue<TResult>(this object source, string propertyName, out TResult value)
+        {
+            return Emit.ObjectExtensions.TryGetPropertyValue(source, propertyName, out value);
+        }
+
+        /// <summary>
+        /// Tries to get the value of an instance field with the specified name.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the field.</typeparam>
+        /// <param name="source">The value that contains the field.</param>
+        /// <param name="fieldName">The name of the field.</param>
+        /// <param name="value">The value of the field, or <c>null</c> if the field is not found.</param>
+        /// <returns><c>true</c> if the field exists, otherwise <c>false</c>.</returns>
+        public static bool TryGetFieldValue<TResult>(this object source, string fieldName, out TResult value)
+        {
+            return Emit.ObjectExtensions.TryGetFieldValue(source, fieldName, out value);
+        }
+    }
+}


### PR DESCRIPTION
Restore `public` types that were moved and changed to `internal` in #271 to avoid breaking changes. The old types are marked `[Obsolete]` and they simply forward calls to the new `internal` types in the `Datadog.Trace.ClrProfiler.Emit` namespace.