### PR TITLE
Update .NET Core requirement to 3.0 and add 2.1/2.2 runtimes as optional

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -53,7 +53,7 @@ Microsoft provides [evaluation developer VMs](https://developer.microsoft.com/en
 
 ### Building from a command line
 
-From a _Developer Command Prompt for VS 2017_:
+From a _Developer Command Prompt for VS 2019_:
 
 ```cmd
 rem Restore NuGet packages

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,9 @@ Integration tests | [![Build Status](https://dev.azure.com/datadog-apm/dd-trace-
     - Optional: ASP.NET and web development (to build samples)
   - Individual components
     - .NET Framework 4.7 targeting pack
-- [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)
+- [.NET Core 3.0 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- Optional: [.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
+- Optional: [.NET Core 2.2 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.2) to test in .NET Core 2.2 locally.
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v3.4.4 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - Requires .NET Framework 3.5 SP2 (install from Windows Features control panel: `OptionalFeatures.exe`)


### PR DESCRIPTION
Changes proposed in this pull request:

The tracer build now requires the .NET Core 3.0 SDK. 
Also added the two .NET Core runtimes, 2.1 and 2.2, as optional installs if there is a need to test apps in those runtimes on your local machine.


@DataDog/apm-dotnet