### PR TITLE
add url to http client resource name

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -10,6 +10,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     /// </summary>
     public static class WebRequestIntegration
     {
+        private const string IntegrationName = "WebRequest";
+
         /// <summary>
         /// Instrumentation wrapper for <see cref="WebRequest.GetResponse"/>.
         /// </summary>
@@ -30,10 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return request.GetResponse();
             }
 
-            string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
-            string integrationName = typeof(WebRequestIntegration).Name.TrimEnd("Integration", StringComparison.OrdinalIgnoreCase);
-
-            using (var scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, httpMethod, request.RequestUri, integrationName))
+            using (var scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, request.Method, request.RequestUri, IntegrationName))
             {
                 try
                 {
@@ -45,9 +44,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     WebResponse response = request.GetResponse();
 
-                    if (response is HttpWebResponse webResponse)
+                    if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        scope?.Span.SetTag(Tags.HttpStatusCode, ((int)webResponse.StatusCode).ToString());
+                        scope.Span.SetTag(Tags.HttpStatusCode, ((int)webResponse.StatusCode).ToString());
                     }
 
                     return response;
@@ -80,10 +79,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return await request.GetResponseAsync().ConfigureAwait(false);
             }
 
-            string httpMethod = request.Method.ToUpperInvariant();
-            string integrationName = typeof(WebRequestIntegration).Name.TrimEnd("Integration", StringComparison.OrdinalIgnoreCase);
-
-            using (var scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, httpMethod, request.RequestUri, integrationName))
+            using (var scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, request.Method, request.RequestUri, IntegrationName))
             {
                 try
                 {
@@ -95,9 +91,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     WebResponse response = await request.GetResponseAsync().ConfigureAwait(false);
 
-                    if (response is HttpWebResponse webResponse)
+                    if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        scope?.Span.SetTag(Tags.HttpStatusCode, ((int)webResponse.StatusCode).ToString());
+                        scope.Span.SetTag(Tags.HttpStatusCode, ((int)webResponse.StatusCode).ToString());
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static async Task<WebResponse> GetResponseAsyncInternal(WebRequest request)
         {
-            if (!IsTracingEnabled(request))
+            if (!(request is HttpWebRequest) || !IsTracingEnabled(request))
             {
                 return await request.GetResponseAsync().ConfigureAwait(false);
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.ClrProfiler
     {
         public const string OperationName = "http.request";
         public const string ServiceName = "http-client";
-        public const string UrlIdReplacement = "*";
+        public const string UrlIdPlaceholder = "*";
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(ScopeFactory));
 
@@ -89,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler
 
             // remove path segments that look like int or guid
             segment = int.TryParse(segment, out _) || Guid.TryParse(segment, out _)
-                          ? UrlIdReplacement
+                          ? UrlIdPlaceholder
                           : segment;
 
             return hasTrailingSlash

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             // try to remove segments that look like ids
             string path = tryRemoveIds
-                              ? string.Join("/", uri.Segments.Select(CleanUriSegment))
+                              ? string.Concat(uri.Segments.Select(CleanUriSegment))
                               : uri.AbsolutePath;
 
             // keep only scheme, authority, and path.
@@ -79,12 +79,21 @@ namespace Datadog.Trace.ClrProfiler
 
         public static string CleanUriSegment(string segment)
         {
+            bool hasTrailingSlash = segment.EndsWith("/", StringComparison.Ordinal);
+
             // remove trailing slash
-            segment = segment.TrimEnd('/');
+            if (hasTrailingSlash)
+            {
+                segment = segment.Substring(0, segment.Length - 1);
+            }
 
             // remove path segments that look like int or guid
-            return int.TryParse(segment, out _) || Guid.TryParse(segment, out _)
-                       ? UrlIdReplacement
+            segment = int.TryParse(segment, out _) || Guid.TryParse(segment, out _)
+                          ? UrlIdReplacement
+                          : segment;
+
+            return hasTrailingSlash
+                       ? segment + "/"
                        : segment;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler
@@ -38,10 +39,11 @@ namespace Datadog.Trace.ClrProfiler
 
                 span.Type = SpanTypes.Http;
                 span.ServiceName = $"{tracer.DefaultServiceName}-{ServiceName}";
-                span.ResourceName = httpMethod;
+
+                span.ResourceName = $"{httpMethod} {CleanUri(requestUri, tryRemoveIds: true)}".Trim();
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 span.SetTag(Tags.HttpMethod, httpMethod?.ToUpperInvariant());
-                span.SetTag(Tags.HttpUrl, requestUri.OriginalString);
+                span.SetTag(Tags.HttpUrl, CleanUri(requestUri, tryRemoveIds: false));
                 span.SetTag(Tags.InstrumentationName, integrationName);
 
                 // set analytics sample rate if enabled

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -87,8 +87,10 @@ namespace Datadog.Trace.ClrProfiler
                 segment = segment.Substring(0, segment.Length - 1);
             }
 
-            // remove path segments that look like int or guid
-            segment = int.TryParse(segment, out _) || Guid.TryParse(segment, out _)
+            // remove path segments that look like int or guid (with or without dashes)
+            segment = int.TryParse(segment, out _) ||
+                      Guid.TryParseExact(segment, "N", out _) ||
+                      Guid.TryParseExact(segment, "D", out _)
                           ? UrlIdPlaceholder
                           : segment;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -57,5 +57,30 @@ namespace Datadog.Trace.ClrProfiler
             // or we couldn't populate it completely (some tags is better than no tags)
             return scope;
         }
+
+        public static string CleanUri(Uri uri, bool tryRemoveIds)
+        {
+            // remove username, password
+            string schemeAndAuthority = $"{uri.Scheme}://{uri.Authority}";
+
+            // try to remove ids
+            string path = tryRemoveIds
+                              ? $"{string.Join("/", uri.Segments.Select(CleanUriSegment))}"
+                              : $"{uri.AbsolutePath}";
+
+            // remove query and fragment
+            return schemeAndAuthority + path;
+        }
+
+        public static string CleanUriSegment(string segment)
+        {
+            // remove trailing slash
+            segment = segment.TrimEnd('/');
+
+            // remove path segments that look like int or guid
+            return int.TryParse(segment, out _) || Guid.TryParse(segment, out _)
+                       ? "*"
+                       : segment;
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -72,9 +72,8 @@ namespace Datadog.Trace.ClrProfiler
                               ? string.Concat(uri.Segments.Select(CleanUriSegment))
                               : uri.AbsolutePath;
 
-            // keep only scheme, authority, and path.
-            // remove username, password, query, and fragment
-            return $"{uri.Scheme}{Uri.SchemeDelimiter}{uri.Authority}{path}";
+            // keep only host and path, remove userinfo, query, and fragment
+            return $"{uri.Authority}{path}";
         }
 
         public static string CleanUriSegment(string segment)

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.ClrProfiler
     {
         public const string OperationName = "http.request";
         public const string ServiceName = "http-client";
-        public const string UrlIdPlaceholder = "*";
+        public const string UrlIdPlaceholder = "?";
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(ScopeFactory));
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler
                 span.ServiceName = $"{tracer.DefaultServiceName}-{ServiceName}";
                 span.ResourceName = httpMethod;
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
-                span.SetTag(Tags.HttpMethod, httpMethod);
+                span.SetTag(Tags.HttpMethod, httpMethod?.ToUpperInvariant());
                 span.SetTag(Tags.HttpUrl, requestUri.OriginalString);
                 span.SetTag(Tags.InstrumentationName, integrationName);
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -34,9 +34,27 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("https://example.com/path/123", "example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/" + Id)]
-        public void CleanUri_RemoveIdSegments(string uri, string expected)
+        public void CleanUri_RemoveIdSegmentsEnabled(string uri, string expected)
         {
             string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: true);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "example.com/path/to/file.aspx")]
+        [InlineData("https://username@example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx?query=1", "example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx#fragment", "example.com/path/to/file.aspx")]
+        [InlineData("http://example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/123/file.aspx", "example.com/path/123/file.aspx")]
+        [InlineData("https://example.com/path/123/", "example.com/path/123/")]
+        [InlineData("https://example.com/path/123", "example.com/path/123")]
+        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3")]
+        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/E653C852227B4F0C9E48D30D83C68BF3")]
+        public void CleanUri_RemoveIdSegmentsDisabled(string uri, string expected)
+        {
+            string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: false);
 
             Assert.Equal(expected, actual);
         }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -35,27 +35,27 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("https://example.com/path/123", "example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/" + Id)]
-        public void CleanUri_RemoveIdSegmentsEnabled(string uri, string expected)
+        public void CleanUri_ResourceName(string uri, string expected)
         {
-            string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: true);
+            string actual = ScopeFactory.CleanUri(new Uri(uri), removeScheme: true, tryRemoveIds: true);
 
             Assert.Equal(expected, actual);
         }
 
         [Theory]
-        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "example.com/path/to/file.aspx")]
-        [InlineData("https://username@example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/to/file.aspx?query=1", "example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/to/file.aspx#fragment", "example.com/path/to/file.aspx")]
-        [InlineData("http://example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/123/file.aspx", "example.com/path/123/file.aspx")]
-        [InlineData("https://example.com/path/123/", "example.com/path/123/")]
-        [InlineData("https://example.com/path/123", "example.com/path/123")]
-        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3")]
-        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/E653C852227B4F0C9E48D30D83C68BF3")]
-        public void CleanUri_RemoveIdSegmentsDisabled(string uri, string expected)
+        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "https://example.com/path/to/file.aspx")]
+        [InlineData("https://username@example.com/path/to/file.aspx", "https://example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx?query=1", "https://example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx#fragment", "https://example.com/path/to/file.aspx")]
+        [InlineData("http://example.com/path/to/file.aspx", "http://example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/123/file.aspx", "https://example.com/path/123/file.aspx")]
+        [InlineData("https://example.com/path/123/", "https://example.com/path/123/")]
+        [InlineData("https://example.com/path/123", "https://example.com/path/123")]
+        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3")]
+        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3")]
+        public void CleanUri_HttpUrlTag(string uri, string expected)
         {
-            string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: false);
+            string actual = ScopeFactory.CleanUri(new Uri(uri), removeScheme: false, tryRemoveIds: false);
 
             Assert.Equal(expected, actual);
         }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -24,16 +24,16 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         [Theory]
-        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "https://example.com/path/to/file.aspx")]
-        [InlineData("https://username@example.com/path/to/file.aspx", "https://example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/to/file.aspx?query=1", "https://example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/to/file.aspx#fragment", "https://example.com/path/to/file.aspx")]
-        [InlineData("http://example.com/path/to/file.aspx", "http://example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/123/file.aspx", "https://example.com/path/" + Id + "/file.aspx")]
-        [InlineData("https://example.com/path/123/", "https://example.com/path/" + Id + "/")]
-        [InlineData("https://example.com/path/123", "https://example.com/path/" + Id)]
-        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "https://example.com/path/" + Id)]
-        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "https://example.com/path/" + Id)]
+        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "example.com/path/to/file.aspx")]
+        [InlineData("https://username@example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx?query=1", "example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx#fragment", "example.com/path/to/file.aspx")]
+        [InlineData("http://example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/123/file.aspx", "example.com/path/" + Id + "/file.aspx")]
+        [InlineData("https://example.com/path/123/", "example.com/path/" + Id + "/")]
+        [InlineData("https://example.com/path/123", "example.com/path/" + Id)]
+        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/" + Id)]
+        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/" + Id)]
         public void CleanUri_RemoveIdSegments(string uri, string expected)
         {
             string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: true);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -1,0 +1,41 @@
+using System;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class ScopeFactoryTests
+    {
+        private const string Id = ScopeFactory.UrlIdReplacement;
+
+        [Theory]
+        [InlineData("users/", "users/")]
+        [InlineData("users", "users")]
+        [InlineData("123/", Id + "/")]
+        [InlineData("123", Id)]
+        [InlineData("E653C852-227B-4F0C-9E48-D30D83C68BF3/", Id + "/")]
+        [InlineData("E653C852-227B-4F0C-9E48-D30D83C68BF3", Id)]
+        public void CleanUriSegment(string segment, string expected)
+        {
+            string actual = ScopeFactory.CleanUriSegment(segment);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "https://example.com/path/to/file.aspx")]
+        [InlineData("https://username@example.com/path/to/file.aspx", "https://example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx?query=1", "https://example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx#fragment", "https://example.com/path/to/file.aspx")]
+        [InlineData("http://example.com/path/to/file.aspx", "http://example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/123/file.aspx", "https://example.com/path/" + Id + "/file.aspx")]
+        [InlineData("https://example.com/path/123/", "https://example.com/path/" + Id + "/")]
+        [InlineData("https://example.com/path/123", "https://example.com/path/" + Id)]
+        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "https://example.com/path/" + Id)]
+        public void CleanUri_RemoveIdSegments(string uri, string expected)
+        {
+            string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: true);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -5,7 +5,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 {
     public class ScopeFactoryTests
     {
-        private const string Id = ScopeFactory.UrlIdPlaceholder;
+        // declare here instead of using ScopeFactory.UrlIdPlaceholder so tests fails if value changes
+        private const string Id = "?";
 
         [Theory]
         [InlineData("users/", "users/")]

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -5,7 +5,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 {
     public class ScopeFactoryTests
     {
-        private const string Id = ScopeFactory.UrlIdReplacement;
+        private const string Id = ScopeFactory.UrlIdPlaceholder;
 
         [Theory]
         [InlineData("users/", "users/")]

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -14,6 +14,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("123", Id)]
         [InlineData("E653C852-227B-4F0C-9E48-D30D83C68BF3/", Id + "/")]
         [InlineData("E653C852-227B-4F0C-9E48-D30D83C68BF3", Id)]
+        [InlineData("E653C852227B4F0C9E48D30D83C68BF3/", Id + "/")]
+        [InlineData("E653C852227B4F0C9E48D30D83C68BF3", Id)]
         public void CleanUriSegment(string segment, string expected)
         {
             string actual = ScopeFactory.CleanUriSegment(segment);
@@ -31,6 +33,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("https://example.com/path/123/", "https://example.com/path/" + Id + "/")]
         [InlineData("https://example.com/path/123", "https://example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "https://example.com/path/" + Id)]
+        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "https://example.com/path/" + Id)]
         public void CleanUri_RemoveIdSegments(string uri, string expected)
         {
             string actual = ScopeFactory.CleanUri(new Uri(uri), tryRemoveIds: true);


### PR DESCRIPTION
For outbound HTTP requests
- `http.url` tag: remove username, password, query string, and fragment from url
- resource name: remove all of the above and try to remove id-looking path segments (anything that parses to `int` or `Guid`)

Examples

| url | resoure name |
| -- | -- |
| `http://username:password@example.com/path/to/file.aspx?query=1#fragment` | `GET example.com/path/to/file.aspx` |
| `http://example.com/users/123/edit` | `GET example.com/users/?/edit` |
| `http://example.com/users/e8a16cd1-5638-49ad-bb92-3422a99e3836` | `GET example.com/users/?` |

edit: dropped url scheme and changed id placeholder to `?`