### PR TITLE
change yaml capitalization so jobs don't show up twice in github

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -16,7 +16,7 @@ variables:
 
 jobs:
 
-- job: linux
+- job: Linux
 
   pool:
     vmImage: ubuntu-16.04
@@ -48,7 +48,7 @@ jobs:
       testResultsFiles: test/**/*.trx
     condition: succeededOrFailed()
 
-- job: windows
+- job: Windows
 
   pool:
     vmImage: windows-2019


### PR DESCRIPTION
In GitHub, jobs appear in lower case when they start running, but then show up capitalized when they finish. If a job is restarted, you can see both jobs at the same time. I'm changing the capitalization on the job name in yaml to see if that fixes this purely cosmetic issue.

----

Before (running test in lower case, finished test capitalized):

![image](https://user-images.githubusercontent.com/1851278/63166895-a822e100-bffd-11e9-84a9-a2f2e302c019.png)

----

After (both running and finished tests are capitalized):

![image](https://user-images.githubusercontent.com/1851278/63167698-0d77d180-c000-11e9-9ffd-6440fff941ec.png)


