### PR TITLE
report "interpreter" version

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -40,11 +40,12 @@ namespace Datadog.Trace.Agent
             _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
 
             var interpreterVersion = GetInterpreterVersion();
+            var managedAssemblyVersion = this.GetType().Assembly.GetName().Version.ToString();
 
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageInterpreter, interpreterVersion.Item1);
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageVersion, interpreterVersion.Item2);
-            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, this.GetType().Assembly.GetName().Version.ToString());
+            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, managedAssemblyVersion);
 
             // don't add automatic instrumentation to requests from this HttpClient
             _client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -14,10 +14,16 @@ namespace Datadog.Trace
         public const string Language = "Datadog-Meta-Lang";
 
         /// <summary>
-        /// The interpreter version for the given language, e.g. ".NET Framework 4.7.2" or ".NET Core 2.1".
+        /// The interpreter for the given language, e.g. ".NET Framework" or ".NET Core".
         /// The value of <see cref="RuntimeInformation.FrameworkDescription"/>.
         /// </summary>
         public const string LanguageInterpreter = "Datadog-Meta-Lang-Interpreter";
+
+        /// <summary>
+        /// The interpreter version for the given language, e.g. "4.7.2" for .NET Framework or "2.1" for .NET Core.
+        /// The value of <see cref="RuntimeInformation.FrameworkDescription"/>.
+        /// </summary>
+        public const string LanguageVersion = "Datadog-Meta-Lang-Version";
 
         /// <summary>
         /// The version of the tracer that generated this span.


### PR DESCRIPTION
Changes proposed in this pull request:

Use separate `Datadog-Meta-Lang-Interpreter` and `Datadog-Meta-Lang-Version` http headers to report the framework name (e.g. `.NET Framework`, `.NET Core`) separately from the version. Currently we send the entire `FrameworkDescription` (e.g. `.NET Framework 4.8.3752.0`) in a single `Datadog-Meta-Lang-Interpreter` which breaks internal analytics.