### PR TITLE
Compare wrapper method to target

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -226,12 +226,29 @@ struct FunctionInfo {
   const mdToken id;
   const WSTRING name;
   const TypeInfo type;
+  const BOOL is_generic;
   const MethodSignature signature;
+  const MethodSignature function_spec_signature;
 
-  FunctionInfo() : id(0), name(""_W), type({}), signature() {}
+  FunctionInfo() : id(0), name(""_W), type({}), is_generic(false) {}
+
+  FunctionInfo(mdToken id, WSTRING name, TypeInfo type,
+               MethodSignature signature,
+               MethodSignature function_spec_signature)
+      : id(id),
+        name(name),
+        type(type),
+        is_generic(true),
+        signature(signature),
+        function_spec_signature(function_spec_signature) {}
+
   FunctionInfo(mdToken id, WSTRING name, TypeInfo type,
                MethodSignature signature)
-      : id(id), name(name), type(type), signature(signature) {}
+      : id(id),
+        name(name),
+        type(type),
+        is_generic(false),
+        signature(signature) {}
 
   bool IsValid() const { return id != 0; }
 };

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -164,6 +164,10 @@ struct MethodSignature {
     }
     return ss.str();
   }
+
+  BOOL IsInstanceMethod() const {
+    return (CallingConvention() & IMAGE_CEE_CS_CALLCONV_HASTHIS) != 0;
+  }
 };
 
 struct MethodReference {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -4,6 +4,8 @@ using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
+#if !NET452
+
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class Elasticsearch5Tests : TestHelper
@@ -136,3 +138,5 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
     }
 }
+
+#endif


### PR DESCRIPTION
Override signature when we are targeting a generic method.
Introduce counts comparing wrappers against targets.