### PR TITLE
remove inline variable in C++

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -8,6 +8,8 @@
 
 namespace trace {
 
+bool debug_logging_enabled = false;
+
 void Log(const std::string& str) {
   static auto current_process_name = ToString(GetCurrentProcessName());
 

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -10,31 +10,31 @@ extern bool debug_logging_enabled;
 void Log(const std::string &str);
 
 template <typename Arg>
-inline std::string LogToString(Arg const &arg) {
+std::string LogToString(Arg const &arg) {
   return ToString(arg);
 }
 
 template <typename... Args>
-inline std::string LogToString(Args const &... args) {
+std::string LogToString(Args const &... args) {
   std::ostringstream oss;
   int a[] = {0, ((void)(oss << LogToString(args)), 0)...};
   return oss.str();
 }
 
 template <typename... Args>
-inline void Debug(const Args... args) {
+void Debug(const Args... args) {
   if (debug_logging_enabled) {
     Log("[debug] " + LogToString(args...));
   }
 }
 
 template <typename... Args>
-inline void Info(const Args... args) {
+void Info(const Args... args) {
   Log("[info] " + LogToString(args...));
 }
 
 template <typename... Args>
-inline void Warn(const Args... args) {
+void Warn(const Args... args) {
   Log("[warn] " + LogToString(args...));
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -5,7 +5,7 @@
 
 namespace trace {
 
-inline bool debug_logging_enabled = false;
+extern bool debug_logging_enabled;
 
 void Log(const std::string &str);
 


### PR DESCRIPTION
This inline variable results in compiler warnings on Linux.
Also remove `inline` keywords which are redundant on template functions.