### PR TITLE
Enable Resharper gtest runner

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/Datadog.Trace.ClrProfiler.Native.Tests.vcxproj
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/Datadog.Trace.ClrProfiler.Native.Tests.vcxproj
@@ -49,6 +49,9 @@
     <OutDir>bin\$(Configuration)\$(Platform)\</OutDir>
     <IntDir>obj\$(Configuration)\$(Platform)\</IntDir>
   </PropertyGroup>
+  <PropertyGroup>
+    <LocalDebuggerWorkingDirectory>$(OutDir)</LocalDebuggerWorkingDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
   </ItemGroup>


### PR DESCRIPTION
Enables resharper to run gtest suite. 
Resharper inherits the working directory from the project settings and the default was $(ProjectDir).
This meant the dlls for the sample libraries couldn't be found.
Updated the project to use $(OutDir) as the working directory in local debug.