### PR TITLE
pass module version id to instrumentation wrappers

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -23,7 +23,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 04 1C 1C 08 08 08"
+          "signature": "00 05 1C 1C 08 08 08 0A"
         }
       },
       {
@@ -47,7 +47,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReader",
-          "signature": "00 04 1C 1C 08 08 08"
+          "signature": "00 05 1C 1C 08 08 08 0A"
         }
       },
       {
@@ -72,7 +72,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 05 1C 1C 08 1C 08 08"
+          "signature": "00 06 1C 1C 08 1C 08 08 0A"
         }
       },
       {
@@ -97,7 +97,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNetIntegration",
           "method": "ExecuteDbDataReaderAsync",
-          "signature": "00 05 1C 1C 08 1C 08 08"
+          "signature": "00 06 1C 1C 08 1C 08 08 0A"
         }
       }
     ]
@@ -131,7 +131,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "BeforeAction",
-          "signature": "00 06 01 1C 1C 1C 1C 08 08"
+          "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -160,7 +160,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "AfterAction",
-          "signature": "00 06 01 1C 1C 1C 1C 08 08"
+          "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -186,7 +186,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc2Integration",
           "method": "Rethrow",
-          "signature": "00 03 01 1C 08 08"
+          "signature": "00 04 01 1C 08 08 0A"
         }
       }
     ]
@@ -220,7 +220,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "BeginInvokeAction",
-          "signature": "00 07 1C 1C 1C 1C 1C 1C 08 08"
+          "signature": "00 08 1C 1C 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -246,7 +246,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetMvcIntegration",
           "method": "EndInvokeAction",
-          "signature": "00 04 02 1C 1C 08 08"
+          "signature": "00 05 02 1C 1C 08 08 0A"
         }
       }
     ]
@@ -276,7 +276,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "ExecuteAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -307,7 +307,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 04 1C 1C 1C 08 08"
+          "signature": "10 01 05 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -334,7 +334,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet5Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 05 1C 1C 1C 1C 08 08"
+          "signature": "10 01 06 1C 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -365,7 +365,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearch",
-          "signature": "10 01 04 1C 1C 1C 08 08"
+          "signature": "10 01 05 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -392,7 +392,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ElasticsearchNet6Integration",
           "method": "CallElasticsearchAsync",
-          "signature": "10 01 05 1C 1C 1C 1C 08 08"
+          "signature": "10 01 06 1C 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -426,7 +426,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "Validate",
-          "signature": "00 09 1C 1C 1C 1C 1C 1C 1C 1C 08 08"
+          "signature": "00 0A 1C 1C 1C 1C 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -450,7 +450,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.GraphQLIntegration",
           "method": "ExecuteAsync",
-          "signature": "00 04 1C 1C 1C 08 08"
+          "signature": "00 05 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -480,7 +480,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpMessageHandler_SendAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -505,7 +505,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration",
           "method": "HttpClientHandler_SendAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -535,7 +535,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -560,7 +560,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteGeneric",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -585,7 +585,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsync",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -610,7 +610,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "ExecuteAsyncGeneric",
-          "signature": "00 05 1C 1C 1C 1C 08 08"
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -644,7 +644,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.ServiceStackRedisIntegration",
           "method": "SendReceive",
-          "signature": "10 01 07 1E 00 1C 1D 1D 05 1C 1C 02 08 08"
+          "signature": "10 01 08 1E 00 1C 1D 1D 05 1C 1C 02 08 08 0A"
         }
       }
     ]
@@ -677,7 +677,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 08"
+          "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -705,7 +705,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteSyncImpl",
-          "signature": "10 01 06 1E 00 1C 1C 1C 1C 08 08"
+          "signature": "10 01 07 1E 00 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -734,7 +734,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 08"
+          "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -763,7 +763,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.ConnectionMultiplexer",
           "method": "ExecuteAsyncImpl",
-          "signature": "10 01 07 1C 1C 1C 1C 1C 1C 08 08"
+          "signature": "10 01 08 1C 1C 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -791,7 +791,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 06 1C 1C 1C 1C 1C 08 08"
+          "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -819,7 +819,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis.RedisBatch",
           "method": "ExecuteAsync",
-          "signature": "10 01 06 1C 1C 1C 1C 1C 08 08"
+          "signature": "10 01 07 1C 1C 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -849,7 +849,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WcfIntegration",
           "method": "HandleRequest",
-          "signature": "00 05 02 1C 1C 1C 08 08"
+          "signature": "00 06 02 1C 1C 1C 08 08 0A"
         }
       }
     ]
@@ -877,7 +877,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 03 1C 1C 08 08"
+          "signature": "00 04 1C 1C 08 08 0A"
         }
       },
       {
@@ -900,7 +900,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponse",
-          "signature": "00 03 1C 1C 08 08"
+          "signature": "00 04 1C 1C 08 08 0A"
         }
       },
       {
@@ -923,7 +923,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.6.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetResponseAsync",
-          "signature": "00 03 1C 1C 08 08"
+          "signature": "00 04 1C 1C 08 08 0A"
         }
       }
     ]

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -153,12 +153,12 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 declaringTypeGenerics: _declaringTypeGenerics);
 
             return Cache.GetOrAdd(cacheKey, key =>
-                {
-                    // Validate requirements at the last possible moment
-                    // Don't do more than needed before checking the cache
-                    ValidateRequirements();
-                    return EmitDelegate();
-                });
+            {
+                // Validate requirements at the last possible moment
+                // Don't do more than needed before checking the cache
+                ValidateRequirements();
+                return EmitDelegate();
+            });
         }
 
         private TDelegate EmitDelegate()
@@ -409,30 +409,30 @@ namespace Datadog.Trace.ClrProfiler.Emit
             if (_namespaceAndNameFilter != null)
             {
                 methods = methods.Where(m =>
-                                      {
-                                          var parameters = m.GetParameters();
+                {
+                    var parameters = m.GetParameters();
 
-                                          if ((parameters.Length + 1) != _namespaceAndNameFilter.Length)
-                                          {
-                                              return false;
-                                          }
+                    if ((parameters.Length + 1) != _namespaceAndNameFilter.Length)
+                    {
+                        return false;
+                    }
 
-                                          var typesToCheck = new Type[] { m.ReturnType }.Concat(m.GetParameters().Select(p => p.ParameterType)).ToArray();
-                                          for (var i = 0; i < typesToCheck.Length; i++)
-                                          {
-                                              if (_namespaceAndNameFilter == null)
-                                              {
-                                                  // Allow for not specifying
-                                                  continue;
-                                              }
+                    var typesToCheck = new Type[] { m.ReturnType }.Concat(m.GetParameters().Select(p => p.ParameterType)).ToArray();
+                    for (var i = 0; i < typesToCheck.Length; i++)
+                    {
+                        if (_namespaceAndNameFilter == null)
+                        {
+                            // Allow for not specifying
+                            continue;
+                        }
 
-                                              if ($"{typesToCheck[i].Namespace}.{typesToCheck[i].Name}" != _namespaceAndNameFilter[i])
-                                              {
-                                                  return false;
-                                              }
-                                          }
+                        if ($"{typesToCheck[i].Namespace}.{typesToCheck[i].Name}" != _namespaceAndNameFilter[i])
+                        {
+                            return false;
+                        }
+                    }
 
-                                          return true;
+                    return true;
                 }).ToArray();
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -54,12 +54,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
             _forceMethodDefResolve = false;
         }
 
-        public static MethodBuilder<TDelegate> Start(Assembly resolutionAssembly, int mdToken, int opCode, string methodName)
-        {
-            // This method is deprecated in favor of the newer ModuleVersionId lookup
-            return new MethodBuilder<TDelegate>(resolutionAssembly.ManifestModule, mdToken, opCode, methodName);
-        }
-
         public static MethodBuilder<TDelegate> Start(Guid moduleVersionId, int mdToken, int opCode, string methodName)
         {
             return new MethodBuilder<TDelegate>(moduleVersionId, mdToken, opCode, methodName);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -65,13 +65,13 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
 #if NET45
             // deprecated
-            var guid = (Guid)Marshal.PtrToStructure(ptr, typeof(Guid));
+            var moduleVersionId = (Guid)Marshal.PtrToStructure(ptr, typeof(Guid));
 #else
             // added in net451
-            var guid = Marshal.PtrToStructure<Guid>(ptr);
+            var moduleVersionId = Marshal.PtrToStructure<Guid>(ptr);
 #endif
 
-            return new MethodBuilder<TDelegate>(guid, mdToken, opCode, methodName);
+            return new MethodBuilder<TDelegate>(moduleVersionId, mdToken, opCode, methodName);
         }
 
         public MethodBuilder<TDelegate> WithConcreteType(Type type)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="behavior">A value from <see cref="CommandBehavior"/>.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
@@ -39,7 +40,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Data.Common.DbDataReader", "System.Data.CommandBehavior" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object ExecuteDbDataReader(object @this, int behavior, int opCode, int mdToken)
+        public static object ExecuteDbDataReader(
+            object @this,
+            int behavior,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             var command = (DbCommand)@this;
             var commandBehavior = (CommandBehavior)behavior;
@@ -72,6 +78,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token source that can be used to cancel the async operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Data", // .NET Framework
@@ -85,7 +92,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", "System.Data.CommandBehavior", "System.Threading.CancellationToken" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object ExecuteDbDataReaderAsync(object @this, int behavior, object cancellationTokenSource, int opCode, int mdToken)
+        public static object ExecuteDbDataReaderAsync(
+            object @this,
+            int behavior,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Action<object, object, object, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(BeforeAction))
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(BeforeAction))
                        .WithConcreteTypeName(DiagnosticSource)
                        .WithParameters(diagnosticSource, actionDescriptor, httpContext, routeData)
                        .Build();
@@ -245,7 +245,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Action<object, object, object, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(AfterAction))
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(AfterAction))
                        .WithConcreteTypeName(DiagnosticSource)
                        .WithParameters(diagnosticSource, actionDescriptor, httpContext, routeData)
                        .Build();
@@ -305,7 +305,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Action<object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(Rethrow))
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(Rethrow))
                        .WithConcreteTypeName(ResourceInvoker)
                        .WithParameters(context)
                        .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -123,6 +123,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="routeData">A RouteData with information about the current route.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
@@ -136,7 +137,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object httpContext,
             object routeData,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             AspNetCoreMvc2Integration integration = null;
 
@@ -198,6 +200,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="routeData">A RouteData with information about the current route.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
@@ -211,7 +214,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object httpContext,
             object routeData,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             AspNetCoreMvc2Integration integration = null;
 
@@ -275,6 +279,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="context">The DiagnosticSource that this extension method was called on.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
@@ -282,7 +287,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
-        public static void Rethrow(object context, int opCode, int mdToken)
+        public static void Rethrow(object context, int opCode, int mdToken, long moduleVersionPtr)
         {
             if (context == null)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -167,6 +167,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="state">An object that holds the state of the async operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the <see cref="IAsyncResult "/> returned by the original BeginInvokeAction() that is later passed to <see cref="EndInvokeAction"/>.</returns>
         [InterceptMethod(
             CallerAssembly = AssemblyName,
@@ -182,7 +183,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object callback,
             object state,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             Scope scope = null;
 
@@ -224,6 +226,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="asyncResult">The <see cref="IAsyncResult"/> returned by <see cref="BeginInvokeAction"/>.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the <see cref="bool"/> returned by the original EndInvokeAction().</returns>
         [InterceptMethod(
             CallerAssembly = AssemblyName,
@@ -232,7 +235,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Bool, ClrNames.IAsyncResult },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
-        public static bool EndInvokeAction(object asyncControllerActionInvoker, object asyncResult, int opCode, int mdToken)
+        public static bool EndInvokeAction(
+            object asyncControllerActionInvoker,
+            object asyncResult,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             Scope scope = null;
             var httpContext = HttpContext.Current;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -32,6 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">The cancellation token source</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>A task with the result</returns>
         [InterceptMethod(
             TargetAssembly = "System.Web.Http",
@@ -39,7 +40,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Web.Http.Controllers.HttpControllerContext", ClrNames.CancellationToken },
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
-        public static object ExecuteAsync(object apiController, object controllerContext, object cancellationTokenSource, int opCode, int mdToken)
+        public static object ExecuteAsync(
+            object apiController,
+            object controllerContext,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             if (apiController == null) { throw new ArgumentNullException(nameof(apiController)); }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/HttpContextIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/HttpContextIntegration.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Logging;
 
@@ -20,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="features">Initialize features.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         // [InterceptMethod(
         //     TargetAssembly = "Microsoft.AspNetCore.Http.Abstractions",
         //     TargetType = "Microsoft.AspNetCore.Http.DefaultHttpContext",
@@ -27,18 +27,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         // ***************************************************************
         //  DISABLED UNTIL WE FIX SCOPING ISSUES AT HTTP CONTEXT LEVEL
         // ***************************************************************
-        public static void Initialize(object httpContext, object features, int opCode, int mdToken)
+        public static void Initialize(object httpContext, object features, int opCode, int mdToken, long moduleVersionPtr)
         {
             var httpContextType = httpContext.GetType();
             string methodDef = $"{httpContextType.FullName}.Initialize(IFeatureCollection features)";
 
-            Action<object, object> instrumentedMethod = null;
+            Action<object, object> instrumentedMethod;
 
             try
             {
                 instrumentedMethod =
                     MethodBuilder<Action<object, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(Initialize))
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(Initialize))
                        .WithConcreteType(httpContextType)
                        .WithParameters(features)
                        .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 callElasticSearch =
                     MethodBuilder<Func<object, object, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData)
@@ -119,7 +119,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<object, object, CancellationToken, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, nameof(CallElasticsearchAsync))
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(CallElasticsearchAsync))
                        .WithConcreteType(pipeline.GetType())
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData, cancellationToken)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="requestData">The request data</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = ElasticsearchAssembly,
@@ -37,7 +38,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "Elasticsearch.Net.ElasticsearchResponse`1<T>", "Elasticsearch.Net.RequestData" },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
-        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode, int mdToken)
+        public static object CallElasticsearch<TResponse>(
+            object pipeline,
+            object requestData,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             const string methodName = nameof(CallElasticsearch);
             Func<object, object, object> callElasticSearch;
@@ -48,11 +54,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 callElasticSearch =
                     MethodBuilder<Func<object, object, object>>
-                    .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
-                    .WithConcreteType(pipelineType)
-                    .WithMethodGenerics(genericArgument)
-                    .WithParameters(requestData)
-                    .Build();
+                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .WithConcreteType(pipelineType)
+                       .WithMethodGenerics(genericArgument)
+                       .WithParameters(requestData)
+                       .Build();
             }
             catch (Exception ex)
             {
@@ -84,6 +90,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = ElasticsearchAssembly,
@@ -92,7 +99,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<Elasticsearch.Net.ElasticsearchResponse`1<T>>", "Elasticsearch.Net.RequestData", ClrNames.CancellationToken },
             TargetMinimumVersion = Version5,
             TargetMaximumVersion = Version5)]
-        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode, int mdToken)
+        public static object CallElasticsearchAsync<TResponse>(
+            object pipeline,
+            object requestData,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 callElasticSearch =
                     MethodBuilder<Func<object, object, TResponse>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData)
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
-            return CallElasticsearchAsyncInternal<TResponse>(pipeline, requestData, cancellationToken, opCode, mdToken, Assembly.GetCallingAssembly());
+            return CallElasticsearchAsyncInternal<TResponse>(pipeline, requestData, cancellationToken, opCode, mdToken, moduleVersionPtr);
         }
 
         /// <summary>
@@ -118,9 +118,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationToken">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
-        /// <param name="callingAssembly">The calling assembly of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original result</returns>
-        private static async Task<TResponse> CallElasticsearchAsyncInternal<TResponse>(object pipeline, object requestData, CancellationToken cancellationToken, int opCode, int mdToken, Assembly callingAssembly)
+        private static async Task<TResponse> CallElasticsearchAsyncInternal<TResponse>(
+            object pipeline,
+            object requestData,
+            CancellationToken cancellationToken,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             const string methodName = "CallElasticsearchAsync";
             Func<object, object, CancellationToken, Task<TResponse>> callElasticSearchAsync;
@@ -131,7 +137,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 callElasticSearchAsync =
                     MethodBuilder<Func<object, object, CancellationToken, Task<TResponse>>>
-                       .Start(callingAssembly, mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData, cancellationToken)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="requestData">The request data</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -34,7 +35,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "T", "Elasticsearch.Net.RequestData" },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
-        public static object CallElasticsearch<TResponse>(object pipeline, object requestData, int opCode, int mdToken)
+        public static object CallElasticsearch<TResponse>(
+            object pipeline,
+            object requestData,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             const string methodName = nameof(CallElasticsearch);
             Func<object, object, TResponse> callElasticSearch;
@@ -45,11 +51,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 callElasticSearch =
                     MethodBuilder<Func<object, object, TResponse>>
-                    .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
-                    .WithConcreteType(pipelineType)
-                    .WithMethodGenerics(genericArgument)
-                    .WithParameters(requestData)
-                    .Build();
+                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .WithConcreteType(pipelineType)
+                       .WithMethodGenerics(genericArgument)
+                       .WithParameters(requestData)
+                       .Build();
             }
             catch (Exception ex)
             {
@@ -81,6 +87,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "Elasticsearch.Net",
@@ -89,7 +96,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "Elasticsearch.Net.RequestData", ClrNames.CancellationToken },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
-        public static object CallElasticsearchAsync<TResponse>(object pipeline, object requestData, object cancellationTokenSource, int opCode, int mdToken)
+        public static object CallElasticsearchAsync<TResponse>(
+            object pipeline,
+            object requestData,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             var tokenSource = cancellationTokenSource as CancellationTokenSource;
             var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
@@ -118,11 +131,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 callElasticSearchAsync =
                     MethodBuilder<Func<object, object, CancellationToken, Task<TResponse>>>
-                    .Start(callingAssembly, mdToken, opCode, methodName)
-                    .WithConcreteType(pipelineType)
-                    .WithMethodGenerics(genericArgument)
-                    .WithParameters(requestData, cancellationToken)
-                    .Build();
+                       .Start(callingAssembly, mdToken, opCode, methodName)
+                       .WithConcreteType(pipelineType)
+                       .WithMethodGenerics(genericArgument)
+                       .WithParameters(requestData, cancellationToken)
+                       .Build();
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -153,8 +153,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 var graphQLAssembly = AppDomain.CurrentDomain.GetAssemblies()
-                                        .Where(a => a.GetName().Name.Equals(GraphQLAssemblyName))
-                                        .Single();
+                                               .Single(a => a.GetName().Name.Equals(GraphQLAssemblyName));
                 graphQLExecutionResultType = graphQLAssembly.GetType(GraphQLExecutionResultName, throwOnError: true);
                 executionStrategyInterfaceType = graphQLAssembly.GetType(GraphQLExecutionStrategyInterfaceName, throwOnError: true);
             }
@@ -162,7 +161,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 // This shouldn't happen because the GraphQL assembly should have been loaded to construct various other types
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error finding types in the GraphQL assembly.", ex);
+                Log.ErrorException("Error finding types in the GraphQL assembly.", ex);
                 throw;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<object, object, object, object, object, object, object, object>>
-                        .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                         .WithConcreteType(documentValidatorInstanceType)
                         .WithParameters(originalQuery, schema, document, rules, userContext, inputs)
                         .Build();
@@ -174,7 +174,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<object, object, object>>
-                        .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                         .WithConcreteType(executionStrategyInstanceType)
                         .WithParameters(context)
                         .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -48,6 +48,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="inputs">The input variables.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetAssembly = GraphQLAssemblyName,
@@ -64,7 +65,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object userContext,
             object inputs,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             if (documentValidator == null) { throw new ArgumentNullException(nameof(documentValidator)); }
 
@@ -132,6 +134,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="context">The execution context of the GraphQL operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetAssembly = GraphQLAssemblyName,
@@ -139,7 +142,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { TaskOfGraphQLExecutionResult, "GraphQL.Execution.ExecutionContext" },
             TargetMinimumVersion = Major2Minor3,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsync(object executionStrategy, object context, int opCode, int mdToken)
+        public static object ExecuteAsync(object executionStrategy, object context, int opCode, int mdToken, long moduleVersionPtr)
         {
             if (executionStrategy == null) { throw new ArgumentNullException(nameof(executionStrategy)); }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, SendAsync)
+                       .Start(moduleVersionPtr, mdToken, opCode, SendAsync)
                        .WithConcreteType(httpMessageHandler)
                        .WithParameters(request, cancellationToken)
                        .Build();
@@ -120,7 +120,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 instrumentedMethod =
                     MethodBuilder<Func<HttpMessageHandler, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, SendAsync)
+                       .Start(moduleVersionPtr, mdToken, opCode, SendAsync)
                        .WithConcreteType(httpClientHandler)
                        .WithParameters(request, cancellationToken)
                        .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
@@ -46,7 +47,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object request,
             object cancellationTokenSource,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             // original signature:
             // Task<HttpResponseMessage> HttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -88,6 +90,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
@@ -101,7 +104,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object request,
             object cancellationTokenSource,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             // original signature:
             // Task<HttpResponseMessage> HttpClientHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -35,6 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
@@ -42,7 +43,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Void, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken },
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
-        public static object Execute(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
+        public static object Execute(
+            object wireProtocol,
+            object connection,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
@@ -91,6 +98,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetAssembly = MongoDbClientAssembly,
@@ -99,7 +107,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = nameof(Execute),
             TargetMinimumVersion = Major2Minor2,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
+        public static object ExecuteGeneric(
+            object wireProtocol,
+            object connection,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
@@ -148,6 +162,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetMethod = nameof(ExecuteAsync),
@@ -156,7 +171,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Task, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsync(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
+        public static object ExecuteAsync(
+            object wireProtocol,
+            object connection,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
@@ -197,6 +218,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="cancellationTokenSource">A cancellation token source.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original method's return value.</returns>
         [InterceptMethod(
             TargetMethod = nameof(ExecuteAsync),
@@ -205,7 +227,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken },
             TargetMinimumVersion = Major2Minor1,
             TargetMaximumVersion = Major2)]
-        public static object ExecuteAsyncGeneric(object wireProtocol, object connection, object cancellationTokenSource, int opCode, int mdToken)
+        public static object ExecuteAsyncGeneric(
+            object wireProtocol,
+            object connection,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             // The generic type for this method comes from the declaring type of wireProtocol
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 execute =
                     MethodBuilder<Func<object, object, CancellationToken, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(wireProtocolType)
                        .WithParameters(connection, cancellationToken)
                        .Build();
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 execute =
                     MethodBuilder<Func<object, object, CancellationToken, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(wireProtocolType)
                        .WithParameters(connection, cancellationToken)
                        .Build();
@@ -194,7 +194,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 executeAsync =
                     MethodBuilder<Func<object, object, CancellationToken, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(wireProtocolType)
                        .WithDeclaringTypeGenerics(wireProtocolGenericArgs)
                        .WithParameters(connection, cancellationToken)
@@ -251,7 +251,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 executeAsync =
                     MethodBuilder<Func<object, object, CancellationToken, object>>
-                       .Start(Assembly.GetCallingAssembly(), mdToken, opCode, methodName)
+                       .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(wireProtocolType)
                        .WithDeclaringTypeGenerics(wireProtocolGenericArgs)
                        .WithParameters(connection, cancellationToken)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -48,14 +48,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             int mdToken,
             long moduleVersionPtr)
         {
-            Func<object, byte[][], object, object, bool, T> instrumentedMethod = null;
+            Func<object, byte[][], object, object, bool, T> instrumentedMethod;
 
             try
             {
                 var instrumentedType = redisNativeClient.GetInstrumentedType(RedisNativeClient);
                 instrumentedMethod =
                     MethodBuilder<Func<object, byte[][], object, object, bool, T>>
-                       .Start(instrumentedType.Assembly, mdToken, opCode, nameof(SendReceive))
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(SendReceive))
                        .WithConcreteType(instrumentedType)
                        .WithParameters(cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead)
                        .WithMethodGenerics(typeof(T))

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="sendWithoutRead">Whether or to send without waiting for the result</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The original result</returns>
         [InterceptMethod(
             CallerAssembly = "ServiceStack.Redis",
@@ -44,7 +45,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             object completePipelineFn,
             bool sendWithoutRead,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             Func<object, byte[][], object, object, bool, T> instrumentedMethod = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="server">The server to call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The result</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -49,7 +50,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             object processor,
             object server,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             var resultType = typeof(T);
             var multiplexerType = multiplexer.GetType();
@@ -59,12 +61,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             var serverType = asm.GetType("StackExchange.Redis.ServerEndPoint");
 
             var originalMethod = Emit.DynamicMethodBuilder<Func<object, object, object, object, T>>
-               .CreateMethodCallDelegate(
-                    multiplexerType,
-                    methodName: "ExecuteSyncImpl",
-                    (OpCodeValue)opCode,
-                    methodParameterTypes: new[] { messageType, processorType, serverType },
-                    methodGenericArguments: new[] { resultType });
+                                     .CreateMethodCallDelegate(
+                                          multiplexerType,
+                                          methodName: "ExecuteSyncImpl",
+                                          (OpCodeValue)opCode,
+                                          methodParameterTypes: new[] { messageType, processorType, serverType },
+                                          methodGenericArguments: new[] { resultType });
 
             using (var scope = CreateScope(multiplexer, message))
             {
@@ -91,6 +93,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="server">The server to call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>An asynchronous task.</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -115,7 +118,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             object state,
             object server,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             var callOpCode = (OpCodeValue)opCode;
             return ExecuteAsyncImplInternal<T>(multiplexer, message, processor, state, server, callOpCode);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -59,8 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             int mdToken,
             long moduleVersionPtr)
         {
-            var callingAssembly = Assembly.GetCallingAssembly();
-            return ExecuteAsyncInternal<T>(redisBase, message, processor, server, opCode, mdToken, callingAssembly);
+            return ExecuteAsyncInternal<T>(redisBase, message, processor, server, opCode, mdToken, moduleVersionPtr);
         }
 
         /// <summary>
@@ -73,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="server">The server</param>
         /// <param name="callOpCode">The <see cref="OpCodeValue"/> used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
-        /// <param name="callingAssembly">The assembly of the method the invoked the target method.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>An asynchronous task.</returns>
         private static async Task<T> ExecuteAsyncInternal<T>(
             object redisBase,
@@ -82,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             object server,
             int callOpCode,
             int mdToken,
-            Assembly callingAssembly)
+            long moduleVersionPtr)
         {
             var thisType = redisBase.GetType();
 
@@ -96,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             }
 
             var instrumentedMethod = MethodBuilder<Func<object, object, object, object, Task<T>>>
-                                    .Start(callingAssembly, mdToken, callOpCode, nameof(ExecuteAsync))
+                                    .Start(moduleVersionPtr, mdToken, callOpCode, nameof(ExecuteAsync))
                                     .WithConcreteType(_redisBaseType)
                                     .WithMethodGenerics(typeof(T))
                                     .WithParameters(message, processor, server)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -32,6 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <param name="server">The server</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>An asynchronous task.</returns>
         [InterceptMethod(
             Integration = IntegrationName,
@@ -55,7 +56,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             object processor,
             object server,
             int opCode,
-            int mdToken)
+            int mdToken,
+            long moduleVersionPtr)
         {
             var callingAssembly = Assembly.GetCallingAssembly();
             return ExecuteAsyncInternal<T>(redisBase, message, processor, server, opCode, mdToken, callingAssembly);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="currentOperationContext">A System.ServiceModel.OperationContext instance.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssembly = "System.ServiceModel",
@@ -31,7 +32,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { ClrNames.Bool, "System.ServiceModel.Channels.RequestContext", "System.ServiceModel.OperationContext" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static bool HandleRequest(object thisObj, object requestContext, object currentOperationContext, int opCode, int mdToken)
+        public static bool HandleRequest(
+            object thisObj,
+            object requestContext,
+            object currentOperationContext,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
         {
             var handleRequestDelegate = Emit.DynamicMethodBuilder<Func<object, object, object, bool>>
                                             .GetOrCreateMethodCallDelegate(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="webRequest">The <see cref="WebRequest"/> instance to instrument.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System", // .NET Framework
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Net.WebResponse" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object GetResponse(object webRequest, int opCode, int mdToken)
+        public static object GetResponse(object webRequest, int opCode, int mdToken, long moduleVersionPtr)
         {
             var request = (WebRequest)webRequest;
 
@@ -74,6 +75,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="request">The <see cref="WebRequest"/> instance to instrument.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = "System.Net",
@@ -81,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Net.WebResponse>" },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
-        public static object GetResponseAsync(object request, int opCode, int mdToken)
+        public static object GetResponseAsync(object request, int opCode, int mdToken, long moduleVersionPtr)
         {
             return GetResponseAsyncInternal((WebRequest)request);
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -504,11 +504,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
         // Drop out for safety
         if (debug_logging_enabled) {
           Debug(
-              "JITCompilationStarted skipping method: signature too short. "
-              "function_id=",
+              "JITCompilationStarted skipping function call: wrapper signature "
+              "too short. function_id=",
               function_id, " token=", function_token,
-              " name=", caller.type.name, ".", caller.name, "()",
-              " wrapper_method_signature_size=", wrapper_method_signature_size);
+              " wrapper_method=", method_replacement.wrapper_method.type_name,
+              ".", method_replacement.wrapper_method.method_name,
+              "() wrapper_method_signature_size=",
+              wrapper_method_signature_size);
         }
 
         continue;
@@ -532,11 +534,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
         // Number of arguments does not match our wrapper method
         if (debug_logging_enabled) {
           Debug(
-              "JITCompilationStarted skipping method: argument counts don't "
-              "match. function_id=",
+              "JITCompilationStarted skipping function call: argument counts "
+              "don't match. function_id=",
               function_id, " token=", function_token,
-              " name=", caller.type.name, ".", caller.name, "()",
-              " expected_number_args=", expected_number_args,
+              " target_name=", target.type.name, ".", target.name,
+              "() expected_number_args=", expected_number_args,
               " target_arg_count=", target_arg_count);
         }
 
@@ -569,10 +571,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       if (!successfully_parsed_signature) {
         if (debug_logging_enabled) {
           Debug(
-              "JITCompilationStarted skipping method: failed to parse "
+              "JITCompilationStarted skipping function call: failed to parse "
               "signature. function_id=",
               function_id, " token=", function_token,
-              " name=", caller.type.name, ".", caller.name, "()",
+              " target_name=", target.type.name, ".", target.name, "()",
               " successfully_parsed_signature=", successfully_parsed_signature,
               " sig_types.size()=", sig_types.size(),
               " expected_sig_types.size()=", expected_sig_types.size());
@@ -585,11 +587,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
         // we can't safely assume our wrapper methods handle the types
         if (debug_logging_enabled) {
           Debug(
-              "JITCompilationStarted skipping method: unexpected type count. "
-              "function_id=",
+              "JITCompilationStarted skipping function call: unexpected type "
+              "count. function_id=",
               function_id, " token=", function_token,
-              " name=", caller.type.name, ".", caller.name, "()",
-              " successfully_parsed_signature=", successfully_parsed_signature,
+              " target_name=", target.type.name, ".", target.name,
+              "() successfully_parsed_signature=",
+              successfully_parsed_signature,
               " sig_types.size()=", sig_types.size(),
               " expected_sig_types.size()=", expected_sig_types.size());
         }
@@ -607,12 +610,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
           // we have a type mismatch, drop out
           if (debug_logging_enabled) {
             Debug(
-                "JITCompilationStarted skipping method: types don't match. "
-                "function_id=",
+                "JITCompilationStarted skipping function call: types don't "
+                "match. function_id=",
                 function_id, " token=", function_token,
-                " name=", caller.type.name, ".", caller.name, "()",
-                " expected_sig_types[", i, "]=", expected_sig_types[i],
-                " sig_types[", i, "]=", sig_types[i]);
+                " target_name=", target.type.name, ".", target.name,
+                "() sig_types[", i, "]=", sig_types[i], "expected_sig_types[",
+                i, "]=", expected_sig_types[i]);
           }
 
           is_match = false;
@@ -631,8 +634,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
             "JITCompilationStarted skipping method: Method replacement "
             "found but the managed profiler has not yet been loaded. "
             "function_id=",
-            function_id, " token=", function_token, " name=", caller.type.name,
-            ".", caller.name, "()");
+            function_id, " token=", function_token, " target_name=", target.type.name,
+            ".", target.name, "()");
         continue;
       }
 #endif

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -649,6 +649,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       rewriter_wrapper.LoadInt32(pInstr->m_opcode);
       rewriter_wrapper.LoadInt32(method_def_md_token);
 
+      void* module_version_id = &module_metadata->module_version_id;
+      rewriter_wrapper.LoadInt64(reinterpret_cast<INT64>(module_version_id));
+
       // always use CALL because the wrappers methods are all static
       pInstr->m_opcode = CEE_CALL;
       // replace with a call to the instrumentation wrapper

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -642,6 +642,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
 #endif
 
       const auto original_argument = pInstr->m_Arg32;
+      const void* module_version_id_ptr = &module_metadata->module_version_id;
 
       // insert the opcode and signature token as
       // additional arguments for the wrapper method
@@ -649,9 +650,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       rewriter_wrapper.SetILPosition(pInstr);
       rewriter_wrapper.LoadInt32(pInstr->m_opcode);
       rewriter_wrapper.LoadInt32(method_def_md_token);
-
-      void* module_version_id = &module_metadata->module_version_id;
-      rewriter_wrapper.LoadInt64(reinterpret_cast<INT64>(module_version_id));
+      rewriter_wrapper.LoadInt64(reinterpret_cast<INT64>(module_version_id_ptr));
 
       // always use CALL because the wrappers methods are all static
       pInstr->m_opcode = CEE_CALL;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -521,6 +521,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
       auto expected_number_args = method_replacement.wrapper_method
                                       .method_signature.NumberOfArguments();
 
+      // subtract the last arguments we add to every wrapper
       expected_number_args = expected_number_args - added_parameters_count;
 
       if (target.signature.IsInstanceMethod()) {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void WrapperMethodHasMdTokenArgument(MethodInfo wrapperMethod)
         {
             // all wrapper methods should have an additional Int32
-            // parameter for the original method call's opcode
+            // parameter for the original method call's mdToken
             var parameters = wrapperMethod.GetParameters();
             var param = parameters[parameters.Length - 2];
             Assert.Equal(typeof(int), param.ParameterType);
@@ -61,8 +61,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [MemberData(nameof(GetWrapperMethods))]
         public void WrapperMethodHasModuleVersionPtrArgument(MethodInfo wrapperMethod)
         {
-            // all wrapper methods should have an additional Int32
-            // parameter for the original method call's opcode
+            // all wrapper methods should have an additional Int64
+            // parameter for the address of calling module's moduleVersionId
             var parameters = wrapperMethod.GetParameters();
             var param = parameters[parameters.Length - 1];
             Assert.Equal(typeof(long), param.ParameterType);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -40,9 +40,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // all wrapper methods should have an additional Int32
             // parameter for the original method call's opcode
             var parameters = wrapperMethod.GetParameters();
-            ParameterInfo expectedOpCodeParam = parameters[parameters.Length - 2];
-            Assert.Equal(typeof(int), expectedOpCodeParam.ParameterType);
-            Assert.Equal("opCode", expectedOpCodeParam.Name);
+            var param = parameters[parameters.Length - 3];
+            Assert.Equal(typeof(int), param.ParameterType);
+            Assert.Equal("opCode", param.Name);
         }
 
         [Theory]
@@ -52,9 +52,21 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // all wrapper methods should have an additional Int32
             // parameter for the original method call's opcode
             var parameters = wrapperMethod.GetParameters();
-            ParameterInfo expectedOpCodeParam = parameters.Last();
-            Assert.Equal(typeof(int), expectedOpCodeParam.ParameterType);
-            Assert.Equal("mdToken", expectedOpCodeParam.Name);
+            var param = parameters[parameters.Length - 2];
+            Assert.Equal(typeof(int), param.ParameterType);
+            Assert.Equal("mdToken", param.Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetWrapperMethods))]
+        public void WrapperMethodHasModuleVersionPtrArgument(MethodInfo wrapperMethod)
+        {
+            // all wrapper methods should have an additional Int32
+            // parameter for the original method call's opcode
+            var parameters = wrapperMethod.GetParameters();
+            var param = parameters[parameters.Length - 1];
+            Assert.Equal(typeof(long), param.ParameterType);
+            Assert.Equal("moduleVersionPtr", param.Name);
         }
 
         [Theory]
@@ -65,13 +77,13 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 attribute.TargetSignatureTypes != null,
                 $"{wrapperMethod.DeclaringType.Name}.{wrapperMethod.Name}: {nameof(attribute.TargetSignatureTypes)} definition missing.");
 
-            // Return type and opcode and cancel out for count
-            // mdToken means minus 1
-            var expectedParameterCount = wrapperMethod.GetParameters().Length - 1;
+            // add 1 for return type, subtract 3 for extra parameters (opcode, mdToken, moduleVersionPtr)
+            // 1 - 3 = -2
+            var expectedParameterCount = wrapperMethod.GetParameters().Length - 2;
 
             if (!StaticInstrumentations.Contains(wrapperMethod))
             {
-                // Subtract for the instance (this) parameter
+                // Subtract the instance (this) parameter
                 expectedParameterCount--;
             }
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
     /// </summary>
     public class MethodBuilderTests
     {
-        private readonly Assembly _thisAssembly = Assembly.GetExecutingAssembly();
+        private readonly Guid _moduleVersionId = Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
         private readonly Type _testType = typeof(ObscenelyAnnoyingClass);
 
         [Fact]
@@ -243,7 +243,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var expected = MethodReference.Get(() => instance.Method(parameter));
 
             var methodResult = MethodBuilder<Action<object, object>> // Proper use should be Action<object, string>
-                              .Start(_thisAssembly, wrongMethod.MetadataToken, (int)OpCodeValue.Callvirt, "Method")
+                              .Start(_moduleVersionId, wrongMethod.MetadataToken, (int)OpCodeValue.Callvirt, "Method")
                               .WithConcreteType(_testType)
                               .WithParameters(parameter) // The parameter is the saving grace
                               .Build();
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         private MethodBuilder<T> Build<T>(string methodName, Type overrideType = null)
         {
             return MethodBuilder<T>
-                  .Start(_thisAssembly, 0, (int)OpCodeValue.Callvirt, methodName)
+                  .Start(_moduleVersionId, 0, (int)OpCodeValue.Callvirt, methodName)
                   .WithConcreteType(overrideType ?? _testType);
         }
     }

--- a/tools/GenerateIntegrationDefinitions/Program.cs
+++ b/tools/GenerateIntegrationDefinitions/Program.cs
@@ -105,6 +105,16 @@ namespace GenerateIntegrationDefinitions
             var returnType = method.ReturnType;
             var parameters = method.GetParameters().Select(p => p.ParameterType).ToArray();
 
+            var requiredParameterTypes = new[] { typeof(int), typeof(int), typeof(long) };
+            var lastParameterTypes = parameters.Skip(parameters.Length - requiredParameterTypes.Length).ToArray();
+
+            if (!lastParameterTypes.SequenceEqual(requiredParameterTypes))
+            {
+                  throw new Exception(
+                    $"Method {method.DeclaringType.FullName}.{method.Name}() does not meet parameter requirements. " +
+                    "Wrapper methods must have at least 3 parameters and the last 3 must be of types Int32 (opCode), Int32 (mdToken), and Int64 (moduleVersionPtr).");
+            }
+
             var signatureHelper = SignatureHelper.GetMethodSigHelper(method.CallingConvention, returnType);
             signatureHelper.AddArguments(parameters, requiredCustomModifiers: null, optionalCustomModifiers: null);
             var signatureBytes = signatureHelper.GetSignature();

--- a/tools/GenerateIntegrationDefinitions/Program.cs
+++ b/tools/GenerateIntegrationDefinitions/Program.cs
@@ -106,7 +106,7 @@ namespace GenerateIntegrationDefinitions
             var parameters = method.GetParameters().Select(p => p.ParameterType).ToArray();
 
             var requiredParameterTypes = new[] { typeof(int), typeof(int), typeof(long) };
-            var lastParameterTypes = parameters.Skip(parameters.Length - requiredParameterTypes.Length).ToArray();
+            var lastParameterTypes = parameters.Skip(parameters.Length - requiredParameterTypes.Length);
 
             if (!lastParameterTypes.SequenceEqual(requiredParameterTypes))
             {


### PR DESCRIPTION
Changes proposed in this pull request:
- CLR Profiler
  - push `module_version_id` pointer onto stack before calling wrapper methods
  - change some log message to include the name of the target method instead of the caller
- Integrations
  - add `long moduleVersionPtr` parameter to every integration wrapper method
  - add `MethodBuild.Start()` overload that takes `long moduleVersionPtr`
  - replace uses of `Assembly.GetCallingAssembly()` with `moduleVersionPtr`

