### PR TITLE
yaml pipeline updates

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -1,0 +1,48 @@
+trigger:
+  batch: 'true'
+  branches:
+    include:
+      - master
+      - develop
+  paths:
+    exclude:
+      - docs/*
+      - .github/*
+
+variables:
+  buildConfiguration: debug
+  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+
+jobs:
+
+- job: linux
+
+  pool:
+    vmImage: ubuntu-16.04
+
+  steps:
+  - task: DockerCompose@0
+    displayName: docker-compose run build
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run -e TestAllPackageVersions=true build
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Datadog.Trace.ClrProfiler.Native
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeFileArgs: TestAllPackageVersions=true
+      dockerComposeCommand: run Datadog.Trace.ClrProfiler.Native
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Datadog.Trace.ClrProfiler.IntegrationTests
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run -e TestAllPackageVersions=true Datadog.Trace.ClrProfiler.IntegrationTests
+
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: test/**/*.trx
+    condition: succeededOrFailed()

--- a/.azure-pipelines/managed-unit-tests.yml
+++ b/.azure-pipelines/managed-unit-tests.yml
@@ -2,8 +2,7 @@ trigger:
   batch: 'true'
   branches:
     include:
-      - master
-      - develop
+      - refs/heads/*
   paths:
     exclude:
       - docs/*

--- a/.azure-pipelines/managed-unit-tests.yml
+++ b/.azure-pipelines/managed-unit-tests.yml
@@ -42,14 +42,14 @@ steps:
   displayName: dotnet build
   inputs:
     command: build
+    configuration: $(buildConfiguration)
     projects: |
      src/**/*.csproj
      test/**/*.Tests.csproj
-    arguments: --configuration $(buildConfiguration)
 
 - task: DotNetCoreCLI@2
   displayName: dotnet test
   inputs:
     command: test
+    configuration: $(buildConfiguration)
     projects: test/**/*.Tests.csproj
-    arguments: --configuration $(buildConfiguration)

--- a/.azure-pipelines/managed-unit-tests.yml
+++ b/.azure-pipelines/managed-unit-tests.yml
@@ -21,6 +21,7 @@ pool:
 
 variables:
   buildConfiguration: debug
+  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
 
 steps:
 - task: DotNetCoreInstaller@0
@@ -35,7 +36,7 @@ steps:
     projects: |
      src/**/*.csproj
      test/**/*.Tests.csproj
-    vstsFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+    vstsFeed: $(packageFeed)
     verbosityRestore: Normal
 
 - task: DotNetCoreCLI@2

--- a/.azure-pipelines/managed-unit-tests.yml
+++ b/.azure-pipelines/managed-unit-tests.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: 'true'
   branches:
     include:
       - master

--- a/.azure-pipelines/managed-unit-tests.yml
+++ b/.azure-pipelines/managed-unit-tests.yml
@@ -26,7 +26,7 @@ steps:
 - task: DotNetCoreInstaller@0
   displayName: install dotnet core sdk
   inputs:
-    version: 2.1.700
+    version: 2.2.300
 
 - task: DotNetCoreCLI@2
   displayName: dotnet restore

--- a/.azure-pipelines/native-unit-tests.yml
+++ b/.azure-pipelines/native-unit-tests.yml
@@ -2,8 +2,7 @@ trigger:
   batch: 'true'
   branches:
     include:
-      - master
-      - develop
+      - refs/heads/*
   paths:
     exclude:
       - docs/*

--- a/.azure-pipelines/native-unit-tests.yml
+++ b/.azure-pipelines/native-unit-tests.yml
@@ -44,8 +44,8 @@ jobs:
       maximumCpuCount: true
 
   - script: Datadog.Trace.ClrProfiler.Native.Tests.exe --gtest_output=xml
+    displayName: run tests
     workingDirectory: $(System.DefaultWorkingDirectory)/test/Datadog.Trace.ClrProfiler.Native.Tests/bin/$(buildConfiguration)/$(buildPlatform)
-    displayName: Run C++ unit tests
 
   - task: PublishTestResults@2
     displayName: publish test results

--- a/.azure-pipelines/native-unit-tests.yml
+++ b/.azure-pipelines/native-unit-tests.yml
@@ -11,6 +11,7 @@ trigger:
 
 variables:
   buildConfiguration: debug
+  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
 
 jobs:
 
@@ -31,7 +32,7 @@ jobs:
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.Native.sln
-      vstsFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+      vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
   - task: MSBuild@1

--- a/.azure-pipelines/native-unit-tests.yml
+++ b/.azure-pipelines/native-unit-tests.yml
@@ -1,4 +1,5 @@
 trigger:
+  batch: 'true'
   branches:
     include:
       - master

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -1,5 +1,5 @@
 trigger:
-  tags:
+  branches:
     include:
       - refs/tags/*
 pr: none

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -49,7 +49,7 @@ jobs:
   - task: DotNetCoreInstaller@0
     displayName: install dotnet core sdk
     inputs:
-      version: 2.1.700
+      version: 2.2.300
 
   - task: DotNetCoreCLI@2
     displayName: dotnet restore

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -63,8 +63,8 @@ jobs:
     displayName: dotnet build
     inputs:
       command: build
+      configuration: $(buildConfiguration)
       projects: src/**/*.csproj
-      arguments: --configuration $(buildConfiguration)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet pack

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -100,9 +100,6 @@ jobs:
   pool:
     vmImage: ubuntu-16.04
 
-  variables:
-    buildPlatform: x64
-
   steps:
   - task: DockerCompose@0
     displayName: docker-compose run build

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -6,6 +6,7 @@ pr: none
 
 variables:
   buildConfiguration: debug
+  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
 
 jobs:
 
@@ -33,7 +34,7 @@ jobs:
     displayName: nuget restore native
     inputs:
       restoreSolution: Datadog.Trace.Native.sln
-      vstsFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+      vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
   - task: MSBuild@1
@@ -55,7 +56,7 @@ jobs:
     inputs:
       command: restore
       projects: src/**/*.csproj
-      vstsFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+      vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
   - task: DotNetCoreCLI@2

--- a/tools/GenerateIntegrationDefinitions/GenerateIntegrationDefinitions.csproj
+++ b/tools/GenerateIntegrationDefinitions/GenerateIntegrationDefinitions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
changes to ci pipelines:
- integration tests: **add new yaml pipeline**, run only on commits to `master` and `develop` (and all PRs)
- managed tests: **run on every branch**, was only `master` and `develop` (keep running on all PRs, too)
- native tests: **run on every branch**, was only `master` and `develop` (keep running on all PRs, too)
- packages: fix tag filter
- update dotnet sdk to 2.2.300
- move artifact feed guid into a variable

completely-unrelated-but-why-not changes:
- change `GenerateIntegrationDefinitions` target platform to net core so it can run cross-plat
