### PR TITLE
MongoDB tests: Add conditional compilation

### DIFF
--- a/samples/Samples.MongoDB/Program.cs
+++ b/samples/Samples.MongoDB/Program.cs
@@ -53,15 +53,21 @@ namespace Samples.MongoDB
 
             using (var syncScope = Tracer.Instance.StartActive("sync-calls", serviceName: "Samples.MongoDB"))
             {
+#if MONGODB_2_2
                 collection.DeleteMany(allFilter);
                 collection.InsertOne(newDocument);
 
+#if MONGODB_2_7
                 var count = collection.CountDocuments(new BsonDocument());
+#else
+                var count = collection.Count(new BsonDocument());
+#endif
                 Console.WriteLine($"Documents: {count}");
 
                 var find = collection.Find(allFilter);
                 var allDocuments = find.ToList();
                 Console.WriteLine(allDocuments.FirstOrDefault());
+#endif
             }
         }
 
@@ -74,7 +80,12 @@ namespace Samples.MongoDB
                 await collection.DeleteManyAsync(allFilter);
                 await collection.InsertOneAsync(newDocument);
 
+#if MONGODB_2_7
                 var count = await collection.CountDocumentsAsync(new BsonDocument());
+#else
+                var count = await collection.CountAsync(new BsonDocument());
+#endif
+
                 Console.WriteLine($"Documents: {count}");
 
                 var find = await collection.FindAsync(allFilter);

--- a/samples/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/samples/Samples.MongoDB/Samples.MongoDB.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <MongoDBDriverVersion Condition="'$(MongoDBDriverVersion)' == ''">2.8.0</MongoDBDriverVersion>
+    <DefineConstants Condition="'$(MongoDBDriverVersion)'>='2.7.0'">$(DefineConstants);MONGODB_2_7</DefineConstants>
+    <DefineConstants Condition="'$(MongoDBDriverVersion)'>='2.2.0'">$(DefineConstants);MONGODB_2_2</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
+    <PackageReference Include="MongoDB.Driver" Version="$(MongoDBDriverVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
MongoDB tests: Add conditional compilation so MongoDB.Driver 2.0.x - 2.8.x can be compiled without hand-editing changing API calls.

Make property MongoDBDriverVersion the the property that dictates the version of the MongoDB.Driver NuGet package that is restored. This should also allow future test scripting to be made easier by manipulating the one property.