### PR TITLE
fix profiler logging path in Windows

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -224,7 +224,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
       FilterIntegrationsByTarget(filtered_integrations, assembly_import);
   if (filtered_integrations.empty()) {
     // we don't need to instrument anything in this module, skip it
-    Debug("ModuleLoadFinished skipping module ((filtered by target)): ",
+    Debug("ModuleLoadFinished skipping module (filtered by target): ",
           module_id, " ", module_info.assembly.name);
     return S_OK;
   }

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -33,7 +33,9 @@ inline WSTRING DatadogLogFilePath() {
   const errno_t result = _dupenv_s(&p_program_data, &length, "PROGRAMDATA");
   std::string program_data;
 
-  if (FAILED(result) || length == 0) {
+  if (SUCCEEDED(result) && p_program_data > nullptr && length > 0) {
+    program_data = std::string(p_program_data);
+  } else {
     program_data = R"(C:\ProgramData)";
   }
 
@@ -68,6 +70,6 @@ inline int GetPID() {
 #endif
 }
 
-}  // namespace trace
+} // namespace trace
 
 #endif  // DD_CLR_PROFILER_PAL_H_

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -33,7 +33,7 @@ inline WSTRING DatadogLogFilePath() {
   const errno_t result = _dupenv_s(&p_program_data, &length, "PROGRAMDATA");
   std::string program_data;
 
-  if (SUCCEEDED(result) && p_program_data > nullptr && length > 0) {
+  if (SUCCEEDED(result) && p_program_data != nullptr && length > 0) {
     program_data = std::string(p_program_data);
   } else {
     program_data = R"(C:\ProgramData)";


### PR DESCRIPTION
Changes proposed in this pull request:
- use value from `PROGRAMDATA` environment variable as base path for profiler log file

Fixes regression introduced in #387.