### PR TITLE
refactor StackExchange.Redis to use new APIs to emit IL

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -158,6 +158,11 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             if (!requiresBestEffortMatching && _methodBase is MethodInfo info)
             {
+                if (info.IsGenericMethodDefinition)
+                {
+                    info = MakeGenericMethod(info);
+                }
+
                 methodInfo = VerifyMethodFromToken(info);
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -194,14 +194,9 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             var dynamicMethod = Emit<TDelegate>.NewDynamicMethod(methodInfo.Name);
 
-            if (methodInfo.IsGenericMethodDefinition || methodInfo.IsGenericMethod)
+            if (methodInfo.IsGenericMethodDefinition)
             {
-                if (_methodGenerics == null || _methodGenerics.Length == 0)
-                {
-                    throw new ArgumentException($"Must specify {nameof(_methodGenerics)} for a generic method.");
-                }
-
-                methodInfo = methodInfo.MakeGenericMethod(_methodGenerics);
+                methodInfo = MakeGenericMethod(methodInfo);
             }
 
             Type[] effectiveParameterTypes;
@@ -266,6 +261,16 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             dynamicMethod.Return();
             return dynamicMethod.CreateDelegate();
+        }
+
+        private MethodInfo MakeGenericMethod(MethodInfo methodInfo)
+        {
+            if (_methodGenerics == null || _methodGenerics.Length == 0)
+            {
+                throw new ArgumentException($"Must specify {nameof(_methodGenerics)} for a generic method.");
+            }
+
+            return methodInfo.MakeGenericMethod(_methodGenerics);
         }
 
         private MethodInfo VerifyMethodFromToken(MethodInfo methodInfo)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -511,11 +511,14 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             foreach (var actualGenericArg in genericArgs)
             {
+                if (actualGenericArg.IsGenericParameter)
+                {
                 var expectedGenericArg = _methodGenerics[actualGenericArg.GenericParameterPosition];
 
                 if (!MeetsGenericArgumentRequirements(actualGenericArg, expectedGenericArg))
                 {
                     return false;
+                    }
                 }
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -197,8 +197,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 throw new Exception($"Only Func<> or Action<> are supported in {nameof(MethodBuilder)}.");
             }
 
-            var dynamicMethod = Emit<TDelegate>.NewDynamicMethod(methodInfo.Name);
-
             if (methodInfo.IsGenericMethodDefinition)
             {
                 methodInfo = MakeGenericMethod(methodInfo);
@@ -220,6 +218,8 @@ namespace Datadog.Trace.ClrProfiler.Emit
                                          .Concat(reflectedParameterTypes)
                                          .ToArray();
             }
+
+            var dynamicMethod = Emit<TDelegate>.NewDynamicMethod(methodInfo.Name);
 
             // load each argument and cast or unbox as necessary
             for (ushort argumentIndex = 0; argumentIndex < delegateParameterTypes.Length; argumentIndex++)
@@ -513,11 +513,11 @@ namespace Datadog.Trace.ClrProfiler.Emit
             {
                 if (actualGenericArg.IsGenericParameter)
                 {
-                var expectedGenericArg = _methodGenerics[actualGenericArg.GenericParameterPosition];
+                    var expectedGenericArg = _methodGenerics[actualGenericArg.GenericParameterPosition];
 
-                if (!MeetsGenericArgumentRequirements(actualGenericArg, expectedGenericArg))
-                {
-                    return false;
+                    if (!MeetsGenericArgumentRequirements(actualGenericArg, expectedGenericArg))
+                    {
+                        return false;
                     }
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -54,10 +54,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsync<T>(object redisBase, object message, object processor, object server, int opCode, int mdToken)
+        public static object ExecuteAsync<T>(
+            object redisBase,
+            object message,
+            object processor,
+            object server,
+            int opCode,
+            int mdToken)
         {
-            var callOpCode = (OpCodeValue)opCode;
-            return ExecuteAsyncInternal<T>(redisBase, message, processor, server, callOpCode);
+            var callingAssembly = Assembly.GetCallingAssembly();
+            return ExecuteAsyncInternal<T>(redisBase, message, processor, server, opCode, mdToken, callingAssembly);
         }
 
         /// <summary>
@@ -69,8 +75,17 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="processor">The result processor</param>
         /// <param name="server">The server</param>
         /// <param name="callOpCode">The <see cref="OpCodeValue"/> used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="callingAssembly">The assembly of the method the invoked the target method.</param>
         /// <returns>An asynchronous task.</returns>
-        private static async Task<T> ExecuteAsyncInternal<T>(object redisBase, object message, object processor, object server, OpCodeValue callOpCode)
+        private static async Task<T> ExecuteAsyncInternal<T>(
+            object redisBase,
+            object message,
+            object processor,
+            object server,
+            int callOpCode,
+            int mdToken,
+            Assembly callingAssembly)
         {
             var thisType = redisBase.GetType();
 
@@ -88,15 +103,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
 
             // cache one processor type for each type of T
             var genericType = typeof(T);
-            var processorType = ProcessorTypes.GetOrAdd(genericType, t => _processorOpenType.MakeGenericType(t));
+            // var processorType = ProcessorTypes.GetOrAdd(genericType, t => _processorOpenType.MakeGenericType(t));
 
-            var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, Task<T>>>
-                                     .GetOrCreateMethodCallDelegate(
-                                          _redisBaseType,
-                                          methodName: "ExecuteAsync",
-                                          callOpCode,
-                                          methodParameterTypes: new[] { _messageType, processorType, _serverType },
-                                          methodGenericArguments: new[] { genericType });
+            var instrumentedMethod = MethodBuilder<Func<object, object, object, object, Task<T>>>
+                                    .Start(callingAssembly, mdToken, callOpCode, nameof(ExecuteAsync))
+                                    .WithConcreteType(_redisBaseType)
+                                    .WithMethodGenerics(genericType)
+                                    .WithParameters(message, processor, server)
+                                     // .WithExplicitParameterTypes(_messageType, processorType, _serverType)
+                                     // .ForceMethodDefinitionResolution()
+                                    .Build();
 
             // we only trace RedisBatch methods here
             if (thisType == _batchType)
@@ -105,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 {
                     try
                     {
-                        return await originalMethod(redisBase, message, processor, server).ConfigureAwait(false);
+                        return await instrumentedMethod(redisBase, message, processor, server).ConfigureAwait(false);
                     }
                     catch (Exception ex)
                     {
@@ -115,7 +131,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 }
             }
 
-            return await originalMethod(redisBase, message, processor, server).ConfigureAwait(false);
+            return await instrumentedMethod(redisBase, message, processor, server).ConfigureAwait(false);
         }
 
         private static Scope CreateScope(object batch, object message)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -18,13 +18,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         private const string Major1 = "1";
         private const string Major2 = "2";
 
-        private static readonly ConcurrentDictionary<Type, Type> ProcessorTypes = new ConcurrentDictionary<Type, Type>();
-
         private static Assembly _redisAssembly;
         private static Type _redisBaseType;
-        private static Type _messageType;
-        private static Type _processorOpenType;
-        private static Type _serverType;
         private static Type _batchType;
 
         /// <summary>
@@ -96,22 +91,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 _redisAssembly = thisType.Assembly;
                 _redisBaseType = _redisAssembly.GetType("StackExchange.Redis.RedisBase");
                 _batchType = _redisAssembly.GetType("StackExchange.Redis.RedisBatch");
-                _messageType = _redisAssembly.GetType("StackExchange.Redis.Message");
-                _processorOpenType = _redisAssembly.GetType("StackExchange.Redis.ResultProcessor`1");
-                _serverType = _redisAssembly.GetType("StackExchange.Redis.ServerEndPoint");
             }
-
-            // cache one processor type for each type of T
-            var genericType = typeof(T);
-            // var processorType = ProcessorTypes.GetOrAdd(genericType, t => _processorOpenType.MakeGenericType(t));
 
             var instrumentedMethod = MethodBuilder<Func<object, object, object, object, Task<T>>>
                                     .Start(callingAssembly, mdToken, callOpCode, nameof(ExecuteAsync))
                                     .WithConcreteType(_redisBaseType)
-                                    .WithMethodGenerics(genericType)
+                                    .WithMethodGenerics(typeof(T))
                                     .WithParameters(message, processor, server)
-                                     // .WithExplicitParameterTypes(_messageType, processorType, _serverType)
-                                     // .ForceMethodDefinitionResolution()
                                     .Build();
 
             // we only trace RedisBatch methods here


### PR DESCRIPTION
Changes proposed in this pull request:
- refactor `StackExchange.Redis` to use new APIs to emit IL (`DynamicMethodBuilder` -> `MethodBuilder`)