### PR TITLE
include inner exception stack traces

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -295,7 +295,7 @@ namespace Datadog.Trace
                 }
 
                 SetTag(Trace.Tags.ErrorMsg, exception.Message);
-                SetTag(Trace.Tags.ErrorStack, exception.StackTrace);
+                SetTag(Trace.Tags.ErrorStack, exception.ToString());
                 SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
             }
         }


### PR DESCRIPTION
Changes proposed in this pull request:
- use `Exception.ToString()` to include all stack details, including stack traces for inner exceptions
