### PR TITLE
remove RIDs from projects

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -12,7 +12,7 @@ trigger:
 variables:
   buildConfiguration: Debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
-  dotnetCoreSdkVersion: 2.2.300
+  dotnetCoreSdkVersion: 2.2.401
 
 jobs:
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -57,6 +57,11 @@ jobs:
     buildPlatform: 'x64'
 
   steps:
+  - task: DotNetCoreInstaller@0
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build src/**/*.csproj
     inputs:
@@ -80,11 +85,6 @@ jobs:
       configuration: $(buildConfiguration)
       msbuildArguments: /t:BuildCpp
       maximumCpuCount: true
-
-  - task: DotNetCoreInstaller@0
-    displayName: install dotnet core sdk
-    inputs:
-      version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet restore

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -7,7 +7,7 @@ pr: none
 variables:
   buildConfiguration: release
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
-  dotnetCoreSdkVersion: 2.2.300
+  dotnetCoreSdkVersion: 2.2.401
 
 jobs:
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -11,7 +11,7 @@ trigger:
 variables:
   buildConfiguration: Debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
-  dotnetCoreSdkVersion: 2.2.300
+  dotnetCoreSdkVersion: 2.2.401
 
 jobs:
 

--- a/reproduction-dependencies/Directory.Build.props
+++ b/reproduction-dependencies/Directory.Build.props
@@ -4,8 +4,6 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
-    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'netcoreapp2.1'">win-x64;win-x86;linux-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.1'">win-$(Platform)</RuntimeIdentifier>
 
     <BaseIntermediateOutputPath Condition="'$(ApiVersion)'!=''">obj\$(ApiVersion)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition="'$(ApiVersion)'!=''">bin\$(ApiVersion)\</BaseOutputPath>

--- a/reproductions/Directory.Build.props
+++ b/reproductions/Directory.Build.props
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
-    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'netcoreapp2.1'">win-x64;win-x86;linux-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.1'">win-$(Platform)</RuntimeIdentifier>
 
     <BaseIntermediateOutputPath Condition="'$(ApiVersion)'!=''">obj\$(ApiVersion)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition="'$(ApiVersion)'!=''">bin\$(ApiVersion)\</BaseOutputPath>

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -5,8 +5,6 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
-    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'netcoreapp2.1'">win-x64;win-x86;linux-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.1'">win-$(Platform)</RuntimeIdentifier>
 
     <BaseIntermediateOutputPath Condition="'$(ApiVersion)'!=''">obj\$(ApiVersion)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition="'$(ApiVersion)'!=''">bin\$(ApiVersion)\</BaseOutputPath>

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -412,8 +412,7 @@ namespace Datadog.Trace.TestHelpers
                     packageVersion,
                     GetPlatform(),
                     GetBuildConfiguration(),
-                    GetTargetFramework(),
-                    EnvironmentHelper.GetRuntimeIdentifier());
+                    GetTargetFramework());
             }
             else
             {
@@ -422,7 +421,6 @@ namespace Datadog.Trace.TestHelpers
                     packageVersion,
                     GetBuildConfiguration(),
                     GetTargetFramework(),
-                    EnvironmentHelper.GetRuntimeIdentifier(),
                     "publish");
             }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- remove all `RuntimeIdentifiers` and `RuntimeIdentifier` project properties (they required when targeting specific platforms with SDK 2.0)
- update dotnet sdk to latest version, `2.2.401`
- install dotnet sdk earlier in the build process (_before_ building `src/**/*.csproj`)



@DataDog/apm-dotnet