### PR TITLE
Automatic Correlation Identifier Injection: Add properties as strings instead of longs

### DIFF
--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -121,10 +121,10 @@ namespace Datadog.Trace.Logging
             // TODO: Debug logs
             _contextDisposalStack.Push(
                 LogProvider.OpenMappedContext(
-                    CorrelationIdentifier.TraceIdKey, traceId, destructure: false));
+                    CorrelationIdentifier.TraceIdKey, traceId.ToString(), destructure: false));
             _contextDisposalStack.Push(
                 LogProvider.OpenMappedContext(
-                    CorrelationIdentifier.SpanIdKey, spanId, destructure: false));
+                    CorrelationIdentifier.SpanIdKey, spanId.ToString(), destructure: false));
         }
     }
 }

--- a/test/Datadog.Trace.TestHelpers/AlphabeticalOrderer.cs
+++ b/test/Datadog.Trace.TestHelpers/AlphabeticalOrderer.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class AlphabeticalOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+                where TTestCase : ITestCase
+        {
+            var result = testCases.ToList();
+            result.Sort((x, y) => StringComparer.OrdinalIgnoreCase.Compare(x.TestMethod.Method.Name, y.TestMethod.Method.Name));
+            return result;
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -1,10 +1,13 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.LogProviders;
 using log4net.Appender;
 using log4net.Config;
 using log4net.Core;
+using log4net.Layout;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Logging
@@ -146,6 +149,37 @@ namespace Datadog.Trace.Tests.Logging
             Assert.DoesNotContain(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.DoesNotContain(LoggingProviderTestHelpers.CustomPropertyName, logEvent.Properties.GetKeys());
+        }
+
+        /// <summary>
+        /// Lighweight JSON-formatter for Log4Net inspired by https://github.com/Litee/log4net.Layout.Json
+        /// </summary>
+        internal class Log4NetJsonLayout : LayoutSkeleton
+        {
+            public override void ActivateOptions()
+            {
+            }
+
+            public override void Format(TextWriter writer, LoggingEvent e)
+            {
+                var dic = new Dictionary<string, object>
+                {
+                    ["level"] = e.Level.DisplayName,
+                    ["messageObject"] = e.MessageObject,
+                    ["renderedMessage"] = e.RenderedMessage,
+                    ["timestampUtc"] = e.TimeStamp.ToUniversalTime().ToString("O"),
+                    ["logger"] = e.LoggerName,
+                    ["thread"] = e.ThreadName,
+                    ["exceptionObject"] = e.ExceptionObject,
+                    ["exceptionObjectString"] = e.ExceptionObject == null ? null : e.GetExceptionString(),
+                    ["userName"] = e.UserName,
+                    ["domain"] = e.Domain,
+                    ["identity"] = e.Identity,
+                    ["location"] = e.LocationInformation.FullInfo,
+                    ["properties"] = e.GetProperties()
+                };
+                writer.Write(JsonConvert.SerializeObject(dic));
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -57,10 +57,18 @@ namespace Datadog.Trace.Tests.Logging
 
         internal static void Contains(this log4net.Core.LoggingEvent logEvent, ulong traceId, ulong spanId)
         {
+            // First, verify that the properties are attached to the LogEvent
             Assert.Contains(CorrelationIdentifier.TraceIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(traceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString()));
             Assert.Contains(CorrelationIdentifier.SpanIdKey, logEvent.Properties.GetKeys());
             Assert.Equal<ulong>(spanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString()));
+
+            // Second, verify that the message formatting correctly encloses the
+            // values in quotes, since they are string values
+            Log4NetLogProviderTests.Log4NetJsonLayout layout = new Log4NetLogProviderTests.Log4NetJsonLayout();
+            string formattedMessage = layout.Format(logEvent);
+            Assert.Contains($"\"{CorrelationIdentifier.TraceIdKey}\":\"{traceId}\"", formattedMessage);
+            Assert.Contains($"\"{CorrelationIdentifier.SpanIdKey}\":\"{spanId}\"", formattedMessage);
         }
 
         internal static void Contains(this Serilog.Events.LogEvent logEvent, Scope scope)


### PR DESCRIPTION
We currently save the `dd.trace_id` and `dd.span_id` values in the logging library's logging context as `long` values. This causes an issue when producing JSON formatted output for `Serilog` because the resulting values are integers, not strings. This PR changes our automatic correlation identifier injection to store the values as `string` values instead of `long` values.

Additionally, re-write the unit tests for each logging library to test that JSON formatting results in `string` values.

@DataDog/apm-dotnet