### PR TITLE
reduce log message verbosity when closing active scope

### DIFF
--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -24,13 +24,9 @@ namespace Datadog.Trace
 
             if (current != null && current == scope)
             {
-                // replace active scope with its parent,
-                // but only if it's the scope we were expecting
+                // if the scope that was just closed was the active scope,
+                // set its parent as the new active scope
                 _activeScope.Set(current.Parent);
-            }
-            else
-            {
-                Log.Debug("Specified scope is not the active scope.");
             }
         }
     }

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -22,18 +22,16 @@ namespace Datadog.Trace
         {
             var current = _activeScope.Get();
 
-            if (current != scope)
+            if (current != null && current == scope)
             {
-                Log.Warn("Specified scope is not the active scope.");
+                // replace active scope with its parent,
+                // but only if it's the scope we were expecting
+                _activeScope.Set(current.Parent);
             }
-
-            if (current == null)
+            else
             {
-                Log.Error("Trying to close a null scope.");
-                return;
+                Log.Debug("Specified scope is not the active scope.");
             }
-
-            _activeScope.Set(current.Parent);
         }
     }
 }


### PR DESCRIPTION
Reduce log messages severity and the number of messages logged when closing the active scope in `AsyncLocalScopeManager.Close(Scope)`.