### PR TITLE
remove obsolete LIBLOG_PORTABLE build constant

### DIFF
--- a/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -9,10 +9,6 @@
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -8,10 +8,6 @@
     <Authors>lucas.pimentel.datadog;bmermet</Authors>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />


### PR DESCRIPTION
Changes proposed in this pull request:
- remove obsolete references to `LIBLOG_PORTABLE` build constant (LibLog no longer uses this)