### PR TITLE
package pipeline fixes

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -90,7 +90,7 @@ jobs:
       solution: Datadog.Trace.proj
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%;OutputName=datadog-dotnet-apm-%GitVersion_MajorMinorPatch%-$(buildPlatform)
+      msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%;OutputName=datadog-dotnet-apm-%GitVersion_MajorMinorPatch%-$(buildPlatform);RunWixToolsOutOfProc=true
 
   - task: PublishPipelineArtifact@0
     displayName: publish msi artifact

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -90,7 +90,7 @@ jobs:
       solution: Datadog.Trace.proj
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%;OutputName=DatadogDotNetTracing-%GitVersion_MajorMinorPatch%-$(buildPlatform)
+      msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%;OutputName=datadog-dotnet-apm-%GitVersion_MajorMinorPatch%-$(buildPlatform)
 
   - task: PublishPipelineArtifact@0
     displayName: publish msi artifact

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -65,17 +65,17 @@ jobs:
     displayName: dotnet build
     inputs:
       command: build
-      configuration: $(buildConfiguration)
       projects: src/**/*.csproj
+      arguments: --configuration $(buildConfiguration)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet pack
     condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
     inputs:
       command: pack
-      configuration: $(buildConfiguration)
       packagesToPack: src/**/*.csproj
       packDirectory: nuget-output
+      configuration: $(buildConfiguration)
 
   - task: PublishPipelineArtifact@0
     displayName: publish nuget artifacts

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -70,7 +70,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: dotnet pack
-    condition: eq(variables['nugetPack'], 'true')
+    condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
     inputs:
       command: pack
       configuration: $(buildConfiguration)
@@ -79,7 +79,7 @@ jobs:
 
   - task: PublishPipelineArtifact@0
     displayName: publish nuget artifacts
-    condition: eq(variables['nugetPack'], 'true')
+    condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
     inputs:
       artifactName: nuget-packages
       targetPath: nuget-output

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -90,7 +90,7 @@ jobs:
       solution: Datadog.Trace.proj
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%
+      msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%;OutputName=DatadogDotNetTracing-%GitVersion_MajorMinorPatch%-$(buildPlatform)
 
   - task: PublishPipelineArtifact@0
     displayName: publish msi artifact

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -19,7 +19,7 @@
          accessed as $(var.InstallerVersion) from WiX files.
          This is the default value if one is not specified when building. -->
     <InstallerVersion Condition="'$(InstallerVersion)'==''">0.1</InstallerVersion>
-    <OutputName>DatadogDotNetTracing-$(InstallerVersion)-$(Platform)-$(Configuration)</OutputName>
+    <OutputName Condition="'$(OutputName)'==''">DatadogDotNetTracing-$(InstallerVersion)-$(Platform)-$(Configuration)</OutputName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug;InstallerVersion=$(InstallerVersion)</DefineConstants>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -19,7 +19,8 @@
          accessed as $(var.InstallerVersion) from WiX files.
          This is the default value if one is not specified when building. -->
     <InstallerVersion Condition="'$(InstallerVersion)'==''">0.1</InstallerVersion>
-    <OutputName Condition="'$(OutputName)'==''">DatadogDotNetTracing-$(InstallerVersion)-$(Platform)-$(Configuration)</OutputName>
+    <!-- default msi filename if not specified -->
+    <OutputName Condition="'$(OutputName)'==''">datadog-dotnet-apm-$(InstallerVersion)-$(Platform)-$(Configuration)</OutputName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug;InstallerVersion=$(InstallerVersion)</DefineConstants>


### PR DESCRIPTION
Changes proposed in this pull request:
- msi installer project
  - allow setting output msi filename externally through build properties
  - change default filename to match linux packages, `datadog-dotnet-apm-*`
- pipeline
  - fix build **errors** caused by skipping `dotnet pack` not building files required for msi
  - fix build configuration for `dotnet build` to avoid building projects multiple times (debug & release)
  - add `RunWixToolsOutOfProc=true` as workaround for Wix hanging in CI build (which was hiding the errors above)
  - override default msi filename in ci pipeline to remove `$(Configuration)` from filename so we don't need to remove it on every release
