### PR TITLE
fix Instrumentation.ProfilerAttached on .NET Framework

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Threading;
 
-// [assembly: System.Security.SecurityCritical]
-// [assembly: System.Security.AllowPartiallyTrustedCallers]
 namespace Datadog.Trace.ClrProfiler
 {
     /// <summary>
@@ -15,8 +12,15 @@ namespace Datadog.Trace.ClrProfiler
         /// </summary>
         public static readonly string ProfilerClsid = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
 
-        private static readonly Lazy<bool> _profilerAttached = new Lazy<bool>(
-            () =>
+        /// <summary>
+        /// Gets a value indicating whether Datadog's profiler is attached to the current process.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if the profiler is currently attached; <c>false</c> otherwise.
+        /// </value>
+        public static bool ProfilerAttached
+        {
+            get
             {
                 try
                 {
@@ -26,15 +30,7 @@ namespace Datadog.Trace.ClrProfiler
                 {
                     return false;
                 }
-            },
-            LazyThreadSafetyMode.PublicationOnly);
-
-        /// <summary>
-        /// Gets a value indicating whether Datadog's profiler is currently attached.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if the profiler is currently attached; <c>false</c> otherwise.
-        /// </value>
-        public static bool ProfilerAttached => _profilerAttached.Value;
+            }
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
@@ -13,23 +12,21 @@ namespace Datadog.Trace.ClrProfiler
                 return Windows.IsProfilerAttached();
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                return Linux.IsProfilerAttached();
-            }
-
-            throw new PlatformNotSupportedException();
+            return NonWindows.IsProfilerAttached();
         }
 
+        // the "dll" extension is required on .NET Framework
+        // and optional on .NET Core
         private static class Windows
         {
             [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
             public static extern bool IsProfilerAttached();
         }
 
-        private static class Linux
+        // assume .NET Core if not running on Windows
+        private static class NonWindows
         {
-            [DllImport("Datadog.Trace.ClrProfiler.Native.so")]
+            [DllImport("Datadog.Trace.ClrProfiler.Native")]
             public static extern bool IsProfilerAttached();
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
@@ -1,10 +1,36 @@
+using System;
 using System.Runtime.InteropServices;
 
+// ReSharper disable MemberHidesStaticFromOuterClass
 namespace Datadog.Trace.ClrProfiler
 {
     internal static class NativeMethods
     {
-        [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        public static extern bool IsProfilerAttached();
+        public static bool IsProfilerAttached()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Windows.IsProfilerAttached();
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return Linux.IsProfilerAttached();
+            }
+
+            throw new PlatformNotSupportedException();
+        }
+
+        private static class Windows
+        {
+            [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
+            public static extern bool IsProfilerAttached();
+        }
+
+        private static class Linux
+        {
+            [DllImport("Datadog.Trace.ClrProfiler.Native.so")]
+            public static extern bool IsProfilerAttached();
+        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- add filename extensions to P/Invoke calls so they work in .NET Framework 