### PR TITLE
Convert WebRequestIntegration to MethodBuilder / ModuleVersionId

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object GetResponse(object webRequest, int opCode, int mdToken, long moduleVersionPtr)
         {
             const string methodName = nameof(GetResponse);
-            var webRequestType = webRequest.GetType();
+
             Func<object, WebResponse> callGetResponse;
 
             try
@@ -111,7 +111,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object GetResponseAsync(object webRequest, int opCode, int mdToken, long moduleVersionPtr)
         {
             const string methodName = nameof(GetResponseAsync);
-            var webRequestType = webRequest.GetType();
             Func<object, Task<WebResponse>> callGetResponseAsync;
 
             try

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error retrieving {webRequestType.Name}.{methodName}()", ex);
+                Log.ErrorException($"Error retrieving {instrumentedType.Name}.{methodName}()", ex);
                 throw;
             }
 
@@ -127,7 +127,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error retrieving {webRequestType.Name}.{methodName}()", ex);
+                Log.ErrorException($"Error retrieving {instrumentedType.Name}.{methodName}()", ex);
                 throw;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error retrieving {instrumentedType.Name}.{methodName}()", ex);
+                Log.ErrorException($"Error retrieving System.Net.WebRequest.{methodName}()", ex);
                 throw;
             }
 
@@ -127,7 +127,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             catch (Exception ex)
             {
                 // profiled app will not continue working as expected without this method
-                Log.ErrorException($"Error retrieving {instrumentedType.Name}.{methodName}()", ex);
+                Log.ErrorException($"Error retrieving System.Net.WebRequest.{methodName}()", ex);
                 throw;
             }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -23,6 +23,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();
 
+            Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
             using (var agent = new MockTracerAgent(agentPort))
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"HttpClient Port={httpPort}"))
             {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         /// <summary>
         /// Method to execute a smoke test.
         /// </summary>
-        /// <param name="shouldSerializeTraces">Optimization parameter, pass false when the resulting traces aren't being verified</param>
+        /// <param name="shouldDeserializeTraces">Optimization parameter, pass false when the resulting traces aren't being verified</param>
         protected void CheckForSmoke(bool shouldDeserializeTraces = true)
         {
             var applicationPath = EnvironmentHelper.GetSampleApplicationPath().Replace(@"\\", @"\");
@@ -55,6 +55,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int aspNetCorePort = TcpPortProvider.GetOpenPort(); // unused for now
+            Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
+            Output.WriteLine($"Assigning port {aspNetCorePort} for the aspNetCorePort.");
 
             if (EnvironmentHelper.IsCoreClr())
             {

--- a/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
+++ b/test/Datadog.Trace.TestHelpers/TcpPortProvider.cs
@@ -46,6 +46,9 @@ namespace Datadog.Trace.TestHelpers
             var usedPorts = IPGlobalProperties.GetIPGlobalProperties()
                                               .GetActiveTcpListeners()
                                               .Select(ipEndPoint => ipEndPoint.Port);
+            usedPorts.Concat(IPGlobalProperties.GetIPGlobalProperties()
+                                               .GetActiveTcpConnections()
+                                               .Select(information => information.LocalEndPoint.Port));
 
             return new HashSet<int>(usedPorts);
         }


### PR DESCRIPTION
Changes proposed in this pull request:

Convert the `WebRequest` integration to the `MethodBuilder` API

@DataDog/apm-dotnet