### PR TITLE
fix p/invoke on Linux

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
@@ -4,7 +4,7 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal static class NativeMethods
     {
-        [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
+        [DllImport("Datadog.Trace.ClrProfiler.Native")]
         public static extern bool IsProfilerAttached();
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
@@ -4,16 +4,7 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal static class NativeMethods
     {
-        public static class Windows
-        {
-            [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
-            public static extern bool IsProfilerAttached();
-        }
-
-        public static class Linux
-        {
-            [DllImport("Datadog.Trace.ClrProfiler.Native.so")]
-            public static extern bool IsProfilerAttached();
-        }
+        [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
+        public static extern bool IsProfilerAttached();
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
@@ -4,7 +4,16 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal static class NativeMethods
     {
-        [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
-        public static extern bool IsProfilerAttached();
+        public static class Windows
+        {
+            [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
+            public static extern bool IsProfilerAttached();
+        }
+
+        public static class Linux
+        {
+            [DllImport("Datadog.Trace.ClrProfiler.Native.so")]
+            public static extern bool IsProfilerAttached();
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -16,7 +16,6 @@ add_library("Datadog.Trace.ClrProfiler.Native.static" STATIC
     il_rewriter.cpp
     integration_loader.cpp
     integration.cpp
-    interop.cpp
     logging.cpp
     metadata_builder.cpp
     miniutf.cpp
@@ -40,6 +39,7 @@ target_link_libraries("Datadog.Trace.ClrProfiler.Native.static"
 
 add_library("Datadog.Trace.ClrProfiler.Native" SHARED
     dllmain.cpp
+    interop.cpp
 )
 set_target_properties("Datadog.Trace.ClrProfiler.Native" PROPERTIES PREFIX "")
 target_link_libraries("Datadog.Trace.ClrProfiler.Native" "Datadog.Trace.ClrProfiler.Native.static")


### PR DESCRIPTION
Fix the p/invoke call in property `Instrumentation.ProfilerAttached` so it works on Linux.

- bind to either `dll` or `so` file according to OS
- move exported method from static library to shared library