### PR TITLE
fix default json config file path on ASP.NET

### DIFF
--- a/samples-aspnet/Samples.AspNetMvc5/Views/Home/Index.cshtml
+++ b/samples-aspnet/Samples.AspNetMvc5/Views/Home/Index.cshtml
@@ -16,6 +16,14 @@
                 <td>@Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached</td>
             </tr>
             <tr>
+                <th scope="row">Current directory</th>
+                <td>@(Environment.CurrentDirectory)</td>
+            </tr>
+            <tr>
+                <th scope="row">MapPath("~")</th>
+                <td>@(System.Web.Hosting.HostingEnvironment.IsHosted ? System.Web.Hosting.HostingEnvironment.MapPath("~") : null)</td>
+            </tr>
+            <tr>
                 <th scope="row">Datadog.Trace.dll path</th>
                 <td>@typeof(Datadog.Trace.Tracer).Assembly.Location</td>
             </tr>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -170,9 +170,20 @@ namespace Datadog.Trace.Configuration
 #endif
             };
 
+            string currentDirectory = System.Environment.CurrentDirectory;
+
+#if !NETSTANDARD2_0
+            // on .NET Framework only, use application's root folder
+            // as default path when looking for datadog.json
+            if (System.Web.Hosting.HostingEnvironment.IsHosted)
+            {
+                currentDirectory = System.Web.Hosting.HostingEnvironment.MapPath("~");
+            }
+#endif
+
             // if environment variable is not set, look for default file name in the current directory
             var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName) ??
-                                        Path.Combine(System.Environment.CurrentDirectory, "datadog.json");
+                                        Path.Combine(currentDirectory, "datadog.json");
 
             if (Path.GetExtension(configurationFileName).ToUpperInvariant() == ".JSON" &&
                 File.Exists(configurationFileName))


### PR DESCRIPTION
Changes proposed in this pull request:
- on ASP.NET, use `MapPath("~")` to determine the application's root folder and use it (instead of the current directory) as the default search path for `datadog.json`