### PR TITLE
Install the 32-bit Profiler with the 64-bit Installer

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -34,13 +34,11 @@ jobs:
     inputs:
       preferBundledVersion: false
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk
     inputs:
-      command: build
-      configuration: $(buildConfiguration)
-      projects: |
-        src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      packageType: sdk
+      version: $(dotnetCoreSdkVersion)
 
   - task: NuGetCommand@2
     displayName: nuget restore native
@@ -48,31 +46,6 @@ jobs:
       restoreSolution: Datadog.Trace.Native.sln
       vstsFeed: $(packageFeed)
       verbosityRestore: Normal
-
-  - task: MSBuild@1
-    displayName: msbuild native
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp
-      maximumCpuCount: true
-
-  - task: MSBuild@1
-    displayName: msbuild native -- x86
-    condition: eq(variables.buildPlatform, 'x64')
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: x86
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp
-      maximumCpuCount: true
-
-  - task: UseDotNet@2
-    displayName: install dotnet core sdk
-    inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
@@ -104,36 +77,6 @@ jobs:
       artifactName: nuget-packages
       targetPath: nuget-output
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net45
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework net45 --output $(publishOutput)/net45
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net461
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework net461 --output $(publishOutput)/net461
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
-
   - task: MSBuild@1
     displayName: msbuild msi
     inputs:
@@ -141,6 +84,7 @@ jobs:
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
       msbuildArguments: /t:msi /p:InstallerVersion=%GitVersion_MajorMinorPatch%;OutputName=datadog-dotnet-apm-%GitVersion_MajorMinorPatch%-$(buildPlatform);RunWixToolsOutOfProc=true
+      maximumCpuCount: true
 
   - task: PublishPipelineArtifact@0
     displayName: publish msi artifact

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -58,6 +58,16 @@ jobs:
       msbuildArguments: /t:BuildCpp
       maximumCpuCount: true
 
+  - task: MSBuild@1
+    displayName: msbuild native -- x86
+    condition: eq(variables.buildPlatform, 'x64')
+    inputs:
+      solution: Datadog.Trace.proj
+      platform: x86
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:BuildCpp
+      maximumCpuCount: true
+
   - task: UseDotNet@2
     displayName: install dotnet core sdk
     inputs:

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -56,6 +56,10 @@
     <MSBuild Targets="Build" Projects="@(CppProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
+
+    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(BuildAdditionalx86Profiler)' == 'true'" Properties="Platform=x86">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+    </MSBuild>
   </Target>
 
   <Target Name="BuildCppTests">
@@ -103,7 +107,13 @@
     </MSBuild>
   </Target>
 
-  <Target Name="Msi" DependsOnTargets="BuildCsharp;BuildCpp">
+  <Target Name="SetMsiProperties">
+    <PropertyGroup>
+      <BuildAdditionalx86Profiler Condition="'$(Platform)' == 'x64'">true</BuildAdditionalx86Profiler>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="Msi" DependsOnTargets="SetMsiProperties;BuildCsharp;BuildCpp">
     <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -41,7 +41,7 @@
   </Target>
 
   <Target Name="BuildCsharp">
-    <MSBuild Targets="Build" Projects="@(CsharpProject)">
+    <MSBuild Targets="Build" Projects="@(CsharpProject)" RemoveProperties="Platform">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
@@ -72,10 +72,10 @@
 
     <!-- Build the core C# projects first, so that the sample project builds do not need to build them and can be run
          concurrently -->
-    <MSBuild Targets="Restore" Projects="@(CsharpProject)" BuildInParallel="false" RemoveProperties="TargetFramework">
+    <MSBuild Targets="Restore" Projects="@(CsharpProject)" BuildInParallel="false" RemoveProperties="TargetFramework;Platform">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
-    <MSBuild Targets="Build" Projects="@(CsharpProject)" BuildInParallel="false" RemoveProperties="TargetFramework">
+    <MSBuild Targets="Build" Projects="@(CsharpProject)" BuildInParallel="false" RemoveProperties="TargetFramework;Platform">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
 

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -113,7 +113,27 @@
     </PropertyGroup>
   </Target>
 
-  <Target Name="Msi" DependsOnTargets="SetMsiProperties;BuildCsharp;BuildCpp">
+  <Target Name="PublishManagedProfilerOnDisk">
+    <ItemGroup>
+      <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
+        <Properties>TargetFramework=net45;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\net45</Properties>
+      </ManagedProfilerPublishProject>
+
+      <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
+        <Properties>TargetFramework=net461;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\net461</Properties>
+      </ManagedProfilerPublishProject>
+
+      <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
+        <Properties>TargetFramework=netstandard2.0;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\netstandard2.0</Properties>
+      </ManagedProfilerPublishProject>
+    </ItemGroup>
+
+    <MSBuild Targets="Publish" Projects="@(ManagedProfilerPublishProject)" BuildInParallel="$(BuildInParallel)" RemoveProperties="Platform">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+    </MSBuild>
+  </Target>
+
+  <Target Name="Msi" DependsOnTargets="SetMsiProperties;BuildCsharp;BuildCpp;PublishManagedProfilerOnDisk">
     <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
@@ -4,8 +4,10 @@
   <?define BaseProductName = ".NET Tracer" ?>
   <?define ArpManufacturer = "Datadog, Inc." ?>
   <?define Company = "Datadog" ?>
+  <?define ProductNamePlatformAgnostic = "Datadog $(var.BaseProductName)" ?>
   <?define ManagedDllPath = "$(sys.CURRENTDIR)..\..\src\bin\managed-publish" ?>
   <?define NativeDllPath = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\$(var.Platform)" ?>
+  <?define NativeDll32Path = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\x86" ?>
   <?define ProfilerCLSID = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" ?>
 
   <?if $(var.Platform) = x64 ?>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -44,6 +44,7 @@
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.IIS"/>
 
+      <!-- For the 64-bit installer, also install the 32-bit profiler -->
       <?if $(var.Win64) = yes ?>
       <ComponentGroupRef Id="Files.Native.32"/>
       <?endif ?>
@@ -74,6 +75,7 @@
         </Directory>
       </Directory>
 
+      <!-- For the 64-bit installer, also install the 32-bit profiler -->
       <?if $(var.Win64) = yes ?>
       <Directory Id="ProgramFilesFolder">
         <!-- "C:\Program Files (x86)" -->

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -43,6 +43,10 @@
       <ComponentGroupRef Id="Registry"/>
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.IIS"/>
+
+      <?if $(var.Win64) = yes ?>
+      <ComponentGroupRef Id="Files.Native.32"/>
+      <?endif ?>
     </Feature>
   </Product>
 
@@ -70,6 +74,18 @@
         </Directory>
       </Directory>
 
+      <?if $(var.Win64) = yes ?>
+      <Directory Id="ProgramFilesFolder">
+        <!-- "C:\Program Files (x86)" -->
+        <Directory Id="ProgramFilesFolder.Datadog.32" Name="$(var.Company)">
+          <!-- ".\Datadog" -->
+          <Directory Id="INSTALLFOLDER.32" Name="$(var.BaseProductName)">
+            <!-- ".\.NET Tracer" -->
+          </Directory>
+        </Directory>
+      </Directory>
+      <?endif ?>
+
       <Directory Id="CommonAppDataFolder">
         <!-- "C:\ProgramData" -->
         <Directory Id="CommonAppDataFolder.DatadogDotNetTracer" Name="Datadog .NET Tracer">
@@ -94,10 +110,23 @@
         <File Id="Datadog.Trace.ClrProfiler.Native"
               Source="$(var.NativeDllPath)\Datadog.Trace.ClrProfiler.Native.dll"
               Checksum="yes">
-          <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductName)"/>
+          <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
         </File>
       </Component>
     </ComponentGroup>
+
+    <!-- For the 64-bit installer, also install the 32-bit profiler -->
+    <?if $(var.Win64) = yes ?>
+    <ComponentGroup Id="Files.Native.32" Directory="INSTALLFOLDER.32">
+      <Component Win64="no" Id="Datadog.Trace.ClrProfiler.Native.32">
+        <File Id="Datadog.Trace.ClrProfiler.Native.32"
+              Source="$(var.NativeDll32Path)\Datadog.Trace.ClrProfiler.Native.dll"
+              Checksum="yes">
+          <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
+        </File>
+      </Component>
+    </ComponentGroup>
+    <?endif ?>
 
     <ComponentGroup Id="EmptyFolders" Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">
       <Component Id="EmptyFolders.Logs" Guid="0A9B510D-44F6-41A9-9EFE-E2CEB7314CF3">

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ rem (see https://github.com/NuGet/Home/issues/7386)
 nuget restore Datadog.Trace.sln
 
 rem Build C# projects (Platform: always AnyCPU)
-msbuild Datadog.Trace.proj /t:BuildCsharp /p:Configuration=Release;Platform=AnyCPU
+msbuild Datadog.Trace.proj /t:BuildCsharp /p:Configuration=Release
 
 rem Build NuGet packages
 dotnet pack src\Datadog.Trace\Datadog.Trace.csproj
@@ -68,6 +68,7 @@ dotnet pack src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj
 dotnet pack src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj
 
 rem Build C++ projects (Platform: x64 or x86)
+rem The native profiler depends on the Datadog.Trace.ClrProfiler.Managed.Loader C# project so be sure that is built first
 msbuild Datadog.Trace.proj /t:BuildCpp /p:Configuration=Release;Platform=x64
 
 rem Build MSI installer (Platform: x64 or x86)


### PR DESCRIPTION
Changes proposed in this pull request:
- For 64-bit installer builds, make sure to build the 32-bit Profiler before building the MSI
- Place the 32-bit Profiler on-disk in the x86-equivalent ProgramFiles directory.
- Register the 32-bit Profiler as a COM component.
- Change the `Description` of the COM component from `Datadog .NET Tracer <bitness>-bit` to `Datadog .NET Tracer`

Result: Less installation confusion. Customers can install the MSI that targets their operating system instead of the application's process architecture.

@DataDog/apm-dotnet