### PR TITLE
Module lookup overload

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -67,13 +67,13 @@ namespace Datadog.Trace.ClrProfiler.Emit
         public MethodBuilder<TDelegate> WithConcreteType(Type type)
         {
             _concreteType = type;
-            _concreteTypeName = type.FullName;
+            _concreteTypeName = type?.FullName;
             return this;
         }
 
         public MethodBuilder<TDelegate> WithConcreteTypeName(string typeName)
         {
-            var concreteType = _resolutionModule.GetType(typeName);
+            var concreteType = _resolutionModule?.GetType(typeName);
             return this.WithConcreteType(concreteType);
         }
 
@@ -314,7 +314,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
         private MethodInfo VerifyMethodFromToken(MethodInfo methodInfo)
         {
             // Verify baselines to ensure this isn't the wrong method somehow
-            var detailMessage = $"Unexpected method: {_concreteTypeName}.{_methodName} received for mdToken: {_mdToken} in module: {_resolutionModule.Name}, {_resolutionModule.ModuleVersionId}";
+            var detailMessage = $"Unexpected method: {_concreteTypeName}.{_methodName} received for mdToken: {_mdToken} in module: {_resolutionModule?.FullyQualifiedName ?? "NULL"}, {_resolutionModule?.ModuleVersionId ?? _moduleVersionId}";
 
             if (!string.Equals(_methodName, methodInfo.Name))
             {
@@ -382,7 +382,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         private MethodInfo TryFindMethod()
         {
-            var logDetail = $"mdToken {_mdToken} on {_concreteTypeName}.{_methodName} in {_resolutionModule}, {_resolutionModule.ModuleVersionId}";
+            var logDetail = $"mdToken {_mdToken} on {_concreteTypeName}.{_methodName} in {_resolutionModule?.FullyQualifiedName ?? "NULL"}, {_resolutionModule?.ModuleVersionId ?? _moduleVersionId}";
             Log.Warn($"Using fallback method matching ({logDetail})");
 
             var methods =

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -370,7 +370,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         private MethodInfo TryFindMethod()
         {
-            var logDetail = $"mdToken {_mdToken} on {_concreteTypeName}.{_methodName} in {_resolutionAssembly.FullName}";
+            var logDetail = $"mdToken {_mdToken} on {_concreteTypeName}.{_methodName} in {_resolutionModule}, {_resolutionModule.ModuleVersionId}";
             Log.Warn($"Using fallback method matching ({logDetail})");
 
             var methods =

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ModuleLookup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ModuleLookup.cs
@@ -23,11 +23,16 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         public static Module Get(Guid moduleVersionId)
         {
-            Module value = null;
+            // First attempt at cached values with no blocking
+            if (_modules.TryGetValue(moduleVersionId, out Module value))
+            {
+                return value;
+            }
 
             // Block if a population event is happening
             _populationResetEvent.Wait();
 
+            // See if the previous population event populated what we need
             if (_modules.TryGetValue(moduleVersionId, out value))
             {
                 return value;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ModuleLookup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ModuleLookup.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Threading;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Emit
+{
+    internal static class ModuleLookup
+    {
+        private static readonly ILog Log = LogProvider.GetLogger(typeof(ModuleLookup));
+
+        private static ManualResetEventSlim _populationResetEvent = new ManualResetEventSlim(initialState: true);
+        private static ConcurrentDictionary<Guid, Module> _modules = new ConcurrentDictionary<Guid, Module>();
+
+        public static Module Get(Guid moduleVersionId)
+        {
+            Module value = null;
+
+            // Block if a population event is happening
+            _populationResetEvent.Wait();
+
+            if (_modules.TryGetValue(moduleVersionId, out value))
+            {
+                return value;
+            }
+
+            // Block threads on this event
+            _populationResetEvent.Reset();
+
+            try
+            {
+                PopulateModules();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Error when populating modules.", ex);
+            }
+            finally
+            {
+                // Continue threads blocked on this event
+                _populationResetEvent.Set();
+            }
+
+            _modules.TryGetValue(moduleVersionId, out value);
+
+            return value;
+        }
+
+        private static void PopulateModules()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            foreach (var assembly in assemblies)
+            {
+                foreach (var module in assembly.Modules)
+                {
+                    _modules.TryAdd(module.ModuleVersionId, module);
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ModuleLookupTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ModuleLookupTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Datadog.Trace.ClrProfiler.Emit;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class ModuleLookupTests
+    {
+        [Fact]
+        public void Lookup_SystemData_Succeeds_WithTwentyThreads()
+        {
+            var threads = new List<Thread>();
+
+            var systemDataGuid = typeof(System.Data.DataTable).Assembly.ManifestModule.ModuleVersionId;
+
+            var bag = new ConcurrentBag<Module>();
+
+            for (var i = 0; i < 20; i++)
+            {
+                threads.Add(new Thread(thread =>
+                {
+                    bag.Add(ModuleLookup.Get(systemDataGuid));
+                }));
+            }
+
+            System.Threading.Tasks.Parallel.ForEach(threads, t => t.Start());
+
+            while (threads.Any(t => t.IsAlive))
+            {
+                Thread.Sleep(200);
+            }
+
+            Assert.True(bag.All(m => m.ModuleVersionId == systemDataGuid) && bag.Count() == threads.Count());
+        }
+
+        [Fact]
+        public void Lookup_Self_Succeeds()
+        {
+            var expectedModule = typeof(ModuleLookupTests).Assembly.ManifestModule;
+            var lookup = ModuleLookup.Get(expectedModule.ModuleVersionId);
+            Assert.Equal(expectedModule, lookup);
+        }
+
+        [Fact]
+        public void Lookup_DatadogTraceClrProfilerManaged_Succeeds()
+        {
+            var expectedModule = typeof(MethodBuilder<>).Assembly.ManifestModule;
+            var lookup = ModuleLookup.Get(expectedModule.ModuleVersionId);
+            Assert.Equal(expectedModule, lookup);
+        }
+
+        [Fact]
+        public void Lookup_DatadogTrace_Succeeds()
+        {
+            var expectedModule = typeof(Span).Assembly.ManifestModule;
+            var lookup = ModuleLookup.Get(expectedModule.ModuleVersionId);
+            Assert.Equal(expectedModule, lookup);
+        }
+
+        [Fact]
+        public void Lookup_SystemData_Succeeds()
+        {
+            var expectedModule = typeof(System.Data.DataTable).Assembly.ManifestModule;
+            var lookup = ModuleLookup.Get(expectedModule.ModuleVersionId);
+            Assert.Equal(expectedModule, lookup);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ModuleLookupTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ModuleLookupTests.cs
@@ -21,16 +21,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
             for (var i = 0; i < 20; i++)
             {
-                var task = new Task(() =>
+                tasks[i] = Task.Run(() =>
                 {
                     resetEvent.Wait();
-                    var module = ModuleLookup.Get(systemDataGuid);
-                    bag.Add(module);
+                    bag.Add(ModuleLookup.Get(systemDataGuid));
                 });
-
-                task.Start();
-
-                tasks[i] = task;
             }
 
             resetEvent.Set();

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ModuleLookupTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ModuleLookupTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 {
                     resetEvent.Wait();
                     var module = ModuleLookup.Get(systemDataGuid);
-                    bag.Add(ModuleLookup.Get(systemDataGuid));
+                    bag.Add(module);
                 });
 
                 task.Start();


### PR DESCRIPTION
Changes proposed in this pull request:
Overload on method builder with ModuleVersionId to enable a lookup for the module

After merge, and after the ModuleVersionId is available, signatures can change from: 
```
MethodBuilder<Action<object, object, object, object>>
    .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(BeforeAction));
```
to:
```
MethodBuilder<Action<object, object, object, object>>
    .Start(moduleVersionId, mdToken, opCode, nameof(BeforeAction));
```

@DataDog/apm-dotnet