### PR TITLE
Container tagging

### DIFF
--- a/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -4,6 +4,12 @@ set -euxo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 $DIR/with-profiler-logs.bash \
+    dotnet test --verbosity minimal --logger trx --results-directory $DIR/../test/Datadog.Trace.IntegrationTests/results $DIR/../test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+
+$DIR/with-profiler-logs.bash \
+    dotnet test --verbosity minimal --logger trx --results-directory $DIR/../test/Datadog.Trace.OpenTracing.IntegrationTests/results $DIR/../test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+
+$DIR/with-profiler-logs.bash \
     wait-for-it servicestackredis:6379 -- \
     wait-for-it stackexchangeredis:6379 -- \
     wait-for-it elasticsearch6:9200 -- \

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -46,12 +46,15 @@ namespace Datadog.Trace.Agent
 
             var containerId = ContainerInfo.GetContainerId();
 
+            // report runtime details
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageInterpreter, frameworkName);
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageVersion, frameworkVersion);
+
+            // report Tracer version
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, tracerVersion);
 
-            // linux container id
+            // report container id (only Linux containers supported for now)
             if (containerId != null)
             {
                 _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.ContainerId, containerId);

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using Datadog.Trace.Containers;
 using Datadog.Trace.Logging;
 using MsgPack.Serialization;
 using Newtonsoft.Json;
@@ -43,10 +44,18 @@ namespace Datadog.Trace.Agent
             GetFrameworkDescription(out string frameworkName, out string frameworkVersion);
             var tracerVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 
+            var containerId = ContainerInfo.GetContainerId();
+
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageInterpreter, frameworkName);
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageVersion, frameworkVersion);
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, tracerVersion);
+
+            // linux container id
+            if (containerId != null)
+            {
+                _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.ContainerId, containerId);
+            }
 
             // don't add automatic instrumentation to requests from this HttpClient
             _client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -34,5 +34,10 @@ namespace Datadog.Trace
         /// The number of unique traces per request.
         /// </summary>
         public const string TraceCount = "X-Datadog-Trace-Count";
+
+        /// <summary>
+        /// The id of the container where the traced application is running.
+        /// </summary>
+        public const string ContainerId = "Datadog-Container-ID";
     }
 }

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Containers
 {
@@ -18,6 +19,8 @@ namespace Datadog.Trace.Containers
         private const string ContainerIdRegex = @"^(?:\d+):(?:[^:]*):/?(?:.+/)([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64}(?:\.scope)?)$";
 
         private static readonly Lazy<string> ContainerId = new Lazy<string>(GetContainerIdInternal, LazyThreadSafetyMode.ExecutionAndPublication);
+
+        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
 
         /// <summary>
         /// Gets the id of the container executing the code.
@@ -56,10 +59,30 @@ namespace Datadog.Trace.Containers
 
         private static string GetContainerIdInternal()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists(ControlGroupsFilePath))
+            bool isLinux;
+
+            try
             {
-                IEnumerable<string> lines = File.ReadLines(ControlGroupsFilePath);
-                return ParseCgroupLines(lines);
+                isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+            catch (Exception ex)
+            {
+                Log.WarnException("Unable to determine OS. Will not report container id.", ex);
+                return null;
+            }
+
+            try
+            {
+                if (isLinux && File.Exists(ControlGroupsFilePath))
+                {
+                    var lines = File.ReadLines(ControlGroupsFilePath);
+                    return ParseCgroupLines(lines);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.WarnException("Error reading cgroup file. Will not report container id.", ex);
+                return null;
             }
 
             return null;

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -30,56 +30,6 @@ namespace Datadog.Trace.Containers
         }
 
         /// <summary>
-        /// Extract the container id from the specified cgroup file contents.
-        /// </summary>
-        /// <remarks>
-        /// This method is used when passing the entire cgroup text for testing purposes.
-        /// When reading from file system, we only read one line at a time until we find a match,
-        /// which is usually the first line.
-        /// </remarks>
-        /// <param name="contents">The contents of a cgroup file.</param>
-        /// <returns>The container id if a match is found; otherwise, <c>null</c>.</returns>
-        public static string ParseCgroupText(string contents)
-        {
-            if (contents == null)
-            {
-                return null;
-            }
-
-            IEnumerable<string> lines = SplitLines(contents);
-            return ParseCgroupLines(lines);
-        }
-
-        /// <summary>
-        /// Used by <see cref="ParseCgroupText"/> to split the entire file contents
-        /// into individual lines to mock <see cref="File.ReadLines(string)"/>.
-        /// </summary>
-        /// <param name="contents">The multi-line string.</param>
-        /// <returns>An enumerable that returns each line from <paramref name="contents"/> when iterated.</returns>
-        public static IEnumerable<string> SplitLines(string contents)
-        {
-            if (contents == null)
-            {
-                yield break;
-            }
-
-            using (var reader = new StringReader(contents))
-            {
-                while (true)
-                {
-                    string line = reader.ReadLine();
-
-                    if (line == null)
-                    {
-                        yield break;
-                    }
-
-                    yield return line;
-                }
-            }
-        }
-
-        /// <summary>
         /// Uses regular expression to try to extract a container id from the specified string.
         /// </summary>
         /// <param name="lines">Lines of text from a cgroup file.</param>

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -17,9 +17,7 @@ namespace Datadog.Trace.Containers
 
         private const string LineRegex = @"^(?:\d+):(?:[^:]*):(.+)$";
 
-        private const string ContainerIdRegex = @"(?:pod)?" +
-                                                @"([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})" +
-                                                @"(?:\.scope|\.slice)?$";
+        private const string ContainerIdRegex = @"([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})(?:\.scope)?$";
 
         private static readonly Lazy<string> ContainerId = new Lazy<string>(GetContainerIdInternal, LazyThreadSafetyMode.ExecutionAndPublication);
 

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Containers
         /// </remarks>
         /// <param name="contents">The contents of a cgroup file.</param>
         /// <returns>The container id if a match is found; otherwise, <c>null</c>.</returns>
-        internal static string ParseCgroupText(string contents)
+        public static string ParseCgroupText(string contents)
         {
             if (contents == null)
             {
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Containers
         /// </summary>
         /// <param name="contents">The multi-line string.</param>
         /// <returns>An enumerable that returns each line from <paramref name="contents"/> when iterated.</returns>
-        internal static IEnumerable<string> SplitLines(string contents)
+        public static IEnumerable<string> SplitLines(string contents)
         {
             if (contents == null)
             {
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Containers
         /// </summary>
         /// <param name="lines">Lines of text from a cgroup file.</param>
         /// <returns>The container id if found; otherwise, <c>null</c>.</returns>
-        internal static string ParseCgroupLines(IEnumerable<string> lines)
+        public static string ParseCgroupLines(IEnumerable<string> lines)
         {
             return lines.Select(ParseCgroupLine)
                         .FirstOrDefault(id => !string.IsNullOrWhiteSpace(id));
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Containers
         /// </summary>
         /// <param name="line">A single line from a cgroup file.</param>
         /// <returns>The container id if found; otherwise, <c>null</c>.</returns>
-        internal static string ParseCgroupLine(string line)
+        public static string ParseCgroupLine(string line)
         {
             var lineMatch = Regex.Match(line, LineRegex);
 

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace Datadog.Trace.Containers
+{
+    /// <summary>
+    /// Utility class with methods to interact with container hosts.
+    /// </summary>
+    internal static class ContainerInfo
+    {
+        private const string ControlGroupsFilePath = "/proc/self/cgroup";
+
+        private const string LineRegex = @"^(?:\d+):(?:[^:]*):(.+)$";
+
+        private const string ContainerIdRegex = @"(?:pod)?" +
+                                                @"([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})" +
+                                                @"(?:\.scope|\.slice)?$";
+
+        /// <summary>
+        /// Gets the id of the container executing the code.
+        /// Return <c>null</c> if code is not executing inside a supported container.
+        /// </summary>
+        /// <returns>The container id or <c>null</c>.</returns>
+        public static string GetContainerId()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists(ControlGroupsFilePath))
+            {
+                IEnumerable<string> lines = File.ReadLines(ControlGroupsFilePath);
+                return ParseLines(lines);
+            }
+
+            return null;
+        }
+
+        internal static string ParseFile(string file)
+        {
+            if (file == null)
+            {
+                return null;
+            }
+
+            IEnumerable<string> lines = SplitLines(file);
+            return ParseLines(lines);
+        }
+
+        internal static IEnumerable<string> SplitLines(string lines)
+        {
+            if (lines == null)
+            {
+                yield break;
+            }
+
+            using (var reader = new StringReader(lines))
+            {
+                while (true)
+                {
+                    string line = reader.ReadLine();
+
+                    if (line == null)
+                    {
+                        yield break;
+                    }
+
+                    yield return line;
+                }
+            }
+        }
+
+        internal static string ParseLines(IEnumerable<string> lines)
+        {
+            return lines.Select(ParseLine)
+                        .FirstOrDefault(id => !string.IsNullOrWhiteSpace(id));
+        }
+
+        internal static string ParseLine(string line)
+        {
+            var lineMatch = Regex.Match(line, LineRegex);
+
+            if (lineMatch.Success)
+            {
+                string path = lineMatch.Groups[1].Value;
+                string lastPathPart = path.Split('/').Last();
+
+                var containerIdMatch = Regex.Match(lastPathPart, ContainerIdRegex);
+
+                if (containerIdMatch.Success)
+                {
+                    return containerIdMatch.Groups[1].Value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -15,9 +15,7 @@ namespace Datadog.Trace.Containers
     {
         private const string ControlGroupsFilePath = "/proc/self/cgroup";
 
-        private const string LineRegex = @"^(?:\d+):(?:[^:]*):(.+)$";
-
-        private const string ContainerIdRegex = @"([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64})(?:\.scope)?$";
+        private const string ContainerIdRegex = @"^(?:\d+):(?:[^:]*):/?(?:.+/)([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64}(?:\.scope)?)$";
 
         private static readonly Lazy<string> ContainerId = new Lazy<string>(GetContainerIdInternal, LazyThreadSafetyMode.ExecutionAndPublication);
 
@@ -99,22 +97,11 @@ namespace Datadog.Trace.Containers
         /// <returns>The container id if found; otherwise, <c>null</c>.</returns>
         public static string ParseCgroupLine(string line)
         {
-            var lineMatch = Regex.Match(line, LineRegex);
+            var lineMatch = Regex.Match(line, ContainerIdRegex);
 
-            if (lineMatch.Success)
-            {
-                string path = lineMatch.Groups[1].Value;
-                string lastPathPart = path.Split('/').Last();
-
-                var containerIdMatch = Regex.Match(lastPathPart, ContainerIdRegex);
-
-                if (containerIdMatch.Success)
-                {
-                    return containerIdMatch.Groups[1].Value;
-                }
-            }
-
-            return null;
+            return lineMatch.Success
+                       ? lineMatch.Groups[1].Value
+                       : null;
         }
 
         private static string GetContainerIdInternal()

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
@@ -238,6 +239,11 @@ namespace Datadog.Trace
         internal static Uri GetAgentUri(TracerSettings settings)
         {
             return settings.AgentUri;
+        }
+
+        internal async Task FlushAsync()
+        {
+            await _agentWriter.FlushAndCloseAsync();
         }
 
         /// <summary>

--- a/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.IntegrationTests
         }
 
         [Fact]
-        public async Task Foo()
+        public async Task Http_Headers_Contain_ContainerId()
         {
             if (EnvironmentHelper.IsWindows())
             {

--- a/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests
+{
+    public class ContainerTaggingTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ContainerTaggingTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public async Task Foo()
+        {
+            if (EnvironmentHelper.IsWindows())
+            {
+                _output.WriteLine("Ignored for Windows OS for now.");
+                return;
+            }
+
+            string containerId = null;
+            var agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            {
+                agent.RequestReceived += (sender, args) =>
+                {
+                    containerId = args.Value.Request.Headers[AgentHttpHeaderNames.ContainerId];
+                };
+
+                var settings = new TracerSettings { AgentUri = new Uri($"http://localhost:{agentPort}") };
+                var tracer = new Tracer(settings);
+
+                using (var scope = tracer.StartActive("operationName"))
+                {
+                    scope.Span.ResourceName = "resourceName";
+                }
+
+                await tracer.FlushAsync();
+
+                var spans = agent.WaitForSpans(1);
+                Assert.Equal(1, spans.Count);
+                Assert.NotNull(containerId);
+                Assert.NotEqual(string.Empty, containerId);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.IntegrationTests
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null);
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void MinimalSpan()
         {
             var scope = _tracer.StartActive("Operation");
@@ -42,7 +42,7 @@ namespace Datadog.Trace.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(scope.Span, trace.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void CustomServiceName()
         {
             const string ServiceName = "MyService";
@@ -61,7 +61,7 @@ namespace Datadog.Trace.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(scope.Span, trace.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void Utf8Everywhere()
         {
             var scope = _tracer.StartActive("Aᛗᚪᚾᚾᚪ", serviceName: "На берегу пустынных волн");
@@ -79,7 +79,7 @@ namespace Datadog.Trace.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(scope.Span, trace.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void SubmitsOutOfOrderSpans()
         {
             var scope1 = _tracer.StartActive("op1");
@@ -97,7 +97,7 @@ namespace Datadog.Trace.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(scope2.Span, trace[0].AsList()[1]);
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public void WithDefaultFactory()
         {
             // This test does not check anything it validates that this codepath runs without exceptions
@@ -106,7 +106,7 @@ namespace Datadog.Trace.IntegrationTests
                   .Dispose();
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public void WithGlobalTracer()
         {
             // This test does not check anything it validates that this codepath runs without exceptions

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
             _tracer = new OpenTracingTracer(tracer);
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void MinimalSpan()
         {
             var span = (OpenTracingSpan)_tracer.BuildSpan("Operation")
@@ -44,7 +44,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(span.DDSpan, trace.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void CustomServiceName()
         {
             const string ServiceName = "MyService";
@@ -65,7 +65,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(span.DDSpan, trace.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public async void Utf8Everywhere()
         {
             var span = (OpenTracingSpan)_tracer.BuildSpan("Aᛗᚪᚾᚾᚪ")
@@ -85,7 +85,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
             MsgPackHelpers.AssertSpanEqual(span.DDSpan, trace.Single());
         }
 
-        [Fact]
+        [Fact(Skip = "Run manually")]
         public void WithDefaultFactory()
         {
             // This test does not check anything it validates that this codepath runs without exceptions

--- a/test/Datadog.Trace.TestHelpers/EventArgs.cs
+++ b/test/Datadog.Trace.TestHelpers/EventArgs.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class EventArgs<T> : EventArgs
+    {
+        public EventArgs(T value)
+        {
+            Value = value;
+        }
+
+        public T Value { get; }
+    }
+}

--- a/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
+++ b/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Tests.Containers
         [MemberData(nameof(GetCgroupFiles))]
         public void ParseFile(string file, string expected)
         {
-            string actual = ContainerInfo.ParseFile(file);
+            string actual = ContainerInfo.ParseCgroupText(file);
             Assert.Equal(expected, actual);
         }
     }

--- a/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
+++ b/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using Datadog.Trace.Containers;
 using Xunit;
 
@@ -69,11 +70,45 @@ namespace Datadog.Trace.Tests.Containers
             yield return new object[] { Fargate, "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da" };
         }
 
+        /// <summary>
+        /// Splits multi-line string into individual strings, one string per line.
+        /// </summary>
+        /// <param name="contents">The multi-line string.</param>
+        /// <returns>An enumerable that returns each line from <paramref name="contents"/> when iterated.</returns>
+        public static IEnumerable<string> SplitLines(string contents)
+        {
+            if (contents == null)
+            {
+                yield break;
+            }
+
+            using (var reader = new StringReader(contents))
+            {
+                while (true)
+                {
+                    string line = reader.ReadLine();
+
+                    if (line == null)
+                    {
+                        yield break;
+                    }
+
+                    yield return line;
+                }
+            }
+        }
+
         [Theory]
         [MemberData(nameof(GetCgroupFiles))]
         public void ParseFile(string file, string expected)
         {
-            string actual = ContainerInfo.ParseCgroupText(file);
+            // arrange
+            var lines = SplitLines(file);
+
+            // act
+            string actual = ContainerInfo.ParseCgroupLines(lines);
+
+            // assert
             Assert.Equal(expected, actual);
         }
     }

--- a/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
+++ b/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tests.Containers
 
         [Theory]
         [MemberData(nameof(GetCgroupFiles))]
-        public void ParseFile(string file, string expected)
+        public void Parse_ContainerId_From_Cgroup_File(string file, string expected)
         {
             // arrange
             var lines = SplitLines(file);

--- a/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
+++ b/test/Datadog.Trace.Tests/Containers/ContainerInfoTests.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using Datadog.Trace.Containers;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Containers
+{
+    public class ContainerInfoTests
+    {
+        public const string Docker = @"
+13:name=systemd:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+12:pids:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+11:hugetlb:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+10:net_prio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+9:perf_event:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+8:net_cls:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+7:freezer:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+6:devices:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+5:memory:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+4:blkio:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+3:cpuacct:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+2:cpu:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860
+1:cpuset:/docker/3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860";
+
+        public const string Kubernetes = @"
+11:perf_event:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+10:pids:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+9:memory:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+8:cpu,cpuacct:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+7:blkio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+6:cpuset:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+5:devices:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+4:freezer:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+";
+
+        public const string Ecs = @"
+9:perf_event:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+8:memory:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+7:hugetlb:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+6:freezer:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+5:devices:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+4:cpuset:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+3:cpuacct:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+2:cpu:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+1:blkio:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
+";
+
+        public const string Fargate = @"
+11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+8:net_cls,net_prio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+7:cpu,cpuacct:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+6:perf_event:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+5:freezer:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+4:devices:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+3:blkio:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+2:memory:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
+";
+
+        public static IEnumerable<object[]> GetCgroupFiles()
+        {
+            yield return new object[] { Docker, "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860" };
+            yield return new object[] { Kubernetes, "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1" };
+            yield return new object[] { Ecs, "38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce" };
+            yield return new object[] { Fargate, "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da" };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetCgroupFiles))]
+        public void ParseFile(string file, string expected)
+        {
+            string actual = ContainerInfo.ParseFile(file);
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- [x] extract container id from `/proc/self/cgroup`
- [x] inject container id http header when sending data to the Agent

Tests:
- [x] unit tests for `ContainerInfo`
- [x] integration tests (local)
- [x] integration tests (CI)

Bonus testing improvements:
- add internal `Tracer.FlushAsync()`
- add `MockTracerAgent.OnRequestReceived` event