### PR TITLE
Convert ServiceStack.Redis to use mdToken

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -46,16 +46,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             int opCode,
             int mdToken)
         {
-            var runtimeType = redisNativeClient.GetType();
-
             Func<object, byte[][], object, object, bool, T> instrumentedMethod = null;
 
             try
             {
+                var instrumentedType = redisNativeClient.GetInstrumentedType(RedisNativeClient);
                 instrumentedMethod =
                     MethodBuilder<Func<object, byte[][], object, object, bool, T>>
-                       .Start(runtimeType.Assembly, mdToken, opCode, nameof(SendReceive))
-                       .WithConcreteType(runtimeType)
+                       .Start(instrumentedType.Assembly, mdToken, opCode, nameof(SendReceive))
+                       .WithConcreteType(instrumentedType)
                        .WithParameters(cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead)
                        .Build();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(instrumentedType.Assembly, mdToken, opCode, nameof(SendReceive))
                        .WithConcreteType(instrumentedType)
                        .WithParameters(cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead)
+                       .WithMethodGenerics(typeof(T))
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
@@ -1,0 +1,27 @@
+namespace Datadog.Trace.ClrProfiler
+{
+    internal static class TypeExtensions
+    {
+        public static System.Type GetInstrumentedType(this object runtimeObject, string name)
+        {
+            if (runtimeObject == null)
+            {
+                return null;
+            }
+
+            var currentType = runtimeObject.GetType();
+
+            while (currentType != null)
+            {
+                if (currentType.FullName.Contains(name))
+                {
+                    return currentType;
+                }
+
+                currentType = currentType.BaseType;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
@@ -2,7 +2,9 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal static class TypeExtensions
     {
-        public static System.Type GetInstrumentedType(this object runtimeObject, string name)
+        public static System.Type GetInstrumentedType(
+            this object runtimeObject,
+            string instrumentedTypeName)
         {
             if (runtimeObject == null)
             {
@@ -13,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler
 
             while (currentType != null)
             {
-                if (currentType.FullName.Contains(name))
+                if ($"{currentType.Namespace}.{currentType.Name}" == instrumentedTypeName)
                 {
                     return currentType;
                 }


### PR DESCRIPTION
Changes proposed in this pull request:
Convert ServiceStack.Redis to use the new MethodBuilder API and resolve by mdToken.

@DataDog/apm-dotnet