### PR TITLE
allow disabling WCF integration

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -12,6 +12,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     /// </summary>
     public static class WcfIntegration
     {
+        private const string IntegrationName = "Wcf";
         private const string Major4 = "4";
 
         /// <summary>
@@ -32,7 +33,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             var handleRequestDelegate = Emit.DynamicMethodBuilder<Func<object, object, object, bool>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "HandleRequest");
 
-            if (!(requestContext is RequestContext castRequestContext))
+            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName) ||
+                !(requestContext is RequestContext castRequestContext))
             {
                 return handleRequestDelegate(thisObj, requestContext, currentOperationContext);
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Models/WcfRequestMessageSpanIntegrationDelegate.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Models/WcfRequestMessageSpanIntegrationDelegate.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.Models
 
         public void OnError()
         {
-            // Currently only used in extension for excpetion filtering, where we set the actual excpetion
+            // Currently only used in extension for exception filtering, where we set the actual exception
         }
 
         public void Dispose()


### PR DESCRIPTION
Changes proposed in this pull request:
- in WCF integration, don't create a span if the integration (or tracing in general) is disabled