### PR TITLE
Installer Bug Fix: Install net45 files on-disk (in addition to GAC)

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -35,6 +35,7 @@
     <DefineConstants>InstallerVersion=$(InstallerVersion)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Files.Managed.Net45.GAC.wxs" />
     <Compile Include="Files.Managed.Net45.wxs" />
     <Compile Include="Files.Managed.Net461.wxs" />
     <Compile Include="Files.Managed.NetStandard20.wxs" />

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
@@ -4,36 +4,36 @@
      xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
   <?include $(sys.CURRENTDIR)\Config.wxi?>
   <Fragment>
-    <ComponentGroup Id="Files.Managed.Net45" Directory="net45">
+    <ComponentGroup Id="Files.Managed.Net45.GAC" Directory="net45.GAC">
       <Component Win64="$(var.Win64)">
-        <File Id="net45_Datadog.Trace.ClrProfiler.Managed.dll"
+        <File Id="net45_GAC_Datadog.Trace.ClrProfiler.Managed.dll"
               Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
-              KeyPath="yes" Checksum="yes"/>
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="net45_Datadog.Trace.dll"
+        <File Id="net45_GAC_Datadog.Trace.dll"
               Source="$(var.ManagedDllPath)\net45\Datadog.Trace.dll"
-              KeyPath="yes" Checksum="yes"/>
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="net45_MsgPack.dll"
+        <File Id="net45_GAC_MsgPack.dll"
               Source="$(var.ManagedDllPath)\net45\MsgPack.dll"
-              KeyPath="yes" Checksum="yes"/>
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="net45_Newtonsoft.Json.dll"
+        <File Id="net45_GAC_Newtonsoft.Json.dll"
               Source="$(var.ManagedDllPath)\net45\Newtonsoft.Json.dll"
-              KeyPath="yes" Checksum="yes"/>
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="net45_Sigil.dll"
+        <File Id="net45_GAC_Sigil.dll"
               Source="$(var.ManagedDllPath)\net45\Sigil.dll"
-              KeyPath="yes" Checksum="yes"/>
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="net45_System.Runtime.InteropServices.RuntimeInformation.dll"
+        <File Id="net45_GAC_System.Runtime.InteropServices.RuntimeInformation.dll"
               Source="$(var.ManagedDllPath)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
-              KeyPath="yes" Checksum="yes"/>
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -35,6 +35,7 @@
     <Feature Id="ProductFeature" Title="Datadog.Trace.ClrProfiler" Level="1">
       <ComponentGroupRef Id="Files"/>
       <ComponentGroupRef Id="Files.Native"/>
+      <ComponentGroupRef Id="Files.Managed.Net45.GAC"/>
       <ComponentGroupRef Id="Files.Managed.Net45"/>
       <ComponentGroupRef Id="Files.Managed.Net461"/>
       <ComponentGroupRef Id="Files.Managed.NetStandard20"/>
@@ -61,6 +62,9 @@
               </Directory>
               <Directory Id="netstandard2.0" Name="netstandard2.0">
                 <!-- ".\netstandard2.0" -->
+              </Directory>
+              <Directory Id="net45.GAC" Name="net45.GAC">
+                <!-- Ignored as all of its components will be installed in the GAC -->
               </Directory>
           </Directory>
         </Directory>


### PR DESCRIPTION
Changes proposed in this pull request:
In recent changes, we realized we needed to re-install the net45 files in the GAC to allow IIS automatic instrumentation to succeed so we made the change. However, as a result, the net45 files were not placed on-disk in a subdirectory of `DD_DOTNET_TRACER_HOME`. This change fixes that by installing the files twice: once into the GAC and once on-disk.


@DataDog/apm-dotnet