### PR TITLE
HttpMessageHandler Smoke Test with Refactor

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,6 +16,8 @@ for config in Debug Release ; do
 
 	dotnet publish -f netcoreapp2.1 -c $config reproductions/DataDogThreadTest/DataDogThreadTest.csproj
 
+	dotnet publish -f netcoreapp2.1 -c $config reproductions/HttpMessageHandler.StackOverflow/HttpMessageHandler.StackOverflow.csproj
+
     dotnet msbuild Datadog.Trace.proj -t:RestoreAndBuildSamplesForPackageVersions
 
     for proj in Datadog.Trace.ClrProfiler.IntegrationTests ; do

--- a/reproductions/DataDogThreadTest/Program.cs
+++ b/reproductions/DataDogThreadTest/Program.cs
@@ -157,7 +157,7 @@ namespace DataDogThreadTest
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
 
@@ -174,7 +174,7 @@ namespace DataDogThreadTest
         enum ExitCode : int
         {
             Success = 0,
-            UnknownError = 10
+            UnknownError = -10
         }
     }
 }

--- a/reproductions/HttpMessageHandler.StackOverflow/HttpMessageHandler.StackOverflow.csproj
+++ b/reproductions/HttpMessageHandler.StackOverflow/HttpMessageHandler.StackOverflow.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.2;netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net461</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>

--- a/reproductions/HttpMessageHandler.StackOverflow/Program.cs
+++ b/reproductions/HttpMessageHandler.StackOverflow/Program.cs
@@ -9,24 +9,37 @@ namespace HttpMessageHandler.StackOverflow
 {
     internal class Program
     {
-        private static async Task Main()
+        private static async Task<int> Main()
         {
-            Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
-
-            var baseAddress = new Uri("https://www.example.com/");
-            var regularHttpClient = new HttpClient { BaseAddress = baseAddress };
-            var customHandlerHttpClient = new HttpClient(new DerivedHandler()) { BaseAddress = baseAddress };
-
-            using (var scope = Tracer.Instance.StartActive("main"))
+            try
             {
-                Console.WriteLine("Calling regularHttpClient.GetAsync");
-                await regularHttpClient.GetAsync("default-handler");
-                Console.WriteLine("Called regularHttpClient.GetAsync");
+                Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
 
-                Console.WriteLine("Calling customHandlerHttpClient.GetAsync");
-                await customHandlerHttpClient.GetAsync("derived-handler");
-                Console.WriteLine("Called customHandlerHttpClient.GetAsync");
+                var baseAddress = new Uri("https://www.example.com/");
+                var regularHttpClient = new HttpClient { BaseAddress = baseAddress };
+                var customHandlerHttpClient = new HttpClient(new DerivedHandler()) { BaseAddress = baseAddress };
+
+                using (var scope = Tracer.Instance.StartActive("main"))
+                {
+                    Console.WriteLine("Calling regularHttpClient.GetAsync");
+                    await regularHttpClient.GetAsync("default-handler");
+                    Console.WriteLine("Called regularHttpClient.GetAsync");
+
+                    Console.WriteLine("Calling customHandlerHttpClient.GetAsync");
+                    await customHandlerHttpClient.GetAsync("derived-handler");
+                    Console.WriteLine("Called customHandlerHttpClient.GetAsync");
+                }
+
+                Console.WriteLine("No stack overflow exceptions!");
+                Console.WriteLine("All is well!");
             }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                return (int)ExitCode.UnknownError;
+            }
+
+            return (int)ExitCode.Success;
         }
     }
 
@@ -41,5 +54,11 @@ namespace HttpMessageHandler.StackOverflow
             Console.WriteLine("Called base.SendAsync()");
             return result;
         }
+    }
+
+    enum ExitCode : int
+    {
+        Success = 0,
+        UnknownError = -10
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = SystemNetHttp,
             TargetType = HttpMessageHandler,
             TargetMethod = SendAsync,
-            TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Net.Http.HttpRequestMessage", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpMessageHandler_SendAsync(
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = SystemNetHttp,
             TargetType = HttpClientHandler,
             TargetMethod = SendAsync,
-            TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Net.Http.HttpRequestMessage", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object HttpClientHandler_SendAsync(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -17,6 +19,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string SystemNetHttp = "System.Net.Http";
         private const string Major4 = "4";
 
+        private const string HttpMessageHandler = "System.Net.Http.HttpMessageHandler";
+        private const string HttpClientHandler = "System.Net.Http.HttpClientHandler";
+        private const string SendAsync = "SendAsync";
+
+        private static readonly ILog Log = LogProvider.GetLogger(typeof(HttpMessageHandlerIntegration));
+
         /// <summary>
         /// Instrumentation wrapper for <see cref="HttpMessageHandler.SendAsync"/>.
         /// </summary>
@@ -28,8 +36,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
-            TargetType = "System.Net.Http.HttpMessageHandler",
-            TargetMethod = "SendAsync",
+            TargetType = HttpMessageHandler,
+            TargetMethod = SendAsync,
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Net.Http.HttpRequestMessage", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
@@ -47,13 +55,25 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var callOpCode = (OpCodeValue)opCode;
             var httpMessageHandler = typeof(HttpMessageHandler); // Note the HttpMessageHandler to match the method call we replaced
 
-            var sendAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
-                                .GetOrCreateMethodCallDelegate(
-                                     httpMessageHandler,
-                                     "SendAsync");
+            Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> instrumentedMethod = null;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
+                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, SendAsync)
+                       .WithConcreteType(httpMessageHandler)
+                       .WithParameters(request, cancellationToken)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {HttpMessageHandler}.{SendAsync}(...)", ex);
+                throw;
+            }
 
             return SendAsyncInternal(
-                sendAsync,
+                instrumentedMethod,
                 reportedType: callOpCode == OpCodeValue.Call ? httpMessageHandler : handler.GetType(),
                 (HttpMessageHandler)handler,
                 (HttpRequestMessage)request,
@@ -61,9 +81,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         }
 
         /// <summary>
-        /// Instrumentation wrapper for <see cref="HttpMessageHandler.SendAsync"/>.
+        /// Instrumentation wrapper for <see cref="HttpClientHandler.SendAsync"/>.
         /// </summary>
-        /// <param name="handler">The <see cref="HttpMessageHandler"/> instance to instrument.</param>
+        /// <param name="handler">The <see cref="HttpClientHandler"/> instance to instrument.</param>
         /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
         /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -71,8 +91,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
-            TargetType = "System.Net.Http.HttpClientHandler",
-            TargetMethod = "SendAsync",
+            TargetType = HttpClientHandler,
+            TargetMethod = SendAsync,
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Net.Http.HttpRequestMessage", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
@@ -90,13 +110,25 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var callOpCode = (OpCodeValue)opCode;
             var httpClientHandler = typeof(HttpClientHandler); // Note the HttpClientHandler to match the method call we replaced
 
-            var sendAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
-                                .GetOrCreateMethodCallDelegate(
-                                     httpClientHandler,
-                                     "SendAsync");
+            Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> instrumentedMethod = null;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
+                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, SendAsync)
+                       .WithConcreteType(httpClientHandler)
+                       .WithParameters(request, cancellationToken)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {HttpClientHandler}.{SendAsync}(...)", ex);
+                throw;
+            }
 
             return SendAsyncInternal(
-                sendAsync,
+                instrumentedMethod,
                 reportedType: callOpCode == OpCodeValue.Call ? httpClientHandler : handler.GetType(),
                 (HttpMessageHandler)handler,
                 (HttpRequestMessage)request,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -50,8 +50,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var sendAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
                                 .GetOrCreateMethodCallDelegate(
                                      httpMessageHandler,
-                                     "SendAsync",
-                                     callOpCode);
+                                     "SendAsync");
 
             return SendAsyncInternal(
                 sendAsync,
@@ -94,8 +93,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var sendAsync = Emit.DynamicMethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
                                 .GetOrCreateMethodCallDelegate(
                                      httpClientHandler,
-                                     "SendAsync",
-                                     callOpCode);
+                                     "SendAsync");
 
             return SendAsyncInternal(
                 sendAsync,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.ClrProfiler
         public const string IAsyncResult = "System.IAsyncResult";
         public const string AsyncCallback = "System.AsyncCallback";
 
+        public const string HttpRequestMessage = "System.Net.Http.HttpRequestMessage";
         public const string HttpResponseMessageTask = "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>";
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/HttpHandlerStackOverflowSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/HttpHandlerStackOverflowSmokeTest.cs
@@ -4,10 +4,10 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
-    public class MultiThreadedSmokeTest : SmokeTestBase
+    public class HttpHandlerStackOverflowSmokeTest : SmokeTestBase
     {
-        public MultiThreadedSmokeTest(ITestOutputHelper output)
-            : base(output, "DataDogThreadTest")
+        public HttpHandlerStackOverflowSmokeTest(ITestOutputHelper output)
+            : base(output, "HttpMessageHandler.StackOverflow", maxTestRunSeconds: 15)
         {
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Diagnostics;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public abstract class SmokeTestBase
+    {
+        protected SmokeTestBase(
+            ITestOutputHelper output,
+            string smokeTestName,
+            int maxTestRunSeconds = 30)
+        {
+            Output = output;
+            MaxTestRunMilliseconds = maxTestRunSeconds * 1000;
+            EnvironmentHelper = new EnvironmentHelper(
+                smokeTestName,
+                this.GetType(),
+                output,
+                samplesDirectory: "reproductions",
+                prependSamplesToAppName: false);
+        }
+
+        protected ITestOutputHelper Output { get; }
+
+        protected EnvironmentHelper EnvironmentHelper { get; }
+
+        protected int MaxTestRunMilliseconds { get; }
+
+        protected void CheckForSmoke()
+        {
+            var applicationPath = EnvironmentHelper.GetSampleApplicationPath().Replace(@"\\", @"\");
+            Output.WriteLine($"Application path: {applicationPath}");
+            var executable = EnvironmentHelper.GetSampleExecutionSource();
+            Output.WriteLine($"Executable path: {executable}");
+
+            if (!System.IO.File.Exists(applicationPath))
+            {
+                throw new Exception($"Smoke test file does not exist: {applicationPath}");
+            }
+
+            // clear all relevant environment variables to start with a clean slate
+            EnvironmentHelper.ClearProfilerEnvironmentVariables();
+
+            ProcessStartInfo startInfo;
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            int aspNetCorePort = TcpPortProvider.GetOpenPort(); // unused for now
+
+            if (EnvironmentHelper.IsCoreClr())
+            {
+                // .NET Core
+                startInfo = new ProcessStartInfo(executable, $"{applicationPath}");
+                EnvironmentHelper.SetEnvironmentVariableDefaults(agentPort, aspNetCorePort, executable, startInfo.EnvironmentVariables);
+            }
+            else
+            {
+                // .NET Framework
+                startInfo = new ProcessStartInfo(executable);
+                EnvironmentHelper.SetEnvironmentVariableDefaults(agentPort, aspNetCorePort, executable, startInfo.EnvironmentVariables);
+            }
+
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.RedirectStandardInput = false;
+
+            ProcessResult result;
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (var process = Process.Start(startInfo))
+            {
+                if (process == null)
+                {
+                    throw new NullException("We need a reference to the process for this test.");
+                }
+
+                var ranToCompletion = process.WaitForExit(MaxTestRunMilliseconds);
+
+                if (!ranToCompletion)
+                {
+                    throw new TimeoutException("The smoke test is running for too long or was lost.");
+                }
+
+                string standardOutput = process.StandardOutput.ReadToEnd();
+                string standardError = process.StandardError.ReadToEnd();
+                int exitCode = process.ExitCode;
+
+                if (!string.IsNullOrWhiteSpace(standardOutput))
+                {
+                    Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(standardError))
+                {
+                    Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+                }
+
+                result = new ProcessResult(process, standardOutput, standardError, exitCode);
+            }
+
+            var successCode = 0;
+            Assert.True(successCode == result.ExitCode, $"Non-success exit code {result.ExitCode}");
+            Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             yield return new object[] { ClrNames.Task, typeof(Task) };
             yield return new object[] { ClrNames.IAsyncResult, typeof(IAsyncResult) };
             yield return new object[] { ClrNames.AsyncCallback, typeof(AsyncCallback) };
+            yield return new object[] { ClrNames.HttpRequestMessage, typeof(System.Net.Http.HttpRequestMessage) };
             yield return new object[] { ClrNames.HttpResponseMessageTask, "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>" }; // Generic full names have square brackets
         }
 


### PR DESCRIPTION
Changes proposed in this pull request:
Run stack overflow test in CI
Resolve HttpMessageHandler methods by mdToken

@DataDog/apm-dotnet