### PR TITLE
migrate more integrations to newer MethodBuilder

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -81,12 +81,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return this;
         }
 
-        public MethodBuilder<TDelegate> WithConcreteTypeName(string typeName)
-        {
-            var concreteType = _resolutionModule?.GetType(typeName);
-            return this.WithConcreteType(concreteType);
-        }
-
         public MethodBuilder<TDelegate> WithNamespaceAndNameFilters(params string[] namespaceNameFilters)
         {
             _namespaceAndNameFilter = namespaceNameFilters;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -312,7 +312,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             var shouldTrace = Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName);
 
-            Action<object> instrumentedMethod = null;
+            Action<object> instrumentedMethod;
 
             try
             {
@@ -327,8 +327,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                var contextTypeName = (context == null) ? string.Empty : (context.GetType().FullName + " ");
-                var methodDef = $"{ResourceInvoker}.{nameof(Rethrow)}({contextTypeName}context)";
+                var contextTypeName = context.GetType().FullName + " ";
+                var methodDef = $"{ResourceInvoker}.{nameof(Rethrow)}({contextTypeName} context)";
                 Log.ErrorException($"Error retrieving {methodDef}", ex);
                 throw;
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -29,6 +29,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         private const string ResourceInvoker = "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker";
 
+        private static readonly Type DiagnosticSourceType = Type.GetType($"{DiagnosticSource}, {AspnetMvcCore}");
+        private static readonly Type ResourceInvokerType = Type.GetType($"{ResourceInvoker}, {AspnetMvcCore}");
         private static readonly ILog Log = LogProvider.GetLogger(typeof(AspNetCoreMvc2Integration));
 
         private readonly object _httpContext;
@@ -168,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 instrumentedMethod =
                     MethodBuilder<Action<object, object, object, object>>
                        .Start(moduleVersionPtr, mdToken, opCode, nameof(BeforeAction))
-                       .WithConcreteTypeName(DiagnosticSource)
+                       .WithConcreteType(DiagnosticSourceType)
                        .WithParameters(diagnosticSource, actionDescriptor, httpContext, routeData)
                        .WithNamespaceAndNameFilters(
                             ClrNames.Void,
@@ -251,7 +253,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 instrumentedMethod =
                     MethodBuilder<Action<object, object, object, object>>
                        .Start(moduleVersionPtr, mdToken, opCode, nameof(AfterAction))
-                       .WithConcreteTypeName(DiagnosticSource)
+                       .WithConcreteType(DiagnosticSourceType)
                        .WithParameters(diagnosticSource, actionDescriptor, httpContext, routeData)
                        .WithNamespaceAndNameFilters(
                             ClrNames.Void,
@@ -317,7 +319,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 instrumentedMethod =
                     MethodBuilder<Action<object>>
                        .Start(moduleVersionPtr, mdToken, opCode, nameof(Rethrow))
-                       .WithConcreteTypeName(ResourceInvoker)
+                       .WithConcreteType(ResourceInvokerType)
                        .WithParameters(context)
                        .WithNamespaceAndNameFilters(ClrNames.Void, ClrNames.Ignore)
                        .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -22,15 +22,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <summary>
         /// Type for unobtrusive hooking into Microsoft.AspNetCore.Mvc.Core pipeline.
         /// </summary>
-        private const string DiagnosticSource = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions";
+        private const string DiagnosticSourceTypeName = "Microsoft.AspNetCore.Mvc.Internal.MvcCoreDiagnosticSourceExtensions";
 
         /// <summary>
         /// Base type used for traversing the pipeline in Microsoft.AspNetCore.Mvc.Core.
         /// </summary>
-        private const string ResourceInvoker = "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker";
+        private const string ResourceInvokerTypeName = "Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker";
 
-        private static readonly Type DiagnosticSourceType = Type.GetType($"{DiagnosticSource}, {AspnetMvcCore}");
-        private static readonly Type ResourceInvokerType = Type.GetType($"{ResourceInvoker}, {AspnetMvcCore}");
+        private static readonly Type DiagnosticSourceType = Type.GetType($"{DiagnosticSourceTypeName}, {AspnetMvcCore}");
+        private static readonly Type ResourceInvokerType = Type.GetType($"{ResourceInvokerTypeName}, {AspnetMvcCore}");
         private static readonly ILog Log = LogProvider.GetLogger(typeof(AspNetCoreMvc2Integration));
 
         private readonly object _httpContext;
@@ -49,14 +49,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 var request = _httpContext.GetProperty("Request").GetValueOrDefault();
 
                 GetTagValues(
-                   actionDescriptor,
-                   request,
-                   out string httpMethod,
-                   out string host,
-                   out string resourceName,
-                   out string url,
-                   out string controllerName,
-                   out string actionName);
+                    actionDescriptor,
+                    request,
+                    out string httpMethod,
+                    out string host,
+                    out string resourceName,
+                    out string url,
+                    out string controllerName,
+                    out string actionName);
 
                 SpanContext propagatedContext = null;
                 var tracer = Tracer.Instance;
@@ -96,10 +96,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 var span = _scope.Span;
 
                 span.DecorateWebServerSpan(
-                   resourceName: resourceName,
-                   method: httpMethod,
-                   host: host,
-                   httpUrl: url);
+                    resourceName: resourceName,
+                    method: httpMethod,
+                    host: host,
+                    httpUrl: url);
 
                 span.SetTag(Tags.AspNetController, controllerName);
                 span.SetTag(Tags.AspNetAction, actionName);
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
-            TargetType = DiagnosticSource,
+            TargetType = DiagnosticSourceTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor", "Microsoft.AspNetCore.Http.HttpContext", "Microsoft.AspNetCore.Routing.RouteData" },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
@@ -183,7 +183,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will continue working as expected without this method
-                Log.ErrorException($"Error resolving {DiagnosticSource}.{nameof(BeforeAction)}(...)", ex);
+                Log.ErrorException($"Error resolving {DiagnosticSourceTypeName}.{nameof(BeforeAction)}(...)", ex);
             }
 
             try
@@ -211,7 +211,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
-            TargetType = DiagnosticSource,
+            TargetType = DiagnosticSourceTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor", "Microsoft.AspNetCore.Http.HttpContext", "Microsoft.AspNetCore.Routing.RouteData" },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
@@ -246,7 +246,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             Action<object, object, object, object> instrumentedMethod = null;
 
-            string methodDef = $"{DiagnosticSource}.{nameof(AfterAction)}(...)";
+            string methodDef = $"{DiagnosticSourceTypeName}.{nameof(AfterAction)}(...)";
 
             try
             {
@@ -296,7 +296,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
-            TargetType = ResourceInvoker,
+            TargetType = ResourceInvokerTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
@@ -328,7 +328,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 // profiled app will not continue working as expected without this method
                 var contextTypeName = context.GetType().FullName + " ";
-                var methodDef = $"{ResourceInvoker}.{nameof(Rethrow)}({contextTypeName} context)";
+                var methodDef = $"{ResourceInvokerTypeName}.{nameof(Rethrow)}({contextTypeName} context)";
                 Log.ErrorException($"Error retrieving {methodDef}", ex);
                 throw;
             }
@@ -396,14 +396,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         }
 
         private static void GetTagValues(
-           object actionDescriptor,
-           object request,
-           out string httpMethod,
-           out string host,
-           out string resourceName,
-           out string url,
-           out string controllerName,
-           out string actionName)
+            object actionDescriptor,
+            object request,
+            out string httpMethod,
+            out string host,
+            out string resourceName,
+            out string url,
+            out string controllerName,
+            out string actionName)
         {
             controllerName = actionDescriptor.GetProperty<string>("ControllerName").GetValueOrDefault()?.ToLowerInvariant();
 
@@ -422,7 +422,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             url = $"{pathBase}{path}{queryString}";
 
             string resourceUrl = actionDescriptor.GetProperty("AttributeRouteInfo").GetProperty<string>("Template").GetValueOrDefault() ??
-                                UriHelpers.GetRelativeUrl(new Uri($"https://{host}{url}"), tryRemoveIds: true).ToLowerInvariant();
+                                 UriHelpers.GetRelativeUrl(new Uri($"https://{host}{url}"), tryRemoveIds: true).ToLowerInvariant();
 
             resourceName = $"{httpMethod} {resourceUrl}";
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -23,11 +23,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string Major5Minor1 = "5.1";
         private const string Major5 = "5";
         private const string AssemblyName = "System.Web.Mvc";
+
         private const string AsyncActionInvokerTypeName = "System.Web.Mvc.Async.IAsyncActionInvoker";
+        private const string ControllerContextTypeName = "System.Web.Mvc.ControllerContext";
+        private const string RouteCollectionRouteTypeName = "System.Web.Mvc.Routing.RouteCollectionRoute";
 
         private static readonly Type ControllerContextType = Type.GetType($"System.Web.Mvc.ControllerContext, {AssemblyName}", throwOnError: false);
         private static readonly Type RouteCollectionRouteType = Type.GetType($"System.Web.Mvc.Routing.RouteCollectionRoute, {AssemblyName}", throwOnError: false);
         private static readonly Type AsyncActionInvokerType = Type.GetType($"{AsyncActionInvokerTypeName}, {AssemblyName}", throwOnError: false);
+
         private static readonly ILog Log = LogProvider.GetLogger(typeof(AspNetMvcIntegration));
 
         /// <summary>
@@ -173,7 +177,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = AssemblyName,
             TargetAssembly = AssemblyName,
             TargetType = AsyncActionInvokerTypeName,
-            TargetSignatureTypes = new[] { ClrNames.IAsyncResult, "System.Web.Mvc.ControllerContext", ClrNames.String, ClrNames.AsyncCallback, ClrNames.Object },
+            TargetSignatureTypes = new[] { ClrNames.IAsyncResult, ControllerContextTypeName, ClrNames.String, ClrNames.AsyncCallback, ClrNames.Object },
             TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static object BeginInvokeAction(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -206,9 +206,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
+                var asyncActionInvokerType = asyncControllerActionInvoker.GetInstrumentedType(AsyncActionInvokerTypeName);
+
                 instrumentedMethod = MethodBuilder<Func<object, object, object, object, object, object>>
                                     .Start(moduleVersionPtr, mdToken, opCode, nameof(BeginInvokeAction))
-                                    .WithConcreteType(AsyncActionInvokerType)
+                                    .WithConcreteType(asyncActionInvokerType)
                                     .WithParameters(controllerContext, actionName, callback, state)
                                     .WithNamespaceAndNameFilters(
                                          ClrNames.IAsyncResult,
@@ -275,9 +277,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
+                var asyncActionInvokerType = asyncControllerActionInvoker.GetInstrumentedType(AsyncActionInvokerTypeName);
+
                 instrumentedMethod = MethodBuilder<Func<object, object, bool>>
                                     .Start(moduleVersionPtr, mdToken, opCode, nameof(EndInvokeAction))
-                                    .WithConcreteType(AsyncActionInvokerType)
+                                    .WithConcreteType(asyncActionInvokerType)
                                     .WithParameters(asyncResult)
                                     .WithNamespaceAndNameFilters(ClrNames.Bool, ClrNames.IAsyncResult)
                                     .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -202,7 +202,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
-                var asyncActionInvokerType = asyncControllerActionInvoker.GetInstrumentedType(AsyncActionInvokerTypeName);
+                var asyncActionInvokerType = asyncControllerActionInvoker.GetInstrumentedInterface(AsyncActionInvokerTypeName);
 
                 instrumentedMethod = MethodBuilder<Func<object, object, object, object, object, object>>
                                     .Start(moduleVersionPtr, mdToken, opCode, nameof(BeginInvokeAction))
@@ -273,7 +273,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
-                var asyncActionInvokerType = asyncControllerActionInvoker.GetInstrumentedType(AsyncActionInvokerTypeName);
+                var asyncActionInvokerType = asyncControllerActionInvoker.GetInstrumentedInterface(AsyncActionInvokerTypeName);
 
                 instrumentedMethod = MethodBuilder<Func<object, object, bool>>
                                     .Start(moduleVersionPtr, mdToken, opCode, nameof(EndInvokeAction))

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -28,10 +28,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string ControllerContextTypeName = "System.Web.Mvc.ControllerContext";
         private const string RouteCollectionRouteTypeName = "System.Web.Mvc.Routing.RouteCollectionRoute";
 
-        private static readonly Type ControllerContextType = Type.GetType($"System.Web.Mvc.ControllerContext, {AssemblyName}", throwOnError: false);
-        private static readonly Type RouteCollectionRouteType = Type.GetType($"System.Web.Mvc.Routing.RouteCollectionRoute, {AssemblyName}", throwOnError: false);
-        private static readonly Type AsyncActionInvokerType = Type.GetType($"{AsyncActionInvokerTypeName}, {AssemblyName}", throwOnError: false);
-
         private static readonly ILog Log = LogProvider.GetLogger(typeof(AspNetMvcIntegration));
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
-                var httpControllerType = apiController.GetInstrumentedType(HttpControllerTypeName);
+                var httpControllerType = apiController.GetInstrumentedInterface(HttpControllerTypeName);
 
                 instrumentedMethod = MethodBuilder<Func<object, object, CancellationToken, Task<HttpResponseMessage>>>
                                     .Start(moduleVersionPtr, mdToken, opCode, nameof(ExecuteAsync))

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
         }
 
-        private static Scope CreateScope(dynamic controllerContext)
+        private static Scope CreateScope(object controllerContext)
         {
             Scope scope = null;
 
@@ -135,7 +135,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
 
                 var tracer = Tracer.Instance;
-                var request = controllerContext?.Request as HttpRequestMessage;
+                var request = controllerContext.GetProperty<HttpRequestMessage>("Request").GetValueOrDefault();
                 SpanContext propagatedContext = null;
 
                 if (request != null && tracer.ActiveScope == null)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -82,9 +82,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             try
             {
+                var httpControllerType = apiController.GetInstrumentedType(HttpControllerTypeName);
+
                 instrumentedMethod = MethodBuilder<Func<object, object, CancellationToken, Task<HttpResponseMessage>>>
                                     .Start(moduleVersionPtr, mdToken, opCode, nameof(ExecuteAsync))
-                                    .WithConcreteType(HttpControllerType)
+                                    .WithConcreteType(httpControllerType)
                                     .WithParameters(controllerContext, cancellationToken)
                                     .WithNamespaceAndNameFilters(
                                          ClrNames.HttpResponseMessageTask,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -24,8 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private const string SystemWebHttpAssemblyName = "System.Web.Http";
         private const string HttpControllerTypeName = "System.Web.Http.Controllers.IHttpController";
-
-        private static readonly Type HttpControllerType = Type.GetType($"{HttpControllerTypeName}, {SystemWebHttpAssemblyName}");
+        private const string HttpControllerContextTypeName = "System.Web.Http.Controllers.HttpControllerContext";
 
         private static readonly ILog Log = LogProvider.GetLogger(typeof(AspNetWebApi2Integration));
 
@@ -42,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = SystemWebHttpAssemblyName,
             TargetType = HttpControllerTypeName,
-            TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, "System.Web.Http.Controllers.HttpControllerContext", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, HttpControllerContextTypeName, ClrNames.CancellationToken },
             TargetMinimumVersion = Major5Minor2,
             TargetMaximumVersion = Major5)]
         public static object ExecuteAsync(
@@ -90,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                                     .WithParameters(controllerContext, cancellationToken)
                                     .WithNamespaceAndNameFilters(
                                          ClrNames.HttpResponseMessageTask,
-                                         "System.Web.Http.Controllers.HttpControllerContext",
+                                         HttpControllerContextTypeName,
                                          ClrNames.CancellationToken)
                                     .Build();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Types/TypeExtensions.cs
@@ -25,5 +25,28 @@ namespace Datadog.Trace.ClrProfiler
 
             return null;
         }
+
+        public static System.Type GetInstrumentedInterface(
+            this object runtimeObject,
+            string instrumentedInterfaceName)
+        {
+            if (runtimeObject == null)
+            {
+                return null;
+            }
+
+            var currentType = runtimeObject.GetType();
+            var interfaces = currentType.GetInterfaces();
+
+            foreach (var interfaceType in interfaces)
+            {
+                if ($"{interfaceType.Namespace}.{interfaceType.Name}" == instrumentedInterfaceName)
+                {
+                    return interfaceType;
+                }
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- migrate remaining integrations to use newer `MethodBuilder` to emit dynamic IL
  - [x] ASP.NET MVC
  - [x] ASP.NET Web API
  - [x] WCF
- refactor ASP.NET Core MVC integration to use `MethodBuilder.WithConcreteType(Type)` instead of `MethodBuilder.WithConcreteTypeName(string)`
- remove unused `MethodBuilder.WithConcreteTypeName(string)`
- remove old uses of `dynamic` keyword