### PR TITLE
MethodBuilder: More logging and assertions

### DIFF
--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 
 namespace Samples.SqlServer
 {
@@ -22,13 +23,34 @@ namespace Samples.SqlServer
                     db.SaveChanges();
                 }
 
-                // Display all Blogs from the database
+                // Display all Blogs from the database syncronously
                 var query = from b in db.Blogs
                             orderby b.Name
                             select b;
 
-                Console.WriteLine("All blogs in the database:");
+                Console.WriteLine("All blogs in the database from the synchronous call:");
                 foreach (var item in query)
+                {
+                    Console.WriteLine(item.Name);
+                }
+
+                var asyncName = "test-async";
+
+                var asyncBlog = (from b in db.Blogs where b.Name == asyncName select b).FirstOrDefaultAsync();
+                if (asyncBlog == null)
+                {
+                    blog = new Blog { Name = asyncName };
+                    db.Blogs.Add(blog);
+                    db.SaveChangesAsync().Wait();
+                }
+
+                // Display all Blogs from the database asynchronously
+                var asyncQueryTask = db.Blogs.Where(b => b.Name == asyncName).ToListAsync();
+
+                asyncQueryTask.Wait();
+
+                Console.WriteLine("All blogs in the database from the async call:");
+                foreach (var item in asyncQueryTask.Result)
                 {
                     Console.WriteLine(item.Name);
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -46,6 +46,12 @@ namespace Datadog.Trace.ClrProfiler.Emit
             _forceMethodDefResolve = false;
         }
 
+#if DEBUG
+        public bool ThrowExceptionWhenNoTokenMatch { get; set; } = true;
+#else
+        public bool ThrowExceptionWhenNoTokenMatch { get; set; } = false;
+#endif
+
         public static MethodBuilder<TDelegate> Start(Assembly resolutionAssembly, int mdToken, int opCode, string methodName)
         {
             return new MethodBuilder<TDelegate>(resolutionAssembly, mdToken, opCode, methodName);
@@ -153,6 +159,14 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 Log.Error(message, ex);
                 requiresBestEffortMatching = true;
                 _methodBase = null; // Be extra sure the assignment never happened
+
+#if DEBUG
+                // Add a secondary preprocessor directive to prevent this from ever happening in release mode, even when it's configured to
+                if (ThrowExceptionWhenNoTokenMatch)
+                {
+                    throw;
+                }
+#endif
             }
 
             MethodInfo methodInfo = null;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,12 +56,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var dataReaderType = instrumentedType.Assembly.GetType(DbDataReader);
 
             Func<object, CommandBehavior, object> instrumentedMethod = null;
+            var callStack = new StackTrace();
+            var callingFrame = callStack.GetFrame(1);
+            var callingMethod = callingFrame.GetMethod();
+            var callingModule = callingMethod.Module;
 
             try
             {
                 instrumentedMethod =
                     MethodBuilder<Func<object, CommandBehavior, object>>
-                       .Start(instrumentedType.Assembly, mdToken, opCode, nameof(ExecuteDbDataReader))
+                       .Start(callingModule, mdToken, opCode, nameof(ExecuteDbDataReader))
                        .WithConcreteType(instrumentedType)
                        .WithParameters(commandBehavior)
                        .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -119,7 +119,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var command = (DbCommand)@this;
             var instanceType = command.GetType();
             var commandBehavior = (CommandBehavior)behavior;
-            var callingAssembly = Assembly.GetCallingAssembly();
             var instrumentedType = @this.GetInstrumentedType(DbCommand);
             var dataReaderType = instrumentedType.Assembly.GetType(DbDataReader);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -51,6 +51,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var command = (DbCommand)@this;
             var commandBehavior = (CommandBehavior)behavior;
             var instanceType = command.GetType();
+            var instrumentedType = @this.GetInstrumentedType(DbCommand);
+            var dataReaderType = instrumentedType.Assembly.GetType(DbDataReader);
 
             Func<object, CommandBehavior, object> instrumentedMethod = null;
 
@@ -58,8 +60,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<object, CommandBehavior, object>>
-                       .Start(instanceType.Assembly, mdToken, opCode, nameof(ExecuteDbDataReader))
-                       .WithConcreteType(typeof(DbCommand))
+                       .Start(instrumentedType.Assembly, mdToken, opCode, nameof(ExecuteDbDataReader))
+                       .WithConcreteType(instrumentedType)
                        .WithParameters(commandBehavior)
                        .Build();
             }
@@ -118,7 +120,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var instanceType = command.GetType();
             var commandBehavior = (CommandBehavior)behavior;
             var callingAssembly = Assembly.GetCallingAssembly();
-            var dataReaderType = callingAssembly.GetType(DbDataReader);
+            var instrumentedType = @this.GetInstrumentedType(DbCommand);
+            var dataReaderType = instrumentedType.Assembly.GetType(DbDataReader);
 
             Func<object, object, object, object> instrumentedMethod = null;
 
@@ -126,8 +129,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<object, object, object, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(ExecuteDbDataReaderAsync))
-                       .WithConcreteType(typeof(DbCommand))
+                       .Start(instrumentedType.Assembly, mdToken, opCode, nameof(ExecuteDbDataReaderAsync))
+                       .WithConcreteType(instrumentedType)
                        .WithParameters(commandBehavior, cancellationToken)
                        .Build();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
@@ -25,5 +25,28 @@ namespace Datadog.Trace.ClrProfiler
 
             return null;
         }
+
+        public static System.Type GetInstrumentedInterface(
+            this object runtimeObject,
+            string instrumentedInterfaceName)
+        {
+            if (runtimeObject == null)
+            {
+                return null;
+            }
+
+            var currentType = runtimeObject.GetType();
+            var implementedInterfaces = currentType.GetInterfaces();
+
+            foreach (var interfaceType in implementedInterfaces)
+            {
+                if ($"{currentType.Namespace}.{currentType.Name}" == instrumentedInterfaceName)
+                {
+                    return interfaceType;
+                }
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
 - [x] More logging in the `MethodBuilder` class detailing the matching process
 - [x] Use parent type and assembly of DbCommand instance to resolve methods
 - [x] Add another tier for counting exact parameter matches when using fallback
 - [x] Add safeguards to be sure MethodBase is not used if resolved from unexpected module
 - [x] Add exception in Debug mode when the match is not made on mdToken
 - [ ] Add async test to Sql Sample

@DataDog/apm-dotnet