### PR TITLE
Fix "runtime description" used for internal analytics

### DIFF
--- a/Datadog.Trace.sln.DotSettings
+++ b/Datadog.Trace.sln.DotSettings
@@ -35,7 +35,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LINES/@EntryValue">False</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_TERNARY_EXPR_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	
 	<s:Boolean x:Key="/Default/CodeStyle/CppUseAuto/AutoWasChosen/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/ShowEditorConfigStatusBarIndicator/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EncapsulateField/UpdateExternalUsagesOnly/@EntryValue">False</s:Boolean>

--- a/Datadog.Trace.sln.DotSettings
+++ b/Datadog.Trace.sln.DotSettings
@@ -43,6 +43,7 @@
 	<s:String x:Key="/Default/CodeStyle/Generate/=Implementations/Options/=Async/@EntryIndexedValue">True</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNamingAutoDetectionCompleted/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNotificationDisabled/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/AutoDetectedNamingRules/=Constants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/AutoDetectedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>

--- a/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 // ReSharper disable MemberHidesStaticFromOuterClass
@@ -5,9 +6,11 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal static class NativeMethods
     {
+        private static readonly bool IsWindows = string.Equals(FrameworkDescription.Create().OSPlatform, "Windows", StringComparison.OrdinalIgnoreCase);
+
         public static bool IsProfilerAttached()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (IsWindows)
             {
                 return Windows.IsProfilerAttached();
             }

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -15,13 +15,11 @@ namespace Datadog.Trace
 
         /// <summary>
         /// The interpreter for the given language, e.g. ".NET Framework" or ".NET Core".
-        /// The value of <see cref="RuntimeInformation.FrameworkDescription"/>.
         /// </summary>
         public const string LanguageInterpreter = "Datadog-Meta-Lang-Interpreter";
 
         /// <summary>
         /// The interpreter version for the given language, e.g. "4.7.2" for .NET Framework or "2.1" for .NET Core.
-        /// The value of <see cref="RuntimeInformation.FrameworkDescription"/>.
         /// </summary>
         public const string LanguageVersion = "Datadog-Meta-Lang-Version";
 

--- a/src/Datadog.Trace/Containers/ContainerInfo.cs
+++ b/src/Datadog.Trace/Containers/ContainerInfo.cs
@@ -59,21 +59,12 @@ namespace Datadog.Trace.Containers
 
         private static string GetContainerIdInternal()
         {
-            bool isLinux;
-
             try
             {
-                isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            }
-            catch (Exception ex)
-            {
-                Log.WarnException("Unable to determine OS. Will not report container id.", ex);
-                return null;
-            }
+                var isLinux = string.Equals(FrameworkDescription.Create().OSPlatform, "Linux", StringComparison.OrdinalIgnoreCase);
 
-            try
-            {
-                if (isLinux && File.Exists(ControlGroupsFilePath))
+                if (isLinux &&
+                    File.Exists(ControlGroupsFilePath))
                 {
                     var lines = File.ReadLines(ControlGroupsFilePath);
                     return ParseCgroupLines(lines);
@@ -82,7 +73,6 @@ namespace Datadog.Trace.Containers
             catch (Exception ex)
             {
                 Log.WarnException("Error reading cgroup file. Will not report container id.", ex);
-                return null;
             }
 
             return null;

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -14,7 +14,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
+    <!--
+    This reference allows us to build the code without precompiler directives,
+    but the logic at runtime will never try to use the Registry if it's not available
+    -->
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- NuGet -->
@@ -11,17 +11,20 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibLog" Version="5.0.6">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="LibLog" Version="5.0.6" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -11,8 +11,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
-
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
@@ -25,6 +23,7 @@
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace
     {
         private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
 
-        private static readonly Assembly RootAssembly = typeof(object).GetTypeInfo().Assembly;
+        private static readonly Assembly RootAssembly = typeof(object).Assembly;
 
         private static readonly Tuple<int, string>[] DotNetFrameworkVersionMapping =
         {

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -95,8 +95,8 @@ namespace Datadog.Trace
 
         private static FrameworkDescription CreateFromRuntimeInformation()
         {
-            string frameworkName;
-            string osPlatform;
+            string frameworkName = null;
+            string osPlatform = null;
 
             try
             {
@@ -109,7 +109,6 @@ namespace Datadog.Trace
             catch (Exception e)
             {
                 Log.ErrorException("Error getting framework name from RuntimeInformation", e);
-                frameworkName = "unknown";
             }
 
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
@@ -124,15 +123,11 @@ namespace Datadog.Trace
             {
                 osPlatform = "MacOS";
             }
-            else
-            {
-                osPlatform = null;
-            }
 
             return new FrameworkDescription(
-                frameworkName,
+                frameworkName ?? "unknown",
                 GetNetCoreVersion() ?? "unknown",
-                osPlatform,
+                osPlatform ?? "unknown",
                 RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
                 RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant());
         }

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -230,7 +230,7 @@ namespace Datadog.Trace
             }
             catch (Exception e)
             {
-                Log.ErrorException("Error getting .NET Core version from [AssemblyInformationalVersion]", e);
+                Log.ErrorException("Error getting framework version from [AssemblyInformationalVersion]", e);
             }
 
             if (productVersion == null)
@@ -243,7 +243,7 @@ namespace Datadog.Trace
                 }
                 catch (Exception e)
                 {
-                    Log.ErrorException("Error getting .NET Core version from [AssemblyFileVersion]", e);
+                    Log.ErrorException("Error getting framework version from [AssemblyFileVersion]", e);
                 }
             }
 

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -158,18 +158,11 @@ namespace Datadog.Trace
                 Log.ErrorException("Error getting .NET Framework version from Windows Registry", e);
             }
 
-            try
+            if (productVersion == null)
             {
-                if (productVersion == null)
-                {
-                    // if we couldn't get the version from the Windows Registry,
-                    // fall back to the [AssemblyInformationalVersion]
-                    productVersion = GetVersionFromAssemblyAttributes();
-                }
-            }
-            catch (Exception e)
-            {
-                Log.ErrorException("Error getting .NET Framework version from assembly attributes.", e);
+                // if we fail to extract version from assembly path,
+                // fall back to the [AssemblyInformationalVersion] or [AssemblyFileVersion]
+                productVersion = GetVersionFromAssemblyAttributes();
             }
 
             return productVersion;

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -148,6 +148,8 @@ namespace Datadog.Trace
 
                 if (registryValue is int release)
                 {
+                    // find the known version on the list with the largest release number
+                    // that is lower than or equal to the release number in the Windows Registry
                     productVersion = DotNetFrameworkVersionMapping.FirstOrDefault(t => release >= t.Item1)?.Item2;
                 }
             }
@@ -160,9 +162,8 @@ namespace Datadog.Trace
             {
                 if (productVersion == null)
                 {
-                    // if we couldn't access the Windows Registry, fall back to the [AssemblyInformationalVersion]
-                    // (this shouldn't happen, but if users get into a place where they are loading
-                    // the assembly that targets .NET Standard 2.0 into .NET Framework, this may happen)
+                    // if we couldn't get the version from the Windows Registry,
+                    // fall back to the [AssemblyInformationalVersion]
                     productVersion = GetVersionFromAssemblyAttributes();
                 }
             }

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -77,20 +77,10 @@ namespace Datadog.Trace
 
         public override string ToString()
         {
-            string architecture;
-
-            if (OSPlatform == "Windows" && ProcessArchitecture == "x86" && OSArchitecture == "x64")
-            {
-                // special case for x86 process on Windows x64
-                // WoW64 = Windows (32-bit) on Windows 64-bit
-                architecture = "WoW64";
-            }
-            else
-            {
-                architecture = $"{OSArchitecture}";
-            }
-
-            return $"{Name} {ProductVersion} {OSPlatform}/{architecture}";
+            // examples:
+            // .NET Framework 4.8 x86 on Windows x64
+            // .NET Core 3.0.0 x64 on Linux x64
+            return $"{Name} {ProductVersion} {ProcessArchitecture} on {OSPlatform} {OSArchitecture}";
         }
 
         private static FrameworkDescription CreateFromRuntimeInformation()
@@ -103,7 +93,7 @@ namespace Datadog.Trace
                 // RuntimeInformation.FrameworkDescription returns a string like ".NET Framework 4.7.2" or ".NET Core 2.1",
                 // we want to return everything before the last space
                 string frameworkDescription = RuntimeInformation.FrameworkDescription;
-                int index = RuntimeInformation.FrameworkDescription.LastIndexOf(' ');
+                int index = frameworkDescription.LastIndexOf(' ');
                 frameworkName = frameworkDescription.Substring(0, index).Trim();
             }
             catch (Exception e)

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace
             }
             catch (Exception e)
             {
-                Log.ErrorException("Error getting .NET Framework version from [AssemblyInformationalVersion]", e);
+                Log.ErrorException("Error getting .NET Framework version from assembly attributes.", e);
             }
 
             return productVersion;
@@ -186,9 +186,9 @@ namespace Datadog.Trace
                 productVersion = Environment.Version.ToString();
             }
 
-            try
+            if (productVersion == null)
             {
-                if (productVersion == null)
+                try
                 {
                     // try to get product version from assembly path
                     Match match = Regex.Match(
@@ -201,10 +201,10 @@ namespace Datadog.Trace
                         productVersion = match.Groups[1].Value;
                     }
                 }
-            }
-            catch (Exception e)
-            {
-                Log.ErrorException("Error getting .NET Core version from assembly path", e);
+                catch (Exception e)
+                {
+                    Log.ErrorException("Error getting .NET Core version from assembly path", e);
+                }
             }
 
             if (productVersion == null)


### PR DESCRIPTION
The changes in this PR try to improve detection of the runtime version the code is running on. In particular, we want the "product" version (e.g. .NET Framework 4.7.2 or .NET Core 2.1.13) instead of some esoteric internal version or the CLR version.

- .NET Core
  - if `Environment.Version.Major` is not 4, use that version (.NET Core 3.0.0 started returning the product version, `3.0.0`, and .NET 5 will presumably continue the trend)
  - if `Environment.Version.Major` is 4, try to find the correct product version by looking at the path for `System.Private.CoreLib`
  - if that fails, fall back to the `[AssemblyInformationalVersion]` version (e.g. `4.6.27817.03`)
  - if that fails, fall back to the `[AssemblyFileVersion]` version (e.g. `4.6.27817.03`)
- .NET Framework
  - try to [get installed version from Windows Registry](https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed)
  - if that fails, fall back to the `[AssemblyInformationalVersion]` version (e.g. `4.8.4010.0`)
  - if that fails, fall back to the `[AssemblyFileVersion]` version (e.g. `4.8.4010.0`)
