### PR TITLE
Http method missing from core mvc resource name

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -418,7 +418,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 scheme = string.Empty;
             }
 
-            resourceName = $"{httpMethod} {UriHelpers.CleanUriSegment(pathBase)}{UriHelpers.CleanUriSegment(path)}".ToLowerInvariant();
+            var relativePath = $"{UriHelpers.CleanUriSegment(pathBase)}{UriHelpers.CleanUriSegment(path)}".ToLowerInvariant();
+            resourceName = $"{httpMethod.ToUpperInvariant()} {relativePath}";
             fullUrl = $"{scheme}://{host}{pathBase}{path}{queryString}".ToLowerInvariant();
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     httpMethod = "UNKNOWN";
                 }
 
-                GetTagValuesFromRequest(request, out host, out resourceName, out url);
+                GetTagValuesFromRequest(request, httpMethod, out host, out resourceName, out url);
                 SpanContext propagatedContext = null;
                 var tracer = Tracer.Instance;
 
@@ -384,6 +384,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void GetTagValuesFromRequest(
             object request,
+            string httpMethod,
             out string host,
             out string resourceName,
             out string fullUrl)
@@ -417,7 +418,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 scheme = string.Empty;
             }
 
-            resourceName = $"{UriHelpers.CleanUriSegment(pathBase)}{UriHelpers.CleanUriSegment(path)}".ToLowerInvariant();
+            resourceName = $"{httpMethod} {UriHelpers.CleanUriSegment(pathBase)}{UriHelpers.CleanUriSegment(path)}".ToLowerInvariant();
             fullUrl = $"{scheme}://{host}{pathBase}{path}{queryString}".ToLowerInvariant();
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCoreMvc2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCoreMvc2Tests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 wh.WaitOne(5000);
 
                 SubmitRequests(aspNetCorePort, Paths);
-                var expected = new List<string>(Paths);
+                var expected = Paths.Select(p => $"GET {p}").ToList();
                 var spans = agent.WaitForSpans(expected.Count)
                                  .Where(s => s.Type == SpanTypes.Web)
                                  .OrderBy(s => s.Start)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCoreMvc2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCoreMvc2Tests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 wh.WaitOne(5000);
 
                 SubmitRequests(aspNetCorePort, Paths);
-                var expected = Paths.Select(p => $"GET {p}").ToList();
+                var expected = Paths.Select(p => $"GET {p.ToLower()}").ToList();
                 var spans = agent.WaitForSpans(expected.Count)
                                  .Where(s => s.Type == SpanTypes.Web)
                                  .OrderBy(s => s.Start)


### PR DESCRIPTION
Changes proposed in this pull request:
Http method is missing in supported routed core mvc requests.

Introduced here: https://github.com/DataDog/dd-trace-dotnet/pull/361

@DataDog/apm-dotnet