### PR TITLE
 Fix issue with auto-injection of Correlation Identifiers (Serilog)

### DIFF
--- a/reproductions/DataDogThreadTest/Program.cs
+++ b/reproductions/DataDogThreadTest/Program.cs
@@ -13,7 +13,7 @@ namespace DataDogThreadTest
     {
         internal static readonly string TraceIdKey = "dd.trace_id";
         internal static readonly string SpanIdKey = "dd.span_id";
-        internal static readonly string NonTraceMessage = "TraceId: 0, SpanId: 0";
+        internal static readonly string NonTraceMessage = "TraceId: , SpanId: ";
 
         static int Main(string[] args)
         {
@@ -142,7 +142,7 @@ namespace DataDogThreadTest
                 logger.Info(NonTraceMessage);
 
                 var lastLog = RelevantLogs().Last();
-                var expectedOutOfTraceLog = "TraceId: 0, SpanId: 0";
+                var expectedOutOfTraceLog = "TraceId: , SpanId: ";
                 var lastLogTraceId = lastLog.Properties[TraceIdKey];
                 var lastLogSpanIdId = lastLog.Properties[SpanIdKey];
                 var actual = $"TraceId: {lastLogTraceId}, SpanId: {lastLogSpanIdId}";

--- a/reproductions/DataDogThreadTest/Program.cs
+++ b/reproductions/DataDogThreadTest/Program.cs
@@ -13,7 +13,7 @@ namespace DataDogThreadTest
     {
         internal static readonly string TraceIdKey = "dd.trace_id";
         internal static readonly string SpanIdKey = "dd.span_id";
-        internal static readonly string NonTraceMessage = "TraceId: , SpanId: ";
+        internal static readonly string NonTraceMessage = "TraceId: 0, SpanId: 0";
 
         static int Main(string[] args)
         {
@@ -142,12 +142,11 @@ namespace DataDogThreadTest
                 logger.Info(NonTraceMessage);
 
                 var lastLog = RelevantLogs().Last();
-                var expectedOutOfTraceLog = "TraceId: , SpanId: ";
                 var lastLogTraceId = lastLog.Properties[TraceIdKey];
                 var lastLogSpanIdId = lastLog.Properties[SpanIdKey];
                 var actual = $"TraceId: {lastLogTraceId}, SpanId: {lastLogSpanIdId}";
 
-                if (!actual.Equals(expectedOutOfTraceLog))
+                if (!actual.Equals(NonTraceMessage))
                 {
                     throw new Exception($"Unexpected TraceId or SpanId: {actual}");
                 }

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -49,17 +49,18 @@ namespace Datadog.Trace
             if (current == null || current != scope)
             {
                 // This is not the current scope for this context, bail out
+                SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));
                 return;
             }
 
             // if the scope that was just closed was the active scope,
             // set its parent as the new active scope
-            _activeScope.Set(current.Parent);
-            SpanDeactivated?.Invoke(this, new SpanEventArgs(current.Span));
+            _activeScope.Set(scope.Parent);
+            SpanDeactivated?.Invoke(this, new SpanEventArgs(scope.Span));
 
             if (!isRootSpan)
             {
-                SpanActivated?.Invoke(this, new SpanEventArgs(current.Parent.Span));
+                SpanActivated?.Invoke(this, new SpanEventArgs(scope.Parent.Span));
             }
 
             SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -38,33 +38,61 @@ namespace Datadog.Trace.Tests.Logging
             var logEvents = _memoryAppender.GetEvents();
             LoggingEvent logEvent;
 
-            // Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: N/A
             logEvent = logEvents[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
-            // Verify the log event is decorated with the child scope properties
+            // Scope: Parent scope
+            // Custom property: SET
+            logEvent = logEvents[logIndex++];
+            Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
+            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
+            Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
+
+            // Scope: Child scope
+            // Custom property: SET
             logEvent = logEvents[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(childScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(childScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: SET
             logEvent = logEvents[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is decorated with zero values
+            // EXISTING: Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: N/A
             logEvent = logEvents[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(0, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
+            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(0, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+
+            // Scope: N/A
+            // Custom property: N/A
+            logEvent = logEvents[logIndex++];
+            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
         }
 
         [Fact]
@@ -81,25 +109,50 @@ namespace Datadog.Trace.Tests.Logging
             var logEvents = _memoryAppender.GetEvents();
             LoggingEvent logEvent;
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: N/A
             logEvent = logEvents[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logEvent = logEvents[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logEvent = logEvents[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logEvent = logEvents[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
+
+            // Scope: N/A
+            // Custom property: N/A
+            logEvent = logEvents[logIndex++];
+            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+
+            // Scope: N/A
+            // Custom property: N/A
+            logEvent = logEvents[logIndex++];
+            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Tests.Logging
             logEvent.Contains(parentScope);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
-            // Scope: N/A
+            // Scope: Default values of TraceId=0,SpanId=0
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
             logEvent.Contains(traceId: 0, spanId: 0);

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -47,39 +47,27 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Parent scope
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: Parent scope
             // Custom property: SET
             logEvent = filteredLogs[logIndex++];
-            Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: Child scope
             // Custom property: SET
             logEvent = filteredLogs[logIndex++];
-            Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(childScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(childScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(childScope);
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: Parent scope
             // Custom property: SET
             logEvent = filteredLogs[logIndex++];
-            Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
@@ -87,17 +75,13 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Parent scope
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: N/A
             // Custom property: N/A
             logEvent = filteredLogs[logIndex++];
-            Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
-            Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
+            logEvent.Contains(traceId: 0, spanId: 0);
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
         }
 

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Reflection;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.LogProviders;
@@ -36,13 +37,16 @@ namespace Datadog.Trace.Tests.Logging
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
             LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
+            // Filter the logs
+            List<LoggingEvent> filteredLogs = new List<LoggingEvent>(_memoryAppender.GetEvents());
+            filteredLogs.RemoveAll(log => !log.MessageObject.ToString().Contains(LoggingProviderTestHelpers.LogPrefix));
+
             int logIndex = 0;
-            var logEvents = _memoryAppender.GetEvents();
             LoggingEvent logEvent;
 
             // Scope: Parent scope
             // Custom property: N/A
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
@@ -51,7 +55,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: Parent scope
             // Custom property: SET
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
@@ -61,7 +65,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: Child scope
             // Custom property: SET
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(childScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
@@ -71,7 +75,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: Parent scope
             // Custom property: SET
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
@@ -82,7 +86,7 @@ namespace Datadog.Trace.Tests.Logging
             // EXISTING: Verify the log event is decorated with the parent scope properties
             // Scope: Parent scope
             // Custom property: N/A
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
@@ -91,7 +95,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: N/A
             // Custom property: N/A
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
@@ -107,20 +111,22 @@ namespace Datadog.Trace.Tests.Logging
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: false);
             LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
+            // Filter the logs
+            List<LoggingEvent> filteredLogs = new List<LoggingEvent>(_memoryAppender.GetEvents());
+            filteredLogs.RemoveAll(log => !log.MessageObject.ToString().Contains(LoggingProviderTestHelpers.LogPrefix));
+
             int logIndex = 0;
-            var logEvents = _memoryAppender.GetEvents();
             LoggingEvent logEvent;
 
             // Scope: N/A
             // Custom property: N/A
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: N/A
             // Custom property: SET
-            logEvent = logEvents[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
@@ -128,7 +134,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: N/A
             // Custom property: SET
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
@@ -136,7 +142,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: N/A
             // Custom property: SET
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
@@ -144,14 +150,14 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: N/A
             // Custom property: N/A
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
 
             // Scope: N/A
             // Custom property: N/A
-            logEvent = logEvents[logIndex++];
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -127,6 +127,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Scope: N/A
             // Custom property: SET
+            logEvent = filteredLogs[logIndex++];
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Contains(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -23,12 +23,12 @@ namespace Datadog.Trace.Tests.Logging
             return new Tracer(settings, writerMock.Object, samplerMock.Object, null);
         }
 
-        internal static void PerformParentChildScopeSequence(Tracer tracer, ILog logger, out Scope parentScope, out Scope childScope)
+        internal static void PerformParentChildScopeSequence(Tracer tracer, ILog logger, Func<string, object, bool, IDisposable> openMappedContext, out Scope parentScope, out Scope childScope)
         {
             parentScope = tracer.StartActive("parent");
             logger.Log(LogLevel.Info, () => "Started and activated parent scope.");
 
-            var customPropertyContext = LogProvider.OpenMappedContext(CustomPropertyName, CustomPropertyValue);
+            var customPropertyContext = openMappedContext(CustomPropertyName, CustomPropertyValue, false);
             logger.Log(LogLevel.Info, () => "Added custom property to MDC");
 
             childScope = tracer.StartActive("child");

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -11,6 +11,7 @@ namespace Datadog.Trace.Tests.Logging
     {
         internal static readonly string CustomPropertyName = "custom";
         internal static readonly int CustomPropertyValue = 1;
+        internal static readonly string LogPrefix = "[Datadog.Trace.Tests.Logging]";
 
         internal static Tracer InitializeTracer(bool enableLogsInjection)
         {
@@ -26,22 +27,22 @@ namespace Datadog.Trace.Tests.Logging
         internal static void PerformParentChildScopeSequence(Tracer tracer, ILog logger, Func<string, object, bool, IDisposable> openMappedContext, out Scope parentScope, out Scope childScope)
         {
             parentScope = tracer.StartActive("parent");
-            logger.Log(LogLevel.Info, () => "Started and activated parent scope.");
+            logger.Log(LogLevel.Info, () => $"{LogPrefix}Started and activated parent scope.");
 
             var customPropertyContext = openMappedContext(CustomPropertyName, CustomPropertyValue, false);
-            logger.Log(LogLevel.Info, () => "Added custom property to MDC");
+            logger.Log(LogLevel.Info, () => $"{LogPrefix}Added custom property to MDC");
 
             childScope = tracer.StartActive("child");
-            logger.Log(LogLevel.Info, () => "Started and activated child scope.");
+            logger.Log(LogLevel.Info, () => $"{LogPrefix}Started and activated child scope.");
 
             childScope.Close();
-            logger.Log(LogLevel.Info, () => "Closed child scope and reactivated parent scope.");
+            logger.Log(LogLevel.Info, () => $"{LogPrefix}Closed child scope and reactivated parent scope.");
 
             customPropertyContext.Dispose();
-            logger.Log(LogLevel.Info, () => "Removed custom property from MDC");
+            logger.Log(LogLevel.Info, () => $"{LogPrefix}Removed custom property from MDC");
 
             parentScope.Close();
-            logger.Log(LogLevel.Info, () => "Closed child scope so there is no active scope.");
+            logger.Log(LogLevel.Info, () => $"{LogPrefix}Closed child scope so there is no active scope.");
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
@@ -8,6 +9,9 @@ namespace Datadog.Trace.Tests.Logging
 {
     internal class LoggingProviderTestHelpers
     {
+        internal static readonly string CustomPropertyName = "custom";
+        internal static readonly int CustomPropertyValue = 1;
+
         internal static Tracer InitializeTracer(bool enableLogsInjection)
         {
             var settings = new TracerSettings();
@@ -24,11 +28,17 @@ namespace Datadog.Trace.Tests.Logging
             parentScope = tracer.StartActive("parent");
             logger.Log(LogLevel.Info, () => "Started and activated parent scope.");
 
+            var customPropertyContext = LogProvider.OpenMappedContext(CustomPropertyName, CustomPropertyValue);
+            logger.Log(LogLevel.Info, () => "Added custom property to MDC");
+
             childScope = tracer.StartActive("child");
             logger.Log(LogLevel.Info, () => "Started and activated child scope.");
 
             childScope.Close();
             logger.Log(LogLevel.Info, () => "Closed child scope and reactivated parent scope.");
+
+            customPropertyContext.Dispose();
+            logger.Log(LogLevel.Info, () => "Removed custom property from MDC");
 
             parentScope.Close();
             logger.Log(LogLevel.Info, () => "Closed child scope so there is no active scope.");

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tests.Logging
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
-            // Scope: N/A
+            // Scope: Default values of TraceId=0,SpanId=0
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=0", logString);

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -88,8 +88,8 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: N/A
             // Custom property: N/A
             logString = filteredLogs[logIndex++];
-            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
-            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=0", logString);
+            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=0", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
         }
 

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.LogProviders;
 using NLog;
@@ -42,47 +43,51 @@ namespace Datadog.Trace.Tests.Logging
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
             LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
+            // Filter the logs
+            List<string> filteredLogs = new List<string>(_target.Logs);
+            filteredLogs.RemoveAll(log => !log.Contains(LoggingProviderTestHelpers.LogPrefix));
+
             int logIndex = 0;
             string logString;
 
             // Scope: Parent scope
             // Custom property: N/A
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
             // Scope: Parent scope
             // Custom property: SET
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
             // Scope: Child scope
             // Custom property: SET
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={childScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={childScope.Span.TraceId}", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
             // Scope: Parent scope
             // Custom property: SET
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
             // Scope: Parent scope
             // Custom property: N/A
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
             // Scope: N/A
             // Custom property: N/A
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
@@ -98,47 +103,51 @@ namespace Datadog.Trace.Tests.Logging
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: false);
             LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
+            // Filter the logs
+            List<string> filteredLogs = new List<string>(_target.Logs);
+            filteredLogs.RemoveAll(log => !log.Contains(LoggingProviderTestHelpers.LogPrefix));
+
             int logIndex = 0;
             string logString;
 
             // Scope: N/A
             // Custom property: N/A
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
             // Scope: N/A
             // Custom property: SET
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
             // Scope: N/A
             // Custom property: SET
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
             // Scope: N/A
             // Custom property: SET
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
             // Scope: N/A
             // Custom property: N/A
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
             // Scope: N/A
             // Custom property: N/A
-            logString = _target.Logs[logIndex++];
+            logString = filteredLogs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
             Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -10,6 +10,7 @@ namespace Datadog.Trace.Tests.Logging
     [Collection(nameof(Datadog.Trace.Tests.Logging))]
     public class NLogLogProviderTests
     {
+        private readonly ILogProvider _logProvider;
         private readonly ILog _logger;
         private readonly MemoryTarget _target;
 
@@ -26,8 +27,9 @@ namespace Datadog.Trace.Tests.Logging
             LogManager.Configuration = config;
             SimpleConfigurator.ConfigureForTargetLogging(_target, NLog.LogLevel.Trace);
 
-            LogProvider.SetCurrentLogProvider(new NLogLogProvider());
-            _logger = LogProvider.GetLogger(typeof(NLogLogProviderTests));
+            _logProvider = new NLogLogProvider();
+            LogProvider.SetCurrentLogProvider(_logProvider);
+            _logger = new LoggerExecutionWrapper(_logProvider.GetLogger("test"));
         }
 
         [Fact]
@@ -38,7 +40,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
-            LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, out var parentScope, out var childScope);
+            LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
             int logIndex = 0;
             string logString;
@@ -94,7 +96,7 @@ namespace Datadog.Trace.Tests.Logging
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: false);
-            LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, out var parentScope, out var childScope);
+            LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
             int logIndex = 0;
             string logString;

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests.Logging
             var config = new LoggingConfiguration();
             _target = new MemoryTarget
             {
-                Layout = string.Format("${{level:uppercase=true}}|{0}=${{mdc:item={0}}}|{1}=${{mdc:item={1}}}|${{message}}", CorrelationIdentifier.SpanIdKey, CorrelationIdentifier.TraceIdKey)
+                Layout = string.Format("${{level:uppercase=true}}|{0}=${{mdc:item={0}}}|{1}=${{mdc:item={1}}}|{2}=${{mdc:item={2}}}|${{message}}", CorrelationIdentifier.SpanIdKey, CorrelationIdentifier.TraceIdKey, LoggingProviderTestHelpers.CustomPropertyName)
             };
 
             config.AddTarget("memory", _target);
@@ -43,25 +43,47 @@ namespace Datadog.Trace.Tests.Logging
             int logIndex = 0;
             string logString;
 
-            // Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: N/A
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
-            // Verify the log event is decorated with the child scope properties
+            // Scope: Parent scope
+            // Custom property: SET
+            logString = _target.Logs[logIndex++];
+            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
+            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
+
+            // Scope: Child scope
+            // Custom property: SET
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={childScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={childScope.Span.TraceId}", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
-            // Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: SET
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
-            // Verify the log event is decorated with zero values
+            // Scope: Parent scope
+            // Custom property: N/A
             logString = _target.Logs[logIndex++];
-            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=0", logString);
-            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=0", logString);
+            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}={parentScope.Span.SpanId}", logString);
+            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}={parentScope.Span.TraceId}", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
+
+            // Scope: N/A
+            // Custom property: N/A
+            logString = _target.Logs[logIndex++];
+            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
+            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
         }
 
         [Fact]
@@ -77,25 +99,47 @@ namespace Datadog.Trace.Tests.Logging
             int logIndex = 0;
             string logString;
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: N/A
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logString = _target.Logs[logIndex++];
             Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
             Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}={LoggingProviderTestHelpers.CustomPropertyValue}", logString);
+
+            // Scope: N/A
+            // Custom property: N/A
+            logString = _target.Logs[logIndex++];
+            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
+            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
+
+            // Scope: N/A
+            // Custom property: N/A
+            logString = _target.Logs[logIndex++];
+            Assert.Contains($"{CorrelationIdentifier.SpanIdKey}=", logString);
+            Assert.Contains($"{CorrelationIdentifier.TraceIdKey}=", logString);
+            Assert.Contains($"{LoggingProviderTestHelpers.CustomPropertyName}=", logString);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -38,6 +38,9 @@ namespace Datadog.Trace.Tests.Logging
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
             LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
 
+            // Filter the logs
+            _logEvents.RemoveAll(log => !log.MessageTemplate.ToString().Contains(LoggingProviderTestHelpers.LogPrefix));
+
             var logIndex = 0;
             LogEvent logEvent;
 
@@ -106,6 +109,9 @@ namespace Datadog.Trace.Tests.Logging
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: false);
             LoggingProviderTestHelpers.PerformParentChildScopeSequence(tracer, _logger, _logProvider.OpenMappedContext, out var parentScope, out var childScope);
+
+            // Filter the logs
+            _logEvents.RemoveAll(log => !log.MessageTemplate.ToString().Contains(LoggingProviderTestHelpers.LogPrefix));
 
             int logIndex = 0;
             LogEvent logEvent;

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -39,33 +39,60 @@ namespace Datadog.Trace.Tests.Logging
             var logIndex = 0;
             LogEvent logEvent;
 
-            // Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: N/A
             logEvent = _logEvents[logIndex++];
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
             Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
-            // Verify the log event is decorated with the child scope properties
+            // Scope: Parent scope
+            // Custom property: SET
+            logEvent = _logEvents[logIndex++];
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
+            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
+
+            // Scope: Child scope
+            // Custom property: SET
             logEvent = _logEvents[logIndex++];
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.Equal<ulong>(childScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
             Assert.Equal<ulong>(childScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is decorated with the parent scope properties
+            // Scope: Parent scope
+            // Custom property: SET
             logEvent = _logEvents[logIndex++];
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
             Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is decorated with zero values
+            // Scope: Parent scope
+            // Custom property: N/A
             logEvent = _logEvents[logIndex++];
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(0, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
+            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(0, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+
+            // Scope: N/A
+            // Custom property: N/A
+            logEvent = _logEvents[logIndex++];
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
         }
 
         [Fact]
@@ -81,25 +108,50 @@ namespace Datadog.Trace.Tests.Logging
             int logIndex = 0;
             LogEvent logEvent;
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: N/A
             logEvent = _logEvents[logIndex++];
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logEvent = _logEvents[logIndex++];
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logEvent = _logEvents[logIndex++];
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
-            // Verify the log event is not decorated with the properties
+            // Scope: N/A
+            // Custom property: SET
             logEvent = _logEvents[logIndex++];
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
             Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+            Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
+
+            // Scope: N/A
+            // Custom property: N/A
+            logEvent = _logEvents[logIndex++];
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
+
+            // Scope: N/A
+            // Custom property: N/A
+            logEvent = _logEvents[logIndex++];
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -47,49 +47,34 @@ namespace Datadog.Trace.Tests.Logging
             // Scope: Parent scope
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
             // Scope: Parent scope
             // Custom property: SET
             logEvent = _logEvents[logIndex++];
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: Child scope
             // Custom property: SET
             logEvent = _logEvents[logIndex++];
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(childScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(childScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(childScope);
             Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: Parent scope
             // Custom property: SET
             logEvent = _logEvents[logIndex++];
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.True(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
             Assert.Equal<int>(LoggingProviderTestHelpers.CustomPropertyValue, int.Parse(logEvent.Properties[LoggingProviderTestHelpers.CustomPropertyName].ToString()));
 
             // Scope: Parent scope
             // Custom property: N/A
             logEvent = _logEvents[logIndex++];
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal<ulong>(parentScope.Span.SpanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal<ulong>(parentScope.Span.TraceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
+            logEvent.Contains(parentScope);
             Assert.False(logEvent.Properties.ContainsKey(LoggingProviderTestHelpers.CustomPropertyName));
 
             // Scope: N/A


### PR DESCRIPTION
Scenario: Some time after the first span is activated, we have set the
logging context properties dd.trace_id=0 and dd.span_id=0. Application
code (using Serilog) then sets their own logging context properties. Then, a new span
is created and previously-set properties no longer exist in the logging context.

Problem: Our OnSpanActivated event immediately disposes the previously-set
correlation identifier properties before re-adding the new values.
Serilog has a strict correctness guarantee that requires properties be
modified in stack order. Since we remove properties further down the stack,
we end up losing properties.

Fix: For all logging libraries, do not set initial values
(dd.trace_id=0, dd.span_id=0). For Serilog, add and remove the two
properties on SpanOpened and on SpanClosed. This ensures that properties
only get added to/removed from the stack once.

@DataDog/apm-dotnet