### PR TITLE
add process exclusion list to clr profiler

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -48,7 +48,7 @@ SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Limit profiling to these processes only
-SET DD_PROFILER_PROCESSES=w3wp.exe;iisexpress.exe;Samples.AspNetCoreMvc2.exe;dotnet.exe;Samples.SqlServer.exe;Samples.ServiceStack.Redis.exe;Samples.StackExchange.Redis.exe;Samples.Elasticsearch.exe;Samples.Elasticsearch.V5.exe;Samples.MongoDB.exe;Samples.HttpMessageHandler.exe;Samples.Npgsql.exe;wcfsvchost.exe
+SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe
 
 rem Set location of integration definitions
 SET DD_INTEGRATIONS=%~dp0\integrations.json;%~dp0\test-integrations.json

--- a/devenv.bat
+++ b/devenv.bat
@@ -48,7 +48,7 @@ SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Limit profiling to these processes only
-SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe
+SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe
 
 rem Set location of integration definitions
 SET DD_INTEGRATIONS=%~dp0\integrations.json;%~dp0\test-integrations.json

--- a/devenv.bat
+++ b/devenv.bat
@@ -47,7 +47,7 @@ SET CORECLR_ENABLE_PROFILING=1
 SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
-rem Limit profiling to these processes only
+rem Don't attach the profiler to these processes
 SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe
 
 rem Set location of integration definitions

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -40,17 +40,17 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     return E_FAIL;
   }
 
-  // check if there is a whitelist of process names
-  const auto allowed_process_names =
-      GetEnvironmentValues(environment::process_names);
+  // check if there is a process name inclusion list
+  const auto include_process_names =
+      GetEnvironmentValues(environment::include_process_names);
 
-  if (!allowed_process_names.empty()) {
+  if (!include_process_names.empty()) {
     const auto process_name = GetCurrentProcessName();
 
-    if (std::find(allowed_process_names.begin(), allowed_process_names.end(),
-                  process_name) == allowed_process_names.end()) {
+    if (std::find(include_process_names.begin(), include_process_names.end(),
+                  process_name) == include_process_names.end()) {
       Info("Profiler disabled: ", process_name, " not found in ",
-           environment::process_names, ".");
+           environment::include_process_names, ".");
       return E_FAIL;
     }
   }
@@ -68,7 +68,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   WSTRING env_vars[]{environment::tracing_enabled,
                      environment::debug_enabled,
                      environment::integrations_path,
-                     environment::process_names,
+                     environment::include_process_names,
                      environment::agent_host,
                      environment::agent_port,
                      environment::env,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -40,13 +40,15 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     return E_FAIL;
   }
 
-  // check if there is a process name inclusion list
+  const auto process_name = GetCurrentProcessName();
   const auto include_process_names =
       GetEnvironmentValues(environment::include_process_names);
+  const auto exclude_process_names =
+      GetEnvironmentValues(environment::exclude_process_names);
 
+  // if there is a process inclusion list, attach profiler only if this
+  // process's name is on the list
   if (!include_process_names.empty()) {
-    const auto process_name = GetCurrentProcessName();
-
     if (std::find(include_process_names.begin(), include_process_names.end(),
                   process_name) == include_process_names.end()) {
       Info("Profiler disabled: ", process_name, " not found in ",
@@ -55,13 +57,9 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     }
   }
 
-  // check if there is a process name exclusion list
-  const auto exclude_process_names =
-      GetEnvironmentValues(environment::exclude_process_names);
-
+  // if there is a process exclusion list, attach profiler only if this
+  // process's name is NOT on the list
   if (!exclude_process_names.empty()) {
-    const auto process_name = GetCurrentProcessName();
-
     if (std::find(exclude_process_names.begin(), exclude_process_names.end(),
                   process_name) != exclude_process_names.end()) {
       Info("Profiler disabled: ", process_name, " found in ",

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -55,6 +55,21 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     }
   }
 
+  // check if there is a process name exclusion list
+  const auto exclude_process_names =
+      GetEnvironmentValues(environment::exclude_process_names);
+
+  if (!exclude_process_names.empty()) {
+    const auto process_name = GetCurrentProcessName();
+
+    if (std::find(exclude_process_names.begin(), exclude_process_names.end(),
+                  process_name) != exclude_process_names.end()) {
+      Info("Profiler disabled: ", process_name, " found in ",
+           environment::exclude_process_names, ".");
+      return E_FAIL;
+    }
+  }
+
   // get Profiler interface
   HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo3>(
       &this->info_);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -84,6 +84,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
                      environment::debug_enabled,
                      environment::integrations_path,
                      environment::include_process_names,
+                     environment::exclude_process_names,
                      environment::agent_host,
                      environment::agent_port,
                      environment::env,

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -18,11 +18,11 @@ const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
 // "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
 const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
 
-// Sets the filename of executables the profiler will attach to.
+// Sets the filename of executables the profiler can attach to.
 // If not defined (default), the profiler will attach to any process.
 // Supports multiple values separated with semi-colons, for example:
 // "MyApp.exe;dotnet.exe"
-const WSTRING process_names = "DD_PROFILER_PROCESSES"_W;
+const WSTRING include_process_names = "DD_PROFILER_PROCESSES"_W;
 
 // Sets the Agent's host. Default is localhost.
 const WSTRING agent_host = "DD_AGENT_HOST"_W;

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -24,6 +24,12 @@ const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
 // "MyApp.exe;dotnet.exe"
 const WSTRING include_process_names = "DD_PROFILER_PROCESSES"_W;
 
+// Sets the filename of executables the profiler cannot attach to.
+// If not defined (default), the profiler will attach to any process.
+// Supports multiple values separated with semi-colons, for example:
+// "MyApp.exe;dotnet.exe"
+const WSTRING exclude_process_names = "DD_PROFILER_EXCLUDE_PROCESSES"_W;
+
 // Sets the Agent's host. Default is localhost.
 const WSTRING agent_host = "DD_AGENT_HOST"_W;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -29,7 +29,13 @@ std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path) {
   try {
     std::ifstream stream;
     stream.open(ToString(file_path));
-    integrations = LoadIntegrationsFromStream(stream);
+
+    if (static_cast<bool>(stream)) {
+      integrations = LoadIntegrationsFromStream(stream);
+    } else {
+      Warn("Failed to load integrations from file ", file_path);
+    }
+
     stream.close();
   } catch (...) {
     auto ex = std::current_exception();
@@ -112,14 +118,18 @@ std::pair<MethodReplacement, bool> MethodReplacementFromJson(
     return std::make_pair<MethodReplacement, bool>({}, false);
   }
 
-  const auto caller = MethodReferenceFromJson(src.value("caller", json::object()), false);
-  const auto target = MethodReferenceFromJson(src.value("target", json::object()), true);
-  const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()), false);
+  const auto caller =
+      MethodReferenceFromJson(src.value("caller", json::object()), false);
+  const auto target =
+      MethodReferenceFromJson(src.value("target", json::object()), true);
+  const auto wrapper =
+      MethodReferenceFromJson(src.value("wrapper", json::object()), false);
   return std::make_pair<MethodReplacement, bool>({caller, target, wrapper},
                                                  true);
 }
 
-MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method) {
+MethodReference MethodReferenceFromJson(const json::value_type& src,
+                                        const bool is_target_method) {
   if (!src.is_object()) {
     return {};
   }
@@ -202,8 +212,8 @@ MethodReference MethodReferenceFromJson(const json::value_type& src, const bool 
       prev = b;
     }
   }
-  return MethodReference(
-      assembly, type, method, Version(min_major, min_minor, min_patch, 0),
+  return MethodReference(assembly, type, method,
+                         Version(min_major, min_minor, min_patch, 0),
                          Version(max_major, max_minor, max_patch, USHRT_MAX),
                          signature, signature_type_array);
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- add a profiler exclusion list (by process name)
- change `devenv.bat` to use the new exclusion list so we don't need to keep adding every sample app ever
- bonus: replace useless log message about not being able to deserialize json (if the file is not found) with a message that includes the filename