### PR TITLE
Add trace count header for statistics agent side

### DIFF
--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -29,5 +29,10 @@ namespace Datadog.Trace
         /// The version of the tracer that generated this span.
         /// </summary>
         public const string TracerVersion = "Datadog-Meta-Tracer-Version";
+
+        /// <summary>
+        /// The number of unique traces per request.
+        /// </summary>
+        public const string TraceCount = "X-Datadog-Trace-Count";
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
Add `X-Datadog-Trace-Count` header with count of unique traces for use in statistics.

@DataDog/apm-dotnet