### PR TITLE
fix C++ compiler warnings

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -414,7 +414,7 @@ bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
   }
 
   const auto expected_number_of_types = param_count + 1;
-  auto current_type_index = 0;
+  size_t current_type_index = 0;
   std::vector<WSTRING> type_names(expected_number_of_types);
 
   std::stack<int> generic_arg_stack;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -391,7 +391,7 @@ bool DisableOptimizations() {
 
 TypeInfo RetrieveTypeForSignature(
     const ComPtr<IMetaDataImport2>& metadata_import,
-    const FunctionInfo& function_info, const int& current_index,
+    const FunctionInfo& function_info, const size_t current_index,
     ULONG& token_length) {
   mdToken type_token;
   const auto type_token_start =
@@ -407,7 +407,7 @@ bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
   const auto signature_size = function_info.signature.data.size();
   const auto generic_count = function_info.signature.NumberOfTypeArguments();
   const auto param_count = function_info.signature.NumberOfArguments();
-  auto current_index = 2;  // Where the parameters actually start
+  size_t current_index = 2;  // Where the parameters actually start
 
   if (generic_count > 0) {
     current_index++;  // offset by one because the method is generic

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -139,7 +139,7 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
       if (FAILED(hr)) {
         return {};
       }
-      auto generic_info = GetFunctionInfo(metadata_import, parent_token);
+      const auto generic_info = GetFunctionInfo(metadata_import, parent_token);
       final_signature_bytes = generic_info.signature.data;
       method_spec_signature =
           GetSignatureByteRepresentation(raw_signature_len, raw_signature);
@@ -255,7 +255,7 @@ mdAssemblyRef FindAssemblyRef(
 
 std::vector<Integration> FilterIntegrationsByName(
     const std::vector<Integration>& integrations,
-    const std::vector<WSTRING> integration_names) {
+    const std::vector<WSTRING>& integration_names) {
   std::vector<Integration> enabled;
 
   for (auto& i : integrations) {
@@ -518,7 +518,7 @@ bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
       case ELEMENT_TYPE_SZARRAY: {
         append_to_type.append("[]"_W);
         while (function_info.signature.data[(current_index + 1)] ==
-            ELEMENT_TYPE_SZARRAY) {
+               ELEMENT_TYPE_SZARRAY) {
           append_to_type.append("[]"_W);
           current_index++;
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -404,23 +404,23 @@ TypeInfo RetrieveTypeForSignature(
 bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
                          const FunctionInfo& function_info,
                          std::vector<WSTRING>& signature_result) {
-  const int signature_size = function_info.signature.data.size();
-  auto generic_count = function_info.signature.NumberOfTypeArguments();
-  auto param_count = function_info.signature.NumberOfArguments();
+  const auto signature_size = function_info.signature.data.size();
+  const auto generic_count = function_info.signature.NumberOfTypeArguments();
+  const auto param_count = function_info.signature.NumberOfArguments();
   auto current_index = 2;  // Where the parameters actually start
 
   if (generic_count > 0) {
     current_index++;  // offset by one because the method is generic
   }
 
-  const UINT expected_number_of_types = param_count + 1;
-  UINT current_type_index = 0;
+  const auto expected_number_of_types = param_count + 1;
+  auto current_type_index = 0;
   std::vector<WSTRING> type_names(expected_number_of_types);
 
   std::stack<int> generic_arg_stack;
   WSTRING append_to_type = ""_W;
   WSTRING current_type_name = ""_W;
-  
+
   for (; current_index < signature_size; current_index++) {
     mdToken type_token;
     ULONG token_length;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -145,7 +145,7 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
           GetSignatureByteRepresentation(raw_signature_len, raw_signature);
       std::memcpy(function_name, generic_info.name.c_str(),
                   sizeof(WCHAR) * (generic_info.name.length() + 1));
-      function_name_len = (DWORD)(generic_info.name.length() + 1);
+      function_name_len = DWORD(generic_info.name.length() + 1);
     } break;
     default:
       Warn("[trace::GetFunctionInfo] unknown token type: {}", token_type);
@@ -517,8 +517,7 @@ bool SignatureFuzzyMatch(const ComPtr<IMetaDataImport2>& metadata_import,
 
       case ELEMENT_TYPE_SZARRAY: {
         append_to_type.append("[]"_W);
-        while (
-            CorElementType(function_info.signature.data[current_index + 1]) ==
+        while (function_info.signature.data[(current_index + 1)] ==
             ELEMENT_TYPE_SZARRAY) {
           append_to_type.append("[]"_W);
           current_index++;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -284,7 +284,7 @@ mdAssemblyRef FindAssemblyRef(
 // disabled_integration_names
 std::vector<Integration> FilterIntegrationsByName(
     const std::vector<Integration>& integrations,
-    std::vector<WSTRING> integration_names);
+    const std::vector<WSTRING>& integration_names);
 
 // FlattenIntegrations flattens integrations to per method structures
 std::vector<IntegrationMethod> FlattenIntegrations(


### PR DESCRIPTION
Fixes [C++ compiler warnings in CI](https://dev.azure.com/datadog-apm/dd-trace-dotnet/_build/results?buildId=7486&view=logs&jobId=da49a64b-d66c-5066-198e-9b8a2749369d&taskId=6527c5dc-fc44-516f-edb3-481a9700f992&lineStart=27&lineEnd=28&colStart=1&colEnd=1) about conversions from `size_t` to `int` or `UINT`.
