### PR TITLE
Force the sample projects to build Datadog.Trace.ClrProfiler.Native.dll

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -20,7 +20,7 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.DLL.vcxproj"
                       ReferenceOutputAssembly="false"
-                      Condition="'$(VCTargetsPath)'!=''" />
+                      Condition="'$(BuildingInsideVisualStudio)'=='true'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -18,7 +18,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
-    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.DLL.vcxproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.DLL.vcxproj"
+                      ReferenceOutputAssembly="false"
+                      Condition="'$(VCTargetsPath)'!=''" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.DLL.vcxproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Force the sample projects to build Datadog.Trace.ClrProfiler.Native.dll if it has not yet been built. This builds off Colin's edits to copy the native dll locally for each sample build so a clean build of any sample will build result in a local copy of the native dll and correct instrumentation for testing.