### PR TITLE
improve logging in CLR profiler

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -13,14 +13,28 @@ namespace trace {
 
 AssemblyInfo GetAssemblyInfo(ICorProfilerInfo3* info,
                              const AssemblyID& assembly_id) {
-  WCHAR name[kNameMaxSize];
-  DWORD name_len = 0;
-  auto hr = info->GetAssemblyInfo(assembly_id, kNameMaxSize, &name_len, name,
-                                  nullptr, nullptr);
-  if (FAILED(hr) || name_len == 0) {
+  WCHAR assembly_name[kNameMaxSize];
+  DWORD assembly_name_len = 0;
+  AppDomainID app_domain_id;
+
+  auto hr = info->GetAssemblyInfo(assembly_id, kNameMaxSize, &assembly_name_len,
+                                  assembly_name, &app_domain_id, nullptr);
+
+  if (FAILED(hr) || assembly_name_len == 0) {
     return {};
   }
-  return {assembly_id, WSTRING(name)};
+
+  WCHAR app_domain_name[kNameMaxSize];
+  DWORD app_domain_name_len = 0;
+
+  hr = info->GetAppDomainInfo(app_domain_id, kNameMaxSize, &app_domain_name_len,
+                              app_domain_name, nullptr);
+
+  if (FAILED(hr) || app_domain_name_len == 0) {
+    return {};
+  }
+
+  return {assembly_id, WSTRING(assembly_name), app_domain_id, WSTRING(app_domain_name)};
 }
 
 AssemblyMetadata GetAssemblyMetadata(

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -37,34 +37,6 @@ AssemblyInfo GetAssemblyInfo(ICorProfilerInfo3* info,
   return {assembly_id, WSTRING(assembly_name), app_domain_id, WSTRING(app_domain_name)};
 }
 
-AssemblyMetadata GetAssemblyMetadata(
-    const ModuleID& module_id,
-    const ComPtr<IMetaDataAssemblyImport>& assembly_import) {
-  mdAssembly current = mdAssemblyNil;
-  auto hr = assembly_import->GetAssemblyFromScope(&current);
-
-  if (FAILED(hr)) {
-    return {};
-  }
-
-  WCHAR name[kNameMaxSize];
-  WSTRING assembly_name = ""_W;
-  DWORD name_len = 0;
-  ASSEMBLYMETADATA assembly_m{};
-  DWORD assembly_flags = 0;
-  hr = assembly_import->GetAssemblyProps(current, nullptr, nullptr, nullptr,
-                                         name, kNameMaxSize, &name_len,
-                                         &assembly_m, &assembly_flags);
-  if (!FAILED(hr) && name_len > 0) {
-    assembly_name = WSTRING(name);
-  }
-
-  return AssemblyMetadata(module_id, assembly_name, current,
-                          assembly_m.usMajorVersion, assembly_m.usMinorVersion,
-                          assembly_m.usBuildNumber,
-                          assembly_m.usRevisionNumber);
-}
-
 AssemblyMetadata GetAssemblyImportMetadata(
     const ComPtr<IMetaDataAssemblyImport>& assembly_import) {
   mdAssembly current = mdAssemblyNil;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -171,9 +171,17 @@ static Enumerator<mdAssemblyRef> EnumAssemblyRefs(
 struct AssemblyInfo {
   const AssemblyID id;
   const WSTRING name;
+  const AppDomainID app_domain_id;
+  const WSTRING app_domain_name;
 
-  AssemblyInfo() : id(0), name(""_W) {}
-  AssemblyInfo(AssemblyID id, WSTRING name) : id(id), name(name) {}
+  AssemblyInfo() : id(0), name(""_W), app_domain_id(0), app_domain_name(""_W) {}
+
+  AssemblyInfo(AssemblyID id, WSTRING name, AppDomainID app_domain_id,
+               WSTRING app_domain_name)
+      : id(id),
+        name(name),
+        app_domain_id(app_domain_id),
+        app_domain_name(app_domain_name) {}
 
   bool is_valid() const { return id != 0; }
 };

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -21,11 +21,15 @@ CorProfiler* profiler = nullptr;
 
 HRESULT STDMETHODCALLTYPE
 CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
-  CorProfilerBase::Initialize(cor_profiler_info_unknown);
-
   // check if debug mode is enabled
   const auto debug_enabled_value =
       GetEnvironmentValue(environment::debug_enabled);
+
+  if (debug_enabled_value == "1"_W || debug_enabled_value == "true"_W) {
+    debug_logging_enabled = true;
+  }
+
+  CorProfilerBase::Initialize(cor_profiler_info_unknown);
 
   // check if tracing is completely disabled
   const WSTRING tracing_enabled =

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -34,23 +34,6 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
 
   Debug("CorProfiler::Initialize");
 
-  Info("Environment variables:");
-
-  WSTRING env_vars[] = {environment::tracing_enabled,
-                        environment::debug_enabled,
-                        environment::integrations_path,
-                        environment::process_names,
-                        environment::agent_host,
-                        environment::agent_port,
-                        environment::env,
-                        environment::service_name,
-                        environment::disabled_integrations,
-                        environment::clr_disable_optimizations};
-
-  for (auto&& env_var : env_vars) {
-    Info("  ", env_var, "=", GetEnvironmentValue(env_var));
-  }
-
   // check if tracing is completely disabled
   const WSTRING tracing_enabled =
       GetEnvironmentValue(environment::tracing_enabled);
@@ -81,6 +64,23 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   if (FAILED(hr)) {
     Warn("Failed to attach profiler: interface ICorProfilerInfo3 not found.");
     return E_FAIL;
+  }
+
+  Info("Environment variables:");
+
+  WSTRING env_vars[]{environment::tracing_enabled,
+                     environment::debug_enabled,
+                     environment::integrations_path,
+                     environment::process_names,
+                     environment::agent_host,
+                     environment::agent_port,
+                     environment::env,
+                     environment::service_name,
+                     environment::disabled_integrations,
+                     environment::clr_disable_optimizations};
+
+  for (auto&& env_var : env_vars) {
+    Info("  ", env_var, "=", GetEnvironmentValue(env_var));
   }
 
   // get path to integration definition JSON files

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -312,6 +312,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id) {
 
 HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown() {
   CorProfilerBase::Shutdown();
+
+  // keep this lock until we are done using the module,
+  // to prevent it from unloading while in use
+  std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
+
   is_shutdown_ = true;
   return S_OK;
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -143,8 +143,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   }
 
   if (!is_attached_) {
-    // if module failed to load, skip it entirely,
-    // otherwise we can crash the process if module is not valid
     return S_OK;
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -26,18 +26,21 @@ class CorProfiler : public CorProfilerBase {
   std::unordered_map<ModuleID, ModuleMetadata*> module_id_to_info_map_;
 
  public:
-  CorProfiler();
+  CorProfiler() = default;
 
   bool IsAttached() const;
 
   HRESULT STDMETHODCALLTYPE
   Initialize(IUnknown* cor_profiler_info_unknown) override;
-  HRESULT STDMETHODCALLTYPE ModuleLoadStarted(ModuleID module_id) override;
+
   HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID module_id,
-                                               HRESULT hrStatus) override;
+                                               HRESULT hr_status) override;
+
   HRESULT STDMETHODCALLTYPE ModuleUnloadStarted(ModuleID module_id) override;
+
   HRESULT STDMETHODCALLTYPE
   JITCompilationStarted(FunctionID function_id, BOOL is_safe_to_block) override;
+
   HRESULT STDMETHODCALLTYPE Shutdown() override;
 };
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -19,6 +19,7 @@ namespace trace {
 class CorProfiler : public CorProfilerBase {
  private:
   bool is_attached_ = false;
+  bool is_shutdown_ = false;
   std::vector<Integration> integrations_;
 
   std::mutex module_id_to_info_map_lock_;
@@ -31,12 +32,13 @@ class CorProfiler : public CorProfilerBase {
 
   HRESULT STDMETHODCALLTYPE
   Initialize(IUnknown* cor_profiler_info_unknown) override;
+  HRESULT STDMETHODCALLTYPE ModuleLoadStarted(ModuleID module_id) override;
   HRESULT STDMETHODCALLTYPE ModuleLoadFinished(ModuleID module_id,
                                                HRESULT hrStatus) override;
-  HRESULT STDMETHODCALLTYPE ModuleUnloadFinished(ModuleID module_id,
-                                                 HRESULT hrStatus) override;
+  HRESULT STDMETHODCALLTYPE ModuleUnloadStarted(ModuleID module_id) override;
   HRESULT STDMETHODCALLTYPE
   JITCompilationStarted(FunctionID function_id, BOOL is_safe_to_block) override;
+  HRESULT STDMETHODCALLTYPE Shutdown() override;
 };
 
 // Note: Generally you should not have a single, global callback implementation,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -19,7 +19,6 @@ namespace trace {
 class CorProfiler : public CorProfilerBase {
  private:
   bool is_attached_ = false;
-  bool is_shutdown_ = false;
   std::vector<Integration> integrations_;
 
   std::mutex module_id_to_info_map_lock_;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
@@ -14,89 +14,83 @@ CorProfilerBase::~CorProfilerBase() {
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::Initialize(IUnknown *pICorProfilerInfoUnk) {
-  Debug("CorProfiler::Initialize");
+  Debug("Initialize");
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::Shutdown() {
-  Debug("CorProfiler::Shutdown");
+  Debug("Shutdown");
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AppDomainCreationStarted(AppDomainID appDomainId) {
-  Debug("CorProfiler::AppDomainCreationStarted: ", appDomainId);
+  Debug("AppDomainCreationStarted: ", appDomainId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainCreationFinished(
     AppDomainID appDomainId, HRESULT hrStatus) {
-  Debug("CorProfiler::AppDomainCreationFinished: ", appDomainId,
-        ", HRESULT: ", hrStatus);
+  Debug("AppDomainCreationFinished: ", appDomainId, " hrStatus=", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AppDomainShutdownStarted(AppDomainID appDomainId) {
-  Debug("CorProfiler::AppDomainShutdownStarted: ", appDomainId);
+  Debug("AppDomainShutdownStarted: ", appDomainId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainShutdownFinished(
     AppDomainID appDomainId, HRESULT hrStatus) {
-  Debug("CorProfiler::AppDomainShutdownFinished: ", appDomainId,
-        ", HRESULT: ", hrStatus);
+  Debug("AppDomainShutdownFinished: ", appDomainId, " ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AssemblyLoadStarted(AssemblyID assemblyId) {
-  Debug("CorProfiler::AssemblyLoadStarted: ", assemblyId);
+  Debug("AssemblyLoadStarted: ", assemblyId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus) {
-  Debug("CorProfiler::AssemblyLoadFinished: ", assemblyId,
-        ", HRESULT: ", hrStatus);
+  Debug("AssemblyLoadFinished: ", assemblyId, " ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AssemblyUnloadStarted(AssemblyID assemblyId) {
-  Debug("CorProfiler::AssemblyUnloadStarted: ", assemblyId);
+  Debug("AssemblyUnloadStarted: ", assemblyId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyUnloadFinished(
     AssemblyID assemblyId, HRESULT hrStatus) {
-  Debug("CorProfiler::AssemblyUnloadFinished: ", assemblyId,
-        ", HRESULT: ", hrStatus);
+  Debug("AssemblyUnloadFinished: ", assemblyId, " ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleLoadStarted(ModuleID moduleId) {
-  Debug("CorProfiler::ModuleLoadStarted: ", moduleId);
+  Debug("ModuleLoadStarted: ", moduleId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus) {
-  Debug("CorProfiler::ModuleLoadFinished: ", moduleId, ", HRESULT: ", hrStatus);
+  Debug("ModuleLoadFinished: ", moduleId, " ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleUnloadStarted(ModuleID moduleId) {
-  Debug("CorProfiler::ModuleUnloadStarted: ", moduleId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus) {
-  Debug("CorProfiler::ModuleUnloadFinished: ", moduleId,
-        ", HRESULT: ", hrStatus);
+  Debug("ModuleUnloadFinished: ", moduleId, " ", hrStatus);
   return S_OK;
 }
 
@@ -130,15 +124,13 @@ CorProfilerBase::FunctionUnloadStarted(FunctionID functionId) {
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::JITCompilationStarted(
     FunctionID functionId, BOOL fIsSafeToBlock) {
-  Debug("CorProfiler::JITCompilationStarted: ", functionId,
-        ", fIsSafeToBlock: ", fIsSafeToBlock);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::JITCompilationFinished(
     FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) {
-  Debug("CorProfiler::JITCompilationFinished: ", functionId,
-        ", HRESULT: ", hrStatus);
+  Debug("JITCompilationFinished ", functionId, " ", hrStatus, " ",
+        fIsSafeToBlock);
   return S_OK;
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
@@ -14,68 +14,89 @@ CorProfilerBase::~CorProfilerBase() {
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::Initialize(IUnknown *pICorProfilerInfoUnk) {
+  Debug("CorProfiler::Initialize");
   return S_OK;
 }
 
-HRESULT STDMETHODCALLTYPE CorProfilerBase::Shutdown() { return S_OK; }
+HRESULT STDMETHODCALLTYPE CorProfilerBase::Shutdown() {
+  Debug("CorProfiler::Shutdown");
+  return S_OK;
+}
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AppDomainCreationStarted(AppDomainID appDomainId) {
+  Debug("CorProfiler::AppDomainCreationStarted: ", appDomainId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainCreationFinished(
     AppDomainID appDomainId, HRESULT hrStatus) {
+  Debug("CorProfiler::AppDomainCreationFinished: ", appDomainId,
+        ", HRESULT: ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AppDomainShutdownStarted(AppDomainID appDomainId) {
+  Debug("CorProfiler::AppDomainShutdownStarted: ", appDomainId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AppDomainShutdownFinished(
     AppDomainID appDomainId, HRESULT hrStatus) {
+  Debug("CorProfiler::AppDomainShutdownFinished: ", appDomainId,
+        ", HRESULT: ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AssemblyLoadStarted(AssemblyID assemblyId) {
+  Debug("CorProfiler::AssemblyLoadStarted: ", assemblyId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AssemblyLoadFinished(AssemblyID assemblyId, HRESULT hrStatus) {
+  Debug("CorProfiler::AssemblyLoadFinished: ", assemblyId,
+        ", HRESULT: ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::AssemblyUnloadStarted(AssemblyID assemblyId) {
+  Debug("CorProfiler::AssemblyUnloadStarted: ", assemblyId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::AssemblyUnloadFinished(
     AssemblyID assemblyId, HRESULT hrStatus) {
+  Debug("CorProfiler::AssemblyUnloadFinished: ", assemblyId,
+        ", HRESULT: ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleLoadStarted(ModuleID moduleId) {
+  Debug("CorProfiler::ModuleLoadStarted: ", moduleId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleLoadFinished(ModuleID moduleId, HRESULT hrStatus) {
+  Debug("CorProfiler::ModuleLoadFinished: ", moduleId, ", HRESULT: ", hrStatus);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleUnloadStarted(ModuleID moduleId) {
+  Debug("CorProfiler::ModuleUnloadStarted: ", moduleId);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE
 CorProfilerBase::ModuleUnloadFinished(ModuleID moduleId, HRESULT hrStatus) {
+  Debug("CorProfiler::ModuleUnloadFinished: ", moduleId,
+        ", HRESULT: ", hrStatus);
   return S_OK;
 }
 
@@ -109,11 +130,15 @@ CorProfilerBase::FunctionUnloadStarted(FunctionID functionId) {
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::JITCompilationStarted(
     FunctionID functionId, BOOL fIsSafeToBlock) {
+  Debug("CorProfiler::JITCompilationStarted: ", functionId,
+        ", fIsSafeToBlock: ", fIsSafeToBlock);
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::JITCompilationFinished(
     FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) {
+  Debug("CorProfiler::JITCompilationFinished: ", functionId,
+        ", HRESULT: ", hrStatus);
   return S_OK;
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
@@ -129,8 +129,6 @@ HRESULT STDMETHODCALLTYPE CorProfilerBase::JITCompilationStarted(
 
 HRESULT STDMETHODCALLTYPE CorProfilerBase::JITCompilationFinished(
     FunctionID functionId, HRESULT hrStatus, BOOL fIsSafeToBlock) {
-  Debug("JITCompilationFinished ", functionId, " ", hrStatus, " ",
-        fIsSafeToBlock);
   return S_OK;
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -60,7 +60,7 @@ std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream) {
       }
     }
 
-    Debug("Loaded integrations: ", j.dump());
+    // Debug("Loaded integrations: ", j.dump());
   } catch (const json::parse_error& e) {
     Warn("Invalid integrations:", e.what());
   } catch (const json::type_error& e) {

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -91,7 +91,8 @@ TEST_F(CLRHelperTest, FiltersIntegrationsByCaller) {
   Integration i3 = {L"integration-3", {{{}, {}, {}}}};
   auto all = FlattenIntegrations({i1, i2, i3});
   auto expected = FlattenIntegrations({i1, i3});
-  trace::AssemblyInfo assembly_info = {1, L"Assembly.One"};
+  AppDomainID app_domain_id{};
+  trace::AssemblyInfo assembly_info = {1, L"Assembly.One", app_domain_id, L"AppDomain1"};
   auto actual = FilterIntegrationsByCaller(all, assembly_info);
   EXPECT_EQ(actual, expected);
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- add more logging everywhere
- skip more known assemblies
- remove module data in `ModuleUnloadFinished()` instead of `ModuleUnloadStarted()` to avoid using it while it's being unloaded
- lock module data more aggressively to prevent modules from unloading while being used 
