### PR TITLE
Pass mdToken of original call to every integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -23,7 +23,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 03 1C 1C 08 08"
+          "signature": "00 04 1C 1C 08 08 09"
         }
       },
       {
@@ -47,7 +47,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 03 1C 1C 08 08"
+          "signature": "00 04 1C 1C 08 08 09"
         }
       },
       {
@@ -72,7 +72,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 04 1C 1C 08 1C 08"
+          "signature": "00 05 1C 1C 08 1C 08 09"
         }
       },
       {
@@ -97,7 +97,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 04 1C 1C 08 1C 08"
+          "signature": "00 05 1C 1C 08 1C 08 09"
         }
       }
     ]
@@ -131,7 +131,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "BeforeAction",
-          "signature": "00 05 01 1C 1C 1C 1C 08"
+          "signature": "00 06 01 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -160,7 +160,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "AfterAction",
-          "signature": "00 05 01 1C 1C 1C 1C 08"
+          "signature": "00 06 01 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -186,7 +186,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "Rethrow",
-          "signature": "00 02 01 1C 08"
+          "signature": "00 03 01 1C 08 09"
         }
       }
     ]
@@ -220,7 +220,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "BeginInvokeAction",
-          "signature": "00 06 1C 1C 1C 1C 1C 1C 08"
+          "signature": "00 07 1C 1C 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -246,7 +246,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "EndInvokeAction",
-          "signature": "00 03 02 1C 1C 08"
+          "signature": "00 04 02 1C 1C 08 09"
         }
       }
     ]
@@ -276,7 +276,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "ExecuteAsync",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       }
     ]
@@ -307,7 +307,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 03 1C 1C 1C 08"
+          "signature": "10 01 04 1C 1C 1C 08 09"
         }
       },
       {
@@ -334,7 +334,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 04 1C 1C 1C 1C 08"
+          "signature": "10 01 05 1C 1C 1C 1C 08 09"
         }
       }
     ]
@@ -365,7 +365,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 03 1C 1C 1C 08"
+          "signature": "10 01 04 1C 1C 1C 08 09"
         }
       },
       {
@@ -392,7 +392,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 04 1C 1C 1C 1C 08"
+          "signature": "10 01 05 1C 1C 1C 1C 08 09"
         }
       }
     ]
@@ -422,7 +422,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpMessageHandler_SendAsync",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -447,7 +447,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpClientHandler_SendAsync",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       }
     ]
@@ -477,7 +477,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -502,7 +502,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -527,7 +527,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -552,7 +552,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
-          "signature": "00 04 1C 1C 1C 1C 08"
+          "signature": "00 05 1C 1C 1C 1C 08 09"
         }
       }
     ]
@@ -586,7 +586,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
-          "signature": "10 01 06 1E 00 1C 1D 1D 05 1C 1C 02 08"
+          "signature": "10 01 07 1E 00 1C 1D 1D 05 1C 1C 02 08 09"
         }
       }
     ]
@@ -619,7 +619,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 05 1E 00 1C 1C 1C 1C 08"
+          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -647,7 +647,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 05 1E 00 1C 1C 1C 1C 08"
+          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -676,7 +676,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 06 1C 1C 1C 1C 1C 1C 08"
+          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -705,7 +705,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 06 1C 1C 1C 1C 1C 1C 08"
+          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -733,7 +733,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 05 1C 1C 1C 1C 1C 08"
+          "signature": "10 01 06 1C 1C 1C 1C 1C 08 09"
         }
       },
       {
@@ -761,7 +761,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 05 1C 1C 1C 1C 1C 08"
+          "signature": "10 01 06 1C 1C 1C 1C 1C 08 09"
         }
       }
     ]
@@ -791,7 +791,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
           "method": "HandleRequest",
-          "signature": "00 04 02 1C 1C 1C 08"
+          "signature": "00 05 02 1C 1C 1C 08 09"
         }
       }
     ]
@@ -819,7 +819,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 02 1C 1C 08"
+          "signature": "00 03 1C 1C 08 09"
         }
       },
       {
@@ -842,7 +842,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 02 1C 1C 08"
+          "signature": "00 03 1C 1C 08 09"
         }
       },
       {
@@ -865,7 +865,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
-          "signature": "00 02 1C 1C 08"
+          "signature": "00 03 1C 1C 08 09"
         }
       }
     ]

--- a/integrations.json
+++ b/integrations.json
@@ -23,7 +23,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 04 1C 1C 08 08 09"
+          "signature": "00 04 1C 1C 08 08 08"
         }
       },
       {
@@ -47,7 +47,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 04 1C 1C 08 08 09"
+          "signature": "00 04 1C 1C 08 08 08"
         }
       },
       {
@@ -72,7 +72,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 05 1C 1C 08 1C 08 09"
+          "signature": "00 05 1C 1C 08 1C 08 08"
         }
       },
       {
@@ -97,7 +97,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 05 1C 1C 08 1C 08 09"
+          "signature": "00 05 1C 1C 08 1C 08 08"
         }
       }
     ]
@@ -131,7 +131,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "BeforeAction",
-          "signature": "00 06 01 1C 1C 1C 1C 08 09"
+          "signature": "00 06 01 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -160,7 +160,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "AfterAction",
-          "signature": "00 06 01 1C 1C 1C 1C 08 09"
+          "signature": "00 06 01 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -186,7 +186,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "Rethrow",
-          "signature": "00 03 01 1C 08 09"
+          "signature": "00 03 01 1C 08 08"
         }
       }
     ]
@@ -220,7 +220,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "BeginInvokeAction",
-          "signature": "00 07 1C 1C 1C 1C 1C 1C 08 09"
+          "signature": "00 07 1C 1C 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -246,7 +246,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "EndInvokeAction",
-          "signature": "00 04 02 1C 1C 08 09"
+          "signature": "00 04 02 1C 1C 08 08"
         }
       }
     ]
@@ -276,7 +276,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "ExecuteAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       }
     ]
@@ -307,7 +307,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 04 1C 1C 1C 08 09"
+          "signature": "10 01 04 1C 1C 1C 08 08"
         }
       },
       {
@@ -334,7 +334,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 05 1C 1C 1C 1C 08 09"
+          "signature": "10 01 05 1C 1C 1C 1C 08 08"
         }
       }
     ]
@@ -365,7 +365,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 04 1C 1C 1C 08 09"
+          "signature": "10 01 04 1C 1C 1C 08 08"
         }
       },
       {
@@ -392,7 +392,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 05 1C 1C 1C 1C 08 09"
+          "signature": "10 01 05 1C 1C 1C 1C 08 08"
         }
       }
     ]
@@ -422,7 +422,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpMessageHandler_SendAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -447,7 +447,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpClientHandler_SendAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       }
     ]
@@ -477,7 +477,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -502,7 +502,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -527,7 +527,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -552,7 +552,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
-          "signature": "00 05 1C 1C 1C 1C 08 09"
+          "signature": "00 05 1C 1C 1C 1C 08 08"
         }
       }
     ]
@@ -586,7 +586,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
-          "signature": "10 01 07 1E 00 1C 1D 1D 05 1C 1C 02 08 09"
+          "signature": "10 01 07 1E 00 1C 1D 1D 05 1C 1C 02 08 08"
         }
       }
     ]
@@ -619,7 +619,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 09"
+          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -647,7 +647,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 09"
+          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -676,7 +676,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 09"
+          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -705,7 +705,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 09"
+          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -733,7 +733,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 06 1C 1C 1C 1C 1C 08 09"
+          "signature": "10 01 06 1C 1C 1C 1C 1C 08 08"
         }
       },
       {
@@ -761,7 +761,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 06 1C 1C 1C 1C 1C 08 09"
+          "signature": "10 01 06 1C 1C 1C 1C 1C 08 08"
         }
       }
     ]
@@ -791,7 +791,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
           "method": "HandleRequest",
-          "signature": "00 05 02 1C 1C 1C 08 09"
+          "signature": "00 05 02 1C 1C 1C 08 08"
         }
       }
     ]
@@ -819,7 +819,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 03 1C 1C 08 09"
+          "signature": "00 03 1C 1C 08 08"
         }
       },
       {
@@ -842,7 +842,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 03 1C 1C 08 09"
+          "signature": "00 03 1C 1C 08 08"
         }
       },
       {
@@ -865,7 +865,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
-          "signature": "00 03 1C 1C 08 09"
+          "signature": "00 03 1C 1C 08 08"
         }
       }
     ]

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="this">The <see cref="DbCommand"/> that is references by the "this" pointer in the instrumented method.</param>
         /// <param name="behavior">A value from <see cref="CommandBehavior"/>.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Data.Common.DbDataReader", "System.Data.CommandBehavior" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object ExecuteDbDataReader(object @this, int behavior, int opCode)
+        public static object ExecuteDbDataReader(object @this, int behavior, int opCode, int mdToken)
         {
             var command = (DbCommand)@this;
             var commandBehavior = (CommandBehavior)behavior;
@@ -68,6 +69,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="behavior">A value from <see cref="CommandBehavior"/>.</param>
         /// <param name="cancellationTokenSource">A cancellation token source that can be used to cancel the async operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
@@ -81,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", "System.Data.CommandBehavior", "System.Threading.CancellationToken" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode)
+        public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode, int mdToken)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -138,6 +138,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="httpContext">The HttpContext for the current request.</param>
         /// <param name="routeData">A RouteData with information about the current route.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
@@ -150,7 +151,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object actionDescriptor,
             object httpContext,
             object routeData,
-            int opCode)
+            int opCode,
+            int mdToken)
         {
             AspNetCoreMvc2Integration integration = null;
 
@@ -212,6 +214,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="httpContext">The HttpContext for the current request.</param>
         /// <param name="routeData">A RouteData with information about the current route.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
@@ -224,7 +227,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object actionDescriptor,
             object httpContext,
             object routeData,
-            int opCode)
+            int opCode,
+            int mdToken)
         {
             AspNetCoreMvc2Integration integration = null;
 
@@ -285,6 +289,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="context">The DiagnosticSource that this extension method was called on.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
@@ -292,7 +297,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
-        public static void Rethrow(object context, int opCode)
+        public static void Rethrow(object context, int opCode, int mdToken)
         {
             AspNetCoreMvc2Integration integration = null;
             const string methodName = nameof(Rethrow);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -166,6 +166,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="callback">An <see cref="AsyncCallback"/> delegate.</param>
         /// <param name="state">An object that holds the state of the async operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>Returns the <see cref="IAsyncResult "/> returned by the original BeginInvokeAction() that is later passed to <see cref="EndInvokeAction"/>.</returns>
         [InterceptMethod(
             CallerAssembly = AssemblyName,
@@ -180,7 +181,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object actionName,
             object callback,
             object state,
-            int opCode)
+            int opCode,
+            int mdToken)
         {
             Scope scope = null;
 
@@ -221,6 +223,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="asyncControllerActionInvoker">The IAsyncActionInvoker instance.</param>
         /// <param name="asyncResult">The <see cref="IAsyncResult"/> returned by <see cref="BeginInvokeAction"/>.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>Returns the <see cref="bool"/> returned by the original EndInvokeAction().</returns>
         [InterceptMethod(
             CallerAssembly = AssemblyName,
@@ -229,7 +232,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Bool, ClrNames.IAsyncResult },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
-        public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode)
+        public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode, int mdToken)
         {
             Scope scope = null;
             var httpContext = HttpContext.Current;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="controllerContext">The controller context for the call</param>
         /// <param name="cancellationTokenSource">The cancellation token source</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>A task with the result</returns>
         [InterceptMethod(
             TargetAssembly = "System.Web.Http",
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Web.Http.Controllers.HttpControllerContext", ClrNames.CancellationToken },
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
-        public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode)
+        public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode, int mdToken)
         {
             if (apiController == null) { throw new ArgumentNullException(nameof(apiController)); }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -25,6 +25,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -33,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "Elasticsearch.Net.ElasticsearchResponse`1<T>", "Elasticsearch.Net.RequestData" },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
-        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
+        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode, int mdToken)
         {
             // TResponse CallElasticsearch<TResponse>(RequestData requestData) where TResponse : class, IElasticsearchResponse, new();
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object>>
@@ -64,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="requestData">The request data</param>
         /// <param name="cancellationTokenSource">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -72,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<Elasticsearch.Net.ElasticsearchResponse`1<T>>", "Elasticsearch.Net.RequestData", ClrNames.CancellationToken },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
-        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)
+        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode, int mdToken)
         {
             // Task<ElasticsearchResponse<TReturn>> CallElasticsearchAsync<TReturn>(RequestData requestData, CancellationToken cancellationToken) where TReturn : class;
             var tokenSource = cancellationTokenSource as CancellationTokenSource;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -31,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "T", "Elasticsearch.Net.RequestData" },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
-        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode)
+        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode, int mdToken)
         {
             // TResponse CallElasticsearch<TResponse>(RequestData requestData) where TResponse : class, IElasticsearchResponse, new();
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, TResponse>>
@@ -62,6 +63,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="requestData">The request data</param>
         /// <param name="cancellationTokenSource">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -70,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "Elasticsearch.Net.RequestData", ClrNames.CancellationToken },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
-        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode)
+        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode, int mdToken)
         {
             // Task<TResponse> CallElasticsearchAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken) where TResponse : class, IElasticsearchResponse, new();
             var tokenSource = cancellationTokenSource as CancellationTokenSource;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
         /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
@@ -36,7 +37,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object handler,
             object request,
             object cancellationTokenSource,
-            int opCode)
+            int opCode,
+            int mdToken)
         {
             // original signature:
             // Task<HttpResponseMessage> HttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -66,6 +68,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
         /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
@@ -78,7 +81,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object handler,
             object request,
             object cancellationTokenSource,
-            int opCode)
+            int opCode,
+            int mdToken)
         {
             // original signature:
             // Task<HttpResponseMessage> HttpClientHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -35,6 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="connection">The connection.</param>
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "T", "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
-        public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
+        public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
@@ -95,6 +96,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="connection">The connection.</param>
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetMethod = nameof(ExecuteAsync),
@@ -103,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Task, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
+        public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
@@ -117,6 +119,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="connection">The connection.</param>
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetMethod = nameof(ExecuteAsync),
@@ -125,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode)
+        public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="completePipelineFn">An optional function to call to complete a pipeline</param>
         /// <param name="sendWithoutRead">Whether or to send without waiting for the result</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "ServiceStack.Redis",
@@ -31,7 +32,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "T", "System.Byte[][]", "System.Func`1<T>", "System.Action`1<System.Func`1<T>>", ClrNames.Bool },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
-        public static T SendReceive<T>(object redisNativeClient, byte[][] cmdWithBinaryArgs, object fn, object completePipelineFn, bool sendWithoutRead, int opCode)
+        public static T SendReceive<T>(
+            object redisNativeClient,
+            byte[][] cmdWithBinaryArgs,
+            object fn,
+            object completePipelineFn,
+            bool sendWithoutRead,
+            int opCode,
+            int mdToken)
         {
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, byte[][], object, object, bool, T>>
                .GetOrCreateMethodCallDelegate(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="processor">The processor to handle the result.</param>
         /// <param name="server">The server to call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The result</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -41,7 +42,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetSignatureTypes = new[] { "T", "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
-        public static T ExecuteSyncImpl<T>(object multiplexer, object message, object processor, object server, int opCode)
+        public static T ExecuteSyncImpl<T>(
+            object multiplexer,
+            object message,
+            object processor,
+            object server,
+            int opCode,
+            int mdToken)
         {
             var resultType = typeof(T);
             var multiplexerType = multiplexer.GetType();
@@ -81,6 +88,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="state">The state to use for the task.</param>
         /// <param name="server">The server to call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>An asynchronous task.</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -98,7 +106,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "System.Object", "StackExchange.Redis.ServerEndPoint" },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsyncImpl<T>(object multiplexer, object message, object processor, object state, object server, int opCode)
+        public static object ExecuteAsyncImpl<T>(
+            object multiplexer,
+            object message,
+            object processor,
+            object state,
+            object server,
+            int opCode,
+            int mdToken)
         {
             return ExecuteAsyncImplInternal<T>(multiplexer, message, processor, state, server);
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="processor">The result processor</param>
         /// <param name="server">The server</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>An asynchronous task.</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -41,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode)
+        public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode, int mdToken)
         {
             return ExecuteAsyncInternal<T>(redisBase, message, processor, server);
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -22,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="requestContext">A System.ServiceModel.Channels.RequestContext implementation instance.</param>
         /// <param name="currentOperationContext">A System.ServiceModel.OperationContext instance.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.ServiceModel",
@@ -29,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Bool, "System.ServiceModel.Channels.RequestContext", "System.ServiceModel.OperationContext" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode)
+        public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode, int mdToken)
         {
             var handleRequestDelegate = Emit.DynamicMethodBuilder<Func<object, object, object, bool>>.GetOrCreateMethodCallDelegate(thisObj.GetType(), "HandleRequest");
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="webRequest">The <see cref="WebRequest"/> instance to instrument.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System", // .NET Framework
@@ -31,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Net.WebResponse" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object GetResponse(object webRequest, int opCode)
+        public static object GetResponse(object webRequest, int opCode, int mdToken)
         {
             var request = (WebRequest)webRequest;
 
@@ -72,6 +73,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="request">The <see cref="WebRequest"/> instance to instrument.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Net",
@@ -79,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Net.WebResponse>" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object GetResponseAsync(object request, int opCode)
+        public static object GetResponseAsync(object request, int opCode, int mdToken)
         {
             return GetResponseAsyncInternal((WebRequest)request);
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -413,8 +413,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       auto expected_number_args = method_replacement.wrapper_method
                                       .method_signature.NumberOfArguments();
 
-      // We pass the opcode as the last argument to every wrapper method
-      expected_number_args--;
+      // We pass the opcode and mdToken as the last arguments to every wrapper method
+      expected_number_args = expected_number_args - 2;
 
       if (target.signature.IsInstanceMethod()) {
         // We always pass the instance as the first argument
@@ -477,6 +477,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       ILRewriterWrapper rewriter_wrapper(&rewriter);
       rewriter_wrapper.SetILPosition(pInstr);
       rewriter_wrapper.LoadInt32(pInstr->m_opcode);
+      rewriter_wrapper.LoadInt32(pInstr->m_Arg32);
 
       // always use CALL because the wrappers methods are all static
       pInstr->m_opcode = CEE_CALL;

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -39,9 +39,22 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // all wrapper methods should have an additional Int32
             // parameter for the original method call's opcode
-            ParameterInfo lastParameter = wrapperMethod.GetParameters().Last();
-            Assert.Equal(typeof(int), lastParameter.ParameterType);
-            Assert.Equal("opCode", lastParameter.Name);
+            var parameters = wrapperMethod.GetParameters();
+            ParameterInfo expectedOpCodeParam = parameters[parameters.Length - 2];
+            Assert.Equal(typeof(int), expectedOpCodeParam.ParameterType);
+            Assert.Equal("opCode", expectedOpCodeParam.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetWrapperMethods))]
+        public void WrapperMethodHasMdTokenArgument(MethodInfo wrapperMethod)
+        {
+            // all wrapper methods should have an additional Int32
+            // parameter for the original method call's opcode
+            var parameters = wrapperMethod.GetParameters();
+            ParameterInfo expectedOpCodeParam = parameters.Last();
+            Assert.Equal(typeof(int), expectedOpCodeParam.ParameterType);
+            Assert.Equal("mdToken", expectedOpCodeParam.Name);
         }
 
         [Theory]
@@ -52,8 +65,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 attribute.TargetSignatureTypes != null,
                 $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} definition missing.");
 
-            // Return type and opcode cancel out for count
-            var expectedParameterCount = wrapperMethod.GetParameters().Length;
+            // Return type and opcode and cancel out for count
+            // mdToken means minus 1
+            var expectedParameterCount = wrapperMethod.GetParameters().Length - 1;
 
             if (!StaticInstrumentations.Contains(wrapperMethod))
             {


### PR DESCRIPTION
Changes proposed in this pull request:
Pass original mdToken to enable resolving methods through calling assembly.

@DataDog/apm-dotnet