### PR TITLE
Fix GetProperty and GetField caching bug

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 var type = source.GetType();
 
                 object cachedItem = Cache.GetOrAdd(
-                    $"{type.AssemblyQualifiedName}.{propertyName}",
+                    GetKey<TResult>(propertyName, type),
                     key => CreatePropertyDelegate<TResult>(type, propertyName));
 
                 if (cachedItem is Func<object, TResult> func)
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
             var type = source.GetType();
 
             object cachedItem = Cache.GetOrAdd(
-                $"{type.AssemblyQualifiedName}.{fieldName}",
+                GetKey<TResult>(fieldName, type),
                 key => CreateFieldDelegate<TResult>(type, fieldName));
 
             if (cachedItem is Func<object, TResult> func)
@@ -140,6 +140,11 @@ namespace Datadog.Trace.ClrProfiler.Emit
         public static MemberResult<object> GetField(this object source, string fieldName)
         {
             return GetField<object>(source, fieldName);
+        }
+
+        private static string GetKey<TResult>(string name, Type type)
+        {
+            return $"{typeof(TResult).FullName}.{type.FullName}.{name}";
         }
 
         private static Func<object, TResult> CreatePropertyDelegate<TResult>(Type containerType, string propertyName)

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
@@ -1,0 +1,55 @@
+using Datadog.Trace.ClrProfiler.Emit;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class ObjectExtensionTests
+    {
+        [Fact]
+        public void GetProperty_WithDifferentType_ShouldNotAffectResult()
+        {
+            SomeBaseClass someAbstractInstance = new SomeClass();
+            var expected = someAbstractInstance.SomeIntProperty;
+
+            var someCast = (object)someAbstractInstance;
+
+            var objectResult = someCast.GetProperty<object>("SomeIntProperty");
+            var actualResult = someCast.GetProperty<int>("SomeIntProperty");
+
+            Assert.Equal(actual: expected, expected: (int)objectResult.GetValueOrDefault());
+            Assert.Equal(actual: expected, expected: actualResult.GetValueOrDefault());
+        }
+
+        [Fact]
+        public void GetField_WithDifferentType_ShouldNotAffectResult()
+        {
+            var someInstance = new SomeClass();
+            var expected = someInstance.GetSomeIntField();
+
+            var someCast = (object)someInstance;
+
+            var objectResult = someCast.GetField<object>("someIntField");
+            var actualResult = someCast.GetField<int>("someIntField");
+
+            Assert.Equal(actual: expected, expected: (int)objectResult.GetValueOrDefault());
+            Assert.Equal(actual: expected, expected: actualResult.GetValueOrDefault());
+        }
+
+        private class SomeClass : SomeBaseClass
+        {
+            private readonly int someIntField = 305;
+
+            public override int SomeIntProperty { get; } = 205;
+
+            public int GetSomeIntField()
+            {
+                return someIntField;
+            }
+        }
+
+        private abstract class SomeBaseClass
+        {
+            public abstract int SomeIntProperty { get; }
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
Fix small caching bug in reflection helpers.
Introduce tests to prevent it in the future.

@DataDog/apm-dotnet