### PR TITLE
Method Lookup Safeties for mdToken

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -158,8 +158,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             if (!requiresBestEffortMatching && _methodBase is MethodInfo info)
             {
-                methodInfo = info;
-                methodInfo = VerifyMethodFromToken(methodInfo);
+                methodInfo = VerifyMethodFromToken(info);
             }
 
             if (methodInfo == null)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -279,12 +279,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 return null;
             }
 
-            if (!methodInfo.DeclaringType?.IsAssignableFrom(_concreteType) ?? false)
-            {
-                Log.Warn($"Type mismatch: {detailMessage}");
-                return null;
-            }
-
             if (!GenericsAreViable(methodInfo))
             {
                 Log.Warn($"Generics not viable: {detailMessage}");

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -279,7 +279,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 return null;
             }
 
-            if (methodInfo.DeclaringType?.IsAssignableFrom(_concreteType) ?? false)
+            if (!methodInfo.DeclaringType?.IsAssignableFrom(_concreteType) ?? false)
             {
                 Log.Warn($"Type mismatch: {detailMessage}");
                 return null;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -111,7 +111,8 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 callingModule: _callingAssembly.ManifestModule,
                 mdToken: _mdToken,
                 callOpCode: _opCode,
-                concreteType: _concreteType, // Needed for Generic DeclaringType MethodSpec scenarios
+                concreteType: _concreteType,
+                explicitParameterTypes: _explicitParameterTypes,
                 methodGenerics: _methodGenerics,
                 declaringTypeGenerics: _declaringTypeGenerics);
 
@@ -532,12 +533,14 @@ namespace Datadog.Trace.ClrProfiler.Emit
             public readonly OpCodeValue CallOpCode;
             public readonly string ConcreteTypeName;
             public readonly string GenericSpec;
+            public readonly string ExplicitParams;
 
             public Key(
                 Module callingModule,
                 int mdToken,
                 OpCodeValue callOpCode,
                 Type concreteType,
+                Type[] explicitParameterTypes,
                 Type[] methodGenerics,
                 Type[] declaringTypeGenerics)
             {
@@ -564,6 +567,13 @@ namespace Datadog.Trace.ClrProfiler.Emit
                     {
                         GenericSpec = string.Concat(GenericSpec, $"_{declaringTypeGenerics[i].FullName}_");
                     }
+                }
+
+                ExplicitParams = string.Empty;
+
+                if (explicitParameterTypes != null)
+                {
+                    ExplicitParams = string.Join("_", explicitParameterTypes.Select(ept => ept.FullName));
                 }
             }
         }
@@ -592,6 +602,11 @@ namespace Datadog.Trace.ClrProfiler.Emit
                     return false;
                 }
 
+                if (!string.Equals(x.ExplicitParams, y.ExplicitParams))
+                {
+                    return false;
+                }
+
                 if (!string.Equals(x.GenericSpec, y.GenericSpec))
                 {
                     return false;
@@ -610,6 +625,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                     hash = (hash * 23) + obj.CallOpCode.GetHashCode();
                     hash = (hash * 23) + obj.ConcreteTypeName.GetHashCode();
                     hash = (hash * 23) + obj.GenericSpec.GetHashCode();
+                    hash = (hash * 23) + obj.ExplicitParams.GetHashCode();
                     return hash;
                 }
             }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
@@ -90,6 +90,21 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         [Fact]
+        public void StringParameterAsObject_WithExplicitTypeSpecified_ProperlyCalls_StringMethod()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            object parameter = string.Empty;
+            var expected = MethodReference.Get(() => instance.Method(string.Empty));
+            var methodResult =
+                Build<Action<object, object>>(expected.Name)
+                   .WithParameters(parameter)
+                   .WithExplicitParameterTypes(typeof(string))
+                   .Build();
+            methodResult.Invoke(instance, parameter);
+            Assert.Equal(expected: expected.MetadataToken, instance.LastCall.MetadataToken);
+        }
+
+        [Fact]
         public void DeclaringTypeGenericParameter_ProperlyCalls_ClosedGenericMethod()
         {
             var instance = new ObscenelyAnnoyingGenericClass<ClassA>();


### PR DESCRIPTION
Changes proposed in this pull request:
Add safety mechanisms to keep in place until the mdToken code has had time to mature.

@DataDog/apm-dotnet