### PR TITLE
Fix Linux packaging build

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -106,6 +106,25 @@ jobs:
     vmImage: ubuntu-16.04
 
   steps:
+  - task: DotNetCoreInstaller@0
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet restore
+    inputs:
+      command: restore
+      projects: src/**/*.csproj
+      vstsFeed: $(packageFeed)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      projects: src/**/.csproj
+      arguments: --configuration $(buildConfiguration)
+
   - task: DockerCompose@0
     displayName: docker-compose run Profiler
     inputs:

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -122,7 +122,7 @@ jobs:
     displayName: dotnet build
     inputs:
       command: build
-      projects: src/**/.csproj
+      projects: src/**/*.csproj
       arguments: --configuration $(buildConfiguration)
 
   - task: DockerCompose@0


### PR DESCRIPTION
Changes proposed in this pull request:
Fix Linux packaging build by building managed components before building the Profiler. The Profiler now needs to embed `Datadog.Trace.ClrProfiler.Managed.Loader` which means it must be built first.

@DataDog/apm-dotnet