### PR TITLE
Make possible to create an OpenTrace tracer from existing Tracer

### DIFF
--- a/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.OpenTracing
         /// </summary>
         /// <param name="tracer">Existing Datadog Tracer instance</param>
         /// <returns>A Datadog compatible ITracer implementation</returns>
-        public static ITracer RegisterTracer(Tracer tracer)
+        public static ITracer WrapTracer(Tracer tracer)
         {
             return new OpenTracingTracer(tracer);
         }

--- a/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -21,6 +21,16 @@ namespace Datadog.Trace.OpenTracing
             return CreateTracer(agentEndpoint, defaultServiceName, null, isDebugEnabled);
         }
 
+        /// <summary>
+        /// Create a new Datadog compatible ITracer implementation using an existing Datadog Tracer instance
+        /// </summary>
+        /// <param name="tracer">Existing Datadog Tracer instance</param>
+        /// <returns>A Datadog compatible ITracer implementation</returns>
+        public static ITracer RegisterTracer(Tracer tracer)
+        {
+            return new OpenTracingTracer(tracer);
+        }
+
         internal static OpenTracingTracer CreateTracer(Uri agentEndpoint, string defaultServiceName, DelegatingHandler delegatingHandler, bool isDebugEnabled)
         {
             var tracer = Tracer.Create(agentEndpoint, defaultServiceName, isDebugEnabled);


### PR DESCRIPTION
Changes proposed in this pull request:

The current `OpenTracingTracerFactory` implicitly creates a new instance of `Tracer` with a very limited set of options. If we already have a pre-configured `Tracer` instance, we need to be able just to wrap it into the `OpenTracingTracer`.

@DataDog/apm-dotnet