### PR TITLE
stop disabling JIT optimizations on Linux

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -387,18 +387,8 @@ bool DisableOptimizations() {
     return true;
   }
 
-  if (disable_optimizations == "0"_W ||
-      disable_optimizations == "false"_W) {
-    return false;
-  }
-
-#ifdef _WIN32
-  // default to false on Windows
+  // default to false: don't disable JIT optimizations
   return false;
-#else
-  // default to true on Linux
-  return true;
-#endif
 }
 
 TypeInfo RetrieveTypeForSignature(

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -379,16 +379,16 @@ mdMethodSpec DefineMethodSpec(const ComPtr<IMetaDataEmit2>& metadata_emit,
 }
 
 bool DisableOptimizations() {
-  const auto clr_optimizations_enabled =
+  const auto disable_optimizations =
       GetEnvironmentValue(environment::clr_disable_optimizations);
 
-  if (clr_optimizations_enabled == "1"_W ||
-      clr_optimizations_enabled == "true"_W) {
+  if (disable_optimizations == "1"_W ||
+      disable_optimizations == "true"_W) {
     return true;
   }
 
-  if (clr_optimizations_enabled == "0"_W ||
-      clr_optimizations_enabled == "false"_W) {
+  if (disable_optimizations == "0"_W ||
+      disable_optimizations == "false"_W) {
     return false;
   }
 
@@ -699,7 +699,7 @@ HRESULT CreateAssemblyRefToMscorlib(const ComPtr<IMetaDataAssemblyEmit>& assembl
   return hr;
 }
 
-bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,                                        
+bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
                                             const ComPtr<IMetaDataEmit2>& metadata_emit,
                                             const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
                                             mdToken* ret_type_token) {


### PR DESCRIPTION
Changes proposed in this pull request:
- on Linux, don't disable JIT optimizations by default
- on Windows, the default was already to not disable JIT optimizations
- users can still override with `DD_CLR_DISABLE_OPTIMIZATIONS`

See https://github.com/DataDog/dd-trace-dotnet/issues/302#issuecomment-511011364

NOTE: this change requires updating troubleshooting documents and should be called out in the release notes. Affected users (specific versions of .NET Core combined with AutoMapper) will need to set `DD_CLR_DISABLE_OPTIMIZATIONS` as a workaround.