### PR TITLE
use new "pipeline" artifacts

### DIFF
--- a/.azure-pipelines/managed-unit-tests.yml
+++ b/.azure-pipelines/managed-unit-tests.yml
@@ -21,12 +21,13 @@ pool:
 variables:
   buildConfiguration: debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+  dotnetCoreSdkVersion: 2.2.300
 
 steps:
 - task: DotNetCoreInstaller@0
   displayName: install dotnet core sdk
   inputs:
-    version: 2.2.300
+    version: $(dotnetCoreSdkVersion)
 
 - task: DotNetCoreCLI@2
   displayName: dotnet restore
@@ -36,7 +37,6 @@ steps:
      src/**/*.csproj
      test/**/*.Tests.csproj
     vstsFeed: $(packageFeed)
-    verbosityRestore: Normal
 
 - task: DotNetCoreCLI@2
   displayName: dotnet build

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -11,62 +11,17 @@ variables:
 
 jobs:
 
-#### Nuget packages
+#### NuGet packages and Windows msi installer
 
-- job: nuget
-
-  pool:
-    vmImage: windows-2019
-
-  steps:
-    
-  - task: gittools.gitversion.gitversion-task.GitVersion@4
-    displayName: GitVersion
-    inputs:
-      preferBundledVersion: false
-
-  - task: DotNetCoreInstaller@0
-    displayName: install dotnet core sdk
-    inputs:
-      version: $(dotnetCoreSdkVersion)
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      configuration: $(buildConfiguration)
-      projects: src/**/*.csproj
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet pack
-    inputs:
-      command: pack
-      configuration: $(buildConfiguration)
-      packagesToPack: src/**/*.csproj
-      packDirectory: nuget-output
-
-  - task: PublishPipelineArtifact@0
-    displayName: publish nuget artifacts
-    inputs:
-      artifactName: nuget-packages
-      targetPath: nuget-output
-
-#### Windows installer
-
-- job: msi
+- job: nuget_and_windows_msi
   strategy:
     matrix:
       x64:
         buildPlatform: x64
+        nugetPack: true
       x86:
         buildPlatform: x86
+        nugetPack: false
 
   pool:
     vmImage: windows-2019
@@ -113,6 +68,22 @@ jobs:
       configuration: $(buildConfiguration)
       projects: src/**/*.csproj
 
+  - task: DotNetCoreCLI@2
+    displayName: dotnet pack
+    condition: $(nugetPack)
+    inputs:
+      command: pack
+      configuration: $(buildConfiguration)
+      packagesToPack: src/**/*.csproj
+      packDirectory: nuget-output
+
+  - task: PublishPipelineArtifact@0
+    displayName: publish nuget artifacts
+    condition: $(nugetPack)
+    inputs:
+      artifactName: nuget-packages
+      targetPath: nuget-output
+
   - task: MSBuild@1
     displayName: msbuild msi
     inputs:
@@ -129,7 +100,7 @@ jobs:
 
 #### Linux packages
 
-- job: linux
+- job: linux_packages
 
   pool:
     vmImage: ubuntu-16.04

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -71,13 +71,13 @@ jobs:
     inputs:
       command: pack
       packagesToPack: src/**/*.csproj
-      packDirectory: $(Build.ArtifactStagingDirectory)/nuget
+      packDirectory: nuget-output
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@0
     displayName: publish nuget artifacts
     inputs:
-      PathtoPublish: $(Build.ArtifactStagingDirectory)/nuget
-      ArtifactName: nuget
+      artifactName: nuget
+      targetPath: nuget-output
 
   - task: MSBuild@1
     displayName: msbuild msi
@@ -87,11 +87,11 @@ jobs:
       configuration: $(buildConfiguration)
       msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@0
     displayName: publish msi artifact
     inputs:
-      PathtoPublish: deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/bin/en-us
-      ArtifactName: windows-msi
+      artifactName: windows-msi
+      targetPath: deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/bin/en-us
 
 #### Linux
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -11,9 +11,56 @@ variables:
 
 jobs:
 
-#### Windows
+#### Nuget packages
 
-- job: windows
+- job: nuget
+
+  pool:
+    vmImage: windows-2019
+
+  steps:
+    
+  - task: gittools.gitversion.gitversion-task.GitVersion@4
+    displayName: GitVersion
+    inputs:
+      preferBundledVersion: false
+
+  - task: DotNetCoreInstaller@0
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet restore
+    inputs:
+      command: restore
+      projects: src/**/*.csproj
+      vstsFeed: $(packageFeed)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      configuration: $(buildConfiguration)
+      projects: src/**/*.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet pack
+    inputs:
+      command: pack
+      configuration: $(buildConfiguration)
+      packagesToPack: src/**/*.csproj
+      packDirectory: nuget-output
+
+  - task: PublishPipelineArtifact@0
+    displayName: publish nuget artifacts
+    inputs:
+      artifactName: nuget-packages
+      targetPath: nuget-output
+
+#### Windows installer
+
+- job: msi
   strategy:
     matrix:
       x64:
@@ -58,7 +105,6 @@ jobs:
       command: restore
       projects: src/**/*.csproj
       vstsFeed: $(packageFeed)
-      verbosityRestore: Normal
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -66,19 +112,6 @@ jobs:
       command: build
       configuration: $(buildConfiguration)
       projects: src/**/*.csproj
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet pack
-    inputs:
-      command: pack
-      packagesToPack: src/**/*.csproj
-      packDirectory: nuget-output
-
-  - task: PublishPipelineArtifact@0
-    displayName: publish nuget artifacts
-    inputs:
-      artifactName: nuget
-      targetPath: nuget-output
 
   - task: MSBuild@1
     displayName: msbuild msi
@@ -91,10 +124,10 @@ jobs:
   - task: PublishPipelineArtifact@0
     displayName: publish msi artifact
     inputs:
-      artifactName: windows-msi
+      artifactName: windows-msi-$(buildPlatform)
       targetPath: deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/bin/en-us
 
-#### Linux
+#### Linux packages
 
 - job: linux
 
@@ -124,4 +157,4 @@ jobs:
     displayName: publish artifacts
     inputs:
       PathtoPublish: deploy/linux
-      ArtifactName: linux
+      ArtifactName: linux-packages

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -70,7 +70,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: dotnet pack
-    condition: $(nugetPack)
+    condition: eq(variables['nugetPack'], 'true')
     inputs:
       command: pack
       configuration: $(buildConfiguration)
@@ -79,7 +79,7 @@ jobs:
 
   - task: PublishPipelineArtifact@0
     displayName: publish nuget artifacts
-    condition: $(nugetPack)
+    condition: eq(variables['nugetPack'], 'true')
     inputs:
       artifactName: nuget-packages
       targetPath: nuget-output

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -153,8 +153,8 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run package
 
-  - task: PublishBuildArtifacts@1
+  - task: PublishPipelineArtifact@0
     displayName: publish artifacts
     inputs:
-      PathtoPublish: deploy/linux
-      ArtifactName: linux-packages
+      artifactName: linux-packages
+      targetPath: deploy/linux

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -7,6 +7,7 @@ pr: none
 variables:
   buildConfiguration: debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+  dotnetCoreSdkVersion: 2.2.300
 
 jobs:
 
@@ -49,7 +50,7 @@ jobs:
   - task: DotNetCoreInstaller@0
     displayName: install dotnet core sdk
     inputs:
-      version: 2.2.300
+      version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet restore

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -136,12 +136,6 @@ jobs:
 
   steps:
   - task: DockerCompose@0
-    displayName: docker-compose run build
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run build
-
-  - task: DockerCompose@0
     displayName: docker-compose run Datadog.Trace.ClrProfiler.Native
     inputs:
       containerregistrytype: Container Registry


### PR DESCRIPTION
changes to `packages` pipeline:
- migrate from `PublishBuildArtifacts` to the new `PublishPipelineArtifact` ([docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts))
- split windows job into separate nuget (anycpu) and msi (x64 and x86) jobs

parallel jobs in `packages` pipeline:
- nuget packages
- windows msi installer x64
- windows msi installer x86
- linux packages

[latest test build](https://dev.azure.com/datadog-apm/dd-trace-dotnet/_build/results?buildId=8011&view=results) (normally only triggered when tag is added)