### PR TITLE
Clean up MockTraceAgent, add event-based API

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.TestHelpers
             var deadline = DateTime.Now.AddMilliseconds(timeoutInMilliseconds);
             var minimumOffset = (minDateTime ?? DateTimeOffset.MinValue).ToUnixTimeNanoseconds();
 
-            IImmutableList<Span> relevantSpans = null;
+            IImmutableList<Span> relevantSpans = ImmutableList<Span>.Empty;
 
             while (DateTime.Now < deadline)
             {

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -233,9 +233,17 @@ namespace Datadog.Trace.TestHelpers
             [Key("duration")]
             public long Duration { get; set; }
 
+            [Key("parent_id")]
+            public ulong? ParentId { get; set; }
+
+            [Key("error")]
+            public byte Error { get; set; }
 
             [Key("meta")]
             public Dictionary<string, string> Tags { get; set; }
+
+            [Key("metrics")]
+            public Dictionary<string, double> Metrics { get; set; }
         }
     }
 }

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -56,6 +56,8 @@ namespace Datadog.Trace.TestHelpers
 
         public event EventHandler<EventArgs<HttpListenerContext>> RequestReceived;
 
+        public event EventHandler<EventArgs<IList<IList<Span>>>> RequestDeserialized;
+
         /// <summary>
         /// Gets or sets a value indicating whether to skip serialization of traces.
         /// </summary>
@@ -152,6 +154,11 @@ namespace Datadog.Trace.TestHelpers
             RequestReceived?.Invoke(this, new EventArgs<HttpListenerContext>(context));
         }
 
+        protected virtual void OnRequestDeserialized(IList<IList<Span>> traces)
+        {
+            RequestDeserialized?.Invoke(this, new EventArgs<IList<IList<Span>>>(traces));
+        }
+
         private void AssertHeader(
             NameValueCollection headers,
             string headerKey,
@@ -182,6 +189,7 @@ namespace Datadog.Trace.TestHelpers
                     if (ShouldDeserializeTraces)
                     {
                         var spans = MessagePackSerializer.Deserialize<IList<IList<Span>>>(ctx.Request.InputStream);
+                        OnRequestDeserialized(spans);
 
                         lock (this)
                         {


### PR DESCRIPTION
Changes proposed in this pull request:
- refactor `MockTracerAgent.ToSpans()` to be less ~magical~ `dynamic` and be more static
- add missing properties to the mock `Span` (`ParentId`, `Error`, and the `Metrics` dictionary)
- add `MockTracerAgent.RequestDeserialized` event as a "push" alternative to `WaitForSpans()`