### PR TITLE
fix stack overflow when overriding HttpClientHandler.SendAsync()

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -141,12 +141,20 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.WebForms", "samples-aspnet\Samples.WebForms\Samples.WebForms.csproj", "{99A62CCF-8E7F-4D57-8383-D38C371C8087}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "reproductions", "reproductions", "{550AE553-2BBB-4021-B55A-137EF31A6B1F}"
+	ProjectSection(SolutionItems) = preProject
+		reproductions\Directory.Build.props = reproductions\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExpenseItDemo", "reproductions\Reproduction.Wpf.ExpenseIt\ExpenseIt\ExpenseItDemo\ExpenseItDemo.csproj", "{D1729F17-99A5-45AF-AB38-72FA6ECCE609}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Elasticsearch.V5", "samples\Samples.Elasticsearch.V5\Samples.Elasticsearch.V5.csproj", "{AD119B05-A092-41AD-B68E-4AE2DB5A96D9}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AutomapperTest", "reproductions\AutomapperTest\AutomapperTest.csproj", "{2AD18622-9A02-41B4-915E-798BD64044D5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{C0C8D381-D6B9-4C76-9428-F40F2FA93A9A} = {C0C8D381-D6B9-4C76-9428-F40F2FA93A9A}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HttpMessageHandler.StackOverflow", "reproductions\HttpMessageHandler.StackOverflow\HttpMessageHandler.StackOverflow.csproj", "{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}"
 	ProjectSection(ProjectDependencies) = postProject
 		{C0C8D381-D6B9-4C76-9428-F40F2FA93A9A} = {C0C8D381-D6B9-4C76-9428-F40F2FA93A9A}
 	EndProjectSection
@@ -501,6 +509,16 @@ Global
 		{2AD18622-9A02-41B4-915E-798BD64044D5}.Release|x64.Build.0 = Release|x64
 		{2AD18622-9A02-41B4-915E-798BD64044D5}.Release|x86.ActiveCfg = Release|x86
 		{2AD18622-9A02-41B4-915E-798BD64044D5}.Release|x86.Build.0 = Release|x86
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|x64.ActiveCfg = Debug|x64
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|x64.Build.0 = Debug|x64
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|x86.ActiveCfg = Debug|x86
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Debug|x86.Build.0 = Debug|x86
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|Any CPU.ActiveCfg = Release|x86
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|x64.ActiveCfg = Release|x64
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|x64.Build.0 = Release|x64
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|x86.ActiveCfg = Release|x86
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -537,6 +555,7 @@ Global
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{AD119B05-A092-41AD-B68E-4AE2DB5A96D9} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 		{2AD18622-9A02-41B4-915E-798BD64044D5} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{F47F206E-4CCA-4AD0-AEBA-FD9F491E05EC} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/integrations.json
+++ b/integrations.json
@@ -19,7 +19,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 02 1C 1C 08"
+          "signature": "00 03 1C 1C 08 08"
         }
       },
       {
@@ -39,7 +39,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 02 1C 1C 08"
+          "signature": "00 03 1C 1C 08 08"
         }
       },
       {
@@ -59,7 +59,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 03 1C 1C 08 1C"
+          "signature": "00 04 1C 1C 08 1C 08"
         }
       },
       {
@@ -79,7 +79,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 03 1C 1C 08 1C"
+          "signature": "00 04 1C 1C 08 1C 08"
         }
       }
     ]
@@ -106,7 +106,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "BeforeAction",
-          "signature": "00 04 01 1C 1C 1C 1C"
+          "signature": "00 05 01 1C 1C 1C 1C 08"
         }
       },
       {
@@ -128,7 +128,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "AfterAction",
-          "signature": "00 04 01 1C 1C 1C 1C"
+          "signature": "00 05 01 1C 1C 1C 1C 08"
         }
       },
       {
@@ -150,7 +150,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "Rethrow",
-          "signature": "00 01 01 1C"
+          "signature": "00 02 01 1C 08"
         }
       }
     ]
@@ -177,7 +177,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "BeginInvokeAction",
-          "signature": "00 05 1C 1C 1C 1C 1C 1C"
+          "signature": "00 06 1C 1C 1C 1C 1C 1C 08"
         }
       },
       {
@@ -199,7 +199,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "EndInvokeAction",
-          "signature": "00 02 02 1C 1C"
+          "signature": "00 03 02 1C 1C 08"
         }
       }
     ]
@@ -224,7 +224,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "ExecuteAsync",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       }
     ]
@@ -251,7 +251,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 02 1C 1C 1C"
+          "signature": "10 01 03 1C 1C 1C 08"
         }
       },
       {
@@ -273,7 +273,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 03 1C 1C 1C 1C"
+          "signature": "10 01 04 1C 1C 1C 1C 08"
         }
       }
     ]
@@ -300,7 +300,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 02 1C 1C 1C"
+          "signature": "10 01 03 1C 1C 1C 08"
         }
       },
       {
@@ -322,7 +322,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 03 1C 1C 1C 1C"
+          "signature": "10 01 04 1C 1C 1C 1C 08"
         }
       }
     ]
@@ -347,7 +347,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "SendAsync",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       },
       {
@@ -367,7 +367,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "SendAsync",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       }
     ]
@@ -392,7 +392,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       },
       {
@@ -412,7 +412,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       },
       {
@@ -432,7 +432,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       },
       {
@@ -452,7 +452,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
-          "signature": "00 03 1C 1C 1C 1C"
+          "signature": "00 04 1C 1C 1C 1C 08"
         }
       }
     ]
@@ -479,7 +479,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
-          "signature": "10 01 05 1E 00 1C 1D 1D 05 1C 1C 02"
+          "signature": "10 01 06 1E 00 1C 1D 1D 05 1C 1C 02 08"
         }
       }
     ]
@@ -506,7 +506,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 04 1E 00 1C 1C 1C 1C"
+          "signature": "10 01 05 1E 00 1C 1C 1C 1C 08"
         }
       },
       {
@@ -528,7 +528,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 04 1E 00 1C 1C 1C 1C"
+          "signature": "10 01 05 1E 00 1C 1C 1C 1C 08"
         }
       },
       {
@@ -550,7 +550,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 05 1C 1C 1C 1C 1C 1C"
+          "signature": "10 01 06 1C 1C 1C 1C 1C 1C 08"
         }
       },
       {
@@ -572,7 +572,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 05 1C 1C 1C 1C 1C 1C"
+          "signature": "10 01 06 1C 1C 1C 1C 1C 1C 08"
         }
       },
       {
@@ -594,7 +594,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 04 1C 1C 1C 1C 1C"
+          "signature": "10 01 05 1C 1C 1C 1C 1C 08"
         }
       },
       {
@@ -616,7 +616,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 04 1C 1C 1C 1C 1C"
+          "signature": "10 01 05 1C 1C 1C 1C 1C 08"
         }
       }
     ]
@@ -641,7 +641,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
           "method": "HandleRequest",
-          "signature": "00 03 02 1C 1C 1C"
+          "signature": "00 04 02 1C 1C 1C 08"
         }
       }
     ]
@@ -666,7 +666,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 01 1C 1C"
+          "signature": "00 02 1C 1C 08"
         }
       },
       {
@@ -686,7 +686,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 01 1C 1C"
+          "signature": "00 02 1C 1C 08"
         }
       },
       {
@@ -706,7 +706,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
-          "signature": "00 01 1C 1C"
+          "signature": "00 02 1C 1C 08"
         }
       }
     ]

--- a/integrations.json
+++ b/integrations.json
@@ -346,7 +346,7 @@
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
-          "method": "SendAsync",
+          "method": "HttpMessageHandler_SendAsync",
           "signature": "00 04 1C 1C 1C 1C 08"
         }
       },
@@ -366,7 +366,7 @@
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.2.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
-          "method": "SendAsync",
+          "method": "HttpClientHandler_SendAsync",
           "signature": "00 04 1C 1C 1C 1C 08"
         }
       }

--- a/reproductions/AutomapperTest/AutomapperTest.csproj
+++ b/reproductions/AutomapperTest/AutomapperTest.csproj
@@ -14,18 +14,4 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.8" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
-          CopyToOutputDirectory="Always"
-          CopyToPublishDirectory="Always"
-          Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Content Include="..\..\integrations.json"
-             CopyToOutputDirectory="Always"
-             CopyToPublishDirectory="Always"
-             Link="profiler-lib\integrations.json" />
-  </ItemGroup>
 </Project>

--- a/reproductions/Directory.Build.props
+++ b/reproductions/Directory.Build.props
@@ -1,6 +1,23 @@
 <Project>
   <PropertyGroup>
+    <Platforms>x64;x86</Platforms>
+    <PlatformTarget>$(Platform)</PlatformTarget>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
+          CopyToOutputDirectory="Always"
+          CopyToPublishDirectory="Always"
+          Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Content Include="..\..\integrations.json"
+             CopyToOutputDirectory="Always"
+             CopyToPublishDirectory="Always"
+             Link="profiler-lib\integrations.json" />
+  </ItemGroup>
 </Project>

--- a/reproductions/Directory.Build.props
+++ b/reproductions/Directory.Build.props
@@ -4,6 +4,7 @@
     <PlatformTarget>$(Platform)</PlatformTarget>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <ProfilerOutputDirectory>..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)</ProfilerOutputDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.dll;..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.so"
+    <None Include="$(ProfilerOutputDirectory)\*.dll;$(ProfilerOutputDirectory)\*.so;$(ProfilerOutputDirectory)\*.pdb"
           CopyToOutputDirectory="Always"
           CopyToPublishDirectory="Always"
           Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/reproductions/Directory.Build.props
+++ b/reproductions/Directory.Build.props
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
+    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.dll;..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.so"
           CopyToOutputDirectory="Always"
           CopyToPublishDirectory="Always"
           Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/reproductions/HttpMessageHandler.StackOverflow/HttpMessageHandler.StackOverflow.csproj
+++ b/reproductions/HttpMessageHandler.StackOverflow/HttpMessageHandler.StackOverflow.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
+    <Platforms>x64;x86</Platforms>
+    <PlatformTarget>$(Platform)</PlatformTarget>
+  </PropertyGroup>
+
+</Project>

--- a/reproductions/HttpMessageHandler.StackOverflow/Program.cs
+++ b/reproductions/HttpMessageHandler.StackOverflow/Program.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace;
+using Datadog.Trace.ClrProfiler;
+
+namespace HttpMessageHandler.StackOverflow
+{
+    internal class Program
+    {
+        private static async Task Main()
+        {
+            Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
+
+            var baseAddress = new Uri("https://www.example.com/");
+            var regularHttpClient = new HttpClient { BaseAddress = baseAddress };
+            var customHandlerHttpClient = new HttpClient(new DerivedHandler()) { BaseAddress = baseAddress };
+
+            using (var scope = Tracer.Instance.StartActive("main"))
+            {
+                Console.WriteLine("Calling regularHttpClient.GetAsync");
+                await regularHttpClient.GetAsync("default-handler");
+                Console.WriteLine("Called regularHttpClient.GetAsync");
+
+                Console.WriteLine("Calling customHandlerHttpClient.GetAsync");
+                await customHandlerHttpClient.GetAsync("derived-handler");
+                Console.WriteLine("Called customHandlerHttpClient.GetAsync");
+            }
+        }
+    }
+
+    public class DerivedHandler : HttpClientHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Tracer.Instance.ActiveScope?.Span.SetTag("class", nameof(DerivedHandler));
+
+            Console.WriteLine("Calling base.SendAsync()");
+            var result = await base.SendAsync(request, cancellationToken);
+            Console.WriteLine("Called base.SendAsync()");
+            return result;
+        }
+    }
+}

--- a/reproductions/HttpMessageHandler.StackOverflow/Properties/launchSettings.json
+++ b/reproductions/HttpMessageHandler.StackOverflow/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "profiles": {
+    "HttpMessageHandler.StackOverflow": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -10,6 +10,7 @@
 
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <ProfilerOutputDirectory>..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)</ProfilerOutputDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,10 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.dll;..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.so"
-             CopyToOutputDirectory="Always"
-             CopyToPublishDirectory="Always"
-             Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <None Include="$(ProfilerOutputDirectory)\*.dll;$(ProfilerOutputDirectory)\*.so;$(ProfilerOutputDirectory)\*.pdb"
+          CopyToOutputDirectory="Always"
+          CopyToPublishDirectory="Always"
+          Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Content Include="..\..\integrations.json"
              CopyToOutputDirectory="Always"
              CopyToPublishDirectory="Always"

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**"
+    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.dll;..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\*.so"
              CopyToOutputDirectory="Always"
              CopyToPublishDirectory="Always"
              Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/DynamicMethodBuilder.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection.Emit;
+using Datadog.Trace.ClrProfiler.Emit;
 
 namespace Datadog.Trace.ClrProfiler
 {
@@ -32,6 +31,7 @@ namespace Datadog.Trace.ClrProfiler
             return Emit.DynamicMethodBuilder<TDelegate>.GetOrCreateMethodCallDelegate(
                 type,
                 methodName,
+                OpCodeValue.Callvirt,
                 returnType,
                 methodParameterTypes,
                 methodGenericArguments);
@@ -52,7 +52,12 @@ namespace Datadog.Trace.ClrProfiler
             Type[] methodParameterTypes = null,
             Type[] methodGenericArguments = null)
         {
-            return Emit.DynamicMethodBuilder<TDelegate>.CreateMethodCallDelegate(type, methodName, methodParameterTypes, methodGenericArguments);
+            return Emit.DynamicMethodBuilder<TDelegate>.CreateMethodCallDelegate(
+                type,
+                methodName,
+                OpCodeValue.Callvirt,
+                methodParameterTypes,
+                methodGenericArguments);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
@@ -9,7 +9,7 @@ using Sigil;
 namespace Datadog.Trace.ClrProfiler.Emit
 {
     /// <summary>
-    /// Helper class to instances of <see cref="DynamicMethod"/> using <see cref="System.Reflection.Emit"/>.
+    /// Helper class to create instances of <see cref="DynamicMethod"/> using <see cref="System.Reflection.Emit"/>.
     /// </summary>
     /// <typeparam name="TDelegate">The type of delegate</typeparam>
     internal static class DynamicMethodBuilder<TDelegate>
@@ -18,7 +18,8 @@ namespace Datadog.Trace.ClrProfiler.Emit
         private static readonly ConcurrentDictionary<Key, TDelegate> _cached = new ConcurrentDictionary<Key, TDelegate>(new KeyComparer());
 
         /// <summary>
-        /// Memoizes CreateMethodCallDelegate
+        /// Gets a previously cache delegate used to call the specified method,
+        /// or creates and caches a new delegate if not found.
         /// </summary>
         /// <param name="type">The <see cref="Type"/> that contains the method.</param>
         /// <param name="methodName">The name of the method.</param>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
@@ -336,7 +336,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 }
             }
 
-            if (callOpCode == OpCodeValue.Call)
+            if (callOpCode == OpCodeValue.Call || methodInfo.IsStatic)
             {
                 // non-virtual call (e.g. static method, or method override calling overriden implementation)
                 dynamicMethod.Call(methodInfo);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/OpCodeValues.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/OpCodeValues.cs
@@ -1,0 +1,11 @@
+namespace Datadog.Trace.ClrProfiler.Emit
+{
+    internal enum OpCodeValue : short
+    {
+        /// <seealso cref="System.Reflection.Emit.OpCodes.Call"/>
+        Call = 40,
+
+        /// <seealso cref="System.Reflection.Emit.OpCodes.Callvirt"/>
+        Callvirt = 111
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="this">The <see cref="DbCommand"/> that is references by the "this" pointer in the instrumented method.</param>
         /// <param name="behavior">A value from <see cref="CommandBehavior"/>.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
@@ -34,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "System.Data.Common.DbCommand",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object ExecuteDbDataReader(object @this, int behavior)
+        public static object ExecuteDbDataReader(object @this, int behavior, int opCode)
         {
             var command = (DbCommand)@this;
             var commandBehavior = (CommandBehavior)behavior;
@@ -64,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="this">The <see cref="DbCommand"/> that is references by the "this" pointer in the instrumented method.</param>
         /// <param name="behavior">A value from <see cref="CommandBehavior"/>.</param>
         /// <param name="cancellationTokenSource">A cancellation token source that can be used to cancel the async operation.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
@@ -75,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "System.Data.Common.DbCommand",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource)
+        public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -136,6 +136,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="actionDescriptor">An ActionDescriptor with information about the current action.</param>
         /// <param name="httpContext">The HttpContext for the current request.</param>
         /// <param name="routeData">A RouteData with information about the current route.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         [InterceptMethod(
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
@@ -146,7 +147,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object diagnosticSource,
             object actionDescriptor,
             object httpContext,
-            object routeData)
+            object routeData,
+            int opCode)
         {
             AspNetCoreMvc2Integration integration = null;
 
@@ -207,6 +209,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="actionDescriptor">An ActionDescriptor with information about the current action.</param>
         /// <param name="httpContext">The HttpContext for the current request.</param>
         /// <param name="routeData">A RouteData with information about the current route.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         [InterceptMethod(
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
@@ -217,7 +220,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object diagnosticSource,
             object actionDescriptor,
             object httpContext,
-            object routeData)
+            object routeData,
+            int opCode)
         {
             AspNetCoreMvc2Integration integration = null;
 
@@ -277,13 +281,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// Wrapper method used to catch unhandled exceptions in the incoming request pipeline for Microsoft.AspNetCore.Mvc.Core
         /// </summary>
         /// <param name="context">The DiagnosticSource that this extension method was called on.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         [InterceptMethod(
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = ResourceInvoker,
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
-        public static void Rethrow(object context)
+        public static void Rethrow(object context, int opCode)
         {
             AspNetCoreMvc2Integration integration = null;
             const string methodName = nameof(Rethrow);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -154,6 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="actionName">The name of the controller action.</param>
         /// <param name="callback">An <see cref="AsyncCallback"/> delegate.</param>
         /// <param name="state">An object that holds the state of the async operation.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>Returns the <see cref="IAsyncResult "/> returned by the original BeginInvokeAction() that is later passed to <see cref="EndInvokeAction"/>.</returns>
         [InterceptMethod(
             CallerAssembly = "System.Web.Mvc",
@@ -166,7 +167,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             dynamic controllerContext,
             dynamic actionName,
             dynamic callback,
-            dynamic state)
+            dynamic state,
+            int opCode)
         {
             Scope scope = null;
 
@@ -200,6 +202,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="asyncControllerActionInvoker">The IAsyncActionInvoker instance.</param>
         /// <param name="asyncResult">The <see cref="IAsyncResult"/> returned by <see cref="BeginInvokeAction"/>.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>Returns the <see cref="bool"/> returned by the original EndInvokeAction().</returns>
         [InterceptMethod(
             CallerAssembly = "System.Web.Mvc",
@@ -207,7 +210,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "System.Web.Mvc.Async.IAsyncActionInvoker",
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
-        public static bool EndInvokeAction(dynamic asyncControllerActionInvoker, dynamic asyncResult)
+        public static bool EndInvokeAction(dynamic asyncControllerActionInvoker, dynamic asyncResult, int opCode)
         {
             Scope scope = null;
             var httpContext = HttpContext.Current;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -29,13 +29,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="apiController">The Api Controller</param>
         /// <param name="controllerContext">The controller context for the call</param>
         /// <param name="cancellationTokenSource">The cancellation token source</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>A task with the result</returns>
         [InterceptMethod(
             TargetAssembly = "System.Web.Http",
             TargetType = "System.Web.Http.Controllers.IHttpController",
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
-        public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource)
+        public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode)
         {
             if (apiController == null) { throw new ArgumentNullException(nameof(apiController)); }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <typeparam name="TResponse">The type of the response</typeparam>
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -31,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "Elasticsearch.Net.IRequestPipeline",
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
-        public static object CallElasticsearch<TResponse>(object pipeline, object requestData)
+        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
         {
             // TResponse CallElasticsearch<TResponse>(RequestData requestData) where TResponse : class, IElasticsearchResponse, new();
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object>>
@@ -61,6 +62,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
         /// <param name="cancellationTokenSource">A cancellation token</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -68,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "Elasticsearch.Net.IRequestPipeline",
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
-        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource)
+        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)
         {
             // Task<ElasticsearchResponse<TReturn>> CallElasticsearchAsync<TReturn>(RequestData requestData, CancellationToken cancellationToken) where TReturn : class;
             var tokenSource = cancellationTokenSource as CancellationTokenSource;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <typeparam name="TResponse">The type of the response</typeparam>
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -29,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "Elasticsearch.Net.IRequestPipeline",
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
-        public static object CallElasticsearch<TResponse>(object pipeline, object requestData)
+        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
         {
             // TResponse CallElasticsearch<TResponse>(RequestData requestData) where TResponse : class, IElasticsearchResponse, new();
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, TResponse>>
@@ -59,6 +60,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
         /// <param name="cancellationTokenSource">A cancellation token</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -66,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "Elasticsearch.Net.IRequestPipeline",
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
-        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource)
+        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)
         {
             // Task<TResponse> CallElasticsearchAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken) where TResponse : class, IElasticsearchResponse, new();
             var tokenSource = cancellationTokenSource as CancellationTokenSource;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="handler">The <see cref="HttpMessageHandler"/> instance to instrument.</param>
         /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
         /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Net.Http",
@@ -35,7 +36,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object SendAsync(
             object handler,
             object request,
-            object cancellationTokenSource)
+            object cancellationTokenSource,
+            int opCode)
         {
             // HttpMessageHandler
             // Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -31,12 +31,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpClientHandler",
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)] // .NET Framework and .NET Core 2.0 and earlier
-            /*
-        [InterceptMethod(
-            TargetAssembly = "System.Net.Http",
-            TargetType = "System.Net.Http.SocketsHttpHandler")] // .NET Core 2.1 and later
-        */
+            TargetMaximumVersion = Major4)]
         public static object SendAsync(
             object handler,
             object request,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -3,12 +3,13 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
     /// <summary>
-    /// Tracer integration for HttpMessageHandler.
+    /// Tracer integration for HttpClientHandler.
     /// </summary>
     public static class HttpMessageHandlerIntegration
     {
@@ -26,46 +27,88 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpMessageHandler",
+            TargetMethod = "SendAsync",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        [InterceptMethod(
-            TargetAssembly = "System.Net.Http",
-            TargetType = "System.Net.Http.HttpClientHandler",
-            TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
-        public static object SendAsync(
+        public static object HttpMessageHandler_SendAsync(
             object handler,
             object request,
             object cancellationTokenSource,
             int opCode)
         {
-            // HttpMessageHandler
-            // Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            // original signature:
+            // Task<HttpResponseMessage> HttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var callOpCode = (OpCodeValue)opCode;
+            var handlerType = typeof(HttpMessageHandler); // Note the HttpMessageHandler to match the method call we replaced
+
+            var sendAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
+                                .GetOrCreateMethodCallDelegate(
+                                     handlerType,
+                                     "SendAsync",
+                                     callOpCode);
 
             return SendAsyncInternal(
+                sendAsync,
+                callOpCode == OpCodeValue.Call ? handlerType : handler.GetType(),
+                (HttpMessageHandler)handler,
+                (HttpRequestMessage)request,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for <see cref="HttpMessageHandler.SendAsync"/>.
+        /// </summary>
+        /// <param name="handler">The <see cref="HttpMessageHandler"/> instance to instrument.</param>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
+        /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <returns>Returns the value returned by the inner method call.</returns>
+        [InterceptMethod(
+            TargetAssembly = "System.Net.Http",
+            TargetType = "System.Net.Http.HttpClientHandler",
+            TargetMethod = "SendAsync",
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object HttpClientHandler_SendAsync(
+            object handler,
+            object request,
+            object cancellationTokenSource,
+            int opCode)
+        {
+            // original signature:
+            // Task<HttpResponseMessage> HttpClientHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            var tokenSource = cancellationTokenSource as CancellationTokenSource;
+            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var callOpCode = (OpCodeValue)opCode;
+            var handlerType = typeof(HttpClientHandler); // Note the HttpClientHandler to match the method call we replaced
+
+            var sendAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
+                                .GetOrCreateMethodCallDelegate(
+                                     handlerType,
+                                     "SendAsync",
+                                     callOpCode);
+
+            return SendAsyncInternal(
+                sendAsync,
+                callOpCode == OpCodeValue.Call ? handlerType : handler.GetType(),
                 (HttpMessageHandler)handler,
                 (HttpRequestMessage)request,
                 cancellationToken);
         }
 
         private static async Task<HttpResponseMessage> SendAsyncInternal(
+            Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> sendAsync,
+            Type handlerType,
             HttpMessageHandler handler,
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var handlerType = handler.GetType();
-
-            var executeAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
-               .GetOrCreateMethodCallDelegate(
-                    handlerType,
-                    nameof(SendAsync));
-
-            if (handlerType.FullName != "System.Net.Http.HttpClientHandler" || !IsTracingEnabled(request))
+            if (!(handler is HttpClientHandler) || !IsTracingEnabled(request))
             {
                 // skip instrumentation
-                return await executeAsync(handler, request, cancellationToken).ConfigureAwait(false);
+                return await sendAsync(handler, request, cancellationToken).ConfigureAwait(false);
             }
 
             string httpMethod = request.Method?.Method;
@@ -76,11 +119,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                     if (scope != null)
                     {
+                        scope.Span.SetTag("http-client-handler-type", handlerType.FullName);
+
                         // add distributed tracing headers to the HTTP request
                         SpanContextPropagator.Instance.Inject(scope.Span.Context, request.Headers.Wrap());
                     }
 
-                    HttpResponseMessage response = await executeAsync(handler, request, cancellationToken).ConfigureAwait(false);
+                    HttpResponseMessage response = await sendAsync(handler, request, cancellationToken).ConfigureAwait(false);
 
                     // this tag can only be set after the response is returned
                     scope?.Span.SetTag(Tags.HttpStatusCode, ((int)response.StatusCode).ToString());

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="wireProtocol">The IWireProtocol`1 or IWireProtocol instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
@@ -45,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = IWireProtocolGeneric,
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
-        public static object Execute(object wireProtocol, object connection, object cancellationTokenSource)
+        public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
@@ -91,6 +92,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="wireProtocol">The IWireProtocol instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetMethod = nameof(ExecuteAsync),
@@ -98,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = IWireProtocol,
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource)
+        public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
@@ -111,6 +113,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="wireProtocol">The IWireProtocol`1 instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetMethod = nameof(ExecuteAsync),
@@ -118,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = IWireProtocolGeneric,
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource)
+        public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="fn">The function</param>
         /// <param name="completePipelineFn">An optional function to call to complete a pipeline</param>
         /// <param name="sendWithoutRead">Whether or to send without waiting for the result</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "ServiceStack.Redis",
@@ -29,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "ServiceStack.Redis.RedisNativeClient",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
-        public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead)
+        public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)
         {
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, byte[][], object, object, bool, T>>
                .GetOrCreateMethodCallDelegate(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -47,9 +47,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, T>>
                .CreateMethodCallDelegate(
                     multiplexerType,
-                    "ExecuteSyncImpl",
-                    new[] { messageType, processorType, serverType },
-                    new[] { resultType });
+                    methodName: "ExecuteSyncImpl",
+                    methodParameterTypes: new[] { messageType, processorType, serverType },
+                    methodGenericArguments: new[] { resultType });
 
             using (var scope = CreateScope(multiplexer, message))
             {
@@ -117,9 +117,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, object, Task<T>>>
                .CreateMethodCallDelegate(
                     multiplexerType,
-                    "ExecuteAsyncImpl",
-                    new[] { messageType, processorType, stateType, serverType },
-                    new[] { genericType });
+                    methodName: "ExecuteAsyncImpl",
+                    methodParameterTypes: new[] { messageType, processorType, stateType, serverType },
+                    methodGenericArguments: new[] { genericType });
 
             using (var scope = CreateScope(multiplexer, message))
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="message">The message to send to redis.</param>
         /// <param name="processor">The processor to handle the result.</param>
         /// <param name="server">The server to call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The result</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
-        public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server)
+        public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server, int opCode)
         {
             var resultType = typeof(T);
             var multiplexerType = multiplexer.GetType();
@@ -74,6 +75,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="processor">The processor to handle the result.</param>
         /// <param name="state">The state to use for the task.</param>
         /// <param name="server">The server to call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>An asynchronous task.</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -89,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server)
+        public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server, int opCode)
         {
             return ExecuteAsyncImplInternal<T>(multiplexer, message, processor, state, server);
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="message">The message</param>
         /// <param name="processor">The result processor</param>
         /// <param name="server">The server</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>An asynchronous task.</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -34,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetType = "StackExchange.Redis.RedisBase",
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
-        public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server)
+        public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode)
         {
             return ExecuteAsyncInternal<T>(redisBase, message, processor, server);
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -61,9 +61,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, Task<T>>>
                .CreateMethodCallDelegate(
                     thisType,
-                    "ExecuteAsync",
-                    new[] { messageType, processorType, serverType },
-                    new[] { genericType });
+                    methodName: "ExecuteAsync",
+                    methodParameterTypes: new[] { messageType, processorType, serverType },
+                    methodGenericArguments: new[] { genericType });
 
             // we only trace RedisBatch methods here
             if (thisType == batchType)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -20,13 +20,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="thisObj">The ChannelHandler instance.</param>
         /// <param name="requestContext">A System.ServiceModel.Channels.RequestContext implementation instance.</param>
         /// <param name="currentOperationContext">A System.ServiceModel.OperationContext instance.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.ServiceModel",
             TargetType = "System.ServiceModel.Dispatcher.ChannelHandler",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext)
+        public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode)
         {
             var handleRequestDelegate = Emit.DynamicMethodBuilder<Func<object, object, object, bool>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "HandleRequest");
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// Instrumentation wrapper for <see cref="WebRequest.GetResponse"/>.
         /// </summary>
         /// <param name="webRequest">The <see cref="WebRequest"/> instance to instrument.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System", // .NET Framework
@@ -28,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = "System.Net.WebRequest",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object GetResponse(object webRequest)
+        public static object GetResponse(object webRequest, int opCode)
         {
             var request = (WebRequest)webRequest;
 
@@ -68,13 +69,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// Instrumentation wrapper for <see cref="WebRequest.GetResponseAsync"/>.
         /// </summary>
         /// <param name="request">The <see cref="WebRequest"/> instance to instrument.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Net",
             TargetType = "System.Net.WebRequest",
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object GetResponseAsync(object request)
+        public static object GetResponseAsync(object request, int opCode)
         {
             return GetResponseAsyncInternal((WebRequest)request);
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -7,6 +7,7 @@
 #include "clr_helpers.h"
 #include "environment_variables.h"
 #include "il_rewriter.h"
+#include "il_rewriter_wrapper.h"
 #include "integration_loader.h"
 #include "logging.h"
 #include "metadata_builder.h"
@@ -361,9 +362,17 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
                              target.signature);
       }
 
-      // replace with a call to the instrumentation wrapper
       const auto original_argument = pInstr->m_Arg32;
+
+      // insert the opcode and signature token as
+      // additional arguments for the wrapper method
+      ILRewriterWrapper rewriter_wrapper(&rewriter);
+      rewriter_wrapper.SetILPosition(pInstr);
+      rewriter_wrapper.LoadInt32(pInstr->m_opcode);
+
+      // always use CALL because the wrappers methods are all static
       pInstr->m_opcode = CEE_CALL;
+      // replace with a call to the instrumentation wrapper
       pInstr->m_Arg32 = wrapper_method_ref;
 
       modified = true;

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class IntegrationSignatureTests
+    {
+        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1009:ClosingParenthesisMustBeSpacedCorrectly", Justification = "Reviewed.")]
+        public static IEnumerable<object[]> GetWrapperMethods()
+        {
+            var integrationsAssembly = typeof(Instrumentation).Assembly;
+
+            // find all methods in Datadog.Trace.ClrProfiler.Managed.dll with [InterceptMethod]
+            var integrations = from wrapperType in integrationsAssembly.GetTypes()
+                               from wrapperMethod in wrapperType.GetRuntimeMethods()
+                               let attributes = wrapperMethod.GetCustomAttributes<InterceptMethodAttribute>(inherit: false)
+                               where attributes.Any()
+                               select new object[] { wrapperMethod };
+
+            return integrations;
+        }
+
+        [Theory]
+        [MemberData(nameof(GetWrapperMethods))]
+        public void WrapperMethodHasOpCodeArgument(MethodInfo wrapperMethod)
+        {
+            // all wrapper methods should have an additional Int32
+            // parameter for the original method call's opcode
+            ParameterInfo lastParameter = wrapperMethod.GetParameters().Last();
+            Assert.Equal(typeof(int), lastParameter.ParameterType);
+            Assert.Equal("opCode", lastParameter.Name);
+        }
+    }
+}


### PR DESCRIPTION
Fix `StackOverflowException` when `HttpClientHandler.SendAsync()` is overridden by a method that calls the base method. See #351.

For example:
```csharp
public class DerivedHandler : HttpClientHandler
{
    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
    {
        return await base.SendAsync(request, cancellationToken);
    }
}
```

This PR makes changes that affect _all_ integrations:
- profiler: push new argument (the original call's opcode) to execution stack when replacing a method call
- integrations: add new opcode argument to every wrapper method to pop this value off the stack
- most integration won't use this yet and default to `CALLVIRT` to keep the current behavior

Changes to `HttpMessageHandlerIntegration`:
- split into separate wrappers for calls to `HttpMessageHandler.SendAsync()` and `HttpClientHandler.SendAsync()`
- use the new opcode argument to emit the correct IL (`CALL` or `CALLVIRT`) when calling original method