### PR TITLE
AspNet MVC Explicit Type Arrays

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -203,11 +203,11 @@
           "type": "System.Web.Mvc.Async.IAsyncActionInvoker",
           "method": "BeginInvokeAction",
           "signature_types": [
-            "_",
-            "_",
-            "_",
-            "_",
-            "_"
+            "System.IAsyncResult",
+            "System.Web.Mvc.ControllerContext",
+            "System.String",
+            "System.AsyncCallback",
+            "System.Object"
           ],
           "minimum_major": 5,
           "minimum_minor": 1,
@@ -233,7 +233,7 @@
           "method": "EndInvokeAction",
           "signature_types": [
             "System.Boolean",
-            "_"
+            "System.IAsyncResult"
           ],
           "minimum_major": 5,
           "minimum_minor": 1,

--- a/samples-aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/samples-aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -228,7 +228,7 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
-          <DevelopmentServerPort>51281</DevelopmentServerPort>
+          <DevelopmentServerPort>50449</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:50449/</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 using System.Web.Routing;
 using Datadog.Trace.ClrProfiler.Emit;
@@ -83,7 +84,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                         if (route != null)
                         {
-                            resourceName = $"{httpMethod} {route.Url.ToLowerInvariant()}";
+                            var resourceUrl = route.Url.ToLowerInvariant();
+                            if (resourceUrl.First() != '/')
+                            {
+                                resourceUrl = string.Concat("/", resourceUrl);
+                            }
+
+                            resourceName = $"{httpMethod} {resourceUrl}";
                         }
                     }
                 }
@@ -164,7 +171,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new[] { ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.IAsyncResult, "System.Web.Mvc.ControllerContext", ClrNames.String, ClrNames.AsyncCallback, ClrNames.Object },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static object BeginInvokeAction(
@@ -219,7 +226,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new[] { ClrNames.Bool, ClrNames.Ignore },
+            TargetSignatureTypes = new[] { ClrNames.Bool, ClrNames.IAsyncResult },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
@@ -22,5 +22,8 @@ namespace Datadog.Trace.ClrProfiler
 
         public const string Task = "System.Threading.Tasks.Task";
         public const string CancellationToken = "System.Threading.CancellationToken";
+        // ReSharper disable once InconsistentNaming
+        public const string IAsyncResult = "System.IAsyncResult";
+        public const string AsyncCallback = "System.AsyncCallback";
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc4Tests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET home.index")]
+        [InlineData("/Home/Index", "GET /home/index")]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetMvc5Tests.cs
@@ -22,9 +22,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET", "home/index")]
-        [InlineData("/delay/0", "GET", "home/delay/{seconds}")]
-        [InlineData("/delay-async/0", "GET", "home/delayasync/{seconds}")]
+        [InlineData("/Home/Index", "GET", "/home/index")]
+        [InlineData("/delay/0", "GET", "/delay/{seconds}")]
+        [InlineData("/delay-async/0", "GET", "/delay-async/{seconds}")]
         public async Task SubmitsTraces(
             string path,
             string expectedVerb,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetWebApi2Tests.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private readonly IisFixture _iisFixture;
 
         public AspNetWebApi2Tests(IisFixture iisFixture, ITestOutputHelper output)
-            : base("AspNetMvc5", output)
+            : base("AspNetMvc5", "samples-aspnet", output)
         {
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -25,6 +25,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             yield return new object[] { ClrNames.UInt64, typeof(ulong) };
             yield return new object[] { ClrNames.CancellationToken, typeof(System.Threading.CancellationToken) };
             yield return new object[] { ClrNames.Task, typeof(System.Threading.Tasks.Task) };
+            yield return new object[] { ClrNames.IAsyncResult, typeof(IAsyncResult) };
+            yield return new object[] { ClrNames.AsyncCallback, typeof(AsyncCallback) };
         }
 
         [Fact]

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -155,6 +155,8 @@ namespace Datadog.Trace.TestHelpers
             string processPath,
             StringDictionary environmentVariables)
         {
+            var processName = processPath;
+
             if (IsCoreClr())
             {
                 environmentVariables["CORECLR_ENABLE_PROFILING"] = "1";
@@ -166,9 +168,11 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["COR_ENABLE_PROFILING"] = "1";
                 environmentVariables["COR_PROFILER"] = EnvironmentHelper.ProfilerClsId;
                 environmentVariables["COR_PROFILER_PATH"] = GetProfilerPath();
+
+                processName = Path.GetFileName(processPath);
             }
 
-            environmentVariables["DD_PROFILER_PROCESSES"] = processPath;
+            environmentVariables["DD_PROFILER_PROCESSES"] = processName;
 
             string integrations = string.Join(";", GetIntegrationsFilePaths());
             environmentVariables["DD_INTEGRATIONS"] = integrations;
@@ -178,7 +182,7 @@ namespace Datadog.Trace.TestHelpers
             // for ASP.NET Core sample apps, set the server's port
             environmentVariables["ASPNETCORE_URLS"] = $"http://localhost:{aspNetCorePort}/";
 
-            foreach (var name in new string[] { "SERVICESTACK_REDIS_HOST", "STACKEXCHANGE_REDIS_HOST" })
+            foreach (var name in new[] { "SERVICESTACK_REDIS_HOST", "STACKEXCHANGE_REDIS_HOST" })
             {
                 var value = Environment.GetEnvironmentVariable(name);
                 if (!string.IsNullOrEmpty(value))


### PR DESCRIPTION
Changes proposed in this pull request:
AspnetMvc explicit type arrays
Framework tests should be using exe file name, not path.

@DataDog/apm-dotnet