### PR TITLE
Add automatic integration for GraphQL (graphql-dotnet)

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -181,6 +181,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataDogThreadTest", "reprod
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrleansCrash", "reproductions\OrleansCrash\OrleansCrash.csproj", "{DAD5E1F2-A158-4624-9FB4-C89E98DFF0D4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.GraphQL", "samples\Samples.GraphQL\Samples.GraphQL.csproj", "{43782238-E7BB-49D0-9541-1121DACA6EB5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -605,6 +607,16 @@ Global
 		{DAD5E1F2-A158-4624-9FB4-C89E98DFF0D4}.Release|x64.Build.0 = Release|x64
 		{DAD5E1F2-A158-4624-9FB4-C89E98DFF0D4}.Release|x86.ActiveCfg = Release|x86
 		{DAD5E1F2-A158-4624-9FB4-C89E98DFF0D4}.Release|x86.Build.0 = Release|x86
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|x64.ActiveCfg = Debug|x64
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|x64.Build.0 = Debug|x64
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|x86.ActiveCfg = Debug|x86
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Debug|x86.Build.0 = Debug|x86
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|Any CPU.ActiveCfg = Release|x86
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|x64.ActiveCfg = Release|x64
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|x64.Build.0 = Release|x64
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|x86.ActiveCfg = Release|x86
+		{43782238-E7BB-49D0-9541-1121DACA6EB5}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -648,6 +660,7 @@ Global
 		{DA0A44FB-D562-4776-AAFB-8266E78AA1A6} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 		{3CDCE3AA-7CAF-4A27-B1D3-9D558B74D084} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{DAD5E1F2-A158-4624-9FB4-C89E98DFF0D4} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{43782238-E7BB-49D0-9541-1121DACA6EB5} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -10,7 +10,7 @@ for config in Debug Release ; do
         dotnet publish -f netstandard2.0 -c $config src/$proj/$proj.csproj
     done
 
-    for sample in Samples.AspNetCoreMvc2 Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.MongoDB Samples.HttpMessageHandler Samples.Npgsql ; do
+    for sample in Samples.AspNetCoreMvc2 Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.MongoDB Samples.HttpMessageHandler Samples.Npgsql Samples.GraphQL ; do
         dotnet publish -f netcoreapp2.1 -c $config samples/$sample/$sample.csproj
     done
 

--- a/integrations.json
+++ b/integrations.json
@@ -415,10 +415,10 @@
             "_",
             "GraphQL.Inputs"
           ],
-          "minimum_major": 0,
-          "minimum_minor": 0,
+          "minimum_major": 2,
+          "minimum_minor": 3,
           "minimum_patch": 0,
-          "maximum_major": 65535,
+          "maximum_major": 2,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -439,10 +439,10 @@
             "System.Threading.Tasks.Task`1<GraphQL.ExecutionResult>",
             "GraphQL.Execution.ExecutionContext"
           ],
-          "minimum_major": 0,
-          "minimum_minor": 0,
+          "minimum_major": 2,
+          "minimum_minor": 3,
           "minimum_patch": 0,
-          "maximum_major": 65535,
+          "maximum_major": 2,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },

--- a/integrations.json
+++ b/integrations.json
@@ -408,12 +408,12 @@
           "method": "Validate",
           "signature_types": [
             "GraphQL.Validation.IValidationResult",
+            "System.String",
+            "GraphQL.Types.ISchema",
+            "GraphQL.Language.AST.Document",
+            "System.Collections.Generic.IEnumerable`1<GraphQL.Validation.IValidationRule>",
             "_",
-            "_",
-            "_",
-            "_",
-            "_",
-            "_"
+            "GraphQL.Inputs"
           ],
           "minimum_major": 0,
           "minimum_minor": 0,
@@ -437,7 +437,7 @@
           "method": "ExecuteAsync",
           "signature_types": [
             "System.Threading.Tasks.Task`1<GraphQL.ExecutionResult>",
-            "_"
+            "GraphQL.Execution.ExecutionContext"
           ],
           "minimum_major": 0,
           "minimum_minor": 0,

--- a/integrations.json
+++ b/integrations.json
@@ -398,6 +398,39 @@
     ]
   },
   {
+    "name": "GraphQL",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "GraphQL.Server.Core",
+          "type": "GraphQL.Server.Internal.IGraphQLExecuter",
+          "method": "ExecuteAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<GraphQL.ExecutionResult>",
+            "System.String",
+            "System.String",
+            "_",
+            "_",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
+          "method": "ExecuteAsync",
+          "signature": "00 08 1C 1C 1C 1C 1C 1C 1C 08 08"
+        }
+      }
+    ]
+  },
+  {
     "name": "HttpContext",
     "method_replacements": [
       {

--- a/integrations.json
+++ b/integrations.json
@@ -423,7 +423,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.5.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "Validate",
           "signature": "00 09 1C 1C 1C 1C 1C 1C 1C 1C 08 08"
@@ -447,7 +447,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.5.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
           "signature": "00 04 1C 1C 1C 08 08"

--- a/integrations.json
+++ b/integrations.json
@@ -404,6 +404,35 @@
         "caller": {},
         "target": {
           "assembly": "GraphQL",
+          "type": "GraphQL.Validation.IDocumentValidator",
+          "method": "Validate",
+          "signature_types": [
+            "GraphQL.Validation.IValidationResult",
+            "_",
+            "_",
+            "_",
+            "_",
+            "_",
+            "_"
+          ],
+          "minimum_major": 0,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 65535,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
+          "method": "Validate",
+          "signature": "00 09 1C 1C 1C 1C 1C 1C 1C 1C 08 08"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "GraphQL",
           "type": "GraphQL.Execution.IExecutionStrategy",
           "method": "ExecuteAsync",
           "signature_types": [

--- a/integrations.json
+++ b/integrations.json
@@ -423,7 +423,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.5.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.5.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "Validate",
           "signature": "00 09 1C 1C 1C 1C 1C 1C 1C 1C 08 08"
@@ -447,7 +447,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.5.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.5.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
           "signature": "00 04 1C 1C 1C 08 08"

--- a/integrations.json
+++ b/integrations.json
@@ -403,16 +403,12 @@
       {
         "caller": {},
         "target": {
-          "assembly": "GraphQL.Server.Core",
-          "type": "GraphQL.Server.Internal.IGraphQLExecuter",
+          "assembly": "GraphQL",
+          "type": "GraphQL.Execution.IExecutionStrategy",
           "method": "ExecuteAsync",
           "signature_types": [
             "System.Threading.Tasks.Task`1<GraphQL.ExecutionResult>",
-            "System.String",
-            "System.String",
-            "_",
-            "_",
-            "System.Threading.CancellationToken"
+            "_"
           ],
           "minimum_major": 0,
           "minimum_minor": 0,
@@ -425,7 +421,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.4.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
-          "signature": "00 08 1C 1C 1C 1C 1C 1C 1C 08 08"
+          "signature": "00 04 1C 1C 1C 08 08"
         }
       }
     ]

--- a/samples/Samples.GraphQL/GraphQLUserContext.cs
+++ b/samples/Samples.GraphQL/GraphQLUserContext.cs
@@ -1,0 +1,9 @@
+using System.Security.Claims;
+
+namespace Samples.GraphQL
+{
+    public class GraphQLUserContext
+    {
+        public ClaimsPrincipal User { get; set; }
+    }
+}

--- a/samples/Samples.GraphQL/Program.cs
+++ b/samples/Samples.GraphQL/Program.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Datadog.Trace.ClrProfiler;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections;
+
+namespace Samples.GraphQL
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var directory = Directory.GetCurrentDirectory();
+
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .UseContentRoot(directory)
+                .UseIISIntegration()
+                .UseStartup<Startup>()
+                .Build();
+
+            var logger = host.Services.GetRequiredService<ILogger<Program>>();
+            logger.LogInformation($"Instrumentation.ProfilerAttached = {Instrumentation.ProfilerAttached}");
+
+            var prefixes = new[] { "COR_", "CORECLR_", "DD_", "DATADOG_" };
+            var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
+                          from prefix in prefixes
+                          let key = (envVar.Key as string)?.ToUpperInvariant()
+                          let value = envVar.Value as string
+                          where key.StartsWith(prefix)
+                          orderby key
+                          select new KeyValuePair<string, string>(key, value);
+
+            foreach (var kvp in envVars)
+            {
+                logger.LogInformation($"{kvp.Key} = {kvp.Value}");
+            }
+
+            host.Run();
+        }
+    }
+}

--- a/samples/Samples.GraphQL/Properties/launchSettings.json
+++ b/samples/Samples.GraphQL/Properties/launchSettings.json
@@ -1,0 +1,50 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:54567/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "use64Bit": true,
+      "nativeDebugging": true
+    },
+    "Samples.GraphQL": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "applicationUrl": "http://localhost:54568/",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/samples/Samples.GraphQL/Samples.GraphQL.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <!-- override to remove net452 -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GraphQL" Version="2.4.0" />
+    <PackageReference Include="GraphQL.StarWars" Version="1.0.0" />
+    <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />
+    <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/samples/Samples.GraphQL/Samples.GraphQL.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GraphQL" Version="2.4.0" />
+    <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="GraphQL.StarWars" Version="1.0.0" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />

--- a/samples/Samples.GraphQL/StarWarsExtensions/StarWarsSubscription.cs
+++ b/samples/Samples.GraphQL/StarWarsExtensions/StarWarsSubscription.cs
@@ -34,6 +34,13 @@ namespace Samples.GraphQL.StarWarsExtensions
                 Resolver = new FuncFieldResolver<Human>(ResolveMessage),
                 Subscriber = new EventStreamResolver<Human>(Subscribe)
             });
+            AddField(new EventStreamFieldType
+            {
+                Name = "throwNotImplementedException",
+                Type = typeof(HumanType),
+                Resolver = new FuncFieldResolver<Human>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Human>(ThrowNotImplementedException)
+            });
         }
 
         private Human ResolveMessage(ResolveFieldContext context)
@@ -62,6 +69,11 @@ namespace Samples.GraphQL.StarWarsExtensions
             }
 
             return listOfHumans.ToObservable();
+        }
+
+        private IObservable<Human> ThrowNotImplementedException(ResolveEventStreamContext context)
+        {
+            throw new NotImplementedException("This API purposely throws a NotImplementedException");
         }
     }
 }

--- a/samples/Samples.GraphQL/StarWarsExtensions/StarWarsSubscription.cs
+++ b/samples/Samples.GraphQL/StarWarsExtensions/StarWarsSubscription.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using GraphQL.Resolvers;
+using GraphQL.StarWars;
+using GraphQL.StarWars.Types;
+using GraphQL.Subscription;
+using GraphQL.Types;
+
+namespace Samples.GraphQL.StarWarsExtensions
+{
+    /// <example>
+    /// This is an example JSON request for a subscription
+    /// {
+    ///   "query": "subscription HumanAddedSub{ humanAdded { name } }",
+    /// }
+    /// </example>
+    public class StarWarsSubscription : ObjectGraphType<object>
+    {
+        private readonly StarWarsData _starWarsData;
+
+        private readonly ISubject<Human> _humanStream = new ReplaySubject<Human>(1);
+
+        public StarWarsSubscription(StarWarsData data)
+        {
+            Name = "Subscription";
+            _starWarsData = data;
+
+            AddField(new EventStreamFieldType
+            {
+                Name = "humanAdded",
+                Type = typeof(HumanType),
+                Resolver = new FuncFieldResolver<Human>(ResolveMessage),
+                Subscriber = new EventStreamResolver<Human>(Subscribe)
+            });
+        }
+
+        private Human ResolveMessage(ResolveFieldContext context)
+        {
+            return context.Source as Human;
+        }
+
+        private IObservable<Human> Subscribe(ResolveEventStreamContext context)
+        {
+            List<Human> listOfHumans = new List<Human>();
+
+            var task = _starWarsData.GetHumanByIdAsync("1");
+            task.Wait();
+            var result = task.Result;
+            if (result != null)
+            {
+                listOfHumans.Add(task.Result);
+            }
+
+            task = _starWarsData.GetHumanByIdAsync("2");
+            task.Wait();
+            result = task.Result;
+            if (result != null)
+            {
+                listOfHumans.Add(task.Result);
+            }
+
+            return listOfHumans.ToObservable();
+        }
+    }
+}

--- a/samples/Samples.GraphQL/Startup.cs
+++ b/samples/Samples.GraphQL/Startup.cs
@@ -26,6 +26,7 @@ namespace Samples.GraphQL
             services.AddSingleton<StarWarsData>();
             services.AddSingleton<StarWarsQuery>();
             services.AddSingleton<StarWarsMutation>();
+            services.AddSingleton<StarWarsExtensions.StarWarsSubscription>();
             services.AddSingleton<HumanType>();
             services.AddSingleton<HumanInputType>();
             services.AddSingleton<DroidType>();
@@ -45,6 +46,16 @@ namespace Samples.GraphQL
 
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            // Get StarWarsSchema Singleton
+            var starWarsSchema = (StarWarsSchema)app.ApplicationServices.GetService(typeof(ISchema));
+
+            // Get StarWarsSubscription Singleton
+            var starWarsSubscription = (StarWarsExtensions.StarWarsSubscription) app.ApplicationServices.GetService(typeof(StarWarsExtensions.StarWarsSubscription));
+
+            // Set the subscription
+            // We do this roundabout mechanism to keep using the GraphQL.StarWars NuGet package
+            starWarsSchema.Subscription = starWarsSubscription;
+
             loggerFactory.AddConsole();
             app.UseDeveloperExceptionPage();
 

--- a/samples/Samples.GraphQL/Startup.cs
+++ b/samples/Samples.GraphQL/Startup.cs
@@ -1,0 +1,61 @@
+using GraphQL;
+using GraphQL.Http;
+using GraphQL.Server;
+using GraphQL.Server.Transports.AspNetCore;
+using GraphQL.Server.Ui.Playground;
+using GraphQL.Types;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using GraphQL.StarWars;
+using GraphQL.StarWars.Types;
+
+namespace Samples.GraphQL
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<IDependencyResolver>(s => new FuncDependencyResolver(s.GetRequiredService));
+
+            services.AddSingleton<IDocumentExecuter, DocumentExecuter>();
+            services.AddSingleton<IDocumentWriter, DocumentWriter>();
+
+            services.AddSingleton<StarWarsData>();
+            services.AddSingleton<StarWarsQuery>();
+            services.AddSingleton<StarWarsMutation>();
+            services.AddSingleton<HumanType>();
+            services.AddSingleton<HumanInputType>();
+            services.AddSingleton<DroidType>();
+            services.AddSingleton<CharacterInterface>();
+            services.AddSingleton<EpisodeEnum>();
+            services.AddSingleton<ISchema, StarWarsSchema>();
+
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+
+            services.AddGraphQL(_ =>
+            {
+                _.EnableMetrics = true;
+                _.ExposeExceptions = true;
+            })
+            .AddUserContextBuilder(httpContext => new GraphQLUserContext { User = httpContext.User });
+        }
+
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddConsole();
+            app.UseDeveloperExceptionPage();
+
+            // add http for Schema at default url /graphql
+            app.UseGraphQL<ISchema>("/graphql");
+
+            // use graphql-playground at default url /ui/playground
+            app.UseGraphQLPlayground(new GraphQLPlaygroundOptions
+            {
+                Path = "/ui/playground"
+            });
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Helpers/AsyncHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Helpers/AsyncHelper.cs
@@ -29,27 +29,6 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             return asyncDelegate.Invoke(null, parametersToPass);
         }
 
-        internal static object InvokeGenericTaskDelegateWithExplicitParameterTypes(
-            Type owningType,
-            Type taskResultType,
-            string nameOfIntegrationMethod,
-            Type integrationType,
-            Type[] parameterTypes,
-            params object[] parametersToPass)
-        {
-            var methodKey =
-                Interception.MethodKey(
-                    owningType: owningType,
-                    returnType: taskResultType,
-                    genericTypes: Interception.NullTypeArray,
-                    parameterTypes: parameterTypes);
-
-            var asyncDelegate =
-                MethodCache.GetOrAdd(methodKey, _ => GetGenericAsyncMethodInfo(taskResultType, nameOfIntegrationMethod, integrationType));
-
-            return asyncDelegate.Invoke(null, parametersToPass);
-        }
-
         private static MethodInfo GetGenericAsyncMethodInfo(Type taskResultType, string nameOfIntegrationMethod, Type integrationType)
         {
             var method = integrationType.GetMethod(nameOfIntegrationMethod, BindingFlags.Static | BindingFlags.NonPublic);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Helpers/AsyncHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Helpers/AsyncHelper.cs
@@ -29,6 +29,27 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             return asyncDelegate.Invoke(null, parametersToPass);
         }
 
+        internal static object InvokeGenericTaskDelegateWithExplicitParameterTypes(
+            Type owningType,
+            Type taskResultType,
+            string nameOfIntegrationMethod,
+            Type integrationType,
+            Type[] parameterTypes,
+            params object[] parametersToPass)
+        {
+            var methodKey =
+                Interception.MethodKey(
+                    owningType: owningType,
+                    returnType: taskResultType,
+                    genericTypes: Interception.NullTypeArray,
+                    parameterTypes: parameterTypes);
+
+            var asyncDelegate =
+                MethodCache.GetOrAdd(methodKey, _ => GetGenericAsyncMethodInfo(taskResultType, nameOfIntegrationMethod, integrationType));
+
+            return asyncDelegate.Invoke(null, parametersToPass);
+        }
+
         private static MethodInfo GetGenericAsyncMethodInfo(Type taskResultType, string nameOfIntegrationMethod, Type integrationType)
         {
             var method = integrationType.GetMethod(nameOfIntegrationMethod, BindingFlags.Static | BindingFlags.NonPublic);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -15,120 +15,92 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     public static class GraphQLIntegration
     {
         private const string IntegrationName = "GraphQL";
-        private const string OperationName = "graphql.query";
         private const string ServiceName = "graphql";
+        private const string ExecuteOperationName = "graphql.execute";
 
         private const string GraphQLAssemblyName = "GraphQL";
-        private const string GraphQLServerCoreAssemblyName = "GraphQL.Server.Core";
-        private const string GraphQLExecuterInterface = "GraphQL.Server.Internal.IGraphQLExecuter";
-        private const string GraphQLExecutionResult = "GraphQL.ExecutionResult";
-        private const string GraphQLInputs = "GraphQL.Inputs";
-        private const string TaskOfGraphQLExecutionResult = "System.Threading.Tasks.Task`1<" + GraphQLExecutionResult + ">";
-
+        private const string GraphQLExecutionResultName = "GraphQL.ExecutionResult";
+        private const string TaskOfGraphQLExecutionResult = "System.Threading.Tasks.Task`1<" + GraphQLExecutionResultName + ">";
+        private const string GraphQLExecutionStrategyInterfaceName = "GraphQL.Execution.IExecutionStrategy";
         private static readonly ILog Log = LogProvider.GetLogger(typeof(GraphQLIntegration));
 
         /// <summary>
         /// Wrap the original method by adding instrumentation code around it.
         /// </summary>
-        /// <param name="graphQLExecuter">The IGraphQLExecuter</param>
-        /// <param name="operationName">The operation name string.</param>
-        /// <param name="query">The query string.</param>
-        /// <param name="variables">The input variables.</param>
-        /// <param name="context">The context.</param>
-        /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="executionStrategy">The instance of GraphQL.Execution.IExecutionStrategy</param>
+        /// <param name="context">The execution context of the GraphQL operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
-            TargetAssembly = GraphQLServerCoreAssemblyName,
-            TargetType = GraphQLExecuterInterface,
-            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, ClrNames.String, ClrNames.String, ClrNames.Ignore, ClrNames.Ignore, ClrNames.CancellationToken })]
-        public static object ExecuteAsync(object graphQLExecuter, object operationName, object query, object variables, object context, object cancellationTokenSource, int opCode, int mdToken)
+            TargetAssembly = GraphQLAssemblyName,
+            TargetType = GraphQLExecutionStrategyInterfaceName,
+            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, ClrNames.Ignore })]
+        public static object ExecuteAsync(object executionStrategy, object context, int opCode, int mdToken)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
-
-            if (graphQLExecuter == null) { throw new ArgumentNullException(nameof(graphQLExecuter)); }
+            if (executionStrategy == null) { throw new ArgumentNullException(nameof(executionStrategy)); }
 
             const string methodName = nameof(ExecuteAsync);
 
             // At runtime, get a Type object for GraphQL.ExecutionResult
-            var graphQLExecuterType = graphQLExecuter.GetType();
+            var executionStrategyInstanceType = executionStrategy.GetType();
             Type graphQLExecutionResultType;
-            Type graphQLInputsType;
-            Type graphQLExecuterInterfaceType;
+            Type executionStrategyInterfaceType;
 
             try
             {
                 var graphQLAssembly = AppDomain.CurrentDomain.GetAssemblies()
                                         .Where(a => a.GetName().Name.Equals(GraphQLAssemblyName))
                                         .Single();
-                graphQLExecutionResultType = graphQLAssembly.GetType(GraphQLExecutionResult, throwOnError: true);
-                graphQLInputsType = graphQLAssembly.GetType(GraphQLInputs, throwOnError: true);
-
-                var graphQLServerCoreAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                        .Where(a => a.GetName().Name.Equals(GraphQLServerCoreAssemblyName))
-                        .Single();
-                graphQLExecuterInterfaceType = graphQLServerCoreAssembly.GetType(GraphQLExecuterInterface, throwOnError: true);
+                graphQLExecutionResultType = graphQLAssembly.GetType(GraphQLExecutionResultName, throwOnError: true);
+                executionStrategyInterfaceType = graphQLAssembly.GetType(GraphQLExecutionStrategyInterfaceName, throwOnError: true);
             }
             catch (Exception ex)
             {
-                // This shouldn't happen because the GraphQL and GraphQL.Server.Core assembly should have been loaded to construct various other types
+                // This shouldn't happen because the GraphQL assembly should have been loaded to construct various other types
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error calling {graphQLExecuterType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                Log.ErrorException($"Error calling {executionStrategyInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
                 throw;
             }
 
-            Func<object, object, object, object, object, CancellationToken, object> instrumentedMethod;
+            Func<object, object, object> instrumentedMethod;
 
             try
             {
                 instrumentedMethod =
-                    MethodBuilder<Func<object, object, object, object, object, CancellationToken, object>>
+                    MethodBuilder<Func<object, object, object>>
                         .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
-                        .WithConcreteType(graphQLExecuterType)
-                        .WithParameters(operationName, query, variables, context, cancellationToken)
+                        .WithConcreteType(executionStrategyInstanceType)
+                        .WithParameters(context)
                         .Build();
             }
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error resolving {graphQLExecuterType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                Log.ErrorException($"Error resolving {executionStrategyInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
                 throw;
             }
 
-            // The first three arguments may be null, so we must define the parameter types explicitly
-            var parameterTypes = new Type[] { typeof(string), typeof(string), graphQLInputsType, context.GetType(), typeof(CancellationToken) };
-
-            return AsyncHelper.InvokeGenericTaskDelegateWithExplicitParameterTypes(
-                owningType: graphQLExecuterInterfaceType,
+            return AsyncHelper.InvokeGenericTaskDelegate(
+                owningType: executionStrategyInterfaceType,
                 taskResultType: graphQLExecutionResultType,
                 nameOfIntegrationMethod: nameof(CallGraphQLExecuteAsyncInternal),
                 integrationType: typeof(GraphQLIntegration),
-                parameterTypes: parameterTypes,
-                graphQLExecuter,
-                operationName,
-                query,
-                variables,
+                executionStrategy,
                 context,
-                cancellationToken,
                 instrumentedMethod);
         }
 
         private static async Task<T> CallGraphQLExecuteAsyncInternal<T>(
-            object graphQLExecuter,
-            object operationName,
-            object query,
-            object variables,
-            object context,
-            CancellationToken cancellationToken,
-            Func<object, object, object, object, object, CancellationToken, object> originalMethod)
+            object executionStrategy,
+            object options,
+            Func<object, object, object> originalMethod)
         {
-            using (var scope = CreateScope(graphQLExecuter, operationName, query, variables, context))
+            using (var scope = CreateScope(options))
             {
                 try
                 {
-                    var task = (Task<T>)originalMethod(graphQLExecuter, operationName, query, variables, context, cancellationToken);
+                    var task = (Task<T>)originalMethod(executionStrategy, options);
                     return await task.ConfigureAwait(false);
                 }
                 catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
@@ -139,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
         }
 
-        private static Scope CreateScope(object graphQLExecuter, object operationName, object query, object variables, object context)
+        private static Scope CreateScope(object executionContext)
         {
             if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName))
             {
@@ -147,30 +119,30 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return null;
             }
 
-            // Fields
-            string host = null;
-            string port = null;
-
-            // TODO: Insert stuff
-
             Tracer tracer = Tracer.Instance;
+            string source = executionContext.GetProperty("Document")
+                                            .GetProperty<string>("OriginalQuery")
+                                            .GetValueOrDefault();
+            string operationName = executionContext.GetProperty("Operation")
+                                                   .GetProperty<string>("Name")
+                                                   .GetValueOrDefault();
+            string operationType = executionContext.GetProperty("Operation")
+                                                   .GetProperty("OperationType")
+                                                   .ToString();
             string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
 
             Scope scope = null;
 
             try
             {
-                scope = tracer.StartActive(OperationName, serviceName: serviceName);
+                scope = tracer.StartActive(ExecuteOperationName, serviceName: serviceName);
                 var span = scope.Span;
                 span.Type = SpanTypes.GraphQL;
-                // span.ResourceName = resourceName;
+                span.ResourceName = $"{operationType} {operationName ?? "operation"}";
 
-                // TODO: set tag graphql.source
-                // TODO: set tag graphql.operation.type
-                // TODO: set tag graphql.operation.name
-
-                span.SetTag(Tags.OutHost, host);
-                span.SetTag(Tags.OutPort, port);
+                span.SetTag(Tags.GraphQLSource, source);
+                span.SetTag(Tags.GraphQLOperationName, operationName);
+                span.SetTag(Tags.GraphQLOperationType, operationType);
 
                 // set analytics sample rate if enabled
                 var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(IntegrationName, enabledWithGlobalSetting: false);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -18,6 +18,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string IntegrationName = "GraphQL";
         private const string ServiceName = "graphql";
 
+        private const string Major2 = "2";
+        private const string Major2Minor3 = "2.3";
+
         private const string ParseOperationName = "graphql.parse"; // Instrumentation not yet implemented
         private const string ValidateOperationName = "graphql.validate";
         private const string ExecuteOperationName = "graphql.execute";
@@ -49,7 +52,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = GraphQLAssemblyName,
             TargetType = GraphQLDocumentValidatorInterfaceName,
-            TargetSignatureTypes = new[] { GraphQLValidationResultInterfaceName, ClrNames.String, "GraphQL.Types.ISchema", "GraphQL.Language.AST.Document", "System.Collections.Generic.IEnumerable`1<GraphQL.Validation.IValidationRule>", ClrNames.Ignore, "GraphQL.Inputs" })]
+            TargetSignatureTypes = new[] { GraphQLValidationResultInterfaceName, ClrNames.String, "GraphQL.Types.ISchema", "GraphQL.Language.AST.Document", "System.Collections.Generic.IEnumerable`1<GraphQL.Validation.IValidationRule>", ClrNames.Ignore, "GraphQL.Inputs" },
+            TargetMinimumVersion = Major2Minor3,
+            TargetMaximumVersion = Major2)]
         public static object Validate(
             object documentValidator,
             object originalQuery,
@@ -131,7 +136,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = GraphQLAssemblyName,
             TargetType = GraphQLExecutionStrategyInterfaceName,
-            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, "GraphQL.Execution.ExecutionContext" })]
+            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, "GraphQL.Execution.ExecutionContext" },
+            TargetMinimumVersion = Major2Minor3,
+            TargetMaximumVersion = Major2)]
         public static object ExecuteAsync(object executionStrategy, object context, int opCode, int mdToken)
         {
             if (executionStrategy == null) { throw new ArgumentNullException(nameof(executionStrategy)); }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.ClrProfiler.Helpers;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Integrations
+{
+    /// <summary>
+    /// Tracing integration for GraphQL.Server.Transports.AspNetCore
+    /// </summary>
+    public static class GraphQLIntegration
+    {
+        private const string IntegrationName = "GraphQL";
+        private const string OperationName = "graphql.query";
+        private const string ServiceName = "graphql";
+
+        private const string GraphQLAssemblyName = "GraphQL";
+        private const string GraphQLServerCoreAssemblyName = "GraphQL.Server.Core";
+        private const string GraphQLExecuterInterface = "GraphQL.Server.Internal.IGraphQLExecuter";
+        private const string GraphQLExecutionResult = "GraphQL.ExecutionResult";
+        private const string GraphQLInputs = "GraphQL.Inputs";
+        private const string TaskOfGraphQLExecutionResult = "System.Threading.Tasks.Task`1<" + GraphQLExecutionResult + ">";
+
+        private static readonly ILog Log = LogProvider.GetLogger(typeof(GraphQLIntegration));
+
+        /// <summary>
+        /// Wrap the original method by adding instrumentation code around it.
+        /// </summary>
+        /// <param name="graphQLExecuter">The IGraphQLExecuter</param>
+        /// <param name="operationName">The operation name string.</param>
+        /// <param name="query">The query string.</param>
+        /// <param name="variables">The input variables.</param>
+        /// <param name="context">The context.</param>
+        /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <returns>The original method's return value.</returns>
+        [InterceptMethod(
+            TargetAssembly = GraphQLServerCoreAssemblyName,
+            TargetType = GraphQLExecuterInterface,
+            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, ClrNames.String, ClrNames.String, ClrNames.Ignore, ClrNames.Ignore, ClrNames.CancellationToken })]
+        public static object ExecuteAsync(object graphQLExecuter, object operationName, object query, object variables, object context, object cancellationTokenSource, int opCode, int mdToken)
+        {
+            var tokenSource = cancellationTokenSource as CancellationTokenSource;
+            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+
+            if (graphQLExecuter == null) { throw new ArgumentNullException(nameof(graphQLExecuter)); }
+
+            const string methodName = nameof(ExecuteAsync);
+
+            // At runtime, get a Type object for GraphQL.ExecutionResult
+            var graphQLExecuterType = graphQLExecuter.GetType();
+            Type graphQLExecutionResultType;
+            Type graphQLInputsType;
+            Type graphQLExecuterInterfaceType;
+
+            try
+            {
+                var graphQLAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                                        .Where(a => a.GetName().Name.Equals(GraphQLAssemblyName))
+                                        .Single();
+                graphQLExecutionResultType = graphQLAssembly.GetType(GraphQLExecutionResult, throwOnError: true);
+                graphQLInputsType = graphQLAssembly.GetType(GraphQLInputs, throwOnError: true);
+
+                var graphQLServerCoreAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                        .Where(a => a.GetName().Name.Equals(GraphQLServerCoreAssemblyName))
+                        .Single();
+                graphQLExecuterInterfaceType = graphQLServerCoreAssembly.GetType(GraphQLExecuterInterface, throwOnError: true);
+            }
+            catch (Exception ex)
+            {
+                // This shouldn't happen because the GraphQL and GraphQL.Server.Core assembly should have been loaded to construct various other types
+                // profiled app will not continue working as expected without this method
+                Log.ErrorException($"Error calling {graphQLExecuterType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                throw;
+            }
+
+            Func<object, object, object, object, object, CancellationToken, object> instrumentedMethod;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<object, object, object, object, object, CancellationToken, object>>
+                        .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                        .WithConcreteType(graphQLExecuterType)
+                        .WithParameters(operationName, query, variables, context, cancellationToken)
+                        .Build();
+            }
+            catch (Exception ex)
+            {
+                // profiled app will not continue working as expected without this method
+                Log.ErrorException($"Error resolving {graphQLExecuterType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                throw;
+            }
+
+            // The first three arguments may be null, so we must define the parameter types explicitly
+            var parameterTypes = new Type[] { typeof(string), typeof(string), graphQLInputsType, context.GetType(), typeof(CancellationToken) };
+
+            return AsyncHelper.InvokeGenericTaskDelegateWithExplicitParameterTypes(
+                owningType: graphQLExecuterInterfaceType,
+                taskResultType: graphQLExecutionResultType,
+                nameOfIntegrationMethod: nameof(CallGraphQLExecuteAsyncInternal),
+                integrationType: typeof(GraphQLIntegration),
+                parameterTypes: parameterTypes,
+                graphQLExecuter,
+                operationName,
+                query,
+                variables,
+                context,
+                cancellationToken,
+                instrumentedMethod);
+        }
+
+        private static async Task<T> CallGraphQLExecuteAsyncInternal<T>(
+            object graphQLExecuter,
+            object operationName,
+            object query,
+            object variables,
+            object context,
+            CancellationToken cancellationToken,
+            Func<object, object, object, object, object, CancellationToken, object> originalMethod)
+        {
+            using (var scope = CreateScope(graphQLExecuter, operationName, query, variables, context))
+            {
+                try
+                {
+                    var task = (Task<T>)originalMethod(graphQLExecuter, operationName, query, variables, context, cancellationToken);
+                    return await task.ConfigureAwait(false);
+                }
+                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
+                {
+                    // unreachable code
+                    throw;
+                }
+            }
+        }
+
+        private static Scope CreateScope(object graphQLExecuter, object operationName, object query, object variables, object context)
+        {
+            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName))
+            {
+                // integration disabled, don't create a scope, skip this trace
+                return null;
+            }
+
+            // Fields
+            string host = null;
+            string port = null;
+
+            // TODO: Insert stuff
+
+            Tracer tracer = Tracer.Instance;
+            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+
+            Scope scope = null;
+
+            try
+            {
+                scope = tracer.StartActive(OperationName, serviceName: serviceName);
+                var span = scope.Span;
+                span.Type = SpanTypes.GraphQL;
+                // span.ResourceName = resourceName;
+
+                // TODO: set tag graphql.source
+                // TODO: set tag graphql.operation.type
+                // TODO: set tag graphql.operation.name
+
+                span.SetTag(Tags.OutHost, host);
+                span.SetTag(Tags.OutPort, port);
+
+                // set analytics sample rate if enabled
+                var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(IntegrationName, enabledWithGlobalSetting: false);
+                span.SetMetric(Tags.Analytics, analyticsSampleRate);
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException("Error creating or populating scope.", ex);
+            }
+
+            return scope;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = GraphQLAssemblyName,
             TargetType = GraphQLDocumentValidatorInterfaceName,
-            TargetSignatureTypes = new[] { GraphQLValidationResultInterfaceName, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore })]
+            TargetSignatureTypes = new[] { GraphQLValidationResultInterfaceName, ClrNames.String, "GraphQL.Types.ISchema", "GraphQL.Language.AST.Document", "System.Collections.Generic.IEnumerable`1<GraphQL.Validation.IValidationRule>", ClrNames.Ignore, "GraphQL.Inputs" })]
         public static object Validate(
             object documentValidator,
             object originalQuery,
@@ -145,7 +145,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = GraphQLAssemblyName,
             TargetType = GraphQLExecutionStrategyInterfaceName,
-            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, ClrNames.Ignore })]
+            TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, "GraphQL.Execution.ExecutionContext" })]
         public static object ExecuteAsync(object executionStrategy, object context, int opCode, int mdToken)
         {
             if (executionStrategy == null) { throw new ArgumentNullException(nameof(executionStrategy)); }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -260,8 +260,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                                                    .GetProperty<string>("Name")
                                                    .GetValueOrDefault();
             string operationType = executionContext.GetProperty("Operation")
-                                                   .GetProperty("OperationType")
-                                                   .ToString();
+                                                       .GetProperty<Enum>("OperationType")
+                                                       .GetValueOrDefault()
+                                                       .ToString();
             string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
 
             Scope scope = null;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;
@@ -16,18 +17,126 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     {
         private const string IntegrationName = "GraphQL";
         private const string ServiceName = "graphql";
+
+        private const string ParseOperationName = "graphql.parse";
+        private const string ValidateOperationName = "graphql.validate";
         private const string ExecuteOperationName = "graphql.execute";
+        private const string ResolveOperationName = "graphql.resolve";
 
         private const string GraphQLAssemblyName = "GraphQL";
+        private const string GraphQLDocumentValidatorInterfaceName = "GraphQL.Validation.IDocumentValidator";
         private const string GraphQLExecutionResultName = "GraphQL.ExecutionResult";
-        private const string TaskOfGraphQLExecutionResult = "System.Threading.Tasks.Task`1<" + GraphQLExecutionResultName + ">";
         private const string GraphQLExecutionStrategyInterfaceName = "GraphQL.Execution.IExecutionStrategy";
+        private const string GraphQLValidationResultInterfaceName = "GraphQL.Validation.IValidationResult";
+
+        private const string TaskOfGraphQLExecutionResult = "System.Threading.Tasks.Task`1<" + GraphQLExecutionResultName + ">";
+
         private static readonly ILog Log = LogProvider.GetLogger(typeof(GraphQLIntegration));
 
         /// <summary>
         /// Wrap the original method by adding instrumentation code around it.
         /// </summary>
-        /// <param name="executionStrategy">The instance of GraphQL.Execution.IExecutionStrategy</param>
+        /// <param name="documentValidator">The instance of GraphQL.Validation.IDocumentValidator.</param>
+        /// <param name="originalQuery">The source of the original GraphQL query.</param>
+        /// <param name="schema">The GraphQL schema.</param>
+        /// <param name="document">The GraphQL document.</param>
+        /// <param name="rules">The list of validation rules.</param>
+        /// <param name="userContext">The user context.</param>
+        /// <param name="inputs">The input variables.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <returns>The original method's return value.</returns>
+        [InterceptMethod(
+            TargetAssembly = GraphQLAssemblyName,
+            TargetType = GraphQLDocumentValidatorInterfaceName,
+            TargetSignatureTypes = new[] { GraphQLValidationResultInterfaceName, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore, ClrNames.Ignore })]
+        public static object Validate(
+            object documentValidator,
+            object originalQuery,
+            object schema,
+            object document,
+            object rules,
+            object userContext,
+            object inputs,
+            int opCode,
+            int mdToken)
+        {
+            if (documentValidator == null) { throw new ArgumentNullException(nameof(documentValidator)); }
+
+            const string methodName = nameof(Validate);
+
+            // At runtime, get a Type object for GraphQL.ExecutionResult
+            var documentValidatorInstanceType = documentValidator.GetType();
+            Type graphQLExecutionResultType;
+            Type documentValidatorInterfaceType;
+
+            try
+            {
+                var graphQLAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                                        .Where(a => a.GetName().Name.Equals(GraphQLAssemblyName))
+                                        .Single();
+                graphQLExecutionResultType = graphQLAssembly.GetType(GraphQLExecutionResultName, throwOnError: true);
+                documentValidatorInterfaceType = graphQLAssembly.GetType(GraphQLDocumentValidatorInterfaceName, throwOnError: true);
+            }
+            catch (Exception ex)
+            {
+                // This shouldn't happen because the GraphQL assembly should have been loaded to construct various other types
+                // profiled app will not continue working as expected without this method
+                Log.ErrorException($"Error calling {documentValidatorInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                throw;
+            }
+
+            Func<object, object, object, object, object, object, object, object> instrumentedMethod;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<object, object, object, object, object, object, object, object>>
+                        .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                        .WithConcreteType(documentValidatorInstanceType)
+                        .WithParameters(originalQuery, schema, document, rules, userContext, inputs)
+                        .Build();
+            }
+            catch (Exception ex)
+            {
+                // profiled app will not continue working as expected without this method
+                Log.ErrorException($"Error resolving {documentValidatorInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                throw;
+            }
+
+            using (var scope = CreateScopeFromValidationInputs(document))
+            {
+                try
+                {
+                    var validationResult = instrumentedMethod(documentValidator, originalQuery, schema, document, rules, userContext, inputs);
+
+                    // Mark the span as an error if the validation failed
+                    if (!validationResult.GetProperty<bool>("IsValid").GetValueOrDefault())
+                    {
+                        var errors = validationResult.GetProperty("Errors").GetValueOrDefault();
+                        var errorCount = errors.GetProperty<int>("Count").GetValueOrDefault();
+
+                        var span = scope.Span;
+                        span.Error = true;
+                        span.SetTag(Trace.Tags.ErrorMsg, $"{errorCount} error(s)");
+                        span.SetTag(Trace.Tags.ErrorStack, ConstructErrorMessage(errors));
+                        span.SetTag(Trace.Tags.ErrorType, "GraphQL.Validation.ValidationError");
+                    }
+
+                    return validationResult;
+                }
+                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
+                {
+                    // unreachable code
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Wrap the original method by adding instrumentation code around it.
+        /// </summary>
+        /// <param name="executionStrategy">The instance of GraphQL.Execution.IExecutionStrategy.</param>
         /// <param name="context">The execution context of the GraphQL operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
@@ -96,7 +205,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object options,
             Func<object, object, object> originalMethod)
         {
-            using (var scope = CreateScope(options))
+            using (var scope = CreateScopeFromExecutionContext(options))
             {
                 try
                 {
@@ -111,7 +220,42 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
         }
 
-        private static Scope CreateScope(object executionContext)
+        private static Scope CreateScopeFromValidationInputs(object document)
+        {
+            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName))
+            {
+                // integration disabled, don't create a scope, skip this trace
+                return null;
+            }
+
+            Tracer tracer = Tracer.Instance;
+            string source = document.GetProperty<string>("OriginalQuery")
+                                    .GetValueOrDefault();
+            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+
+            Scope scope = null;
+
+            try
+            {
+                scope = tracer.StartActive(ValidateOperationName, serviceName: serviceName);
+                var span = scope.Span;
+                span.Type = SpanTypes.GraphQL;
+
+                span.SetTag(Tags.GraphQLSource, source);
+
+                // set analytics sample rate if enabled
+                var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(IntegrationName, enabledWithGlobalSetting: false);
+                span.SetMetric(Tags.Analytics, analyticsSampleRate);
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException("Error creating or populating scope.", ex);
+            }
+
+            return scope;
+        }
+
+        private static Scope CreateScopeFromExecutionContext(object executionContext)
         {
             if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName))
             {
@@ -154,6 +298,53 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             return scope;
+        }
+
+        private static string ConstructErrorMessage(dynamic errors)
+        {
+            if (errors == null)
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder();
+            var tab = "    ";
+            builder.AppendLine("errors: [");
+
+            foreach (var error in errors)
+            {
+                builder.AppendLine($"{tab}{{");
+                builder.AppendLine($"{tab + tab}\"message\": \"{error.Message.Replace("\r", "\\r").Replace("\n", "\\n")}\",");
+
+                if (error.Path != null)
+                {
+                    builder.AppendLine($"{tab + tab}\"path\": \"{string.Join(".", error.Path)}\",");
+                }
+
+                if (error.Code != null)
+                {
+                    builder.AppendLine($"{tab + tab}\"code\": \"{error.Code}\",");
+                }
+
+                builder.AppendLine($"{tab + tab}\"locations\": [");
+                if (error.Locations != null)
+                {
+                    foreach (var location in error.Locations)
+                    {
+                        builder.AppendLine($"{tab + tab + tab}{{");
+                        builder.AppendLine($"{tab + tab + tab + tab}\"line\": {location.Line},");
+                        builder.AppendLine($"{tab + tab + tab + tab}\"column\": {location.Column}");
+                        builder.AppendLine($"{tab + tab + tab}}},");
+                    }
+                }
+
+                builder.AppendLine($"{tab + tab}]");
+                builder.AppendLine($"{tab}}},");
+            }
+
+            builder.AppendLine("]");
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -189,16 +189,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static async Task<T> CallGraphQLExecuteAsyncInternal<T>(
             object executionStrategy,
-            object options,
+            object executionContext,
             Func<object, object, object> originalMethod)
         {
-            using (var scope = CreateScopeFromExecuteAsync(options))
+            using (var scope = CreateScopeFromExecuteAsync(executionContext))
             {
                 try
                 {
-                    var task = (Task<T>)originalMethod(executionStrategy, options);
+                    var task = (Task<T>)originalMethod(executionStrategy, executionContext);
                     var executionResult = await task.ConfigureAwait(false);
-                    RecordExecutionErrorsIfPresent(scope.Span, "GraphQL.ExecutionError", executionResult.GetProperty("Errors").GetValueOrDefault());
+                    RecordExecutionErrorsIfPresent(scope.Span, "GraphQL.ExecutionError", executionContext.GetProperty("Errors").GetValueOrDefault());
                     return executionResult;
                 }
                 catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -125,9 +125,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     return validationResult;
                 }
-                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
+                catch (Exception ex)
                 {
-                    // unreachable code
+                    scope?.Span.SetException(ex);
                     throw;
                 }
             }
@@ -212,9 +212,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     var task = (Task<T>)originalMethod(executionStrategy, options);
                     return await task.ConfigureAwait(false);
                 }
-                catch (Exception ex) when (scope?.Span.SetExceptionForFilter(ex) ?? false)
+                catch (Exception ex)
                 {
-                    // unreachable code
+                    scope?.Span.SetException(ex);
                     throw;
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 // This shouldn't happen because the GraphQL assembly should have been loaded to construct various other types
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error calling {documentValidatorInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                Log.ErrorException($"Error finding types in the GraphQL assembly.", ex);
                 throw;
             }
 
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error resolving {documentValidatorInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                Log.ErrorException($"Error resolving {documentValidatorInterfaceType.Name}.{methodName}(...)", ex);
                 throw;
             }
 
@@ -155,7 +155,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 // This shouldn't happen because the GraphQL assembly should have been loaded to construct various other types
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error calling {executionStrategyInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                Log.ErrorException($"Error finding types in the GraphQL assembly.", ex);
                 throw;
             }
 
@@ -173,7 +173,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error resolving {executionStrategyInstanceType.Name}.{methodName}(IConnection connection, CancellationToken cancellationToken)", ex);
+                Log.ErrorException($"Error resolving {executionStrategyInterfaceType.Name}.{methodName}(...)", ex);
                 throw;
             }
 

--- a/src/Datadog.Trace/SpanTypes.cs
+++ b/src/Datadog.Trace/SpanTypes.cs
@@ -31,5 +31,10 @@ namespace Datadog.Trace
         /// The span type for an outgoing HTTP integration.
         /// </summary>
         public const string Http = "http";
+
+        /// <summary>
+        /// The span type for a GraphQL integration.
+        /// </summary>
+        public const string GraphQL = "graphql";
     }
 }

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -130,6 +130,21 @@ namespace Datadog.Trace
         public const string MongoDbCollection = "mongodb.collection";
 
         /// <summary>
+        /// The operation name of the GraphQL request.
+        /// </summary>
+        public const string GraphQLOperationName = "graphql.operation.name";
+
+        /// <summary>
+        /// The operation type of the GraphQL request.
+        /// </summary>
+        public const string GraphQLOperationType = "graphql.operation.type";
+
+        /// <summary>
+        /// The source defining the GraphQL request.
+        /// </summary>
+        public const string GraphQLSource = "graphql.source";
+
+        /// <summary>
         /// The sampling priority for the entire trace.
         /// </summary>
         public const string SamplingPriority = "sampling.priority";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+#if !NET452
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class GraphQLTests : TestHelper
+    {
+        private static readonly string _graphQLValidateOperationName = "graphql.validate";
+        private static readonly string _graphQLExecuteOperationName = "graphql.execute";
+
+        private static readonly List<RequestInfo> _requests;
+        private static readonly List<WebServerSpanExpectation> _expectations;
+        private static int _expectedGraphQLValidateSpanCount;
+        private static int _expectedGraphQLExecuteSpanCount;
+
+        static GraphQLTests()
+        {
+            _requests = new List<RequestInfo>(0);
+            _expectations = new List<WebServerSpanExpectation>();
+            _expectedGraphQLValidateSpanCount = 0;
+            _expectedGraphQLExecuteSpanCount = 0;
+
+            CreateGraphQLRequestsAndExpectations(url: "/graphql?query=" + WebUtility.UrlEncode("query{hero{name appearsIn}}"), httpMethod: "GET", graphQLRequestBody: null, graphQLOperationType: "Query", graphQLOperationName: null, graphQLSource: "query{hero{name appearsIn} }");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""query HeroQuery{hero {name appearsIn}}"",""operationName"": ""HeroQuery""}", graphQLOperationType: "Query", graphQLOperationName: "HeroQuery", graphQLSource: "query HeroQuery{hero{name appearsIn}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}"",""variables"":{""human"":{""name"": ""Boba Fett""}}}", graphQLOperationType: "Mutation", graphQLOperationName: "AddBobaFett", graphQLSource: "mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""query HumanError{human(id:1){name apearsIn}}""}", graphQLOperationType: "Query", graphQLOperationName: null, passesValidation: false, graphQLSource: "query HumanError{human(id:1){name apearsIn}}");
+        }
+
+        public GraphQLTests(ITestOutputHelper output)
+            : base("GraphQL", output)
+        {
+        }
+
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        public void SubmitsTraces()
+        {
+            int agentPort = TcpPortProvider.GetOpenPort();
+            int aspNetCorePort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (Process process = StartSample(agent.Port, arguments: null, packageVersion: string.Empty, aspNetCorePort: aspNetCorePort))
+            {
+                var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
+
+                process.OutputDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                    {
+                        if (args.Data.Contains("Now listening on:") || args.Data.Contains("Unable to start Kestrel"))
+                        {
+                            wh.Set();
+                        }
+
+                        Output.WriteLine($"[webserver][stdout] {args.Data}");
+                    }
+                };
+                process.BeginOutputReadLine();
+
+                process.ErrorDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                    {
+                        Output.WriteLine($"[webserver][stderr] {args.Data}");
+                    }
+                };
+                process.BeginErrorReadLine();
+
+                // wait for server to start
+                wh.WaitOne(5000);
+
+                SubmitRequests(aspNetCorePort);
+                var graphQLValidateSpans = agent.WaitForSpans(_expectedGraphQLValidateSpanCount, operationName: _graphQLValidateOperationName, returnAllOperations: false)
+                                 .GroupBy(s => s.SpanId)
+                                 .Select(grp => grp.First())
+                                 .OrderBy(s => s.Start);
+                var graphQLExecuteSpans = agent.WaitForSpans(_expectedGraphQLExecuteSpanCount, operationName: _graphQLExecuteOperationName, returnAllOperations: false)
+                                 .GroupBy(s => s.SpanId)
+                                 .Select(grp => grp.First())
+                                 .OrderBy(s => s.Start);
+
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+
+                var spans = graphQLValidateSpans.Concat(graphQLExecuteSpans).ToList();
+                WebServerTestHelpers.AssertExpectationsMet(_expectations, spans);
+            }
+        }
+
+        private static void CreateGraphQLRequestsAndExpectations(
+            string url,
+            string httpMethod,
+            string graphQLRequestBody,
+            string graphQLOperationType,
+            string graphQLOperationName,
+            string graphQLSource = null,
+            bool passesValidation = true,
+            Func<MockTracerAgent.Span, List<string>> additionalCheck = null)
+        {
+            _requests.Add(new RequestInfo()
+            {
+                Url = url,
+                HttpMethod = httpMethod,
+                RequestBody = graphQLRequestBody,
+            });
+
+            _expectations.Add(new GraphQLSpanExpectation
+            {
+                OriginalUri = url,
+                OperationName = _graphQLValidateOperationName,
+                ResourceName = _graphQLValidateOperationName,
+                ServiceName = "Samples.GraphQL-graphql",
+                Type = SpanTypes.GraphQL,
+                CustomAssertion = additionalCheck,
+
+                GraphQLRequestBody = graphQLRequestBody,
+                GraphQLOperationType = graphQLOperationType,
+                GraphQLOperationName = graphQLOperationName,
+                GraphQLSource = graphQLSource ?? graphQLRequestBody,
+            });
+            _expectedGraphQLValidateSpanCount++;
+
+            if (passesValidation)
+            {
+                _expectations.Add(new GraphQLSpanExpectation
+                {
+                    OriginalUri = url,
+                    OperationName = _graphQLExecuteOperationName,
+                    ResourceName = _graphQLExecuteOperationName,
+                    ServiceName = "Samples.GraphQL-graphql",
+                    Type = SpanTypes.GraphQL,
+                    CustomAssertion = additionalCheck,
+
+                    GraphQLRequestBody = graphQLRequestBody,
+                    GraphQLOperationType = graphQLOperationType,
+                    GraphQLOperationName = graphQLOperationName,
+                    GraphQLSource = graphQLSource,
+                });
+                _expectedGraphQLExecuteSpanCount++;
+            }
+        }
+
+        private void SubmitRequests(int aspNetCorePort)
+        {
+            foreach (RequestInfo requestInfo in _requests)
+            {
+                try
+                {
+                    var request = WebRequest.Create($"http://localhost:{aspNetCorePort}{requestInfo.Url}");
+                    request.Method = requestInfo.HttpMethod;
+
+                    if (requestInfo.RequestBody != null)
+                    {
+                        byte[] requestBytes = System.Text.Encoding.UTF8.GetBytes(requestInfo.RequestBody);
+
+                        request.ContentType = "application/json";
+                        request.ContentLength = requestBytes.Length;
+
+                        using (var dataStream = request.GetRequestStream())
+                        {
+                            dataStream.Write(requestBytes, 0, requestBytes.Length);
+                        }
+                    }
+
+                    using (var response = (HttpWebResponse)request.GetResponse())
+                    using (var stream = response.GetResponseStream())
+                    using (var reader = new StreamReader(stream))
+                    {
+                        string responseText;
+                        try
+                        {
+                            responseText = reader.ReadToEnd();
+                        }
+                        catch (Exception ex)
+                        {
+                            responseText = "ENCOUNTERED AN ERROR WHEN READING RESPONSE.";
+                            Output.WriteLine(ex.ToString());
+                        }
+
+                        Output.WriteLine($"[http] {response.StatusCode} {responseText}");
+                    }
+                }
+                catch (WebException wex)
+                {
+                    Output.WriteLine($"[http] exception: {wex}");
+                    if (wex.Response is HttpWebResponse response)
+                    {
+                        using (var stream = response.GetResponseStream())
+                        using (var reader = new StreamReader(stream))
+                        {
+                            Output.WriteLine($"[http] {response.StatusCode} {reader.ReadToEnd()}");
+                        }
+                    }
+                }
+            }
+        }
+
+        private class RequestInfo
+        {
+            public string Url { get; set; }
+
+            public string HttpMethod { get; set; }
+
+            public string RequestBody { get; set; }
+        }
+    }
+}
+
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             string graphQLRequestBody,
             string graphQLOperationType,
             string graphQLOperationName,
-            string graphQLSource = null,
+            string graphQLSource,
             bool passesValidation = true,
             Func<MockTracerAgent.Span, List<string>> additionalCheck = null)
         {
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 GraphQLRequestBody = graphQLRequestBody,
                 GraphQLOperationType = graphQLOperationType,
                 GraphQLOperationName = graphQLOperationName,
-                GraphQLSource = graphQLSource ?? graphQLRequestBody,
+                GraphQLSource = graphQLSource,
             });
             _expectedGraphQLValidateSpanCount++;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -145,33 +145,34 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 CustomAssertion = additionalCheck,
 
                 GraphQLRequestBody = graphQLRequestBody,
-                GraphQLOperationType = graphQLOperationType,
+                GraphQLOperationType = null,
                 GraphQLOperationName = graphQLOperationName,
                 GraphQLSource = graphQLSource,
                 IsGraphQLError = failsValidation,
             });
             _expectedGraphQLValidateSpanCount++;
 
-            if (failsValidation)
-            {
-                // Expect an 'execute' span
-                _expectations.Add(new GraphQLSpanExpectation
-                {
-                    OriginalUri = url,
-                    OperationName = _graphQLExecuteOperationName,
-                    ResourceName = _graphQLExecuteOperationName,
-                    ServiceName = "Samples.GraphQL-graphql",
-                    Type = SpanTypes.GraphQL,
-                    CustomAssertion = additionalCheck,
+            if (failsValidation) { return; }
 
-                    GraphQLRequestBody = graphQLRequestBody,
-                    GraphQLOperationType = graphQLOperationType,
-                    GraphQLOperationName = graphQLOperationName,
-                    GraphQLSource = graphQLSource,
-                    IsGraphQLError = failsExecution,
-                });
-                _expectedGraphQLExecuteSpanCount++;
-            }
+            // Expect an 'execute' span
+            _expectations.Add(new GraphQLSpanExpectation
+            {
+                OriginalUri = url,
+                OperationName = _graphQLExecuteOperationName,
+                ResourceName = _graphQLExecuteOperationName,
+                ServiceName = "Samples.GraphQL-graphql",
+                Type = SpanTypes.GraphQL,
+                CustomAssertion = additionalCheck,
+
+                GraphQLRequestBody = graphQLRequestBody,
+                GraphQLOperationType = graphQLOperationType,
+                GraphQLOperationName = graphQLOperationName,
+                GraphQLSource = graphQLSource,
+                IsGraphQLError = failsExecution,
+            });
+            _expectedGraphQLExecuteSpanCount++;
+
+            if (failsExecution) { return; }
         }
 
         private void SubmitRequests(int aspNetCorePort)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -42,14 +42,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // SUCCESS: subscription
             CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""subscription HumanAddedSub{humanAdded{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "HumanAddedSub", graphQLSource: "subscription HumanAddedSub{humanAdded{name}}");
 
-            // TODO: When parse is implemented, add a test that fails 'parse'
+            // TODO: When parse is implemented, add a test that fails 'parse' step
 
-            // FAILURE: query fails validation step
+            // FAILURE: query fails 'validate' step
             CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""query HumanError{human(id:1){name apearsIn}}""}", graphQLOperationType: "Query", graphQLOperationName: null, passesValidation: false, graphQLSource: "query HumanError{human(id:1){name apearsIn}}");
 
-            // FAILURE: query fails execution step
+            // FAILURE: query fails 'execute' step
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""subscription NotImplementedSub{throwNotImplementedException{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "NotImplementedSub", graphQLSource: "subscription NotImplementedSub{throwNotImplementedException{name}}", passesExecution: false);
 
-            // TODO: When parse is implemented, add a test that fails 'resolve'
+            // TODO: When parse is implemented, add a test that fails 'resolve' step
         }
 
         public GraphQLTests(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -15,10 +15,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public string GraphQLSource { get; set; }
 
+        public bool IsGraphQLError { get; set; }
+
         public override bool IsSimpleMatch(MockTracerAgent.Span span)
         {
             return span.Name == OperationName
                 && span.Type == Type
+                && !string.IsNullOrEmpty(GetTag(span, Tags.ErrorMsg)) == IsGraphQLError
                 && SourceStringsAreEqual(GetTag(span, Tags.GraphQLSource), GraphQLSource);
         }
 
@@ -39,6 +42,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (span.Type != Type)
             {
                 mismatches.Add(FailureMessage(nameof(Type), actual: span.Type, expected: Type));
+            }
+
+            var spanIsError = !string.IsNullOrEmpty(GetTag(span, Tags.ErrorMsg));
+
+            if (spanIsError != IsGraphQLError)
+            {
+                mismatches.Add(FailureMessage(nameof(IsGraphQLError), actual: spanIsError.ToString(), expected: IsGraphQLError.ToString()));
             }
 
             var actualSource = GetTag(span, Tags.GraphQLSource);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.TestHelpers;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class GraphQLSpanExpectation : WebServerSpanExpectation
+    {
+        public string GraphQLRequestBody { get; set; }
+
+        public string GraphQLOperationType { get; set; }
+
+        public string GraphQLOperationName { get; set; }
+
+        public string GraphQLSource { get; set; }
+
+        public override bool IsSimpleMatch(MockTracerAgent.Span span)
+        {
+            return span.Name == OperationName
+                && span.Type == Type
+                && SourceStringsAreEqual(GetTag(span, Tags.GraphQLSource), GraphQLSource);
+        }
+
+        public override bool IsMatch(MockTracerAgent.Span span, out string message)
+        {
+            var mismatches = new List<string>();
+
+            if (span.Name != OperationName)
+            {
+                mismatches.Add(FailureMessage(nameof(OperationName), actual: span.Name, expected: OperationName));
+            }
+
+            if (span.Service != ServiceName)
+            {
+                mismatches.Add(FailureMessage(nameof(ServiceName), actual: span.Service, expected: ServiceName));
+            }
+
+            if (span.Type != Type)
+            {
+                mismatches.Add(FailureMessage(nameof(Type), actual: span.Type, expected: Type));
+            }
+
+            var actualSource = GetTag(span, Tags.GraphQLSource);
+
+            if (!SourceStringsAreEqual(actualSource, GraphQLSource))
+            {
+                mismatches.Add(FailureMessage(nameof(GraphQLSource), actual: actualSource, expected: GraphQLSource));
+            }
+
+            if (CustomAssertion != null)
+            {
+                mismatches.AddRange(CustomAssertion(span));
+            }
+
+            message = string.Join(", ", mismatches);
+
+            return !mismatches.Any();
+        }
+
+        private static bool SourceStringsAreEqual(string source1, string source2)
+        {
+            return string.Equals(
+                source1.Replace(" ", string.Empty),
+                source2.Replace(" ", string.Empty),
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -58,6 +58,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 mismatches.Add(FailureMessage(nameof(GraphQLSource), actual: actualSource, expected: GraphQLSource));
             }
 
+            var actualGraphQLOperationType = GetTag(span, Tags.GraphQLOperationType);
+
+            if (actualGraphQLOperationType != GraphQLOperationType)
+            {
+                mismatches.Add(FailureMessage(nameof(GraphQLOperationType), actual: actualGraphQLOperationType, expected: GraphQLOperationType));
+            }
+
             if (CustomAssertion != null)
             {
                 mismatches.AddRange(CustomAssertion(span));

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
@@ -23,6 +23,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public Func<MockTracerAgent.Span, List<string>> CustomAssertion { get; set; }
 
+        public virtual bool IsSimpleMatch(MockTracerAgent.Span span)
+        {
+            return span.Resource == ResourceName
+                && span.Name == OperationName
+                && span.Type == Type;
+        }
+
         public virtual bool IsMatch(MockTracerAgent.Span span, out string message)
         {
             var mismatches = new List<string>();
@@ -72,12 +79,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return !mismatches.Any();
         }
 
-        private string FailureMessage(string name, string actual, string expected)
+        protected string FailureMessage(string name, string actual, string expected)
         {
             return $"({name} mismatch: actual: {actual ?? "NULL"}, expected: {expected ?? "NULL"})";
         }
 
-        private string GetTag(MockTracerAgent.Span span, string tag)
+        protected string GetTag(MockTracerAgent.Span span, string tag)
         {
             if (span.Tags.ContainsKey(tag))
             {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerTestHelpers.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerTestHelpers.cs
@@ -20,9 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var possibleSpans =
                     spans
-                       .Where(s => s.Resource == expectation.ResourceName)
-                       .Where(s => s.Name == expectation.OperationName)
-                       .Where(s => s.Type == expectation.Type)
+                       .Where(s => expectation.IsSimpleMatch(s))
                        .ToList();
 
                 var count = possibleSpans.Count();


### PR DESCRIPTION
- Adds automatic integration for the GraphQL NuGet package v2.3.0+ (which also adds support for GraphQL.Server.Transports.AspNetCore v3.3.0+). The integration creates spans for the following parts of the GraphQL pipeline:
   - Validate operation
   - Execute operation
- Later, we can add operation for additional parts of the GraphQL pipeline such as Parse and Resolve if desired.