### PR TITLE
Add language tag to relevant root spans

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ExtensionMethods/SpanExtensions.cs
@@ -1,3 +1,4 @@
+using Datadog.Trace;
 using Datadog.Trace.Interfaces;
 
 namespace Datadog.Trace.ClrProfiler.ExtensionMethods
@@ -26,6 +27,7 @@ namespace Datadog.Trace.ClrProfiler.ExtensionMethods
             span.SetTag(Tags.HttpMethod, method);
             span.SetTag(Tags.HttpRequestHeadersHost, host);
             span.SetTag(Tags.HttpUrl, httpUrl);
+            span.SetTag(Tags.Language, TracerConstants.Language);
         }
     }
 }

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -175,5 +175,11 @@ namespace Datadog.Trace
         /// Configures Trace Analytics.
         /// </summary>
         public const string Analytics = "_dd1.sr.eausr";
+
+        /// <summary>
+        /// Language tag
+        /// RFC: https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/runtime-metrics-collection/rfc.md#traces
+        /// </summary>
+        public const string Language = "language";
     }
 }

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -177,8 +177,7 @@ namespace Datadog.Trace
         public const string Analytics = "_dd1.sr.eausr";
 
         /// <summary>
-        /// Language tag
-        /// RFC: https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/runtime-metrics-collection/rfc.md#traces
+        /// Language tag, applied to root spans that are .NET runtime (e.g., ASP.NET)
         /// </summary>
         public const string Language = "language";
     }

--- a/src/Datadog.Trace/TracerConstants.cs
+++ b/src/Datadog.Trace/TracerConstants.cs
@@ -1,0 +1,7 @@
+namespace Datadog.Trace
+{
+    internal static class TracerConstants
+    {
+        public const string Language = "dotnet";
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace;
 using Datadog.Trace.TestHelpers;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
@@ -58,6 +59,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var actualStatusCode = GetTag(span, Tags.HttpStatusCode);
             var actualHttpMethod = GetTag(span, Tags.HttpMethod);
+            var language = GetTag(span, Tags.Language);
 
             if (StatusCode != null && actualStatusCode != StatusCode)
             {
@@ -67,6 +69,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (actualHttpMethod != HttpMethod)
             {
                 mismatches.Add(FailureMessage(nameof(HttpMethod), actual: actualHttpMethod, expected: HttpMethod));
+            }
+
+            if (language != TracerConstants.Language)
+            {
+                mismatches.Add(FailureMessage(Tags.Language, actual: language, expected: TracerConstants.Language));
             }
 
             if (CustomAssertion != null)


### PR DESCRIPTION
Changes proposed in this pull request:
* add `language` tag to root spans that are ASP.NET (i.e., representing the runtime, instead of a specific database or other external library)

@DataDog/apm-dotnet