### PR TITLE
Add ModuleVersionId to module_metadata for future use

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -309,9 +309,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
     return S_OK;
   }
 
-  ModuleMetadata* module_metadata =
-      new ModuleMetadata(metadata_import, metadata_emit,
-                         module_info.assembly.name, filtered_integrations);
+  GUID module_version_id;
+  metadata_import->GetScopeProps(NULL, 1024, nullptr, &module_version_id);
+
+  ModuleMetadata* module_metadata = new ModuleMetadata(
+      metadata_import, metadata_emit, module_info.assembly.name,
+      module_version_id, filtered_integrations);
 
   const MetadataBuilder metadata_builder(*module_metadata, module,
                                          metadata_import, metadata_emit,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -310,7 +310,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   }
 
   GUID module_version_id;
-  metadata_import->GetScopeProps(NULL, 1024, nullptr, &module_version_id);
+  metadata_import->GetScopeProps(nullptr, 0, nullptr, &module_version_id);
 
   ModuleMetadata* module_metadata = new ModuleMetadata(
       metadata_import, metadata_emit, module_info.assembly.name,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -310,7 +310,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   }
 
   GUID module_version_id;
-  metadata_import->GetScopeProps(nullptr, 0, nullptr, &module_version_id);
+  hr = metadata_import->GetScopeProps(nullptr, 0, nullptr, &module_version_id);
+  if (FAILED(hr)) {
+    Warn("ModuleLoadFinished failed to get module_version_id for ",
+         module_id, " ", module_info.assembly.name);
+    return S_OK;
+  }
 
   ModuleMetadata* module_metadata = new ModuleMetadata(
       metadata_import, metadata_emit, module_info.assembly.name,

--- a/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
@@ -20,14 +20,17 @@ class ModuleMetadata {
   const ComPtr<IMetaDataImport2> metadata_import{};
   const ComPtr<IMetaDataEmit2> metadata_emit{};
   WSTRING assemblyName = ""_W;
+  GUID module_version_id;
   std::vector<IntegrationMethod> integrations = {};
 
   ModuleMetadata(ComPtr<IMetaDataImport2> metadata_import,
                  ComPtr<IMetaDataEmit2> metadata_emit, WSTRING assembly_name,
+                 GUID module_version_id,
                  std::vector<IntegrationMethod> integrations)
       : metadata_import(metadata_import),
         metadata_emit(metadata_emit),
         assemblyName(assembly_name),
+        module_version_id(module_version_id),
         integrations(integrations) {}
 
   bool TryGetWrapperMemberRef(const WSTRING& keyIn,

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
@@ -56,9 +56,14 @@ class MetadataBuilderTest : public ::testing::Test {
         metadataInterfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
 
     const std::wstring assemblyName = L"Samples.ExampleLibrary";
+
+    GUID module_version_id;
+    metadataImport->GetScopeProps(NULL, 1024, nullptr, &module_version_id);
+
     const std::vector<IntegrationMethod> integrations;
     module_metadata_ =
-        new ModuleMetadata(metadataImport, metadataEmit, assemblyName, integrations);
+        new ModuleMetadata(metadataImport, metadataEmit, assemblyName,
+                           module_version_id, integrations);
 
     mdModule module;
     hr = metadataImport->GetModuleFromScope(&module);


### PR DESCRIPTION
Changes proposed in this pull request:
The ModuleVersionId can be passed to the managed code for resolving modules and methods.

@DataDog/apm-dotnet