### PR TITLE
factor out std::vector<T> search logic, exclude more processes from profiling

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -48,7 +48,7 @@ SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Don't attach the profiler to these processes
-SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe
+SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe
 
 rem Set location of integration definitions
 SET DD_INTEGRATIONS=%~dp0\integrations.json;%~dp0\test-integrations.json

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -43,29 +43,24 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto process_name = GetCurrentProcessName();
   const auto include_process_names =
       GetEnvironmentValues(environment::include_process_names);
-  const auto exclude_process_names =
-      GetEnvironmentValues(environment::exclude_process_names);
 
   // if there is a process inclusion list, attach profiler only if this
   // process's name is on the list
-  if (!include_process_names.empty()) {
-    if (std::find(include_process_names.begin(), include_process_names.end(),
-                  process_name) == include_process_names.end()) {
-      Info("Profiler disabled: ", process_name, " not found in ",
-           environment::include_process_names, ".");
-      return E_FAIL;
-    }
+  if (!include_process_names.empty() &&
+      !Contains(include_process_names, process_name)) {
+    Info("Profiler disabled: ", process_name, " not found in ",
+         environment::include_process_names, ".");
+    return E_FAIL;
   }
 
-  // if there is a process exclusion list, attach profiler only if this
-  // process's name is NOT on the list
-  if (!exclude_process_names.empty()) {
-    if (std::find(exclude_process_names.begin(), exclude_process_names.end(),
-                  process_name) != exclude_process_names.end()) {
-      Info("Profiler disabled: ", process_name, " found in ",
-           environment::exclude_process_names, ".");
-      return E_FAIL;
-    }
+  const auto exclude_process_names =
+      GetEnvironmentValues(environment::exclude_process_names);
+
+  // attach profiler only if this process's name is NOT on the list
+  if (Contains(exclude_process_names, process_name)) {
+    Info("Profiler disabled: ", process_name, " found in ",
+         environment::exclude_process_names, ".");
+    return E_FAIL;
   }
 
   // get Profiler interface

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -1,5 +1,6 @@
 #include "util.h"
 
+#include <algorithm>
 #include <cwctype>
 #include <iterator>
 #include <sstream>

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -82,4 +82,9 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name) {
   return GetEnvironmentValues(name, L';');
 }
 
-}  // namespace trace
+bool Contains(const std::vector<WSTRING>& items, const WSTRING& value) {
+  return !items.empty() &&
+         std::find(items.begin(), items.end(), value) != items.end();
+}
+
+} // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -1,6 +1,5 @@
 #include "util.h"
 
-#include <algorithm>
 #include <cwctype>
 #include <iterator>
 #include <sstream>
@@ -83,9 +82,4 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name) {
   return GetEnvironmentValues(name, L';');
 }
 
-bool Contains(const std::vector<WSTRING>& items, const WSTRING& value) {
-  return !items.empty() &&
-         std::find(items.begin(), items.end(), value) != items.end();
-}
-
-} // namespace trace
+}  // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -30,6 +30,8 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name,
 // GetEnvironmentValues calls GetEnvironmentValues with a semicolon delimiter.
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name);
 
+bool Contains(const std::vector<WSTRING> &items, const WSTRING &value);
+
 }  // namespace trace
 
 #endif  // DD_CLR_PROFILER_UTIL_H_

--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -1,6 +1,7 @@
 #ifndef DD_CLR_PROFILER_UTIL_H_
 #define DD_CLR_PROFILER_UTIL_H_
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -30,8 +31,12 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name,
 // GetEnvironmentValues calls GetEnvironmentValues with a semicolon delimiter.
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name);
 
-bool Contains(const std::vector<WSTRING> &items, const WSTRING &value);
-
+template <class Container>
+bool Contains(const Container &items,
+              const typename Container::value_type &value) {
+  return !items.empty() &&
+         std::find(items.begin(), items.end(), value) != items.end();
+}
 }  // namespace trace
 
 #endif  // DD_CLR_PROFILER_UTIL_H_

--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -34,8 +34,7 @@ std::vector<WSTRING> GetEnvironmentValues(const WSTRING &name);
 template <class Container>
 bool Contains(const Container &items,
               const typename Container::value_type &value) {
-  return !items.empty() &&
-         std::find(items.begin(), items.end(), value) != items.end();
+  return std::find(items.begin(), items.end(), value) != items.end();
 }
 }  // namespace trace
 


### PR DESCRIPTION
I merged #433 without pushing the last local commit, so here's another PR for that.

Changes proposed in this pull request:
- move `vector<WSTRING>` search logic into a separate `Contains()` template method
- exclude more processes from the clr profiler
