### PR TITLE
License / Documentation cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Datadog .NET Tracer for APM (dd-trace-csharp)
+Datadog .NET Tracer for APM (dd-trace-dotnet)
 Copyright 2018 Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Linux integration tests        | [![Build Status](https://dev.azure.com/datadog-
   - Individual components
     - .NET Framework 4.7 targeting pack
 - [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)
+- Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v3.4.4 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - Requires .NET Framework 3.5 SP2 (install from Windows Features control panel: `OptionalFeatures.exe`)
   - [WiX Toolset VS2017 Extension](https://marketplace.visualstudio.com/items?itemName=RobMensching.WixToolsetVisualStudio2017Extension) to build installer from VS2017
@@ -57,15 +58,17 @@ From a _Developer Command Prompt for VS 2017_:
 
 ```cmd
 rem Restore NuGet packages
-dotnet restore Datadog.Trace.sln
+rem nuget.exe is required for command line restore because msbuild doesn't support packages.config
+rem (see https://github.com/NuGet/Home/issues/7386)
+nuget restore Datadog.Trace.sln
 
 rem Build C# projects (Platform: always AnyCPU)
 msbuild Datadog.Trace.proj /t:BuildCsharp /p:Configuration=Release;Platform=AnyCPU
 
 rem Build NuGet packages
-dotnet pack src/Datadog.Trace/Datadog.Trace.csproj
-dotnet pack src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
-dotnet pack src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+dotnet pack src\Datadog.Trace\Datadog.Trace.csproj
+dotnet pack src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj
+dotnet pack src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj
 
 rem Build C++ projects (Platform: x64 or x86)
 msbuild Datadog.Trace.proj /t:BuildCpp /p:Configuration=Release;Platform=x64

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/build.ps1
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/build.ps1
@@ -13,7 +13,7 @@ Start-Process -NoNewWindow -Wait -FilePath "${Env:ProgramFiles(x86)}\WiX Toolset
 $args = @(
     ".\output\Product.wixobj",
     ".\output\WixUI_InstallDir_Custom.wixobj",
-    "-out", "output\dd-trace-csharp.msi",
+    "-out", "output\dd-trace-dotnet.msi",
     "-ext", "WixUIExtension"
 )
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <PackageIconUrl>https://github.com/DataDog/dd-trace-dotnet/raw/master/datadog-logo-64x64.png</PackageIconUrl>
     <PackageProjectUrl>https://docs.datadoghq.com/tracing/setup/dotnet/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/DataDog/dd-trace-dotnet/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReleaseNotes>See release notes at https://github.com/DataDog/dd-trace-dotnet/releases</PackageReleaseNotes>
     <PackageTags>Datadog;APM;tracing;profiling;instrumentation</PackageTags>


### PR DESCRIPTION
- Edit whitespace on LICENSE so hopefully GitHub will auto-recognize the license as Apache 2.0
- Change all instances of "dd-trace-csharp" to "dd-trace-dotnet"
- For NuGet packages, change PackageLicenseUrl (which is being deprecated) to License and correctly specify Apache-2.0
- Fix instructions for doing a Windows command line build