### PR TITLE
allow declaring multiple assemblies in a single [InterceptMethod] attribute

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNetIntegration.cs
@@ -35,13 +35,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssembly = FrameworkAssembly, // .NET Framework
-            TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { DbDataReaderTypeName, CommandBehaviorTypeName },
-            TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
-        [InterceptMethod(
-            TargetAssembly = CoreAssembly, // .NET Core
+            TargetAssemblies = new[] { FrameworkAssembly, CoreAssembly },
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { DbDataReaderTypeName, CommandBehaviorTypeName },
             TargetMinimumVersion = Major4,
@@ -110,13 +104,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssembly = FrameworkAssembly, // .NET Framework
-            TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", CommandBehaviorTypeName, ClrNames.CancellationToken },
-            TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
-        [InterceptMethod(
-            TargetAssembly = CoreAssembly, // .NET Core
+            TargetAssemblies = new[] { FrameworkAssembly, CoreAssembly },
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", CommandBehaviorTypeName, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,

--- a/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/InterceptMethodAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace Datadog.Trace.ClrProfiler
 {
@@ -37,9 +38,19 @@ namespace Datadog.Trace.ClrProfiler
 
         /// <summary>
         /// Gets or sets the name of the assembly that contains the target method to be intercepted.
-        /// Required.
+        /// Required if <see cref="TargetAssemblies"/> is not set.
         /// </summary>
-        public string TargetAssembly { get; set; }
+        public string TargetAssembly
+        {
+            get => throw new NotSupportedException("Use property TargetAssemblies instead of TargetAssembly.");
+            set => TargetAssemblies = new[] { value };
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the assemblies that contain the target method to be intercepted.
+        /// Required if <see cref="TargetAssembly"/> is not set.
+        /// </summary>
+        public string[] TargetAssemblies { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the type that contains the target method to be intercepted.

--- a/tools/GenerateIntegrationDefinitions/Program.cs
+++ b/tools/GenerateIntegrationDefinitions/Program.cs
@@ -35,6 +35,7 @@ namespace GenerateIntegrationDefinitions
                                {
                                    name = g.Key,
                                    method_replacements = from item in g
+                                                         from targetAssembly in item.attribute.TargetAssemblies
                                                          select new
                                                          {
                                                              caller = new
@@ -45,7 +46,7 @@ namespace GenerateIntegrationDefinitions
                                                              },
                                                              target = new
                                                              {
-                                                                 assembly = item.attribute.TargetAssembly,
+                                                                 assembly = targetAssembly,
                                                                  type = item.attribute.TargetType,
                                                                  method = item.attribute.TargetMethod ?? item.wrapperMethod.Name,
                                                                  signature = item.attribute.TargetSignature,
@@ -110,7 +111,7 @@ namespace GenerateIntegrationDefinitions
 
             if (!lastParameterTypes.SequenceEqual(requiredParameterTypes))
             {
-                  throw new Exception(
+                throw new Exception(
                     $"Method {method.DeclaringType.FullName}.{method.Name}() does not meet parameter requirements. " +
                     "Wrapper methods must have at least 3 parameters and the last 3 must be of types Int32 (opCode), Int32 (mdToken), and Int64 (moduleVersionPtr).");
             }


### PR DESCRIPTION
Changes proposed in this pull request:
- add property `InterceptMethodAttribute.TargetAssemblies` which allows declaring multiple assemblies in a single attribute to reduce code repetition
- leave `InterceptMethodAttribute.TargetAssembly` (which delegates to `TargetAssemblies`) for now for the common case of a single assembly