### PR TITLE
replace "force.keep" span tag with "manual.keep"

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -157,7 +157,9 @@ namespace Datadog.Trace
                     }
 
                     break;
+#pragma warning disable CS0618 // Type or member is obsolete
                 case Trace.Tags.ForceKeep:
+                case Trace.Tags.ManualKeep:
                     if (value.ToBoolean() ?? false)
                     {
                         // user-friendly tag to set UserKeep priority
@@ -166,6 +168,7 @@ namespace Datadog.Trace
 
                     break;
                 case Trace.Tags.ForceDrop:
+                case Trace.Tags.ManualDrop:
                     if (value.ToBoolean() ?? false)
                     {
                         // user-friendly tag to set UserReject priority
@@ -173,6 +176,7 @@ namespace Datadog.Trace
                     }
 
                     break;
+#pragma warning restore CS0618 // Type or member is obsolete
                 default:
                     // if not a special tag, just add it to the tag bag
                     Tags[key] = value;

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Datadog.Trace
 {
     /// <summary>
@@ -133,13 +135,25 @@ namespace Datadog.Trace
         public const string SamplingPriority = "sampling.priority";
 
         /// <summary>
+        /// Obsolete. Use <see cref="ManualKeep"/>.
+        /// </summary>
+        [Obsolete("This field will be removed in futures versions of this library. Use ManualKeep instead.")]
+        public const string ForceKeep = "force.keep";
+
+        /// <summary>
+        /// Obsolete. Use <see cref="ManualDrop"/>.
+        /// </summary>
+        [Obsolete("This field will be removed in futures versions of this library. Use ManualDrop instead.")]
+        public const string ForceDrop = "force.drop";
+
+        /// <summary>
         /// A user-friendly tag that sets the sampling priority to <see cref="Trace.SamplingPriority.UserKeep"/>.
         /// </summary>
-        public const string ForceKeep = "force.keep";
+        public const string ManualKeep = "manual.keep";
 
         /// <summary>
         /// A user-friendly tag that sets the sampling priority to <see cref="Trace.SamplingPriority.UserReject"/>.
         /// </summary>
-        public const string ForceDrop = "force.drop";
+        public const string ManualDrop = "manual.drop";
     }
 }


### PR DESCRIPTION
- add support for `manual.keep` and `manual.drop`
- keep `force.keep` and `force.drop` for backwards compatibility, but mark them obsolete