### PR TITLE
fix Trace Seach configuration

### DIFF
--- a/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -25,7 +25,8 @@ namespace Datadog.Trace.Configuration
 
             AnalyticsEnabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName));
 
-            AnalyticsSampleRate = source.GetDouble(string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName));
+            AnalyticsSampleRate = source.GetDouble(string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName)) ??
+                                  1.0;
         }
 
         /// <summary>
@@ -49,6 +50,6 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value between 0 and 1 (inclusive)
         /// that determines the sampling rate for this integration.
         /// </summary>
-        public double? AnalyticsSampleRate { get; set; }
+        public double AnalyticsSampleRate { get; set; }
     }
 }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -183,7 +183,7 @@ namespace Datadog.Trace.Configuration
         {
             var integrationSettings = Integrations[name];
             var analyticsEnabled = integrationSettings.AnalyticsEnabled ?? (enabledWithGlobalSetting && AnalyticsEnabled);
-            return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : null;
+            return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : (double?)null;
         }
     }
 }


### PR DESCRIPTION
A last-minute change (8e00ae6ec25e690102d49cbb68b9c915d6755db1) to Trace Search (#299) introduced a bug where the sampling rate defaults to `null` instead of `1.0`. Fix: make `IntegrationSettings.AnalyticsSampleRate` not nullable and default to `1.0`
