### PR TITLE
Introduce Integration Signature Type Array

### DIFF
--- a/Datadog.Trace.sln.DotSettings
+++ b/Datadog.Trace.sln.DotSettings
@@ -104,4 +104,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=opcode/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/integrations.json
+++ b/integrations.json
@@ -8,6 +8,10 @@
           "assembly": "System.Data",
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReader",
+          "signature_types": [
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -28,6 +32,10 @@
           "assembly": "System.Data.Common",
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReader",
+          "signature_types": [
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -48,6 +56,11 @@
           "assembly": "System.Data",
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReaderAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -68,6 +81,11 @@
           "assembly": "System.Data.Common",
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReaderAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -95,6 +113,13 @@
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
           "method": "BeforeAction",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -117,6 +142,13 @@
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
           "method": "AfterAction",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -139,6 +171,10 @@
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker",
           "method": "Rethrow",
+          "signature_types": [
+            "System.Void",
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -166,6 +202,13 @@
           "assembly": "System.Web.Mvc",
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
           "method": "BeginInvokeAction",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 5,
           "minimum_minor": 1,
           "minimum_patch": 0,
@@ -188,6 +231,10 @@
           "assembly": "System.Web.Mvc",
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
           "method": "EndInvokeAction",
+          "signature_types": [
+            null,
+            null
+          ],
           "minimum_major": 5,
           "minimum_minor": 1,
           "minimum_patch": 0,
@@ -213,6 +260,11 @@
           "assembly": "System.Web.Http",
           "type": "System.Web.Http.Controllers.IHttpController",
           "method": "ExecuteAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 5,
           "minimum_minor": 2,
           "minimum_patch": 0,
@@ -240,6 +292,10 @@
           "assembly": "Elasticsearch.Net",
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearch",
+          "signature_types": [
+            null,
+            null
+          ],
           "minimum_major": 5,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -262,6 +318,11 @@
           "assembly": "Elasticsearch.Net",
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearchAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 5,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -289,6 +350,10 @@
           "assembly": "Elasticsearch.Net",
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearch",
+          "signature_types": [
+            null,
+            null
+          ],
           "minimum_major": 6,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -311,6 +376,11 @@
           "assembly": "Elasticsearch.Net",
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearchAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 6,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -336,6 +406,11 @@
           "assembly": "System.Net.Http",
           "type": "System.Net.Http.HttpMessageHandler",
           "method": "SendAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -356,6 +431,11 @@
           "assembly": "System.Net.Http",
           "type": "System.Net.Http.HttpClientHandler",
           "method": "SendAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -381,6 +461,11 @@
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol",
           "method": "Execute",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 2,
           "minimum_patch": 0,
@@ -401,6 +486,11 @@
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol`1",
           "method": "Execute",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 2,
           "minimum_patch": 0,
@@ -421,6 +511,11 @@
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol",
           "method": "ExecuteAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 1,
           "minimum_patch": 0,
@@ -441,6 +536,11 @@
           "assembly": "MongoDB.Driver.Core",
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol`1",
           "method": "ExecuteAsync",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 2,
           "minimum_minor": 1,
           "minimum_patch": 0,
@@ -468,6 +568,13 @@
           "assembly": "ServiceStack.Redis",
           "type": "ServiceStack.Redis.RedisNativeClient",
           "method": "SendReceive",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -495,6 +602,12 @@
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 1,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -517,6 +630,12 @@
           "assembly": "StackExchange.Redis.StrongName",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 1,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -539,6 +658,13 @@
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 1,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -561,6 +687,13 @@
           "assembly": "StackExchange.Redis.StrongName",
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 1,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -583,6 +716,12 @@
           "assembly": "StackExchange.Redis",
           "type": "StackExchange.Redis.RedisBase",
           "method": "ExecuteAsync",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 1,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -605,6 +744,12 @@
           "assembly": "StackExchange.Redis.StrongName",
           "type": "StackExchange.Redis.RedisBase",
           "method": "ExecuteAsync",
+          "signature_types": [
+            null,
+            null,
+            null,
+            null
+          ],
           "minimum_major": 1,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -630,6 +775,11 @@
           "assembly": "System.ServiceModel",
           "type": "System.ServiceModel.Dispatcher.ChannelHandler",
           "method": "HandleRequest",
+          "signature_types": [
+            null,
+            null,
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -655,6 +805,9 @@
           "assembly": "System",
           "type": "System.Net.WebRequest",
           "method": "GetResponse",
+          "signature_types": [
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -675,6 +828,9 @@
           "assembly": "System.Net.Requests",
           "type": "System.Net.WebRequest",
           "method": "GetResponse",
+          "signature_types": [
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
@@ -695,6 +851,9 @@
           "assembly": "System.Net",
           "type": "System.Net.WebRequest",
           "method": "GetResponseAsync",
+          "signature_types": [
+            null
+          ],
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,

--- a/integrations.json
+++ b/integrations.json
@@ -571,7 +571,7 @@
           "signature_types": [
             "T",
             "_",
-            "System.Int8[][]",
+            "System.UInt8[][]",
             "_",
             "System.Boolean"
           ],

--- a/integrations.json
+++ b/integrations.json
@@ -570,8 +570,8 @@
           "method": "SendReceive",
           "signature_types": [
             "T",
+            "System.Byte[][]",
             "_",
-            "System.UInt8[][]",
             "_",
             "System.Boolean"
           ],
@@ -603,7 +603,7 @@
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature_types": [
-            "_",
+            "T",
             "_",
             "_",
             "_"
@@ -631,7 +631,7 @@
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature_types": [
-            "_",
+            "T",
             "_",
             "_",
             "_"

--- a/integrations.json
+++ b/integrations.json
@@ -9,8 +9,8 @@
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReader",
           "signature_types": [
-            null,
-            null
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -33,8 +33,8 @@
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReader",
           "signature_types": [
-            null,
-            null
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -57,9 +57,9 @@
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReaderAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -82,9 +82,9 @@
           "type": "System.Data.Common.DbCommand",
           "method": "ExecuteDbDataReaderAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -114,11 +114,11 @@
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
           "method": "BeforeAction",
           "signature_types": [
-            null,
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 0,
@@ -143,11 +143,11 @@
           "type": "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
           "method": "AfterAction",
           "signature_types": [
-            null,
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 0,
@@ -173,7 +173,7 @@
           "method": "Rethrow",
           "signature_types": [
             "System.Void",
-            null
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 0,
@@ -203,11 +203,11 @@
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
           "method": "BeginInvokeAction",
           "signature_types": [
-            null,
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 5,
           "minimum_minor": 1,
@@ -232,8 +232,8 @@
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
           "method": "EndInvokeAction",
           "signature_types": [
-            null,
-            null
+            "System.Boolean",
+            "_"
           ],
           "minimum_major": 5,
           "minimum_minor": 1,
@@ -261,9 +261,9 @@
           "type": "System.Web.Http.Controllers.IHttpController",
           "method": "ExecuteAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 5,
           "minimum_minor": 2,
@@ -293,8 +293,8 @@
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearch",
           "signature_types": [
-            null,
-            null
+            "_",
+            "_"
           ],
           "minimum_major": 5,
           "minimum_minor": 0,
@@ -319,9 +319,9 @@
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearchAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 5,
           "minimum_minor": 0,
@@ -351,8 +351,8 @@
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearch",
           "signature_types": [
-            null,
-            null
+            "_",
+            "_"
           ],
           "minimum_major": 6,
           "minimum_minor": 0,
@@ -377,9 +377,9 @@
           "type": "Elasticsearch.Net.IRequestPipeline",
           "method": "CallElasticsearchAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 6,
           "minimum_minor": 0,
@@ -407,9 +407,9 @@
           "type": "System.Net.Http.HttpMessageHandler",
           "method": "SendAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -432,9 +432,9 @@
           "type": "System.Net.Http.HttpClientHandler",
           "method": "SendAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -462,9 +462,9 @@
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol",
           "method": "Execute",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 2,
@@ -487,9 +487,9 @@
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol`1",
           "method": "Execute",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 2,
@@ -512,9 +512,9 @@
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol",
           "method": "ExecuteAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 1,
@@ -537,9 +537,9 @@
           "type": "MongoDB.Driver.Core.WireProtocol.IWireProtocol`1",
           "method": "ExecuteAsync",
           "signature_types": [
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 2,
           "minimum_minor": 1,
@@ -569,11 +569,11 @@
           "type": "ServiceStack.Redis.RedisNativeClient",
           "method": "SendReceive",
           "signature_types": [
-            null,
-            null,
-            null,
-            null,
-            null
+            "T",
+            "_",
+            "System.Int8[][]",
+            "_",
+            "System.Boolean"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -603,10 +603,10 @@
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature_types": [
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -631,10 +631,10 @@
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
           "signature_types": [
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -659,11 +659,11 @@
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature_types": [
-            null,
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -688,11 +688,11 @@
           "type": "StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
           "signature_types": [
-            null,
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -717,10 +717,10 @@
           "type": "StackExchange.Redis.RedisBase",
           "method": "ExecuteAsync",
           "signature_types": [
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -745,10 +745,10 @@
           "type": "StackExchange.Redis.RedisBase",
           "method": "ExecuteAsync",
           "signature_types": [
-            null,
-            null,
-            null,
-            null
+            "_",
+            "_",
+            "_",
+            "_"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -776,9 +776,9 @@
           "type": "System.ServiceModel.Dispatcher.ChannelHandler",
           "method": "HandleRequest",
           "signature_types": [
-            null,
-            null,
-            null
+            "System.Boolean",
+            "_",
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -806,7 +806,7 @@
           "type": "System.Net.WebRequest",
           "method": "GetResponse",
           "signature_types": [
-            null
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -829,7 +829,7 @@
           "type": "System.Net.WebRequest",
           "method": "GetResponse",
           "signature_types": [
-            null
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -852,7 +852,7 @@
           "type": "System.Net.WebRequest",
           "method": "GetResponseAsync",
           "signature_types": [
-            null
+            "_"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -28,13 +28,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Data.Common", // .NET Core
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteDbDataReader(object @this, int behavior, int opCode)
@@ -72,13 +72,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Data.Common", // .NET Core
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -166,7 +166,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 case "InterceptableDbCommand":
                 case "ProfiledDbCommand":
                     // don't create spans for these
-                    return TypeNames.Ignore;
+                    return null;
                 default:
                     const string commandSuffix = "Command";
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -28,13 +28,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new string[] { null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Data.Common", // .NET Core
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new string[] { null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteDbDataReader(object @this, int behavior, int opCode)
@@ -72,13 +72,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Data.Common", // .NET Core
             TargetType = "System.Data.Common.DbCommand",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode)
@@ -166,7 +166,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 case "InterceptableDbCommand":
                 case "ProfiledDbCommand":
                     // don't create spans for these
-                    return null;
+                    return TypeNames.Ignore;
                 default:
                     const string commandSuffix = "Command";
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -28,11 +28,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
             TargetType = "System.Data.Common.DbCommand",
+            TargetSignatureTypes = new string[] { null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Data.Common", // .NET Core
             TargetType = "System.Data.Common.DbCommand",
+            TargetSignatureTypes = new string[] { null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteDbDataReader(object @this, int behavior, int opCode)
@@ -70,11 +72,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
             TargetType = "System.Data.Common.DbCommand",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Data.Common", // .NET Core
             TargetType = "System.Data.Common.DbCommand",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -288,7 +288,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = ResourceInvoker,
-            TargetSignatureTypes = new string[] { null },
+            TargetSignatureTypes = new string[] { "System.Void", null },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void Rethrow(object context, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-            TargetSignatureTypes = new string[] { null, null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void BeforeAction(
@@ -215,7 +215,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-            TargetSignatureTypes = new string[] { null, null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void AfterAction(
@@ -288,7 +288,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = ResourceInvoker,
-            TargetSignatureTypes = new string[] { "System.Void", null },
+            TargetSignatureTypes = new[] { "System.Void", TypeNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void Rethrow(object context, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void BeforeAction(
@@ -215,7 +215,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void AfterAction(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -141,6 +141,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
+            TargetSignatureTypes = new string[] { null, null, null, null, null },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void BeforeAction(
@@ -214,6 +215,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
+            TargetSignatureTypes = new string[] { null, null, null, null, null },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void AfterAction(
@@ -286,6 +288,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = ResourceInvoker,
+            TargetSignatureTypes = new string[] { null },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void Rethrow(object context, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -141,7 +141,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void BeforeAction(
@@ -215,7 +215,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void AfterAction(
@@ -288,7 +288,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = ResourceInvoker,
-            TargetSignatureTypes = new[] { TypeNames.Void, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void Rethrow(object context, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -288,7 +288,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetAssembly = "Microsoft.AspNetCore.Mvc.Core",
             TargetType = ResourceInvoker,
-            TargetSignatureTypes = new[] { "System.Void", TypeNames.Ignore },
+            TargetSignatureTypes = new[] { TypeNames.Void, TypeNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static void Rethrow(object context, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -164,7 +164,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new string[] { null, null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static object BeginInvokeAction(
@@ -219,7 +219,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new string[] { null, null },
+            TargetSignatureTypes = new[] { TypeNames.Bool, TypeNames.Ignore },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -164,6 +164,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
+            TargetSignatureTypes = new string[] { null, null, null, null, null },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static object BeginInvokeAction(
@@ -218,6 +219,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
+            TargetSignatureTypes = new string[] { null, null },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -164,7 +164,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static object BeginInvokeAction(
@@ -219,7 +219,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new[] { TypeNames.Bool, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Bool, ClrNames.Ignore },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Web.Http",
             TargetType = "System.Web.Http.Controllers.IHttpController",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
         public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Web.Http",
             TargetType = "System.Web.Http.Controllers.IHttpController",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
         public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Web.Http",
             TargetType = "System.Web.Http.Controllers.IHttpController",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
         public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
@@ -69,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
+            TargetSignatureTypes = new string[] { null, null },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
@@ -68,6 +69,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new string[] { null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
@@ -69,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new string[] { null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
+            TargetSignatureTypes = new string[] { null, null },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
@@ -66,6 +67,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "Elasticsearch.Net",
             TargetAssembly = "Elasticsearch.Net",
             TargetType = "Elasticsearch.Net.IRequestPipeline",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpMessageHandler",
             TargetMethod = "SendAsync",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpMessageHandler_SendAsync(
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpClientHandler",
             TargetMethod = "SendAsync",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpClientHandler_SendAsync(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpMessageHandler",
             TargetMethod = "SendAsync",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpMessageHandler_SendAsync(
@@ -69,6 +70,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpClientHandler",
             TargetMethod = "SendAsync",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpClientHandler_SendAsync(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpMessageHandler",
             TargetMethod = "SendAsync",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpMessageHandler_SendAsync(
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = "System.Net.Http",
             TargetType = "System.Net.Http.HttpClientHandler",
             TargetMethod = "SendAsync",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpClientHandler_SendAsync(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -39,13 +39,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocol,
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocolGeneric,
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
         public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(ExecuteAsync),
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocol,
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
@@ -122,7 +122,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(ExecuteAsync),
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocolGeneric,
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -39,13 +39,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocol,
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocolGeneric,
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
         public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(ExecuteAsync),
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocol,
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
@@ -122,7 +122,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(ExecuteAsync),
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocolGeneric,
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -39,11 +39,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocol,
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocolGeneric,
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
         public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
@@ -98,6 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(ExecuteAsync),
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocol,
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
@@ -119,6 +122,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(ExecuteAsync),
             TargetAssembly = MongoDbClientAssembly,
             TargetType = IWireProtocolGeneric,
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "ServiceStack.Redis",
             TargetAssembly = "ServiceStack.Redis",
             TargetType = "ServiceStack.Redis.RedisNativeClient",
-            TargetSignatureTypes = new string[] { null, null, null, null, null },
+            TargetSignatureTypes = new[] { "T", TypeNames.Ignore, "System.Int8[][]", TypeNames.Ignore, TypeNames.Bool },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "ServiceStack.Redis",
             TargetAssembly = "ServiceStack.Redis",
             TargetType = "ServiceStack.Redis.RedisNativeClient",
-            TargetSignatureTypes = new[] { "T", "System.UInt8[][]", ClrNames.Ignore, ClrNames.Ignore, ClrNames.Bool },
+            TargetSignatureTypes = new[] { "T", "System.Byte[][]", ClrNames.Ignore, ClrNames.Ignore, ClrNames.Bool },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "ServiceStack.Redis",
             TargetAssembly = "ServiceStack.Redis",
             TargetType = "ServiceStack.Redis.RedisNativeClient",
+            TargetSignatureTypes = new string[] { null, null, null, null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "ServiceStack.Redis",
             TargetAssembly = "ServiceStack.Redis",
             TargetType = "ServiceStack.Redis.RedisNativeClient",
-            TargetSignatureTypes = new[] { "T", ClrNames.Ignore, "System.UInt8[][]", ClrNames.Ignore, ClrNames.Bool },
+            TargetSignatureTypes = new[] { "T", "System.UInt8[][]", ClrNames.Ignore, ClrNames.Ignore, ClrNames.Bool },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = "ServiceStack.Redis",
             TargetAssembly = "ServiceStack.Redis",
             TargetType = "ServiceStack.Redis.RedisNativeClient",
-            TargetSignatureTypes = new[] { "T", TypeNames.Ignore, "System.Int8[][]", TypeNames.Ignore, TypeNames.Bool },
+            TargetSignatureTypes = new[] { "T", ClrNames.Ignore, "System.UInt8[][]", ClrNames.Ignore, ClrNames.Bool },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
+            TargetSignatureTypes = new[] { "T", ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
+            TargetSignatureTypes = new[] { "T", ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server, int opCode)
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new string[] { null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new string[] { null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server, int opCode)
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new string[] { null, null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
-            TargetSignatureTypes = new string[] { null, null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
+            TargetSignatureTypes = new string[] { null, null, null, null },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -34,6 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
+            TargetSignatureTypes = new string[] { null, null, null, null },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server, int opCode)
@@ -82,6 +84,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
+            TargetSignatureTypes = new string[] { null, null, null, null, null },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -89,6 +92,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.ConnectionMultiplexer",
+            TargetSignatureTypes = new string[] { null, null, null, null, null },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.RedisBase",
+            TargetSignatureTypes = new string[] { null, null, null, null },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
         [InterceptMethod(
@@ -33,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.RedisBase",
+            TargetSignatureTypes = new string[] { null, null, null, null },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
         public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.RedisBase",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
         [InterceptMethod(
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.RedisBase",
-            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
         public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis",
             TargetAssembly = "StackExchange.Redis",
             TargetType = "StackExchange.Redis.RedisBase",
-            TargetSignatureTypes = new string[] { null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
         [InterceptMethod(
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = "StackExchange.Redis.StrongName",
             TargetAssembly = "StackExchange.Redis.StrongName",
             TargetType = "StackExchange.Redis.RedisBase",
-            TargetSignatureTypes = new string[] { null, null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major1)]
         public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
@@ -9,16 +9,15 @@ namespace Datadog.Trace.ClrProfiler
         public const string Bool = "System.Boolean";
         public const string String = "System.String";
 
-        public const string Int8 = "System.Int8";
+        public const string SByte = "System.SByte";
+        public const string Byte = "System.Byte";
+
         public const string Int16 = "System.Int16";
         public const string Int32 = "System.Int32";
         public const string Int64 = "System.Int64";
 
-        public const string UInt8 = "System.UInt8";
         public const string UInt16 = "System.UInt16";
         public const string UInt32 = "System.UInt32";
         public const string UInt64 = "System.UInt64";
-
-        public const string Byte = UInt8;
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
@@ -1,23 +1,24 @@
 namespace Datadog.Trace.ClrProfiler
 {
-    internal class TypeNames
+    internal static class ClrNames
     {
         public const string Ignore = "_";
 
         public const string Void = "System.Void";
         public const string Object = "System.Object";
         public const string Bool = "System.Boolean";
+        public const string String = "System.String";
 
         public const string Int8 = "System.Int8";
-        public const string Int16 = "System.Int8";
+        public const string Int16 = "System.Int16";
         public const string Int32 = "System.Int32";
         public const string Int64 = "System.Int64";
 
         public const string UInt8 = "System.UInt8";
-        public const string UInt16 = "System.UInt8";
+        public const string UInt16 = "System.UInt16";
         public const string UInt32 = "System.UInt32";
         public const string UInt64 = "System.UInt64";
 
-        public const string Byte = Int8;
+        public const string Byte = UInt8;
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeNames.cs
@@ -1,0 +1,23 @@
+namespace Datadog.Trace.ClrProfiler
+{
+    internal class TypeNames
+    {
+        public const string Ignore = "_";
+
+        public const string Void = "System.Void";
+        public const string Object = "System.Object";
+        public const string Bool = "System.Boolean";
+
+        public const string Int8 = "System.Int8";
+        public const string Int16 = "System.Int8";
+        public const string Int32 = "System.Int32";
+        public const string Int64 = "System.Int64";
+
+        public const string UInt8 = "System.UInt8";
+        public const string UInt16 = "System.UInt8";
+        public const string UInt32 = "System.UInt32";
+        public const string UInt64 = "System.UInt64";
+
+        public const string Byte = Int8;
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -25,6 +25,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.ServiceModel",
             TargetType = "System.ServiceModel.Dispatcher.ChannelHandler",
+            TargetSignatureTypes = new string[] { null, null, null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.ServiceModel",
             TargetType = "System.ServiceModel.Dispatcher.ChannelHandler",
-            TargetSignatureTypes = new[] { TypeNames.Bool, TypeNames.Ignore, TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Bool, ClrNames.Ignore, ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.ServiceModel",
             TargetType = "System.ServiceModel.Dispatcher.ChannelHandler",
-            TargetSignatureTypes = new string[] { null, null, null },
+            TargetSignatureTypes = new[] { TypeNames.Bool, TypeNames.Ignore, TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -22,11 +22,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System", // .NET Framework
             TargetType = "System.Net.WebRequest",
+            TargetSignatureTypes = new string[] { null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Net.Requests", // .NET Core
             TargetType = "System.Net.WebRequest",
+            TargetSignatureTypes = new string[] { null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object GetResponse(object webRequest, int opCode)
@@ -74,6 +76,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Net",
             TargetType = "System.Net.WebRequest",
+            TargetSignatureTypes = new string[] { null },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object GetResponseAsync(object request, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -22,13 +22,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System", // .NET Framework
             TargetType = "System.Net.WebRequest",
-            TargetSignatureTypes = new[] { TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Net.Requests", // .NET Core
             TargetType = "System.Net.WebRequest",
-            TargetSignatureTypes = new[] { TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object GetResponse(object webRequest, int opCode)
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Net",
             TargetType = "System.Net.WebRequest",
-            TargetSignatureTypes = new[] { TypeNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object GetResponseAsync(object request, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -22,13 +22,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System", // .NET Framework
             TargetType = "System.Net.WebRequest",
-            TargetSignatureTypes = new string[] { null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         [InterceptMethod(
             TargetAssembly = "System.Net.Requests", // .NET Core
             TargetType = "System.Net.WebRequest",
-            TargetSignatureTypes = new string[] { null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object GetResponse(object webRequest, int opCode)
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = "System.Net",
             TargetType = "System.Net.WebRequest",
-            TargetSignatureTypes = new string[] { null },
+            TargetSignatureTypes = new[] { TypeNames.Ignore },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object GetResponseAsync(object request, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler
         /// Gets or sets the explicit type array for the target method to be intercepted.
         /// This is a required field.
         /// Must match the wrapper method in count:
-        ///     n (parameters) + 1 (return type) - (is_instance_method : 1 : 0) - 1 (op-code)
+        ///     n (parameters) + 1 (return type) - (is_instance_method : 1 : 0) - 1 (opcode)
         /// NULL indexes are ignored in comparison.
         /// </summary>
         public string[] TargetSignatureTypes { get; set; }

--- a/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
@@ -60,6 +60,15 @@ namespace Datadog.Trace.ClrProfiler
         public string TargetSignature { get; set; }
 
         /// <summary>
+        /// Gets or sets the explicit type array for the target method to be intercepted.
+        /// This is a required field.
+        /// Must match the wrapper method in count:
+        ///     n (parameters) + 1 (return type) - (is_instance_method : 1 : 0) - 1 (op-code)
+        /// NULL indexes are ignored in comparison.
+        /// </summary>
+        public string[] TargetSignatureTypes { get; set; }
+
+        /// <summary>
         /// Gets the target version range for <see cref="TargetAssembly"/>.
         /// </summary>
         public IntegrationVersionRange TargetVersionRange { get; } = new IntegrationVersionRange();

--- a/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
@@ -62,9 +62,11 @@ namespace Datadog.Trace.ClrProfiler
         /// <summary>
         /// Gets or sets the explicit type array for the target method to be intercepted.
         /// This is a required field.
+        /// Follows format:
+        ///     new[] { return_type, param_1_type, param_2_type, ..., param_n_type }
         /// Must match the wrapper method in count:
         ///     n (parameters) + 1 (return type) - (is_instance_method : 1 : 0) - 1 (opcode)
-        /// NULL indexes are ignored in comparison.
+        /// Indexes with "_" are ignored for comparison purposes.
         /// </summary>
         public string[] TargetSignatureTypes { get; set; }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -387,7 +387,7 @@ TypeInfo RetrieveTypeForSignature(
   return type_data;
 }
 
-bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
+bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
                          const FunctionInfo& function_info,
                          std::vector<WSTRING>& signature_result) {
   const auto signature_size = function_info.signature.data.size();

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -388,239 +388,247 @@ TypeInfo RetrieveTypeForSignature(
 }
 
 bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
-                         const FunctionInfo& function_info,
-                         std::vector<WSTRING>& signature_result) {
-  const auto signature_size = function_info.signature.data.size();
-  const auto generic_count = function_info.signature.NumberOfTypeArguments();
-  const auto param_count = function_info.signature.NumberOfArguments();
-  size_t current_index = 2;  // Where the parameters actually start
+                            const FunctionInfo& function_info,
+                            std::vector<WSTRING>& signature_result) {
+  try {
+    const auto signature_size = function_info.signature.data.size();
+    const auto generic_count = function_info.signature.NumberOfTypeArguments();
+    const auto param_count = function_info.signature.NumberOfArguments();
+    size_t current_index = 2;  // Where the parameters actually start
 
-  if (generic_count > 0) {
-    current_index++;  // offset by one because the method is generic
-  }
+    if (generic_count > 0) {
+      current_index++;  // offset by one because the method is generic
+    }
 
-  const auto expected_number_of_types = param_count + 1;
-  size_t current_type_index = 0;
-  std::vector<WSTRING> type_names(expected_number_of_types);
+    const auto expected_number_of_types = param_count + 1;
+    size_t current_type_index = 0;
+    std::vector<WSTRING> type_names(expected_number_of_types);
 
-  std::stack<int> generic_arg_stack;
-  WSTRING append_to_type = ""_W;
-  WSTRING current_type_name = ""_W;
+    std::stack<int> generic_arg_stack;
+    WSTRING append_to_type = ""_W;
+    WSTRING current_type_name = ""_W;
 
-  for (; current_index < signature_size; current_index++) {
-    mdToken type_token;
-    ULONG token_length;
-    auto param_piece = function_info.signature.data[current_index];
-    const auto cor_element_type = CorElementType(param_piece);
+    for (; current_index < signature_size; current_index++) {
+      mdToken type_token;
+      ULONG token_length;
+      auto param_piece = function_info.signature.data[current_index];
+      const auto cor_element_type = CorElementType(param_piece);
 
-    switch (cor_element_type) {
-      case ELEMENT_TYPE_VOID: {
-        current_type_name.append("System.Void"_W);
-        break;
-      }
+      switch (cor_element_type) {
+        case ELEMENT_TYPE_VOID: {
+          current_type_name.append("System.Void"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_BOOLEAN: {
-        current_type_name.append("System.Boolean"_W);
-        break;
-      }
+        case ELEMENT_TYPE_BOOLEAN: {
+          current_type_name.append("System.Boolean"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_CHAR: {
-        current_type_name.append("System.Char16"_W);
-        break;
-      }
+        case ELEMENT_TYPE_CHAR: {
+          current_type_name.append("System.Char16"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_I1: {
-        current_type_name.append("System.SByte"_W);
-        break;
-      }
+        case ELEMENT_TYPE_I1: {
+          current_type_name.append("System.SByte"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_U1: {
-        current_type_name.append("System.Byte"_W);
-        break;
-      }
+        case ELEMENT_TYPE_U1: {
+          current_type_name.append("System.Byte"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_I2: {
-        current_type_name.append("System.Int16"_W);
-        break;
-      }
+        case ELEMENT_TYPE_I2: {
+          current_type_name.append("System.Int16"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_U2: {
-        current_type_name.append("System.UInt16"_W);
-        break;
-      }
+        case ELEMENT_TYPE_U2: {
+          current_type_name.append("System.UInt16"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_I4: {
-        current_type_name.append("System.Int32"_W);
-        break;
-      }
+        case ELEMENT_TYPE_I4: {
+          current_type_name.append("System.Int32"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_U4: {
-        current_type_name.append("System.UInt32"_W);
-        break;
-      }
+        case ELEMENT_TYPE_U4: {
+          current_type_name.append("System.UInt32"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_I8: {
-        current_type_name.append("System.Int64"_W);
-        break;
-      }
+        case ELEMENT_TYPE_I8: {
+          current_type_name.append("System.Int64"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_U8: {
-        current_type_name.append("System.UInt64"_W);
-        break;
-      }
+        case ELEMENT_TYPE_U8: {
+          current_type_name.append("System.UInt64"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_R4: {
-        current_type_name.append("System.Single"_W);
-        break;
-      }
+        case ELEMENT_TYPE_R4: {
+          current_type_name.append("System.Single"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_R8: {
-        current_type_name.append("System.Double"_W);
-        break;
-      }
+        case ELEMENT_TYPE_R8: {
+          current_type_name.append("System.Double"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_STRING: {
-        current_type_name.append("System.String"_W);
-        break;
-      }
+        case ELEMENT_TYPE_STRING: {
+          current_type_name.append("System.String"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_OBJECT: {
-        current_type_name.append("System.Object"_W);
-        break;
-      }
+        case ELEMENT_TYPE_OBJECT: {
+          current_type_name.append("System.Object"_W);
+          break;
+        }
 
-      case ELEMENT_TYPE_VALUETYPE:
-      case ELEMENT_TYPE_CLASS: {
-        current_index++;
-        auto type_data = RetrieveTypeForSignature(
-            metadata_import, function_info, current_index, token_length);
-        // index will be moved up one on every loop
-        // handle tokens which have more than one byte
-        current_index += token_length - 1;
-        current_type_name.append(type_data.name);
-        break;
-      }
-
-      case ELEMENT_TYPE_SZARRAY: {
-        append_to_type.append("[]"_W);
-        while (function_info.signature.data[(current_index + 1)] ==
-               ELEMENT_TYPE_SZARRAY) {
-          append_to_type.append("[]"_W);
+        case ELEMENT_TYPE_VALUETYPE:
+        case ELEMENT_TYPE_CLASS: {
           current_index++;
-        }
-        // Next will be the type of the array(s)
-        continue;
-      }
-
-      case ELEMENT_TYPE_MVAR: {
-        // We are likely parsing a standalone generic param
-        token_length = CorSigUncompressToken(
-            PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
-            &type_token);
-        current_type_name.append("T"_W);
-        current_index += token_length;
-        // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
-        // current_type_name.append(std::to_wstring(type_token));
-        break;
-      }
-
-      case ELEMENT_TYPE_VAR: {
-        // We are likely within a generic variant
-        token_length = CorSigUncompressToken(
-            PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
-            &type_token);
-        current_type_name.append("T"_W);
-        current_index += token_length;
-        // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
-        // current_type_name.append(std::to_wstring(type_token));
-        break;
-      }
-
-      case ELEMENT_TYPE_GENERICINST: {
-        // skip past generic type indicator token
-        current_index++;
-        // skip past actual generic type token (probably a class)
-        current_index++;
-        const auto generic_type_data = RetrieveTypeForSignature(
-            metadata_import, function_info, current_index, token_length);
-        auto type_name = generic_type_data.name;
-        current_type_name.append(type_name);
-        current_type_name.append("<"_W);  // Begin generic args
-
-        // Because we are starting a new generic, decrement any existing level
-        if (!generic_arg_stack.empty()) {
-          generic_arg_stack.top()--;
+          auto type_data = RetrieveTypeForSignature(
+              metadata_import, function_info, current_index, token_length);
+          // index will be moved up one on every loop
+          // handle tokens which have more than one byte
+          current_index += token_length - 1;
+          current_type_name.append(type_data.name);
+          break;
         }
 
-        // figure out how many generic args this type has
-        const auto index_of_tick = type_name.find_last_of('`');
-        auto num_args_text = ToString(type_name.substr(index_of_tick + 1));
-        auto actual_arg_count = std::stoi(num_args_text, nullptr);
-        generic_arg_stack.push(actual_arg_count);
-        current_index += token_length;
-        // Next will be the variants
+        case ELEMENT_TYPE_SZARRAY: {
+          append_to_type.append("[]"_W);
+          while (function_info.signature.data[(current_index + 1)] ==
+                 ELEMENT_TYPE_SZARRAY) {
+            append_to_type.append("[]"_W);
+            current_index++;
+          }
+          // Next will be the type of the array(s)
+          continue;
+        }
+
+        case ELEMENT_TYPE_MVAR: {
+          // We are likely parsing a standalone generic param
+          token_length = CorSigUncompressToken(
+              PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
+              &type_token);
+          current_type_name.append("T"_W);
+          current_index += token_length;
+          // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
+          // current_type_name.append(std::to_wstring(type_token));
+          break;
+        }
+
+        case ELEMENT_TYPE_VAR: {
+          // We are likely within a generic variant
+          token_length = CorSigUncompressToken(
+              PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
+              &type_token);
+          current_type_name.append("T"_W);
+          current_index += token_length;
+          // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
+          // current_type_name.append(std::to_wstring(type_token));
+          break;
+        }
+
+        case ELEMENT_TYPE_GENERICINST: {
+          // skip past generic type indicator token
+          current_index++;
+          // skip past actual generic type token (probably a class)
+          current_index++;
+          const auto generic_type_data = RetrieveTypeForSignature(
+              metadata_import, function_info, current_index, token_length);
+          auto type_name = generic_type_data.name;
+          current_type_name.append(type_name);
+          current_type_name.append("<"_W);  // Begin generic args
+
+          // Because we are starting a new generic, decrement any existing level
+          if (!generic_arg_stack.empty()) {
+            generic_arg_stack.top()--;
+          }
+
+          // figure out how many generic args this type has
+          const auto index_of_tick = type_name.find_last_of('`');
+          auto num_args_text = ToString(type_name.substr(index_of_tick + 1));
+          auto actual_arg_count = std::stoi(num_args_text, nullptr);
+          generic_arg_stack.push(actual_arg_count);
+          current_index += token_length;
+          // Next will be the variants
+          continue;
+        }
+
+        case ELEMENT_TYPE_BYREF: {
+          // TODO: This hasn't been encountered yet
+          current_type_name.append("ref"_W);
+          break;
+        }
+
+        case ELEMENT_TYPE_END: {
+          // we already handle the generic by counting args
+          continue;
+        }
+
+        default: {
+          // This is unexpected and we should report that, and not instrument
+          current_type_name.append(ToWSTRING(ToString(cor_element_type)));
+          break;
+        }
+      }
+
+      if (!append_to_type.empty()) {
+        current_type_name.append(append_to_type);
+        append_to_type = ""_W;
+      }
+
+      if (!generic_arg_stack.empty()) {
+        // decrement this level's args
+        generic_arg_stack.top()--;
+
+        if (generic_arg_stack.top() > 0) {
+          // we're in the middle of generic type args
+          current_type_name.append(", "_W);
+        }
+      }
+
+      while (!generic_arg_stack.empty() && generic_arg_stack.top() == 0) {
+        // unwind the generics with no args left
+        generic_arg_stack.pop();
+        current_type_name.append(">"_W);
+
+        if (!generic_arg_stack.empty() && generic_arg_stack.top() > 0) {
+          // We are in a nested generic and we need a comma to separate args
+          current_type_name.append(", "_W);
+        }
+      }
+
+      if (!generic_arg_stack.empty()) {
         continue;
       }
 
-      case ELEMENT_TYPE_BYREF: {
-        // TODO: This hasn't been encountered yet
-        current_type_name.append("ref"_W);
-        break;
+      if (current_type_index >= expected_number_of_types) {
+        // We missed something, drop out for safety
+        return false;
       }
 
-      case ELEMENT_TYPE_END: {
-        // we already handle the generic by counting args
-        continue;
-      }
-
-      default: {
-        // This is unexpected and we should report that, and not instrument
-        current_type_name.append(ToWSTRING(ToString(cor_element_type)));
-        break;
-      }
+      type_names[current_type_index] = current_type_name;
+      current_type_name = ""_W;
+      current_type_index++;
     }
 
-    if (!append_to_type.empty()) {
-      current_type_name.append(append_to_type);
-      append_to_type = ""_W;
-    }
+    signature_result = type_names;
 
-    if (!generic_arg_stack.empty()) {
-      // decrement this level's args
-      generic_arg_stack.top()--;
-
-      if (generic_arg_stack.top() > 0) {
-        // we're in the middle of generic type args
-        current_type_name.append(", "_W);
-      }
-    }
-
-    while (!generic_arg_stack.empty() && generic_arg_stack.top() == 0) {
-      // unwind the generics with no args left
-      generic_arg_stack.pop();
-      current_type_name.append(">"_W);
-
-      if (!generic_arg_stack.empty() && generic_arg_stack.top() > 0) {
-        // We are in a nested generic and we need a comma to separate args
-        current_type_name.append(", "_W);
-      }
-    }
-
-    if (!generic_arg_stack.empty()) {
-      continue;
-    }
-
-    if (current_type_index >= expected_number_of_types) {
-      // We missed something, drop out for safety
-      return false;
-    }
-
-    type_names[current_type_index] = current_type_name;
-    current_type_name = ""_W;
-    current_type_index++;
+  } catch (...) {
+    // TODO: Add precise exceptions and log
+    // We were unable to parse for some reason
+    // Return that we've failed
+    return false;
   }
-
-  signature_result = type_names;
 
   return true;
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -430,12 +430,12 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
       }
 
       case ELEMENT_TYPE_I1: {
-        current_type_name.append("System.Int8"_W);
+        current_type_name.append("System.SByte"_W);
         break;
       }
 
       case ELEMENT_TYPE_U1: {
-        current_type_name.append("System.UInt8"_W);
+        current_type_name.append("System.Byte"_W);
         break;
       }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -316,7 +316,7 @@ mdMethodSpec DefineMethodSpec(const ComPtr<IMetaDataEmit2>& metadata_emit,
 
 bool DisableOptimizations();
 
-bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
+bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
                          const FunctionInfo& function_info,
                          std::vector<WSTRING>& signature_result);
 }  // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -413,7 +413,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       auto expected_number_args = method_replacement.wrapper_method
                                       .method_signature.NumberOfArguments();
 
-      // We pass the op-code as the last argument to every wrapper method
+      // We pass the opcode as the last argument to every wrapper method
       expected_number_args--;
 
       if (target.signature.IsInstanceMethod()) {
@@ -472,7 +472,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
 
       const auto original_argument = pInstr->m_Arg32;
 
-      // insert the op-code and signature token as
+      // insert the opcode and signature token as
       // additional arguments for the wrapper method
       ILRewriterWrapper rewriter_wrapper(&rewriter);
       rewriter_wrapper.SetILPosition(pInstr);

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -177,6 +177,7 @@ struct MethodReference {
   const MethodSignature method_signature;
   const Version min_version;
   const Version max_version;
+  const std::vector<WSTRING> signature_types;
 
   MethodReference()
       : min_version(Version(0, 0, 0, 0)),
@@ -184,13 +185,15 @@ struct MethodReference {
 
   MethodReference(const WSTRING& assembly_name, WSTRING type_name,
                   WSTRING method_name, Version min_version, Version max_version,
-                  const std::vector<BYTE>& method_signature)
+                  const std::vector<BYTE>& method_signature,
+                  const std::vector<WSTRING>& signature_types)
       : assembly(assembly_name),
         type_name(type_name),
         method_name(method_name),
         method_signature(method_signature),
         min_version(min_version),
-        max_version(max_version) {}
+        max_version(max_version),
+        signature_types(signature_types) {}
 
   inline WSTRING get_type_cache_key() const {
     return "["_W + assembly.name + "]"_W + type_name + "_vMin_"_W +

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -159,6 +159,16 @@ MethodReference MethodReferenceFromJson(const json::value_type& src, const bool 
     if (src.find("maximum_patch") != eoj) {
       max_patch = src["maximum_patch"].get<USHORT>();
     }
+
+    if (src.find("signature_types") != eoj) {
+      // nlohmann is unable to handle null values in this array
+      // we would need to write out own parser here for null values
+      auto sig_types = src["signature_types"].get<std::vector<std::string>>();
+      signature_type_array = std::vector<WSTRING>(sig_types.size());
+      for (auto i = sig_types.size() - 1; i < sig_types.size(); i--) {
+        signature_type_array[i] = ToWSTRING(sig_types[i]);
+      }
+    }
   }
 
   std::vector<BYTE> signature;

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -112,14 +112,14 @@ std::pair<MethodReplacement, bool> MethodReplacementFromJson(
     return std::make_pair<MethodReplacement, bool>({}, false);
   }
 
-  const auto caller = MethodReferenceFromJson(src.value("caller", json::object()));
-  const auto target = MethodReferenceFromJson(src.value("target", json::object()));
-  const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()));
+  const auto caller = MethodReferenceFromJson(src.value("caller", json::object()), false);
+  const auto target = MethodReferenceFromJson(src.value("target", json::object()), true);
+  const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()), false);
   return std::make_pair<MethodReplacement, bool>({caller, target, wrapper},
                                                  true);
 }
 
-MethodReference MethodReferenceFromJson(const json::value_type& src) {
+MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method) {
   if (!src.is_object()) {
     return {};
   }
@@ -136,24 +136,29 @@ MethodReference MethodReferenceFromJson(const json::value_type& src) {
   USHORT max_major = USHRT_MAX;
   USHORT max_minor = USHRT_MAX;
   USHORT max_patch = USHRT_MAX;
+  std::vector<WSTRING> signature_type_array;
 
-  if (src.find("minimum_major") != eoj) {
-    min_major = src["minimum_major"].get<USHORT>();
-  }
-  if (src.find("minimum_minor") != eoj) {
-    min_minor = src["minimum_minor"].get<USHORT>();
-  }
-  if (src.find("minimum_patch") != eoj) {
-    min_patch = src["minimum_patch"].get<USHORT>();
-  }
-  if (src.find("maximum_major") != eoj) {
-    max_major = src["maximum_major"].get<USHORT>();
-  }
-  if (src.find("maximum_minor") != eoj) {
-    max_minor = src["maximum_minor"].get<USHORT>();
-  }
-  if (src.find("maximum_patch") != eoj) {
-    max_patch = src["maximum_patch"].get<USHORT>();
+  if (is_target_method) {
+    // these fields only exist in the target definition
+
+    if (src.find("minimum_major") != eoj) {
+      min_major = src["minimum_major"].get<USHORT>();
+    }
+    if (src.find("minimum_minor") != eoj) {
+      min_minor = src["minimum_minor"].get<USHORT>();
+    }
+    if (src.find("minimum_patch") != eoj) {
+      min_patch = src["minimum_patch"].get<USHORT>();
+    }
+    if (src.find("maximum_major") != eoj) {
+      max_major = src["maximum_major"].get<USHORT>();
+    }
+    if (src.find("maximum_minor") != eoj) {
+      max_minor = src["maximum_minor"].get<USHORT>();
+    }
+    if (src.find("maximum_patch") != eoj) {
+      max_patch = src["maximum_patch"].get<USHORT>();
+    }
   }
 
   std::vector<BYTE> signature;
@@ -189,7 +194,8 @@ MethodReference MethodReferenceFromJson(const json::value_type& src) {
   }
   return MethodReference(
       assembly, type, method, Version(min_major, min_minor, min_patch, 0),
-      Version(max_major, max_minor, max_patch, USHRT_MAX), signature);
+                         Version(max_major, max_minor, max_patch, USHRT_MAX),
+                         signature, signature_type_array);
 }
 
 }  // namespace

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -161,7 +161,7 @@ MethodReference MethodReferenceFromJson(const json::value_type& src, const bool 
     }
 
     if (src.find("signature_types") != eoj) {
-      // nlohmann is unable to handle null values in this array
+      // c++ is unable to handle null values in this array
       // we would need to write out own parsing here for null values
       auto sig_types = src["signature_types"].get<std::vector<std::string>>();
       signature_type_array = std::vector<WSTRING>(sig_types.size());

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -162,7 +162,7 @@ MethodReference MethodReferenceFromJson(const json::value_type& src, const bool 
 
     if (src.find("signature_types") != eoj) {
       // nlohmann is unable to handle null values in this array
-      // we would need to write out own parser here for null values
+      // we would need to write out own parsing here for null values
       auto sig_types = src["signature_types"].get<std::vector<std::string>>();
       signature_type_array = std::vector<WSTRING>(sig_types.size());
       for (auto i = sig_types.size() - 1; i < sig_types.size(); i--) {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
@@ -27,7 +27,8 @@ namespace {
 std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src);
 std::pair<MethodReplacement, bool> MethodReplacementFromJson(
     const json::value_type& src);
-MethodReference MethodReferenceFromJson(const json::value_type& src);
+MethodReference MethodReferenceFromJson(const json::value_type& src,
+                                        const bool is_target_method);
 
 }  // namespace
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -12,6 +12,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.BeforeAction)),
             typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.AfterAction)),
+            typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.Rethrow)),
         };
 
         public static IEnumerable<object[]> GetWrapperMethodWithInterceptionAttributes()

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 attribute.TargetSignatureTypes != null,
                 $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} definition missing.");
 
-            // Return type and op-code cancel out for count
+            // Return type and opcode cancel out for count
             var expectedParameterCount = wrapperMethod.GetParameters().Length;
 
             if (!StaticInstrumentations.Contains(wrapperMethod))

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void WrapperMethodHasOpCodeArgument(MethodInfo wrapperMethod)
         {
             // all wrapper methods should have an additional Int32
-            // parameter for the original method call's op-code
+            // parameter for the original method call's opcode
             ParameterInfo lastParameter = wrapperMethod.GetParameters().Last();
             Assert.Equal(typeof(int), lastParameter.ParameterType);
             Assert.Equal("opCode", lastParameter.Name);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -1,19 +1,22 @@
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
+using Datadog.Trace.ClrProfiler.Integrations;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Tests
 {
     public class IntegrationSignatureTests
     {
-        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1009:ClosingParenthesisMustBeSpacedCorrectly", Justification = "Reviewed.")]
+        private static readonly List<MethodInfo> StaticInstrumentations = new List<MethodInfo>()
+        {
+            typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.Rethrow)),
+        };
+
         public static IEnumerable<object[]> GetWrapperMethods()
         {
             var integrationsAssembly = typeof(Instrumentation).Assembly;
 
-            // find all methods in Datadog.Trace.ClrProfiler.Managed.dll with [InterceptMethod]
             var integrations = from wrapperType in integrationsAssembly.GetTypes()
                                from wrapperMethod in wrapperType.GetRuntimeMethods()
                                let attributes = wrapperMethod.GetCustomAttributes<InterceptMethodAttribute>(inherit: false)
@@ -28,10 +31,37 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void WrapperMethodHasOpCodeArgument(MethodInfo wrapperMethod)
         {
             // all wrapper methods should have an additional Int32
-            // parameter for the original method call's opcode
+            // parameter for the original method call's op-code
             ParameterInfo lastParameter = wrapperMethod.GetParameters().Last();
             Assert.Equal(typeof(int), lastParameter.ParameterType);
             Assert.Equal("opCode", lastParameter.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetWrapperMethods))]
+        public void AllMethodsHaveProperlyFormedTargetSignatureTypes(MethodInfo wrapperMethod)
+        {
+            var attribute = wrapperMethod.GetCustomAttributes<InterceptMethodAttribute>(inherit: false).Single();
+
+            Assert.True(
+                attribute.TargetSignatureTypes != null,
+                $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} definition missing.");
+
+            var expectedParameterCount = wrapperMethod.GetParameters().Length;
+
+            // Return type
+            expectedParameterCount++;
+
+            if (StaticInstrumentations.Contains(wrapperMethod))
+            {
+                // no instance parameter
+                expectedParameterCount--;
+            }
+
+            var typeSigLength = attribute.TargetSignatureTypes.Length;
+            Assert.True(
+                expectedParameterCount == typeSigLength,
+                $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} has {typeSigLength} items, expected {expectedParameterCount}.");
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -65,6 +65,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.True(
                 expectedParameterCount == typeSigLength,
                 $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} has {typeSigLength} items, expected {expectedParameterCount}.");
+
+            Assert.False(
+                attribute.TargetSignatureTypes.Any(string.IsNullOrWhiteSpace),
+                $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} has null or empty arguments.");
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -10,6 +10,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
     {
         public static IEnumerable<object[]> GetConstTypeAssociations()
         {
+            yield return new object[] { ClrNames.Ignore, "_" };
             yield return new object[] { ClrNames.Void, typeof(void) };
             yield return new object[] { ClrNames.Object, typeof(object) };
             yield return new object[] { ClrNames.Bool, typeof(bool) };
@@ -32,7 +33,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 typeof(ClrNames)
                    .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
                    .Where(fi => fi.IsLiteral && !fi.IsInitOnly && fi.FieldType == typeof(string))
-                   .Where(fi => fi.Name != nameof(ClrNames.Ignore))
                    .ToList();
 
             Assert.Equal(actual: associations.Count, expected: expectedItems.Count);
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetConstTypeAssociations))]
-        public void StringMatches(string constant, object type)
+        public void MatchesExpectedTypeName(string constant, object type)
         {
             if (type is Type)
             {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -14,12 +14,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             yield return new object[] { ClrNames.Object, typeof(object) };
             yield return new object[] { ClrNames.Bool, typeof(bool) };
             yield return new object[] { ClrNames.String, typeof(string) };
-            yield return new object[] { ClrNames.Byte, "System.UInt8" };
-            yield return new object[] { ClrNames.Int8, "System.Int8" };
+            yield return new object[] { ClrNames.SByte, typeof(sbyte) };
             yield return new object[] { ClrNames.Int16, typeof(short) };
             yield return new object[] { ClrNames.Int32, typeof(int) };
             yield return new object[] { ClrNames.Int64, typeof(long) };
-            yield return new object[] { ClrNames.UInt8, "System.UInt8" };
+            yield return new object[] { ClrNames.Byte, typeof(byte) };
             yield return new object[] { ClrNames.UInt16, typeof(ushort) };
             yield return new object[] { ClrNames.UInt32, typeof(uint) };
             yield return new object[] { ClrNames.UInt64, typeof(ulong) };

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class TypeNameTests
+    {
+        public static IEnumerable<object[]> GetConstTypeAssociations()
+        {
+            yield return new object[] { ClrNames.Void, typeof(void) };
+            yield return new object[] { ClrNames.Object, typeof(object) };
+            yield return new object[] { ClrNames.Bool, typeof(bool) };
+            yield return new object[] { ClrNames.String, typeof(string) };
+            yield return new object[] { ClrNames.Byte, "System.UInt8" };
+            yield return new object[] { ClrNames.Int8, "System.Int8" };
+            yield return new object[] { ClrNames.Int16, typeof(short) };
+            yield return new object[] { ClrNames.Int32, typeof(int) };
+            yield return new object[] { ClrNames.Int64, typeof(long) };
+            yield return new object[] { ClrNames.UInt8, "System.UInt8" };
+            yield return new object[] { ClrNames.UInt16, typeof(ushort) };
+            yield return new object[] { ClrNames.UInt32, typeof(uint) };
+            yield return new object[] { ClrNames.UInt64, typeof(ulong) };
+        }
+
+        [Fact]
+        public void EveryMemberOfTypeNamesIsRepresented()
+        {
+            var associations = GetConstTypeAssociations().Select(i => i[0]).ToList();
+            var expectedItems =
+                typeof(ClrNames)
+                   .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                   .Where(fi => fi.IsLiteral && !fi.IsInitOnly && fi.FieldType == typeof(string))
+                   .Where(fi => fi.Name != nameof(ClrNames.Ignore))
+                   .ToList();
+
+            Assert.Equal(actual: associations.Count, expected: expectedItems.Count);
+
+            var missing = new List<string>();
+            foreach (var expectedItem in expectedItems)
+            {
+                var value = (string)expectedItem.GetRawConstantValue();
+                if (associations.Contains(value))
+                {
+                    continue;
+                }
+
+                missing.Add(value);
+            }
+
+            Assert.Empty(missing);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetConstTypeAssociations))]
+        public void StringMatches(string constant, object type)
+        {
+            if (type is Type)
+            {
+                Assert.Equal(constant, ((Type)type).FullName);
+            }
+
+            if (type is string)
+            {
+                Assert.Equal(constant, (string)type);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -60,16 +60,17 @@ TEST_F(CLRHelperTest, FiltersEnabledIntegrations) {
                        L"SomeMethod",
                        min_ver_,
                        max_ver_,
-                       {}},
+                       {},
+                       empty_sig_type_},
                       {}}}};
   Integration i2 = {
       L"integration-2",
       {{{},
-        {L"Assembly.Two", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}},
+        {L"Assembly.Two", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}, empty_sig_type_},
         {}}}};
   Integration i3 = {
       L"integration-3",
-      {{{}, {L"System.Runtime", L"", L"", min_ver_, max_ver_, {}}, {}}}};
+      {{{}, {L"System.Runtime", L"", L"", min_ver_, max_ver_, {}, empty_sig_type_}, {}}}};
   std::vector<Integration> all = {i1, i2, i3};
   std::vector<Integration> expected = {i1, i3};
   std::vector<WSTRING> disabled_integrations = {"integration-2"_W};
@@ -80,12 +81,12 @@ TEST_F(CLRHelperTest, FiltersEnabledIntegrations) {
 TEST_F(CLRHelperTest, FiltersIntegrationsByCaller) {
   Integration i1 = {
       L"integration-1",
-      {{{L"Assembly.One", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}},
+      {{{L"Assembly.One", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}, empty_sig_type_},
         {},
         {}}}};
   Integration i2 = {
       L"integration-2",
-      {{{L"Assembly.Two", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}},
+      {{{L"Assembly.Two", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}, empty_sig_type_},
         {},
         {}}}};
   Integration i3 = {L"integration-3", {{{}, {}, {}}}};
@@ -105,16 +106,17 @@ TEST_F(CLRHelperTest, FiltersIntegrationsByTarget) {
                        L"SomeMethod",
                        min_ver_,
                        max_ver_,
-                       {}},
+                       {},
+                       empty_sig_type_},
                       {}}}};
   Integration i2 = {
       L"integration-2",
       {{{},
-        {L"Assembly.Two", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}},
+        {L"Assembly.Two", L"SomeType", L"SomeMethod", min_ver_, max_ver_, {}, empty_sig_type_},
         {}}}};
   Integration i3 = {
       L"integration-3",
-      {{{}, {L"System.Runtime", L"", L"", min_ver_, max_ver_, {}}, {}}}};
+      {{{}, {L"System.Runtime", L"", L"", min_ver_, max_ver_, {}, empty_sig_type_}, {}}}};
   auto all = FlattenIntegrations({i1, i2, i3});
   auto expected = FlattenIntegrations({i1, i3});
   auto actual = FilterIntegrationsByTarget(all, assembly_import_);
@@ -127,11 +129,14 @@ TEST_F(CLRHelperTest, FiltersFlattenedIntegrationMethodsByTarget) {
                               L"SomeMethod",
                               min_ver_,
                               max_ver_,
-                              {}};
+                              {},
+                              empty_sig_type_};
 
   MethodReference excluded = {L"Samples.ExampleLibrary", L"SomeType",
                               L"SomeOtherMethod",        Version(0, 0, 0, 0),
-                              Version(0, 1, 0, 0),       {}};
+                              Version(0, 1, 0, 0),
+                              {},
+                              empty_sig_type_};
 
   Integration i1 = {L"integration-1", {{{}, included, {}}, {{}, excluded, {}}}};
   auto all = FlattenIntegrations({i1});

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
@@ -28,10 +28,10 @@ TEST_F(CLRHelperTypeCheckTest, GetsVeryComplexNestedGenericTypeStrings) {
       L"System.Void",
       L"System.String",
       L"System.Int32",
-      L"System.UInt8[]",
+      L"System.Byte[]",
       L"System.Guid[][]",
       L"T[][][]",
-      L"System.Collections.Generic.List`1<System.UInt8[][]>",
+      L"System.Collections.Generic.List`1<System.Byte[][]>",
       L"System.Collections.Generic.List`1<Samples.ExampleLibrary.FakeClient.DogTrick`1<T>>",
       L"System.Tuple`7<System.Int32, T, System.String, System.Object, System.Tuple`2<System.Tuple`2<T, System.Int64>, System.Int64>, System.Threading.Tasks.Task, System.Guid>",
       L"System.Collections.Generic.Dictionary`2<System.Int32, System.Collections.Generic.IList`1<System.Threading.Tasks.Task`1<Samples.ExampleLibrary.FakeClient.DogTrick`1<T>>>>"};

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
@@ -18,7 +18,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleNoSignatureMethodHasOnlyVoid) {
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
-  SignatureFuzzyMatch(metadata_import_, target, actual);
+  TryParseSignatureTypes(metadata_import_, target, actual);
 
   EXPECT_EQ(expected, actual);
 }
@@ -42,7 +42,7 @@ TEST_F(CLRHelperTypeCheckTest, GetsVeryComplexNestedGenericTypeStrings) {
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
-  SignatureFuzzyMatch(metadata_import_, target, actual);
+  TryParseSignatureTypes(metadata_import_, target, actual);
 
   EXPECT_EQ(expected, actual);
 }
@@ -58,7 +58,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleClassReturnWithSimpleParamsNoGenerics) {
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
-  SignatureFuzzyMatch(metadata_import_, target, actual);
+  TryParseSignatureTypes(metadata_import_, target, actual);
 
   EXPECT_EQ(expected, actual);
 }
@@ -79,7 +79,7 @@ TEST_F(CLRHelperTypeCheckTest, GenericAsyncMethodWithNestedGenericTask) {
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
-  SignatureFuzzyMatch(metadata_import_, target, actual);
+  TryParseSignatureTypes(metadata_import_, target, actual);
 
   EXPECT_EQ(expected, actual);
 }
@@ -89,7 +89,7 @@ TEST_F(CLRHelperTypeCheckTest, SuccessfullyParsesEverySignature) {
     for (auto& method_def : EnumMethods(metadata_import_, type_def)) {
       auto target = GetFunctionInfo(metadata_import_, method_def);
       std::vector<std::wstring> actual;
-      auto success = SignatureFuzzyMatch(metadata_import_, target, actual);
+      auto success = TryParseSignatureTypes(metadata_import_, target, actual);
       EXPECT_TRUE(success == true) << "Could not parse: "_W + target.type.name + "."_W + target.name;
     }
   }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
@@ -204,3 +204,22 @@ TEST(IntegrationLoaderTest, LoadsFromEnvironment) {
   std::filesystem::remove(tmpname1);
   std::filesystem::remove(tmpname2);
 }
+
+TEST(IntegrationLoaderTest, DeserializesSignatureTypeArray) {
+  std::stringstream str(R"TEXT(
+        [{
+            "name": "test-integration",
+            "method_replacements": [{
+                "caller": { },
+                "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One", "signature_types": ["System.Void", "System.Object", "FakeClient.Pipeline'1<T>"] },
+                "wrapper": { "assembly": "Assembly.Two", "type": "Type.Two", "method": "Method.One", "signature": [0, 1, 1, 28] }
+            }]
+        }]
+    )TEXT");
+
+  auto integrations = LoadIntegrationsFromStream(str);
+  const auto target = integrations[0].method_replacements[0].target_method;
+  EXPECT_STREQ(L"System.Void", target.signature_types[0].c_str());
+  EXPECT_STREQ(L"System.Object", target.signature_types[1].c_str());
+  EXPECT_STREQ(L"FakeClient.Pipeline'1<T>", target.signature_types[2].c_str());
+}

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
@@ -211,7 +211,7 @@ TEST(IntegrationLoaderTest, DeserializesSignatureTypeArray) {
             "name": "test-integration",
             "method_replacements": [{
                 "caller": { },
-                "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One", "signature_types": ["System.Void", "System.Object", "FakeClient.Pipeline'1<T>"] },
+                "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One", "signature_types": ["System.Void", null, "FakeClient.Pipeline'1<T>"] },
                 "wrapper": { "assembly": "Assembly.Two", "type": "Type.Two", "method": "Method.One", "signature": [0, 1, 1, 28] }
             }]
         }]

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
@@ -211,7 +211,7 @@ TEST(IntegrationLoaderTest, DeserializesSignatureTypeArray) {
             "name": "test-integration",
             "method_replacements": [{
                 "caller": { },
-                "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One", "signature_types": ["System.Void", null, "FakeClient.Pipeline'1<T>"] },
+                "target": { "assembly": "Assembly.One", "type": "Type.One", "method": "Method.One", "signature_types": ["System.Void", "_", "FakeClient.Pipeline'1<T>"] },
                 "wrapper": { "assembly": "Assembly.Two", "type": "Type.Two", "method": "Method.One", "signature": [0, 1, 1, 28] }
             }]
         }]

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/integration_loader_test.cpp
@@ -220,6 +220,6 @@ TEST(IntegrationLoaderTest, DeserializesSignatureTypeArray) {
   auto integrations = LoadIntegrationsFromStream(str);
   const auto target = integrations[0].method_replacements[0].target_method;
   EXPECT_STREQ(L"System.Void", target.signature_types[0].c_str());
-  EXPECT_STREQ(L"System.Object", target.signature_types[1].c_str());
+  EXPECT_STREQ(L"_", target.signature_types[1].c_str());
   EXPECT_STREQ(L"FakeClient.Pipeline'1<T>", target.signature_types[2].c_str());
 }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
@@ -11,6 +11,7 @@ class MetadataBuilderTest : public ::testing::Test {
   MetadataBuilder* metadata_builder_ = nullptr;
   ICLRStrongName* strong_name_ = nullptr;
   IMetaDataDispenser* metadata_dispenser_ = nullptr;
+  std::vector<WSTRING> empty_sig_type_;
 
   void SetUp() override {
     ICLRMetaHost* metahost = nullptr;
@@ -82,11 +83,9 @@ TEST_F(MetadataBuilderTest, StoresWrapperMemberRef) {
 
   const auto min_ver = Version(0, 0, 0, 0);
   const auto max_ver = Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX);
-  const MethodReference ref1(L"", L"", L"", min_ver, max_ver, {});
-  const MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", min_ver,
-                       max_ver, {});
-  const MethodReference ref3(L"Samples.ExampleLibrary", L"Class1", L"Add", min_ver,
-                       max_ver, {});
+  const MethodReference ref1(L"", L"", L"", min_ver, max_ver, {}, empty_sig_type_);
+  const MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", min_ver, max_ver, {}, empty_sig_type_);
+  const MethodReference ref3(L"Samples.ExampleLibrary", L"Class1", L"Add", min_ver, max_ver, {}, empty_sig_type_);
   const MethodReplacement mr1(ref1, ref2, ref3);
   auto hr = metadata_builder_->StoreWrapperMethodRef(mr1);
   ASSERT_EQ(S_OK, hr);
@@ -107,11 +106,11 @@ TEST_F(MetadataBuilderTest, StoresWrapperMemberRef) {
 TEST_F(MetadataBuilderTest, StoresWrapperMemberRefForSeparateAssembly) {
   const auto min_ver = Version(0, 0, 0, 0);
   const auto max_ver = Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX);
-  const MethodReference ref1(L"", L"", L"", min_ver, max_ver, {});
-  const MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", min_ver,
-                       max_ver, {});
+  const MethodReference ref1(L"", L"", L"", min_ver, max_ver, {},
+                             empty_sig_type_);
+  const MethodReference ref2(L"Samples.ExampleLibrary", L"Class1", L"Add", min_ver, max_ver, {}, empty_sig_type_);
   const MethodReference ref3(L"Samples.ExampleLibraryTracer", L"Class1", L"Add",
-                       min_ver, max_ver, {});
+                             min_ver, max_ver, {}, empty_sig_type_);
   const MethodReplacement mr1(ref1, ref2, ref3);
   auto hr = metadata_builder_->StoreWrapperMethodRef(mr1);
   ASSERT_EQ(S_OK, hr);

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/test_helpers.h
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/test_helpers.h
@@ -12,6 +12,7 @@ class CLRHelperTestBase : public ::testing::Test {
   ComPtr<IMetaDataAssemblyImport> assembly_import_;
   Version min_ver_ = Version(0, 0, 0, 0);
   Version max_ver_ = Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX);
+  std::vector<WSTRING> empty_sig_type_;
 
   void LoadMetadataDependencies() {
     ICLRMetaHost* metahost = nullptr;

--- a/tools/GenerateIntegrationDefinitions/Program.cs
+++ b/tools/GenerateIntegrationDefinitions/Program.cs
@@ -49,6 +49,7 @@ namespace GenerateIntegrationDefinitions
                                                                  type = item.attribute.TargetType,
                                                                  method = item.attribute.TargetMethod ?? item.wrapperMethod.Name,
                                                                  signature = item.attribute.TargetSignature,
+                                                                 signature_types = item.attribute.TargetSignatureTypes,
                                                                  minimum_major = item.attribute.TargetVersionRange.MinimumMajor,
                                                                  minimum_minor = item.attribute.TargetVersionRange.MinimumMinor,
                                                                  minimum_patch = item.attribute.TargetVersionRange.MinimumPatch,


### PR DESCRIPTION
Changes proposed in this pull request:
- [x] Enforce type signature array specification with test
- [x] Decorate every wrapper method with empty type signature array
- [x] Serialize type signature array into integrations.json
- [x] Deserialize type signature array into c++
- [x] Write tests verifying deserialization behavior
- [x] Introduce short-circuits based on signature type parsing

@DataDog/apm-dotnet