### PR TITLE
Add the CorrelationIdentifers to the logging context of the automatic integrations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -49,14 +49,20 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             using (var scope = CreateScope(command))
             {
-                try
+                using (LogProvider.OpenMappedContext(CorrelationIdentifier.TraceIdKey, CorrelationIdentifier.TraceId, destructure: false))
                 {
-                    return executeReader(command, commandBehavior);
-                }
-                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
-                {
-                    // unreachable code
-                    throw;
+                    using (LogProvider.OpenMappedContext(CorrelationIdentifier.SpanIdKey, CorrelationIdentifier.SpanId, destructure: false))
+                    {
+                        try
+                        {
+                            return executeReader(command, commandBehavior);
+                        }
+                        catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
+                        {
+                            // unreachable code
+                            throw;
+                        }
+                    }
                 }
             }
         }
@@ -101,14 +107,20 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             using (var scope = CreateScope(command))
             {
-                try
+                using (LogProvider.OpenMappedContext(CorrelationIdentifier.TraceIdKey, CorrelationIdentifier.TraceId, destructure: false))
                 {
-                    return await executeReader(command, behavior, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
-                {
-                    // unreachable code
-                    throw;
+                    using (LogProvider.OpenMappedContext(CorrelationIdentifier.SpanIdKey, CorrelationIdentifier.SpanId, destructure: false))
+                    {
+                        try
+                        {
+                            return await executeReader(command, behavior, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
+                        {
+                            // unreachable code
+                            throw;
+                        }
+                    }
                 }
             }
         }

--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -7,8 +7,8 @@ namespace Datadog.Trace
     /// </summary>
     public static class CorrelationIdentifier
     {
-        // private static readonly string TraceIdKey = "dd.trace_id";
-        // private static readonly string SpanIdKey = "dd.span_id";
+        internal static readonly string TraceIdKey = "dd.trace_id";
+        internal static readonly string SpanIdKey = "dd.span_id";
 
         /// <summary>
         /// Gets the trace id


### PR DESCRIPTION
Changes proposed in this pull request:

Add the CorrelationIdentifers to the logging context of the automatic instrumentation methods. Integration classes instrumented:

- [ ] AdoNetIntegration.cs


@DataDog/apm-dotnet