### PR TITLE
Enable integration target version ranges

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -142,6 +142,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "reproductions", "reproducti
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpenseItDemo", "reproductions\Reproduction.Wpf.ExpenseIt\ExpenseIt\ExpenseItDemo\ExpenseItDemo.csproj", "{D1729F17-99A5-45AF-AB38-72FA6ECCE609}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Elasticsearch.V5", "samples\Samples.Elasticsearch.V5\Samples.Elasticsearch.V5.csproj", "{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -472,6 +474,16 @@ Global
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609}.Release|x64.Build.0 = Release|Any CPU
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609}.Release|x86.ActiveCfg = Release|Any CPU
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609}.Release|x86.Build.0 = Release|Any CPU
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|x64.ActiveCfg = Debug|x64
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|x64.Build.0 = Debug|x64
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|x86.ActiveCfg = Debug|x86
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Debug|x86.Build.0 = Debug|x86
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|Any CPU.ActiveCfg = Release|x86
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|x64.ActiveCfg = Release|x64
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|x64.Build.0 = Release|x64
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|x86.ActiveCfg = Release|x86
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -506,6 +518,7 @@ Global
 		{B4AE8B0F-C2B2-41DF-88BB-D97E267D8964} = {FA03944C-2391-4C25-8979-2E078A8CE0DD}
 		{99A62CCF-8E7F-4D57-8383-D38C371C8087} = {65DF5743-B7B5-4BC8-8AB5-9DE596AF3FB8}
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/integrations.json
+++ b/integrations.json
@@ -7,7 +7,11 @@
         "target": {
           "assembly": "System.Data",
           "type": "System.Data.Common.DbCommand",
-          "method": "ExecuteDbDataReader"
+          "method": "ExecuteDbDataReader",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -21,7 +25,11 @@
         "target": {
           "assembly": "System.Data.Common",
           "type": "System.Data.Common.DbCommand",
-          "method": "ExecuteDbDataReader"
+          "method": "ExecuteDbDataReader",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -35,7 +43,11 @@
         "target": {
           "assembly": "System.Data",
           "type": "System.Data.Common.DbCommand",
-          "method": "ExecuteDbDataReaderAsync"
+          "method": "ExecuteDbDataReaderAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -49,7 +61,11 @@
         "target": {
           "assembly": "System.Data.Common",
           "type": "System.Data.Common.DbCommand",
-          "method": "ExecuteDbDataReaderAsync"
+          "method": "ExecuteDbDataReaderAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -70,7 +86,11 @@
         "target": {
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-          "method": "BeforeAction"
+          "method": "BeforeAction",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -86,7 +106,11 @@
         "target": {
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-          "method": "AfterAction"
+          "method": "AfterAction",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -102,7 +126,11 @@
         "target": {
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
-          "method": "Rethrow"
+          "method": "Rethrow",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -123,7 +151,11 @@
         "target": {
           "assembly": "System.Web.Mvc",
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
-          "method": "BeginInvokeAction"
+          "method": "BeginInvokeAction",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -139,7 +171,11 @@
         "target": {
           "assembly": "System.Web.Mvc",
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
-          "method": "EndInvokeAction"
+          "method": "EndInvokeAction",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -158,7 +194,11 @@
         "target": {
           "assembly": "System.Web.Http",
           "type": "System.Web.Http.Controllers.IHttpController",
-          "method": "ExecuteAsync"
+          "method": "ExecuteAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -179,7 +219,11 @@
         "target": {
           "assembly": "Elasticsearch.Net",
           "type": "Elasticsearch.Net.IRequestPipeline",
-          "method": "CallElasticsearch"
+          "method": "CallElasticsearch",
+          "minimum_major": 6,
+          "minimum_minor": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -195,7 +239,11 @@
         "target": {
           "assembly": "Elasticsearch.Net",
           "type": "Elasticsearch.Net.IRequestPipeline",
-          "method": "CallElasticsearchAsync"
+          "method": "CallElasticsearchAsync",
+          "minimum_major": 6,
+          "minimum_minor": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -214,7 +262,11 @@
         "target": {
           "assembly": "System.Net.Http",
           "type": "System.Net.Http.HttpMessageHandler",
-          "method": "SendAsync"
+          "method": "SendAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -228,7 +280,11 @@
         "target": {
           "assembly": "System.Net.Http",
           "type": "System.Net.Http.HttpClientHandler",
-          "method": "SendAsync"
+          "method": "SendAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -247,7 +303,11 @@
         "target": {
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol",
-          "method": "Execute"
+          "method": "Execute",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -261,7 +321,11 @@
         "target": {
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol`1",
-          "method": "Execute"
+          "method": "Execute",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -275,7 +339,11 @@
         "target": {
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol",
-          "method": "ExecuteAsync"
+          "method": "ExecuteAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -289,7 +357,11 @@
         "target": {
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol`1",
-          "method": "ExecuteAsync"
+          "method": "ExecuteAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -310,7 +382,11 @@
         "target": {
           "assembly": "ServiceStack.Redis",
           "type": "ServiceStack.Redis.RedisNativeClient",
-          "method": "SendReceive"
+          "method": "SendReceive",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -331,7 +407,11 @@
         "target": {
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
-          "method": "ExecuteSyncImpl"
+          "method": "ExecuteSyncImpl",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -347,7 +427,11 @@
         "target": {
           "assembly": "StackExchange.Redis.StrongName",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
-          "method": "ExecuteSyncImpl"
+          "method": "ExecuteSyncImpl",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -363,7 +447,11 @@
         "target": {
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
-          "method": "ExecuteAsyncImpl"
+          "method": "ExecuteAsyncImpl",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -379,7 +467,11 @@
         "target": {
           "assembly": "StackExchange.Redis.StrongName",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
-          "method": "ExecuteAsyncImpl"
+          "method": "ExecuteAsyncImpl",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -395,7 +487,11 @@
         "target": {
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.RedisBase",
-          "method": "ExecuteAsync"
+          "method": "ExecuteAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -411,7 +507,11 @@
         "target": {
           "assembly": "StackExchange.Redis.StrongName",
           "type": "StackExchange.Redis.RedisBase",
-          "method": "ExecuteAsync"
+          "method": "ExecuteAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -430,7 +530,11 @@
         "target": {
           "assembly": "System.ServiceModel",
           "type": "System.ServiceModel.Dispatcher.ChannelHandler",
-          "method": "HandleRequest"
+          "method": "HandleRequest",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -449,7 +553,11 @@
         "target": {
           "assembly": "System",
           "type": "System.Net.WebRequest",
-          "method": "GetResponse"
+          "method": "GetResponse",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -463,7 +571,11 @@
         "target": {
           "assembly": "System.Net.Requests",
           "type": "System.Net.WebRequest",
-          "method": "GetResponse"
+          "method": "GetResponse",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
@@ -477,7 +589,11 @@
         "target": {
           "assembly": "System.Net",
           "type": "System.Net.WebRequest",
-          "method": "GetResponseAsync"
+          "method": "GetResponseAsync",
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",

--- a/samples/Samples.Elasticsearch.V5/Program.cs
+++ b/samples/Samples.Elasticsearch.V5/Program.cs
@@ -1,0 +1,566 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Elasticsearch.Net;
+using Nest;
+
+namespace Samples.Elasticsearch.V5
+{
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            var host = new Uri("http://" + Host() + ":9200");
+            var settings = new ConnectionSettings(host).DefaultIndex("elastic-net-example");
+            var elastic = new ElasticClient(settings);
+
+            var commands = new List<Func<object>>().
+                Concat(IndexCommands(elastic)).
+                Concat(IndexCommandsAsync(elastic)).
+                Concat(DocumentCommands(elastic)).
+                Concat(DocumentCommandsAsync(elastic)).
+                Concat(CatCommands(elastic)).
+                Concat(CatCommandsAsync(elastic)).
+                Concat(JobCommands(elastic)).
+                Concat(JobCommandsAsync(elastic)).
+                Concat(ClusterCommands(elastic)).
+                Concat(ClusterCommandsAsync(elastic)).
+                Concat(UserCommands(elastic)).
+                Concat(UserCommandsAsync(elastic)).
+                Concat(WatchCommands(elastic));
+
+            var exceptions = new List<Exception>();
+
+            foreach (var action in commands)
+            {
+                try
+                {
+                    var result = action();
+                    if (result is Task task)
+                    {
+                        result = TaskResult(task);
+                    }
+
+                    Console.WriteLine($"{result}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Exception: {ex.Message}");
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions.Count > 0)
+            {
+                throw new AggregateException(exceptions).Flatten();
+            }
+        }
+
+        private static string Host()
+        {
+            return Environment.GetEnvironmentVariable("ELASTICSEARCH_HOST") ?? "localhost";
+        }
+
+        private static List<Func<object>> DocumentCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.Bulk(new BulkRequest("test_index")
+                {
+                    Operations = new List<IBulkOperation>
+                    {
+                        new BulkCreateOperation<Post>(new Post
+                        {
+                            Id = 1,
+                            Title = "BulkCreateOperation",
+                        })
+                    }
+                }),
+                 () => elastic.Create<Post>(new Post
+                 {
+                     Id = 2,
+                     Title = "Create",
+                 }), 
+                // () => elastic.CreateDocument<Post>(new Post
+                // {
+                //     Id = 3,
+                //     Title = "CreateDocument",
+                // }), // V6 Feature
+                () => elastic.Count<Post>(),
+                () => elastic.Search<Post>(s => s.MatchAll()),
+                () => elastic.DeleteByQuery(new DeleteByQueryRequest("test_index")
+                {
+                    Size = 0,
+                }),
+            };
+        }
+
+        private static List<Func<object>> DocumentCommandsAsync(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.BulkAsync(new BulkRequest("test_index")
+                {
+                    Operations = new List<IBulkOperation>
+                    {
+                        new BulkCreateOperation<Post>(new Post
+                        {
+                            Id = 1,
+                            Title = "BulkCreateOperation",
+                        })
+                    }
+                }),
+                () => elastic.CreateAsync<Post>(new Post
+                {
+                    Id = 2,
+                    Title = "Create",
+                }), 
+                () => elastic.CountAsync<Post>(),
+                () => elastic.SearchAsync<Post>(s => s.MatchAll()),
+                () => elastic.DeleteByQueryAsync(new DeleteByQueryRequest("test_index")
+                {
+                    Size = 0,
+                }),
+            };
+        }
+
+        private static List<Func<object>> IndexCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.CreateIndex("test_index_1"),
+                () => elastic.IndexExists("test_index_1"),
+                () => elastic.UpdateIndexSettings(new UpdateIndexSettingsRequest("test_index_1")
+                {
+                    IndexSettings = new IndexSettings()
+                    {
+                        // V6 feature
+                        // Sorting = new SortingSettings
+                        // {
+                        //     Fields = new Field("Title"),
+                        // },
+                    },
+                }),
+                () => elastic.Alias(new BulkAliasRequest
+                {
+                    Actions = new List<IAliasAction>
+                    {
+                        new AliasAddAction
+                        {
+                            Add = new AliasAddOperation
+                            {
+                                Index = "test_index_1",
+                                Alias = "test_index_2",
+                            },
+                        },
+                    },
+                }),
+                () => elastic.GetAliasesPointingToIndex("test_index_1"),
+                () => elastic.PutAlias("test_index_1", "test_index_3"),
+                // () => elastic.AliasExists(new AliasExistsRequest("test_index_1")), // TODO: enable
+                () => elastic.DeleteAlias(new DeleteAliasRequest("test_index_1", "test_index_3")),
+                () => elastic.DeleteAlias(new DeleteAliasRequest("test_index_1", "test_index_2")),
+                () => elastic.CreateIndex("test_index_4"),
+                // () => elastic.SplitIndex("test_index_1", "test_index_4"), // V6 Feature
+                () => elastic.DeleteIndex("test_index_4"),
+                () => elastic.CloseIndex("test_index_1"),
+                () => elastic.OpenIndex("test_index_1"),
+                () => elastic.PutIndexTemplate(new PutIndexTemplateRequest("test_template_1")),
+                () => elastic.IndexTemplateExists("test_template_1"),
+                () => elastic.DeleteIndexTemplate("test_template_1"),
+                () => elastic.IndicesShardStores(),
+                () => elastic.IndicesStats("test_index_1"),
+                () => elastic.DeleteIndex("test_index_1"),
+                () => elastic.GetAlias(new GetAliasRequest()),
+            };
+        }
+
+        private static List<Func<object>> IndexCommandsAsync(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.CreateIndexAsync("test_index_1"),
+                () => elastic.IndexExistsAsync("test_index_1"),
+                () => elastic.UpdateIndexSettingsAsync(new UpdateIndexSettingsRequest("test_index_1")
+                {
+                    IndexSettings = new IndexSettings()
+                    {
+                        // V6 Feature
+                        // Sorting = new SortingSettings
+                        // {
+                        //     Fields = new Field("Title"),
+                        // },
+                    },
+                }),
+                () => elastic.AliasAsync(new BulkAliasRequest
+                {
+                    Actions = new List<IAliasAction>
+                    {
+                        new AliasAddAction
+                        {
+                            Add = new AliasAddOperation
+                            {
+                                Index = "test_index_1",
+                                Alias = "test_index_2",
+                            },
+                        },
+                    },
+                }),
+                () => elastic.GetAliasesPointingToIndexAsync("test_index_1"),
+                () => elastic.PutAliasAsync("test_index_1", "test_index_3"),
+                () => elastic.DeleteAliasAsync(new DeleteAliasRequest("test_index_1", "test_index_3")),
+                () => elastic.DeleteAliasAsync(new DeleteAliasRequest("test_index_1", "test_index_2")),
+                () => elastic.CreateIndexAsync("test_index_4"),
+                () => elastic.DeleteIndexAsync("test_index_4"),
+                () => elastic.CloseIndexAsync("test_index_1"),
+                () => elastic.OpenIndexAsync("test_index_1"),
+                () => elastic.PutIndexTemplateAsync(new PutIndexTemplateRequest("test_template_1")),
+                () => elastic.IndexTemplateExistsAsync("test_template_1"),
+                () => elastic.DeleteIndexTemplateAsync("test_template_1"),
+                () => elastic.IndicesShardStoresAsync(),
+                () => elastic.IndicesStatsAsync("test_index_1"),
+                () => elastic.DeleteIndexAsync("test_index_1"),
+                () => elastic.GetAliasAsync(new GetAliasRequest()),
+            };
+        }
+
+        private static List<Func<object>> CatCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.CatAliases(new CatAliasesRequest()),
+                () => elastic.CatAllocation(new CatAllocationRequest()),
+                () => elastic.CatCount(new CatCountRequest()),
+                () => elastic.CatFielddata(new CatFielddataRequest()),
+                () => elastic.CatHealth(new CatHealthRequest()),
+                () => elastic.CatHelp(new CatHelpRequest()),
+                () => elastic.CatIndices(new CatIndicesRequest()),
+                () => elastic.CatMaster(new CatMasterRequest()),
+                () => elastic.CatNodeAttributes(new CatNodeAttributesRequest()),
+                () => elastic.CatNodes(new CatNodesRequest()),
+                () => elastic.CatPendingTasks(new CatPendingTasksRequest()),
+                () => elastic.CatPlugins(new CatPluginsRequest()),
+                () => elastic.CatRecovery(new CatRecoveryRequest()),
+                () => elastic.CatRepositories(new CatRepositoriesRequest()),
+                () => elastic.CatSegments(new CatSegmentsRequest()),
+                () => elastic.CatShards(new CatShardsRequest()),
+                // CatSnapshots is failing with a JSON deserialization error.
+                // It might be a bug in the client or an incompatibility between client
+                // and server versions.
+                // () => elastic.CatSnapshots(new CatSnapshotsRequest()),
+                () => elastic.CatTasks(new CatTasksRequest()),
+                () => elastic.CatTemplates(new CatTemplatesRequest()),
+                () => elastic.CatThreadPool(new CatThreadPoolRequest()),
+            };
+        }
+
+        private static List<Func<object>> CatCommandsAsync(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.CatAliasesAsync(new CatAliasesRequest()),
+                () => elastic.CatAllocationAsync(new CatAllocationRequest()),
+                () => elastic.CatCountAsync(new CatCountRequest()),
+                () => elastic.CatFielddataAsync(new CatFielddataRequest()),
+                () => elastic.CatHealthAsync(new CatHealthRequest()),
+                () => elastic.CatHelpAsync(new CatHelpRequest()),
+                () => elastic.CatIndicesAsync(new CatIndicesRequest()),
+                () => elastic.CatMasterAsync(new CatMasterRequest()),
+                () => elastic.CatNodeAttributesAsync(new CatNodeAttributesRequest()),
+                () => elastic.CatNodesAsync(new CatNodesRequest()),
+                () => elastic.CatPendingTasksAsync(new CatPendingTasksRequest()),
+                () => elastic.CatPluginsAsync(new CatPluginsRequest()),
+                () => elastic.CatRecoveryAsync(new CatRecoveryRequest()),
+                () => elastic.CatRepositoriesAsync(new CatRepositoriesRequest()),
+                () => elastic.CatSegmentsAsync(new CatSegmentsRequest()),
+                () => elastic.CatShardsAsync(new CatShardsRequest()),
+                // CatSnapshots is failing with a JSON deserialization error.
+                // It might be a bug in the client or an incompatibility between client
+                // and server versions.
+                // () => elastic.CatSnapshotsAsync(new CatSnapshotsRequest()),
+                () => elastic.CatTasksAsync(new CatTasksRequest()),
+                () => elastic.CatTemplatesAsync(new CatTemplatesRequest()),
+                () => elastic.CatThreadPoolAsync(new CatThreadPoolRequest()),
+            };
+        }
+
+        private static List<Func<object>> JobCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.PutJob(new PutJobRequest("test_job")),
+                () => elastic.ValidateJob(new ValidateJobRequest()),
+                () => elastic.GetInfluencers(new GetInfluencersRequest("test_job")),
+                () => elastic.GetJobs(new GetJobsRequest("test_job")),
+                () => elastic.GetJobStats(new GetJobStatsRequest()),
+                () => elastic.GetModelSnapshots(new GetModelSnapshotsRequest("test_job")),
+                // () => elastic.GetOverallBuckets(new GetOverallBucketsRequest("test_job")), // V6 Feature
+                () => elastic.FlushJob(new FlushJobRequest("test_job")),
+                // () => elastic.ForecastJob(new ForecastJobRequest("test_job")), // V6 Feature
+                () => elastic.GetAnomalyRecords(new GetAnomalyRecordsRequest("test_job")),
+                () => elastic.GetBuckets(new GetBucketsRequest("test_job")),
+                () => elastic.GetCategories(new GetCategoriesRequest("test_job")),
+                () => elastic.CloseJob(new CloseJobRequest("test_job")),
+                () => elastic.OpenJob(new OpenJobRequest("test_job")),
+                () => elastic.DeleteJob(new DeleteJobRequest("test_job")),
+            };
+        }
+
+        private static List<Func<object>> JobCommandsAsync(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.PutJobAsync(new PutJobRequest("test_job")),
+                () => elastic.ValidateJobAsync(new ValidateJobRequest()),
+                () => elastic.GetInfluencersAsync(new GetInfluencersRequest("test_job")),
+                () => elastic.GetJobsAsync(new GetJobsRequest("test_job")),
+                () => elastic.GetJobStatsAsync(new GetJobStatsRequest()),
+                () => elastic.GetModelSnapshotsAsync(new GetModelSnapshotsRequest("test_job")),
+                // () => elastic.GetOverallBucketsAsync(new GetOverallBucketsRequest("test_job")), // V6 Feature
+                () => elastic.FlushJobAsync(new FlushJobRequest("test_job")),
+                // () => elastic.ForecastJobAsync(new ForecastJobRequest("test_job")), // V6 Feature
+                () => elastic.GetAnomalyRecordsAsync(new GetAnomalyRecordsRequest("test_job")),
+                () => elastic.GetBucketsAsync(new GetBucketsRequest("test_job")),
+                () => elastic.GetCategoriesAsync(new GetCategoriesRequest("test_job")),
+                () => elastic.CloseJobAsync(new CloseJobRequest("test_job")),
+                () => elastic.OpenJobAsync(new OpenJobRequest("test_job")),
+                () => elastic.DeleteJobAsync(new DeleteJobRequest("test_job")),
+            };
+        }
+
+        private static List<Func<object>> ClusterCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.ClusterAllocationExplain(new ClusterAllocationExplainRequest()),
+                () => elastic.ClusterGetSettings(new ClusterGetSettingsRequest()),
+                () => elastic.ClusterHealth(new ClusterHealthRequest()),
+                () => elastic.ClusterPendingTasks(new ClusterPendingTasksRequest()),
+                () => elastic.ClusterPutSettings(new ClusterPutSettingsRequest()),
+                () => elastic.ClusterReroute(new ClusterRerouteRequest()),
+                () => elastic.ClusterState(new ClusterStateRequest()),
+                () => elastic.ClusterStats(new ClusterStatsRequest()),
+            };
+        }
+
+        private static List<Func<object>> ClusterCommandsAsync(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.ClusterAllocationExplainAsync(new ClusterAllocationExplainRequest()),
+                () => elastic.ClusterGetSettingsAsync(new ClusterGetSettingsRequest()),
+                () => elastic.ClusterHealthAsync(new ClusterHealthRequest()),
+                () => elastic.ClusterPendingTasksAsync(new ClusterPendingTasksRequest()),
+                () => elastic.ClusterPutSettingsAsync(new ClusterPutSettingsRequest()),
+                () => elastic.ClusterRerouteAsync(new ClusterRerouteRequest()),
+                () => elastic.ClusterStateAsync(new ClusterStateRequest()),
+                () => elastic.ClusterStatsAsync(new ClusterStatsRequest()),
+            };
+        }
+
+        private static List<Func<object>> UserCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.PutRole("test_role_1"),
+                () => elastic.PutRoleMapping("test_role_1"),
+                () => elastic.GetRole(new GetRoleRequest("test_role_1")),
+                () => elastic.GetRoleMapping(new GetRoleMappingRequest("test_role_1")),
+                () => elastic.DeleteRoleMapping("test_role_1"),
+                () => elastic.DeleteRole("test_role_1"),
+                () => elastic.PutUser("test_user_1"),
+                () => elastic.ChangePassword(new ChangePasswordRequest("test_user_1")
+                {
+                    Password = "supersecret",
+                }),
+                () => elastic.GetUser(new GetUserRequest("test_user_1")),
+                () => elastic.DisableUser("test_user_1"),
+                () => elastic.DeleteUser("test_user_1"),
+            };
+        }
+
+        private static List<Func<object>> UserCommandsAsync(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                () => elastic.PutRoleAsync("test_role_1"),
+                () => elastic.PutRoleMappingAsync("test_role_1"),
+                () => elastic.GetRoleAsync(new GetRoleRequest("test_role_1")),
+                () => elastic.GetRoleMappingAsync(new GetRoleMappingRequest("test_role_1")),
+                () => elastic.DeleteRoleMappingAsync("test_role_1"),
+                () => elastic.DeleteRoleAsync("test_role_1"),
+                () => elastic.PutUserAsync("test_user_1"),
+                () => elastic.ChangePasswordAsync(new ChangePasswordRequest("test_user_1")
+                {
+                    Password = "supersecret",
+                }),
+                () => elastic.GetUserAsync(new GetUserRequest("test_user_1")),
+                () => elastic.DisableUserAsync("test_user_1"),
+                () => elastic.DeleteUserAsync("test_user_1"),
+            };
+        }
+
+        public static List<Func<object>> WatchCommands(ElasticClient elastic)
+        {
+            return new List<Func<object>>
+            {
+                // elastic.AcknowledgeWatch()
+                // elastic.ActivateWatch()
+                // elastic.PutWatch
+                // elastic.DeactivateWatch
+                // elastic.DeleteWatch(new DeleteWatchRequest("test_watch"));
+                // elastic.ExecuteWatch(new ExecuteWatchRequest());
+                // elastic.GetWatch(new GetWatchRequest("test_watch"));
+                // elastic.RestartWatcher
+                // elastic.WatcherStats
+                // elastic.StopWatcher
+                // elastic.StartWatcher
+            };
+        }
+
+
+        // elastic.MultiTermVectors
+        // elastic.NodesHotThreads
+        // elastic.NodesInfo
+        // elastic.NodesStats
+        // elastic.NodesUsage
+        // elastic.Ping
+        // elastic.PostLicense
+        // elastic.PreviewDatafeed
+        // elastic.PutDatafeed
+        // elastic.PutPipeline
+        // elastic.PutScript
+        // elastic.RecoveryStatus
+        // elastic.Refresh
+        // elastic.Reindex
+        // elastic.ReindexOnServer
+        // elastic.RemoteInfo
+        // elastic.Restore
+        // elastic.RestoreObservable
+        // elastic.Rethrottle
+        // elastic.RevertModelSnapshot
+        // elastic.RolloverIndex
+        // elastic.RootNodeInfo
+        // elastic.Scroll
+        // elastic.ScrollAll
+        // elastic.Segments
+        // elastic.ShrinkIndex
+        // elastic.SimulatePipeline
+        // elastic.Snapshot
+        // elastic.SnapshotObservable
+        // elastic.SnapshotStatus
+        // elastic.StartDatafeed
+        // elastic.StartTrialLicense
+        // elastic.StopDatafeed
+        // elastic.Suffix
+        // elastic.SyncedFlush
+        // elastic.TermVectors
+        // elastic.UpdateDatafeed
+        // elastic.UpdateModelSnapshot
+        // elastic.Upgrade
+        // elastic.UpgradeStatus
+        // elastic.ValidateDetector
+        // elastic.ValidateQuery
+        // elastic.VerifyRepository
+        // elastic.XPackInfo
+        // elastic.XPackUsage
+        // elastic.Analyze(new AnalyzeRequest("test_index"));
+        // elastic.CancelTasks
+        // elastic.ClearCache(new ClearCacheRequest());
+        // elastic.ClearCachedRealms(new ClearCachedRealmsRequest("test_realm"));
+        // elastic.ClearCachedRoles(new ClearCachedRolesRequest("test_role"));
+        // elastic.ClearScroll(new ClearScrollRequest("scroll_id"));
+        // elastic.CreateRepository(new CreateRepositoryRequest("test_create_repository"));
+        // elastic.DeleteDatafeed
+        // elastic.DeleteExpiredData
+        // elastic.DeleteLicense(new DeleteLicenseRequest());
+        // elastic.DeleteModelSnapshot
+        // elastic.DeletePipeline
+        // elastic.DeleteRepository(new DeleteRepositoryRequest("test_delete_repository"));
+        // elastic.DeleteScript(new DeleteScriptRequest("test_script"));
+        // elastic.DeleteSnapshot(new DeleteSnapshotRequest("test_repository", "test_snapshot"));
+        // elastic.DeprecationInfo(new DeprecationInfoRequest());
+        // elastic.FieldCapabilities(new FieldCapabilitiesRequest());
+        // elastic.GetDatafeeds(new GetDatafeedsRequest());
+        // elastic.GetDatafeedStats(new GetDatafeedStatsRequest("test_datafeed"));
+        // elastic.GetFieldMapping(new GetFieldMappingRequest("test_index", "Post", "Title"));
+        // elastic.GetLicense(new GetLicenseRequest());
+        // elastic.GetMapping(new GetMappingRequest());
+        // elastic.GetPipeline(new GetPipelineRequest());
+        // elastic.GetRepository(new GetRepositoryRequest());
+        // elastic.GetScript(new GetScriptRequest("test_script"));
+        // elastic.GetSnapshot(new GetSnapshotRequest("test_repository", "test_snapshot"));
+        // elastic.GetTask(new GetTaskRequest("test_task"));
+        // elastic.GetTrialLicenseStatus(new GetTrialLicenseStatusRequest());
+        // elastic.GraphExplore(new GraphExploreRequest("test_index"));
+        // elastic.GrokProcessorPatterns(new GrokProcessorPatternsRequest());
+        // elastic.InvalidateUserAccessToken
+        // elastic.ListTasks(new ListTasksRequest());
+        // elastic.Map(new PutMappingRequest("test_index", "Post"));
+        // elastic.MigrationAssistance(new MigrationAssistanceRequest());
+        // elastic.MigrationUpgrade(new MigrationUpgradeRequest("test_index"));
+        // elastic.GetIndex(new GetIndexRequest("test_index"));
+        // elastic.GetIndexSettings(new GetIndexSettingsRequest());
+        // elastic.GetIndexTemplate(new GetIndexTemplateRequest());
+        // elastic.GetIndicesPointingToAlias("test_alias");
+        // elastic.Authenticate
+        // elastic.GetUserAccessToken(new GetUserAccessTokenRequest())
+        // elastic.DeleteRole(new DeleteRoleRequest("test_role"));
+        // elastic.DeleteRoleMapping(new DeleteRoleMappingRequest("test_role_mapping"));
+        // elastic.EnableUser(new EnableUserRequest("test_user"));
+        // elastic.UpdateJob
+        // elastic.PostJobData
+        // () => elastic.Delete(new DeleteRequest("test_index", "Post", 2)),
+        // () => elastic.MultiGet
+        // () => elastic.MultiSearch
+        // () => elastic.MultiSearchTemplate
+        // () => elastic.Update
+        // () => elastic.UpdateByQuery
+        // () => elastic.TypeExists
+
+        // () => elastic.Source
+        // () => elastic.SourceExists
+        // () => elastic.SourceMany
+        // () => elastic.Search
+        // () => elastic.SearchShards
+        // () => elastic.SearchTemplate
+        // () => elastic.RenderSearchTemplate
+        // () => elastic.Index<Post>(new IndexRequest<Post>(new Post
+        // {
+        //     Id = 4,
+        //     Title = "Index",
+        // })),
+        // () => elastic.IndexDocument<Post>(new Post
+        // {
+        //     Id = 5,
+        //     Title = "IndexDocument",
+        // }),
+        // () => elastic.IndexMany()
+        // () => elastic.GetMany
+        // () => elastic.Flush(new FlushRequest()),
+        // () => elastic.ForceMerge(new ForceMergeRequest("test_force_merge")),
+        // () => elastic.Get<Post>(new GetRequest("test_index", "Post", 1)),
+        // () => elastic.DocumentExists(new DocumentExistsRequest("test_index", "Post", 2)),
+        // () => elastic.Explain<Post>(new ExplainRequest<Post>("test_index", "Post", 1)),
+
+        private static object TaskResult(Task task)
+        {
+            task.Wait();
+            var taskType = task.GetType();
+
+            bool isTaskOfT =
+                taskType.IsGenericType
+                && taskType.GetGenericTypeDefinition() == typeof(Task<>);
+
+
+            return isTaskOfT ? taskType.GetProperty("Result")?.GetValue(task) : null;
+        }
+
+        public class Post
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+        }
+    }
+}

--- a/samples/Samples.Elasticsearch.V5/Properties/launchSettings.json
+++ b/samples/Samples.Elasticsearch.V5/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "profiles": {
+    "Samples.Elasticsearch.V5": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/samples/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- override to remove net452 -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elasticsearch.Net" Version="5.6.6" />
+    <PackageReference Include="NEST" Version="5.6.6" />
+  </ItemGroup>
+
+</Project>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetIntegration.cs
@@ -39,7 +39,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
-            TargetType = "Elasticsearch.Net.IRequestPipeline")]
+            TargetType = "Elasticsearch.Net.IRequestPipeline",
+            TargetAssemblyMinimumMajor = 6,
+            TargetAssemblyMaximumMajor = 6)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData)
         {
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, TResponse>>
@@ -73,7 +75,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
-            TargetType = "Elasticsearch.Net.IRequestPipeline")]
+            TargetType = "Elasticsearch.Net.IRequestPipeline",
+            TargetAssemblyMinimumMajor = 6,
+            TargetAssemblyMaximumMajor = 6)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource)
         {
             var cancellationToken = ((CancellationTokenSource)cancellationTokenSource)?.Token ?? CancellationToken.None;

--- a/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
@@ -42,6 +42,26 @@ namespace Datadog.Trace.ClrProfiler
         public string TargetAssembly { get; set; }
 
         /// <summary>
+        /// Gets or sets the minimum major version for <see cref="TargetAssembly"/>.
+        /// </summary>
+        public ushort TargetAssemblyMinimumMajor { get; set; } = ushort.MinValue;
+
+        /// <summary>
+        /// Gets or sets the minimum minor version for <see cref="TargetAssembly"/>.
+        /// </summary>
+        public ushort TargetAssemblyMinimumMinor { get; set; } = ushort.MinValue;
+
+        /// <summary>
+        /// Gets or sets the maximum major version for <see cref="TargetAssembly"/>.
+        /// </summary>
+        public ushort TargetAssemblyMaximumMajor { get; set; } = ushort.MaxValue;
+
+        /// <summary>
+        /// Gets or sets the maximum minor version for <see cref="TargetAssembly"/>.
+        /// </summary>
+        public ushort TargetAssemblyMaximumMinor { get; set; } = ushort.MaxValue;
+
+        /// <summary>
         /// Gets or sets the name of the type that contains the target method to be intercepted.
         /// Required.
         /// </summary>

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -19,39 +19,75 @@ AssemblyInfo GetAssemblyInfo(ICorProfilerInfo3* info,
   return {assembly_id, WSTRING(name)};
 }
 
-WSTRING GetAssemblyName(
+AssemblyMetadata GetAssemblyMetadata(
+    const ModuleID& module_id,
+    const ComPtr<IMetaDataAssemblyImport>& assembly_import) {
+  mdAssembly current = mdAssemblyNil;
+  auto hr = assembly_import->GetAssemblyFromScope(&current);
+
+  if (FAILED(hr)) {
+    return {};
+  }
+
+  WCHAR name[kNameMaxSize];
+  WSTRING assembly_name = ""_W;
+  DWORD name_len = 0;
+  ASSEMBLYMETADATA assembly_m{};
+  DWORD assembly_flags = 0;
+  hr = assembly_import->GetAssemblyProps(current, nullptr, nullptr, nullptr,
+                                         name, kNameMaxSize, &name_len,
+                                         &assembly_m, &assembly_flags);
+  if (!FAILED(hr) && name_len > 0) {
+    assembly_name = WSTRING(name);
+  }
+
+  return AssemblyMetadata(
+      module_id, assembly_name, current, assembly_m.usMajorVersion,
+      assembly_m.usMinorVersion, assembly_m.usBuildNumber,
+      assembly_m.usRevisionNumber);
+}
+
+AssemblyMetadata GetAssemblyImportMetadata(
     const ComPtr<IMetaDataAssemblyImport>& assembly_import) {
   mdAssembly current = mdAssemblyNil;
   auto hr = assembly_import->GetAssemblyFromScope(&current);
   if (FAILED(hr)) {
-    return ""_W;
+    return {};
   }
   WCHAR name[kNameMaxSize];
   DWORD name_len = 0;
   ASSEMBLYMETADATA assembly_metadata{};
   DWORD assembly_flags = 0;
+  const ModuleID placeholder_module_id = 0;
+
   hr = assembly_import->GetAssemblyProps(current, nullptr, nullptr, nullptr,
-                                         name, kNameMaxSize, &name_len,
-                                         &assembly_metadata, &assembly_flags);
+                                         name, kNameMaxSize, &name_len, &assembly_metadata,
+                                         &assembly_flags);
   if (FAILED(hr) || name_len == 0) {
-    return ""_W;
+    return {};
   }
-  return WSTRING(name);
+  return AssemblyMetadata(placeholder_module_id, name, current,
+                          assembly_metadata.usMajorVersion, assembly_metadata.usMinorVersion,
+                          assembly_metadata.usBuildNumber, assembly_metadata.usRevisionNumber);
 }
 
-WSTRING GetAssemblyName(const ComPtr<IMetaDataAssemblyImport>& assembly_import,
-                        const mdAssemblyRef& assembly_ref) {
+AssemblyMetadata GetReferencedAssemblyMetadata(
+    const ComPtr<IMetaDataAssemblyImport>& assembly_import,
+    const mdAssemblyRef& assembly_ref) {
   WCHAR name[kNameMaxSize];
   DWORD name_len = 0;
   ASSEMBLYMETADATA assembly_metadata{};
   DWORD assembly_flags = 0;
+  const ModuleID module_id_placeholder = 0;
   const auto hr = assembly_import->GetAssemblyRefProps(
-      assembly_ref, nullptr, nullptr, name, kNameMaxSize, &name_len,
-      &assembly_metadata, nullptr, nullptr, &assembly_flags);
+      assembly_ref, nullptr, nullptr, name, kNameMaxSize, &name_len, &assembly_metadata,
+      nullptr, nullptr, &assembly_flags);
   if (FAILED(hr) || name_len == 0) {
-    return ""_W;
+    return {};
   }
-  return WSTRING(name);
+  return AssemblyMetadata(module_id_placeholder, name, assembly_ref,
+                          assembly_metadata.usMajorVersion, assembly_metadata.usMinorVersion,
+                          assembly_metadata.usBuildNumber, assembly_metadata.usRevisionNumber);
 }
 
 FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
@@ -132,6 +168,7 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
 
   HRESULT hr = E_FAIL;
   const auto token_type = TypeFromToken(token);
+
   switch (token_type) {
     case mdtTypeDef:
       hr = metadata_import->GetTypeDefProps(token, type_name, kNameMaxSize,
@@ -180,7 +217,8 @@ mdAssemblyRef FindAssemblyRef(
     const ComPtr<IMetaDataAssemblyImport>& assembly_import,
     const WSTRING& assembly_name) {
   for (mdAssemblyRef assembly_ref : EnumAssemblyRefs(assembly_import)) {
-    if (GetAssemblyName(assembly_import, assembly_ref) == assembly_name) {
+    if (GetReferencedAssemblyMetadata(assembly_import, assembly_ref).name ==
+        assembly_name) {
       return assembly_ref;
     }
   }
@@ -212,15 +250,14 @@ std::vector<Integration> FilterIntegrationsByName(
 }
 
 std::vector<Integration> FilterIntegrationsByCaller(
-    const std::vector<Integration>& integrations,
-    const WSTRING& assembly_name) {
+    const std::vector<Integration>& integrations, const AssemblyInfo assembly) {
   std::vector<Integration> enabled;
 
   for (auto& i : integrations) {
     bool found = false;
     for (auto& mr : i.method_replacements) {
       if (mr.caller_method.assembly.name.empty() ||
-          mr.caller_method.assembly.name == assembly_name) {
+          mr.caller_method.assembly.name == assembly.name) {
         found = true;
         break;
       }
@@ -233,25 +270,62 @@ std::vector<Integration> FilterIntegrationsByCaller(
   return enabled;
 }
 
+bool AssemblyMeetsIntegrationRequirements(
+    const AssemblyMetadata metadata,
+    const MethodReplacement method_replacement) {
+
+  const auto target = method_replacement.target_method;
+
+  if (target.assembly.name != metadata.name) {
+    // not the expected assembly
+    return false;
+  }
+
+  if (target.min_v_major > metadata.majorVersion) {
+    // below major version requirements
+    return false;
+  }
+
+  if (target.max_v_major < metadata.majorVersion) {
+    // above major version requirements
+    return false;
+  }
+
+  if (target.min_v_major == metadata.majorVersion &&
+      target.min_v_minor > metadata.minorVersion) {
+    // below minimum version requirements
+    return false;
+  }
+
+  if (target.max_v_major == metadata.majorVersion &&
+      target.max_v_minor < metadata.minorVersion) {
+    // above minimum version requirements
+    return false;
+  }
+
+  return true;
+}
+
 std::vector<Integration> FilterIntegrationsByTarget(
     const std::vector<Integration>& integrations,
     const ComPtr<IMetaDataAssemblyImport>& assembly_import) {
   std::vector<Integration> enabled;
 
-  const auto assembly_name = GetAssemblyName(assembly_import);
+  const auto assembly_metadata = GetAssemblyImportMetadata(assembly_import);
 
   for (auto& i : integrations) {
     bool found = false;
+    // ReSharper disable once CppRangeBasedForIncompatibleReference
     for (auto& mr : i.method_replacements) {
-      if (mr.target_method.assembly.name == assembly_name) {
+      if (AssemblyMeetsIntegrationRequirements(assembly_metadata, mr)) {
         found = true;
         break;
       }
       for (auto& assembly_ref : EnumAssemblyRefs(assembly_import)) {
-        auto ref_name = GetAssemblyName(assembly_import, assembly_ref);
+        const auto metadata_ref =
+            GetReferencedAssemblyMetadata(assembly_import, assembly_ref);
         // Info(L"-- assembly ref: " , assembly_name , " to " , ref_name);
-        if (mr.target_method.assembly.name == ref_name) {
-          // Info(L"FOUND IT! -- assembly ref: " , assembly_name , " to " , ref_name);
+        if (AssemblyMeetsIntegrationRequirements(metadata_ref, mr)) {
           found = true;
           break;
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -145,7 +145,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   }
 
   std::vector<Integration> filtered_integrations =
-      FilterIntegrationsByCaller(integrations_, module_info.assembly.name);
+      FilterIntegrationsByCaller(integrations_, module_info.assembly);
   if (filtered_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
     Info("CorProfiler::ModuleLoadFinished: ", module_info.assembly.name,

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -157,8 +157,8 @@ struct MethodReference {
         max_v_minor(USHRT_MAX) {}
 
   MethodReference(const WSTRING& assembly_name, WSTRING type_name,
-                  WSTRING method_name, short min_major, short min_minor,
-                  short max_major, short max_minor,
+                  WSTRING method_name, USHORT min_major, USHORT min_minor,
+                  USHORT max_major, USHORT max_minor,
                   const std::vector<BYTE>& method_signature)
       : assembly(assembly_name),
         type_name(type_name),

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -145,27 +145,49 @@ struct MethodReference {
   const WSTRING type_name;
   const WSTRING method_name;
   const MethodSignature method_signature;
+  const USHORT min_v_major;
+  const USHORT min_v_minor;
+  const USHORT max_v_major;
+  const USHORT max_v_minor;
 
-  MethodReference() {}
+  MethodReference()
+      : min_v_major(0),
+        min_v_minor(0),
+        max_v_major(USHRT_MAX),
+        max_v_minor(USHRT_MAX) {}
 
   MethodReference(const WSTRING& assembly_name, WSTRING type_name,
-                  WSTRING method_name,
+                  WSTRING method_name, short min_major, short min_minor,
+                  short max_major, short max_minor,
                   const std::vector<BYTE>& method_signature)
       : assembly(assembly_name),
         type_name(type_name),
         method_name(method_name),
-        method_signature(method_signature) {}
+        method_signature(method_signature),
+        min_v_major(min_major),
+        min_v_minor(min_minor),
+        max_v_major(max_major),
+        max_v_minor(max_minor) {}
 
   inline WSTRING get_type_cache_key() const {
-    return "["_W + assembly.name + "]"_W + type_name;
+    return "["_W + assembly.name + "]"_W + type_name + "_vMin_"_W +
+           ToWSTRING(min_v_major) + "."_W + ToWSTRING(min_v_minor) +
+           "_vMax_"_W + ToWSTRING(max_v_major) + "."_W + ToWSTRING(max_v_minor);
   }
 
   inline WSTRING get_method_cache_key() const {
-    return "["_W + assembly.name + "]"_W + type_name + "."_W + method_name;
+    return "["_W + assembly.name + "]"_W + type_name + "."_W + method_name +
+           "_vMin_"_W + ToWSTRING(min_v_major) + "."_W +
+           ToWSTRING(min_v_minor) + "_vMax_"_W + ToWSTRING(max_v_major) +
+           "."_W + ToWSTRING(max_v_minor);
   }
 
   inline bool operator==(const MethodReference& other) const {
     return assembly == other.assembly && type_name == other.type_name &&
+           min_v_major == other.min_v_major &&
+           min_v_minor == other.min_v_minor &&
+           max_v_major == other.max_v_major &&
+           max_v_minor == other.max_v_minor &&
            method_name == other.method_name &&
            method_signature == other.method_signature;
   }

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -128,6 +128,26 @@ MethodReference MethodReferenceFromJson(const json::value_type& src) {
   const auto type = ToWSTRING(src.value("type", ""));
   const auto method = ToWSTRING(src.value("method", ""));
   auto raw_signature = src.value("signature", json::array());
+
+  const auto eoj = src.end();
+  USHORT min_major = 0;
+  USHORT min_minor = 0;
+  USHORT max_major = USHRT_MAX;
+  USHORT max_minor = USHRT_MAX;
+
+  if (src.find("minimum_major") != eoj) {
+    min_major = src["minimum_major"].get<USHORT>();
+  }
+  if (src.find("minimum_minor") != eoj) {
+    min_minor = src["minimum_minor"].get<USHORT>();
+  }
+  if (src.find("maximum_major") != eoj) {
+    max_major = src["maximum_major"].get<USHORT>();
+  }
+  if (src.find("maximum_minor") != eoj) {
+    max_minor = src["maximum_minor"].get<USHORT>();
+  }
+
   std::vector<BYTE> signature;
   if (raw_signature.is_array()) {
     for (auto& el : raw_signature) {
@@ -159,7 +179,8 @@ MethodReference MethodReferenceFromJson(const json::value_type& src) {
       prev = b;
     }
   }
-  return MethodReference(assembly, type, method, signature);
+  return MethodReference(assembly, type, method, min_major, min_minor,
+                         max_major, max_minor, signature);
 }
 
 }  // namespace

--- a/src/Datadog.Trace.ClrProfiler.Native/string.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.cpp
@@ -20,6 +20,11 @@ WSTRING ToWSTRING(const std::string& str) {
   return WSTRING(reinterpret_cast<const WCHAR*>(ustr.c_str()));
 }
 
+WSTRING ToWSTRING(const uint64_t i) {
+  const auto ustr = ToString(i);
+  return ToWSTRING(ustr);
+}
+
 WCHAR operator"" _W(const char c) { return WCHAR(c); }
 
 WSTRING operator"" _W(const char* arr, size_t size) {

--- a/src/Datadog.Trace.ClrProfiler.Native/string.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.h
@@ -16,6 +16,7 @@ std::string ToString(const uint64_t i);
 std::string ToString(const WSTRING& wstr);
 
 WSTRING ToWSTRING(const std::string& str);
+WSTRING ToWSTRING(const uint64_t i);
 
 WCHAR operator"" _W(const char c);
 WSTRING operator"" _W(const char* arr, size_t size);

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -74,7 +74,7 @@ TEST_F(DISABLED_CLRHelperTest, EnumeratesAssemblyRefs) {
   std::vector<std::wstring> expected_assemblies = {L"System.Runtime"};
   std::vector<std::wstring> actual_assemblies;
   for (auto& ref : EnumAssemblyRefs(assembly_import_)) {
-    auto name = GetAssemblyName(assembly_import_, ref);
+    auto name = GetReferencedAssemblyMetadata(assembly_import_, ref).name;
     if (!name.empty()) {
       actual_assemblies.push_back(name);
     }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -83,14 +83,33 @@ TEST_F(DISABLED_CLRHelperTest, EnumeratesAssemblyRefs) {
 }
 
 TEST_F(DISABLED_CLRHelperTest, FiltersEnabledIntegrations) {
-  Integration i1 = {
-      L"integration-1",
-      {{{}, {L"Samples.ExampleLibrary", L"SomeType", L"SomeMethod", {}}, {}}}};
-  Integration i2 = {
-      L"integration-2",
-      {{{}, {L"Assembly.Two", L"SomeType", L"SomeMethod", {}}, {}}}};
-  Integration i3 = {L"integration-3",
-                    {{{}, {L"System.Runtime", L"", L"", {}}, {}}}};
+  Integration i1 = {L"integration-1",
+                    {{{},
+                      {L"Samples.ExampleLibrary",
+                       L"SomeType",
+                       L"SomeMethod",
+                       0,
+                       0,
+                       USHRT_MAX,
+                       USHRT_MAX,
+                       {}},
+                      {}}}};
+  Integration i2 = {L"integration-2",
+                    {{{},
+                      {L"Assembly.Two",
+                       L"SomeType",
+                       L"SomeMethod",
+                       0,
+                       0,
+                       USHRT_MAX,
+                       USHRT_MAX,
+                       {}},
+                      {}}}};
+  Integration i3 = {
+      L"integration-3",
+      {{{},
+        {L"System.Runtime", L"", L"", 0, 0, USHRT_MAX, USHRT_MAX, {}},
+        {}}}};
   std::vector<Integration> all = {i1, i2, i3};
   std::vector<Integration> expected = {i1, i3};
   std::vector<WSTRING> disabled_integrations = {"integration-2"_W};
@@ -100,29 +119,65 @@ TEST_F(DISABLED_CLRHelperTest, FiltersEnabledIntegrations) {
 }
 
 TEST_F(DISABLED_CLRHelperTest, FiltersIntegrationsByCaller) {
-  Integration i1 = {
-      L"integration-1",
-      {{{L"Assembly.One", L"SomeType", L"SomeMethod", {}}, {}, {}}}};
-  Integration i2 = {
-      L"integration-2",
-      {{{L"Assembly.Two", L"SomeType", L"SomeMethod", {}}, {}, {}}}};
+  Integration i1 = {L"integration-1",
+                    {{{L"Assembly.One",
+                       L"SomeType",
+                       L"SomeMethod",
+                       0,
+                       0,
+                       USHRT_MAX,
+                       USHRT_MAX,
+                       {}},
+                      {},
+                      {}}}};
+  Integration i2 = {L"integration-2",
+                    {{{L"Assembly.Two",
+                       L"SomeType",
+                       L"SomeMethod",
+                       0,
+                       0,
+                       USHRT_MAX,
+                       USHRT_MAX,
+                       {}},
+                      {},
+                      {}}}};
   Integration i3 = {L"integration-3", {{{}, {}, {}}}};
   std::vector<Integration> all = {i1, i2, i3};
   std::vector<Integration> expected = {i1, i3};
+  trace::AssemblyInfo assembly_info = {1, L"Assembly.One"};
   std::vector<Integration> actual =
-      FilterIntegrationsByCaller(all, L"Assembly.One");
+      FilterIntegrationsByCaller(all, assembly_info);
   EXPECT_EQ(expected, actual);
 }
 
 TEST_F(DISABLED_CLRHelperTest, FiltersIntegrationsByTarget) {
-  Integration i1 = {
-      L"integration-1",
-      {{{}, {L"Samples.ExampleLibrary", L"SomeType", L"SomeMethod", {}}, {}}}};
-  Integration i2 = {
-      L"integration-2",
-      {{{}, {L"Assembly.Two", L"SomeType", L"SomeMethod", {}}, {}}}};
-  Integration i3 = {L"integration-3",
-                    {{{}, {L"System.Runtime", L"", L"", {}}, {}}}};
+  Integration i1 = {L"integration-1",
+                    {{{},
+                      {L"Samples.ExampleLibrary",
+                       L"SomeType",
+                       L"SomeMethod",
+                       0,
+                       0,
+                       USHRT_MAX,
+                       USHRT_MAX,
+                       {}},
+                      {}}}};
+  Integration i2 = {L"integration-2",
+                    {{{},
+                      {L"Assembly.Two",
+                       L"SomeType",
+                       L"SomeMethod",
+                       0,
+                       0,
+                       USHRT_MAX,
+                       USHRT_MAX,
+                       {}},
+                      {}}}};
+  Integration i3 = {
+      L"integration-3",
+      {{{},
+        {L"System.Runtime", L"", L"", 0, 0, USHRT_MAX, USHRT_MAX, {}},
+        {}}}};
   std::vector<Integration> all = {i1, i2, i3};
   std::vector<Integration> expected = {i1, i3};
   std::vector<Integration> actual =

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
@@ -44,7 +44,7 @@ class MetadataBuilderTest : public ::testing::Test {
     hr = metadata_dispenser_->OpenScope(L"Samples.ExampleLibrary.dll",
                                         ofReadWriteMask, IID_IMetaDataImport2,
                                         metadataInterfaces.GetAddressOf());
-    ASSERT_TRUE(SUCCEEDED(hr));
+    ASSERT_TRUE(SUCCEEDED(hr)) << "File not found: Samples.ExampleLibrary.dll";
 
     const auto metadataImport =
         metadataInterfaces.As<IMetaDataImport2>(IID_IMetaDataImport2);
@@ -91,13 +91,13 @@ TEST_F(MetadataBuilderTest, StoresWrapperMemberRef) {
 
   mdMemberRef tmp;
   auto ok = module_metadata_->TryGetWrapperMemberRef(
-      L"[Samples.ExampleLibrary]Class1.Add", tmp);
+      L"[Samples.ExampleLibrary]Class1.Add_vMin_0.0_vMax_65535.65535", tmp);
   EXPECT_TRUE(ok);
   EXPECT_NE(tmp, 0);
 
   tmp = 0;
   ok = module_metadata_->TryGetWrapperMemberRef(
-      L"[Samples.ExampleLibrary]Class2.Add", tmp);
+      L"[Samples.ExampleLibrary]Class2.Add_vMin_0.0_vMax_65535.65535", tmp);
   EXPECT_FALSE(ok);
   EXPECT_EQ(tmp, 0);
 }
@@ -114,7 +114,7 @@ TEST_F(MetadataBuilderTest, StoresWrapperMemberRefForSeparateAssembly) {
 
   mdMemberRef tmp;
   auto ok = module_metadata_->TryGetWrapperMemberRef(
-      L"[Samples.ExampleLibraryTracer]Class1.Add", tmp);
+      L"[Samples.ExampleLibraryTracer]Class1.Add_vMin_0.0_vMax_65535.65535", tmp);
   EXPECT_TRUE(ok);
   EXPECT_NE(tmp, 0);
 }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
@@ -80,9 +80,11 @@ class MetadataBuilderTest : public ::testing::Test {
 };
 
 TEST_F(MetadataBuilderTest, StoresWrapperMemberRef) {
-  MethodReference ref1(L"", L"", L"", {});
-  MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", {});
-  MethodReference ref3(L"Samples.ExampleLibrary", L"Class1", L"Add", {});
+  MethodReference ref1(L"", L"", L"", 0, 0, USHRT_MAX, USHRT_MAX, {});
+  MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", 0, 0,
+                       USHRT_MAX, USHRT_MAX, {});
+  MethodReference ref3(L"Samples.ExampleLibrary", L"Class1", L"Add", 0, 0,
+                       USHRT_MAX, USHRT_MAX, {});
   MethodReplacement mr1(ref1, ref2, ref3);
   auto hr = metadata_builder_->StoreWrapperMethodRef(mr1);
   ASSERT_EQ(S_OK, hr);
@@ -101,9 +103,11 @@ TEST_F(MetadataBuilderTest, StoresWrapperMemberRef) {
 }
 
 TEST_F(MetadataBuilderTest, StoresWrapperMemberRefForSeparateAssembly) {
-  MethodReference ref1(L"", L"", L"", {});
-  MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", {});
-  MethodReference ref3(L"Samples.ExampleLibraryTracer", L"Class1", L"Add", {});
+  MethodReference ref1(L"", L"", L"", 0, 0, USHRT_MAX, USHRT_MAX, {});
+  MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", 0, 0,
+                       USHRT_MAX, USHRT_MAX, {});
+  MethodReference ref3(L"Samples.ExampleLibraryTracer", L"Class1", L"Add", 0, 0,
+                       USHRT_MAX, USHRT_MAX, {});
   MethodReplacement mr1(ref1, ref2, ref3);
   auto hr = metadata_builder_->StoreWrapperMethodRef(mr1);
   ASSERT_EQ(S_OK, hr);

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/packages.config
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.1" targetFramework="native" />
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.0" targetFramework="native" />
   <package id="nlohmann.json" version="3.5.0" targetFramework="native" />
 </packages>

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/packages.config
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.0" targetFramework="native" />
+  <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.1" targetFramework="native" />
   <package id="nlohmann.json" version="3.5.0" targetFramework="native" />
 </packages>

--- a/tools/GenerateIntegrationDefinitions/Program.cs
+++ b/tools/GenerateIntegrationDefinitions/Program.cs
@@ -48,7 +48,11 @@ namespace GenerateIntegrationDefinitions
                                                                  assembly = item.attribute.TargetAssembly,
                                                                  type = item.attribute.TargetType,
                                                                  method = item.attribute.TargetMethod ?? item.wrapperMethod.Name,
-                                                                 signature = item.attribute.TargetSignature
+                                                                 signature = item.attribute.TargetSignature,
+                                                                 minimum_major = item.attribute.TargetAssemblyMinimumMajor,
+                                                                 minimum_minor = item.attribute.TargetAssemblyMinimumMinor,
+                                                                 maximum_major = item.attribute.TargetAssemblyMaximumMajor,
+                                                                 maximum_minor = item.attribute.TargetAssemblyMaximumMinor
                                                              },
                                                              wrapper = new
                                                              {


### PR DESCRIPTION
This pull request enables specifying safe version ranges for targeted methods in integrations.

**Example: An integration which is only safe to load for v6 of the Elasticsearch.Net client**
```
[InterceptMethod(
            CallerAssembly = "Elasticsearch.Net",
            TargetAssembly = "Elasticsearch.Net",
            TargetType = "Elasticsearch.Net.IRequestPipeline",
            TargetAssemblyMinimumMajor = 6,
            TargetAssemblyMaximumMajor = 6)]
```

Filtering happens at `ModuleLoadFinished`, not the `JITCompilationStarted` event. Future enhancement would be to add another check within `JITCompilationStarted`.