### PR TITLE
Disable implicit framework references

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,6 +20,14 @@
     <Copyright>Datadog, Inc. 2017-2019</Copyright>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+  </PropertyGroup>
+
   <!-- StyleCop -->
   <ItemGroup>
     <Compile Include="..\GlobalSuppressions.cs" Link="GlobalSuppressions.src.cs" />


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1801443/65628457-74918a00-df9f-11e9-880a-834302d4b088.png)

After:
![image](https://user-images.githubusercontent.com/1801443/65628420-68a5c800-df9f-11e9-94b8-aeefe5750714.png)



@DataDog/apm-dotnet