### PR TITLE
Add Namespace and Name filters

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -420,7 +420,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                     var typesToCheck = new Type[] { m.ReturnType }.Concat(m.GetParameters().Select(p => p.ParameterType)).ToArray();
                     for (var i = 0; i < typesToCheck.Length; i++)
                     {
-                        if (_namespaceAndNameFilter == null)
+                        if (_namespaceAndNameFilter[i] == ClrNames.Ignore)
                         {
                             // Allow for not specifying
                             continue;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ClrProfiler.ExtensionMethods;
 using Datadog.Trace.Headers;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -171,6 +171,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, nameof(BeforeAction))
                        .WithConcreteTypeName(DiagnosticSource)
                        .WithParameters(diagnosticSource, actionDescriptor, httpContext, routeData)
+                       .WithNamespaceAndNameFilters(
+                            ClrNames.Void,
+                            ClrNames.Ignore,
+                            "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
+                            "Microsoft.AspNetCore.Http.HttpContext",
+                            "Microsoft.AspNetCore.Routing.RouteData")
                        .Build();
             }
             catch (Exception ex)
@@ -248,6 +254,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, nameof(AfterAction))
                        .WithConcreteTypeName(DiagnosticSource)
                        .WithParameters(diagnosticSource, actionDescriptor, httpContext, routeData)
+                       .WithNamespaceAndNameFilters(
+                            ClrNames.Void,
+                            ClrNames.Ignore,
+                            "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
+                            "Microsoft.AspNetCore.Http.HttpContext",
+                            "Microsoft.AspNetCore.Routing.RouteData")
                        .Build();
             }
             catch (Exception ex)
@@ -308,6 +320,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, nameof(Rethrow))
                        .WithConcreteTypeName(ResourceInvoker)
                        .WithParameters(context)
+                       .WithNamespaceAndNameFilters(ClrNames.Void, ClrNames.Ignore)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -57,6 +57,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
+                       .WithNamespaceAndNameFilters("Elasticsearch.Net.ElasticsearchResponse`1", "Elasticsearch.Net.RequestData")
                        .WithParameters(requestData)
                        .Build();
             }
@@ -123,6 +124,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(pipeline.GetType())
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "Elasticsearch.Net.RequestData", ClrNames.CancellationToken)
                        .ForceMethodDefinitionResolution()
                        .Build();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData)
+                       .WithNamespaceAndNameFilters(ClrNames.Ignore, "Elasticsearch.Net.RequestData")
                        .Build();
             }
             catch (Exception ex)
@@ -141,6 +142,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "Elasticsearch.Net.RequestData", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -102,6 +102,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         .Start(moduleVersionPtr, mdToken, opCode, methodName)
                         .WithConcreteType(documentValidatorInstanceType)
                         .WithParameters(originalQuery, schema, document, rules, userContext, inputs)
+                        .WithNamespaceAndNameFilters(
+                            GraphQLValidationResultInterfaceName,
+                            ClrNames.String,
+                            "GraphQL.Types.ISchema",
+                            "GraphQL.Language.AST.Document",
+                            "System.Collections.Generic.IEnumerable`1",
+                            ClrNames.Ignore,
+                            "GraphQL.Inputs")
                         .Build();
             }
             catch (Exception ex)
@@ -177,6 +185,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         .Start(moduleVersionPtr, mdToken, opCode, methodName)
                         .WithConcreteType(executionStrategyInstanceType)
                         .WithParameters(context)
+                        .WithNamespaceAndNameFilters(ClrNames.GenericTask, "GraphQL.Execution.ExecutionContext")
                         .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -66,6 +66,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, SendAsync)
                        .WithConcreteType(httpMessageHandler)
                        .WithParameters(request, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -123,6 +124,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, SendAsync)
                        .WithConcreteType(httpClientHandler)
                        .WithParameters(request, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -67,6 +67,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(wireProtocolType)
                        .WithParameters(connection, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.Void, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -131,6 +132,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(wireProtocolType)
                        .WithParameters(connection, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.Ignore, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -198,6 +200,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(wireProtocolType)
                        .WithDeclaringTypeGenerics(wireProtocolGenericArgs)
                        .WithParameters(connection, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.Task, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -255,6 +258,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(wireProtocolType)
                        .WithDeclaringTypeGenerics(wireProtocolGenericArgs)
                        .WithParameters(connection, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -59,6 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(instrumentedType)
                        .WithParameters(cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead)
                        .WithMethodGenerics(typeof(T))
+                       .WithNamespaceAndNameFilters(ClrNames.Ignore, "System.Byte[][]", "System.Func`1", "System.Action`1", ClrNames.Bool)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -99,6 +99,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                                     .WithConcreteType(_redisBaseType)
                                     .WithMethodGenerics(typeof(T))
                                     .WithParameters(message, processor, server)
+                                    .WithNamespaceAndNameFilters(
+                                        ClrNames.GenericTask,
+                                        "StackExchange.Redis.Message",
+                                        "StackExchange.Redis.ResultProcessor`1",
+                                        "StackExchange.Redis.ServerEndPoint")
                                     .Build();
 
             // we only trace RedisBatch methods here

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/ClrNames.cs
@@ -29,5 +29,7 @@ namespace Datadog.Trace.ClrProfiler
 
         public const string HttpRequestMessage = "System.Net.Http.HttpRequestMessage";
         public const string HttpResponseMessageTask = "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>";
+
+        public const string GenericTask = "System.Threading.Tasks.Task`1";
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 Build<Action<object, object, object, object>>(expected.Name)
                 .WithParameters(p1, p2, p3)
                 .WithNamespaceAndNameFilters(
-                    "System.Void",
+                    ClrNames.Void,
                     "Datadog.Trace.ClrProfiler.Managed.Tests.ClassB",
                     "Datadog.Trace.ClrProfiler.Managed.Tests.ClassC",
                     "Datadog.Trace.ClrProfiler.Managed.Tests.ClassC")
@@ -101,7 +101,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 Build<Action<object, object, object, object>>(expected.Name)
                 .WithParameters(p1, p2, p3)
                 .WithNamespaceAndNameFilters(
-                    "System.Void",
+                    ClrNames.Void,
                     "Datadog.Trace.ClrProfiler.Managed.Tests.ClassA",
                     "Datadog.Trace.ClrProfiler.Managed.Tests.ClassA",
                     "Datadog.Trace.ClrProfiler.Managed.Tests.ClassA")

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             yield return new object[] { ClrNames.AsyncCallback, typeof(AsyncCallback) };
             yield return new object[] { ClrNames.HttpRequestMessage, typeof(System.Net.Http.HttpRequestMessage) };
             yield return new object[] { ClrNames.HttpResponseMessageTask, "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>" }; // Generic full names have square brackets
+            yield return new object[] { ClrNames.GenericTask, typeof(Task<>) };
         }
 
         [Fact]


### PR DESCRIPTION
Changes proposed in this pull request:
Add simple namespace+name filters to integrations using the MethodBuilder

@DataDog/apm-dotnet