### PR TITLE
Colin/better build order

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -2,6 +2,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.28307.329
 MinimumVisualStudioVersion = 15.0.26124.0
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native", "src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.vcxproj", "{91B6272F-5780-4C94-8071-DBBA7B4F67F3}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native.DLL", "src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.DLL.vcxproj", "{C0C8D381-D6B9-4C76-9428-F40F2FA93A9A}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace", "src\Datadog.Trace\Datadog.Trace.csproj", "{5DFDF781-F24C-45B1-82EF-9125875A80A4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tests", "test\Datadog.Trace.Tests\Datadog.Trace.Tests.csproj", "{73A1BE1C-9C8A-43FA-86A8-BF2744B4C1BB}"
@@ -72,10 +76,6 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "Datadog.Trace.ClrProfiler.W
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native.Tests", "test\Datadog.Trace.ClrProfiler.Native.Tests\Datadog.Trace.ClrProfiler.Native.Tests.vcxproj", "{5728056A-51AA-4FF5-AD0C-E86E44E36102}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native", "src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.vcxproj", "{91B6272F-5780-4C94-8071-DBBA7B4F67F3}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native.DLL", "src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.DLL.vcxproj", "{C0C8D381-D6B9-4C76-9428-F40F2FA93A9A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ExampleLibrary", "sample-libs\Samples.ExampleLibrary\Samples.ExampleLibrary.csproj", "{FDB5C8D0-018D-4FF9-9680-C6A5078F819B}"
 EndProject

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\\$(Platform)\\**"
+    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
              CopyToOutputDirectory="PreserveNewest"
              CopyToPublishDirectory="PreserveNewest"
              Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -18,12 +18,12 @@
 
   <ItemGroup>
     <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
-             CopyToOutputDirectory="PreserveNewest"
-             CopyToPublishDirectory="PreserveNewest"
+             CopyToOutputDirectory="Always"
+             CopyToPublishDirectory="Always"
              Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Content Include="..\..\integrations.json"
-             CopyToOutputDirectory="PreserveNewest"
-             CopyToPublishDirectory="PreserveNewest"
-             Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
+             CopyToOutputDirectory="Always"
+             CopyToPublishDirectory="Always"
+             Link="profiler-lib\integrations.json" />
   </ItemGroup>
 </Project>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -17,11 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\**"
+    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\\$(Platform)\\**"
              CopyToOutputDirectory="PreserveNewest"
-             CopyToPublishDirectory="PreserveNewest" />
+             CopyToPublishDirectory="PreserveNewest"
+             Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Content Include="..\..\integrations.json"
              CopyToOutputDirectory="PreserveNewest"
-             CopyToPublishDirectory="PreserveNewest" />
+             CopyToPublishDirectory="PreserveNewest"
+             Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/samples/Samples.AspNetCoreMvc2/Properties/launchSettings.json
+++ b/samples/Samples.AspNetCoreMvc2/Properties/launchSettings.json
@@ -16,13 +16,13 @@
 
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "use64Bit": true,
       "nativeDebugging": true
@@ -35,13 +35,13 @@
 
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "applicationUrl": "http://localhost:54566/",
       "nativeDebugging": true

--- a/samples/Samples.Elasticsearch.V5/Properties/launchSettings.json
+++ b/samples/Samples.Elasticsearch.V5/Properties/launchSettings.json
@@ -5,13 +5,13 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.Elasticsearch/Properties/launchSettings.json
+++ b/samples/Samples.Elasticsearch/Properties/launchSettings.json
@@ -5,13 +5,13 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.HttpMessageHandler/Properties/launchSettings.json
+++ b/samples/Samples.HttpMessageHandler/Properties/launchSettings.json
@@ -6,13 +6,13 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.MongoDB/Properties/launchSettings.json
+++ b/samples/Samples.MongoDB/Properties/launchSettings.json
@@ -5,13 +5,13 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.Npgsql/Properties/launchSettings.json
+++ b/samples/Samples.Npgsql/Properties/launchSettings.json
@@ -5,13 +5,13 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.RedisCore/Properties/launchSettings.json
+++ b/samples/Samples.RedisCore/Properties/launchSettings.json
@@ -4,28 +4,28 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "A_DLL_THAT_I_WANT": "$(SolutionDir)src\\Project.Name\\bin\\$(Configuration)\\$(PlatformShortName)\\Project.Name.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
 
       "commandName": "Project",
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.SqlServer/Properties/launchSettings.json
+++ b/samples/Samples.SqlServer/Properties/launchSettings.json
@@ -5,13 +5,13 @@
       "environmentVariables": {
         "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(OutputRoot)$(Configuration)\\$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_INTEGRATIONS": "$(OutputRoot)integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },
       "nativeDebugging": true
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -5,15 +5,14 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
-  
+
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
-             CopyToOutputDirectory="Always"
-             CopyToPublishDirectory="Always"
-             Link="%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Content Include="..\..\integrations.json"
-             CopyToOutputDirectory="Always"
-             CopyToPublishDirectory="Always" />
+    <Content Include="..\..\integrations.json" Link="integrations.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\**"
+             CopyToOutputDirectory="PreserveNewest"
+             CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -5,14 +5,15 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
   </PropertyGroup>
-
+  
   <ItemGroup>
-    <Content Include="..\..\integrations.json" Link="integrations.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\**"
-             CopyToOutputDirectory="PreserveNewest"
-             CopyToPublishDirectory="PreserveNewest" />
+    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
+             CopyToOutputDirectory="Always"
+             CopyToPublishDirectory="Always"
+             Link="%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Content Include="..\..\integrations.json"
+             CopyToOutputDirectory="Always"
+             CopyToPublishDirectory="Always" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Move c++ projects to top of solution to have them build before samples.
Replace inconsistent OutputRoot variable.
Only copy relevant profiler subdirectory.