### PR TITLE
misc AspNetCoreMvc2Integration fixes

### DIFF
--- a/samples/Samples.AspNetCoreMvc2/Controllers/ApiController.cs
+++ b/samples/Samples.AspNetCoreMvc2/Controllers/ApiController.cs
@@ -4,10 +4,11 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Samples.AspNetCoreMvc2.Controllers
 {
+    [Route("api")]
     public class ApiController : ControllerBase
     {
         [HttpGet]
-        [Route("api/delay/{seconds}")]
+        [Route("delay/{seconds}")]
         public ActionResult Delay(int seconds)
         {
             Thread.Sleep(TimeSpan.FromSeconds(seconds));

--- a/src/Datadog.Trace.ClrProfiler.Managed/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ExtensionMethods/SpanExtensions.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.ClrProfiler.ExtensionMethods
         internal static string GetHttpMethod(this ISpan span)
             => span.GetTag(Tags.HttpMethod);
 
-        internal static void DecorateWebSpan(
+        internal static void DecorateWebServerSpan(
             this Span span,
             string resourceName,
             string method,
@@ -16,6 +16,7 @@ namespace Datadog.Trace.ClrProfiler.ExtensionMethods
         {
             span.Type = SpanTypes.Web;
             span.ResourceName = resourceName?.Trim();
+            span.SetTag(Tags.SpanKind, SpanKinds.Server);
             span.SetTag(Tags.HttpMethod, method);
             span.SetTag(Tags.HttpRequestHeadersHost, host);
             span.SetTag(Tags.HttpUrl, httpUrl);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -393,7 +393,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             url = $"{pathBase}{path}{queryString}";
 
             string resourceUrl = actionDescriptor.GetProperty("AttributeRouteInfo").GetProperty<string>("Template").GetValueOrDefault() ??
-                                 UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true).ToLowerInvariant();
+                                 UriHelpers.GetRelativeUrl(new Uri($"https://{host}{url}"), tryRemoveIds: true).ToLowerInvariant();
 
             resourceName = $"{httpMethod} {resourceUrl}";
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 _scope = tracer.StartActive(OperationName, propagatedContext);
                 var span = _scope.Span;
 
-                span.DecorateWebSpan(
+                span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: httpMethod,
                     host: host,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -395,7 +395,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             url = $"{pathBase}{path}{queryString}";
 
-            resourceName = UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true).ToLowerInvariant();
+            resourceName = actionDescriptor.GetProperty("AttributeRouteInfo").GetProperty<string>("Template").GetValueOrDefault() ??
+                           UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true).ToLowerInvariant();
         }
 
         private bool DisposeObject(IDisposable disposable)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -65,14 +65,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     try
                     {
                         // extract propagated http headers
-                        if (request.TryGetPropertyValue("Headers", out IEnumerable requestHeaders))
+                        var requestHeaders = request.GetProperty<IEnumerable>("Headers").GetValueOrDefault();
+
+                        if (requestHeaders != null)
                         {
                             var headersCollection = new DictionaryHeadersCollection();
 
                             foreach (object header in requestHeaders)
                             {
-                                if (header.TryGetPropertyValue("Key", out string key) &&
-                                    header.TryGetPropertyValue("Value", out IList<string> values))
+                                var key = header.GetProperty<string>("Key").GetValueOrDefault();
+                                var values = header.GetProperty<IList<string>>("Value").GetValueOrDefault();
+
+                                if (key != null && values != null)
                                 {
                                     headersCollection.Add(key, values);
                                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -45,22 +45,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 _httpContext = httpContext;
-                string httpMethod = null;
-
-                if (_httpContext.TryGetPropertyValue("Request", out object request) &&
-                    request.TryGetPropertyValue("Method", out httpMethod))
-                {
-                    httpMethod = httpMethod?.ToUpperInvariant();
-                }
-
-                if (httpMethod == null)
-                {
-                    httpMethod = "UNKNOWN";
-                }
+                var request = _httpContext.GetProperty("Request").GetValueOrDefault();
 
                 GetTagValues(
                     actionDescriptor,
                     request,
+                    out string httpMethod,
                     out string host,
                     out string resourceName,
                     out string url,
@@ -375,6 +365,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private static void GetTagValues(
             object actionDescriptor,
             object request,
+            out string httpMethod,
             out string host,
             out string resourceName,
             out string url,
@@ -386,6 +377,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             actionName = actionDescriptor.GetProperty<string>("ActionName").GetValueOrDefault()?.ToLowerInvariant();
 
             host = request.GetProperty("Host").GetProperty<string>("Value").GetValueOrDefault();
+
+            httpMethod = request.GetProperty<string>("Method").GetValueOrDefault()?.ToUpperInvariant() ?? "UNKNOWN";
 
             string pathBase = request.GetProperty("PathBase").GetProperty<string>("Value").GetValueOrDefault();
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -417,8 +417,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 scheme = string.Empty;
             }
 
-            resourceName = $"{UriHelpers.CleanUriSegment(pathBase)}{UriHelpers.CleanUriSegment(path)}".ToLowerInvariant();
             fullUrl = $"{scheme}://{host}{pathBase}{path}{queryString}".ToLowerInvariant();
+
+            resourceName = UriHelpers.GetRelativeUrl(new Uri(fullUrl), tryRemoveIds: true)
+                                     .ToLowerInvariant();
         }
 
         private bool DisposeObject(IDisposable disposable)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -392,8 +392,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             url = $"{pathBase}{path}{queryString}";
 
-            resourceName = actionDescriptor.GetProperty("AttributeRouteInfo").GetProperty<string>("Template").GetValueOrDefault() ??
-                           UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true).ToLowerInvariant();
+            string resourceUrl = actionDescriptor.GetProperty("AttributeRouteInfo").GetProperty<string>("Template").GetValueOrDefault() ??
+                                 UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true).ToLowerInvariant();
+
+            resourceName = $"{httpMethod} {resourceUrl}";
         }
 
         private bool DisposeObject(IDisposable disposable)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -104,12 +104,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 _scope = tracer.StartActive(OperationName, propagatedContext);
                 var span = _scope.Span;
 
-                if (string.IsNullOrEmpty(resourceName))
-                {
-                    // a legacy fail safe to be removed
-                    resourceName = $"{httpMethod} {controllerName}.{actionName}";
-                }
-
                 span.DecorateWebSpan(
                     resourceName: resourceName,
                     method: httpMethod,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetCoreMvc2Integration.cs
@@ -377,7 +377,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object request,
             out string host,
             out string resourceName,
-            out string fullUrl,
+            out string url,
             out string controllerName,
             out string actionName)
         {
@@ -393,11 +393,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             string queryString = request.GetProperty("QueryString").GetProperty<string>("Value").GetValueOrDefault();
 
-            string scheme = request.GetProperty<string>("Scheme").GetValueOrDefault();
+            url = $"{pathBase}{path}{queryString}";
 
-            fullUrl = $"{scheme}://{host}{pathBase}{path}{queryString}".ToLowerInvariant();
-
-            resourceName = UriHelpers.GetRelativeUrl(new Uri(fullUrl), tryRemoveIds: true).ToLowerInvariant();
+            resourceName = UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true).ToLowerInvariant();
         }
 
         private bool DisposeObject(IDisposable disposable)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetMvcIntegration.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Replace("{controller}", controllerName)
                        .Replace("{action}", actionName);
 
-                span.DecorateWebSpan(
+                span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: httpMethod,
                     host: host,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNetWebApi2Integration.cs
@@ -184,7 +184,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Replace("{controller}", controller)
                        .Replace("{action}", action);
 
-                span.DecorateWebSpan(
+                span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: method,
                     host: host,


### PR DESCRIPTION
Fixes #418

Changes to `AspNetCoreMvc2Integration` proposed in this pull request:
- bugfix
  - use route template for resource name: `user/edit/3` -> `user/edit/{id}`
  - if route template is not available, fallback to removing path segments that look like ids: `user/edit/3` -> `user/edit/?`
  - prefix the resource name with the http method, e.g. `GET`, `POST`
- code clean-up / refactoring
  - rewrite dynamic member access using the newer api
  - move most remaining member access into `GetTagValues()`
