### PR TITLE
add missing DD_DOTNET_TRACER_HOME env var

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -50,8 +50,9 @@ SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profil
 rem Don't attach the profiler to these processes
 SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe
 
-rem Set location of integration definitions
-SET DD_INTEGRATIONS=%~dp0\integrations.json;%~dp0\test-integrations.json
+rem Set dotnet tracer home path
+SET DD_DOTNET_TRACER_HOME=%~dp0
+SET DD_INTEGRATIONS=%DD_DOTNET_TRACER_HOME%\integrations.json
 
 if "%start_visual_studio%" == "true" (
     echo Starting Visual Studio...

--- a/docker/with-profiler.bash
+++ b/docker/with-profiler.bash
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -euxo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd )"
 
 export CORECLR_ENABLE_PROFILING="1"
 export CORECLR_PROFILER="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-export CORECLR_PROFILER_PATH="${DIR}/../src/Datadog.Trace.ClrProfiler.Native/obj/Debug/x64/Datadog.Trace.ClrProfiler.Native.so"
-export DD_INTEGRATIONS="${DIR}/../integrations.json;/project/test-integrations.json"
+export CORECLR_PROFILER_PATH="${DIR}/src/Datadog.Trace.ClrProfiler.Native/obj/Debug/x64/Datadog.Trace.ClrProfiler.Native.so"
+export DD_DOTNET_TRACER_HOME="${DIR}"
+export DD_INTEGRATIONS="${DD_DOTNET_TRACER_HOME}/integrations.json"
 
 eval "$@"

--- a/reproductions/AutomapperTest/Dockerfile
+++ b/reproductions/AutomapperTest/Dockerfile
@@ -7,6 +7,7 @@ RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v$TRACE
 ENV CORECLR_ENABLE_PROFILING=1
 ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
 ENV DD_TRACE_ENABLED=true
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -80,6 +80,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
 
   WSTRING env_vars[]{environment::tracing_enabled,
                      environment::debug_enabled,
+                     environment::profiler_home_path,
                      environment::integrations_path,
                      environment::include_process_names,
                      environment::exclude_process_names,

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -18,6 +18,10 @@ const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
 // "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
 const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
 
+// Sets the path to the profiler's home directory, for example:
+// "C:\Program Files\Datadog .NET Tracer\" or "/opt/datadog/"
+const WSTRING profiler_home_path = "DD_DOTNET_TRACER_HOME"_W;
+
 // Sets the filename of executables the profiler can attach to.
 // If not defined (default), the profiler will attach to any process.
 // Supports multiple values separated with semi-colons, for example:

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -181,6 +181,7 @@ namespace Datadog.Trace.TestHelpers
 
                 // Datadog
                 "DD_PROFILER_PROCESSES",
+                "DD_DOTNET_TRACER_HOME",
                 "DD_INTEGRATIONS",
                 "DD_DISABLED_INTEGRATIONS",
                 "DATADOG_PROFILER_PROCESSES",


### PR DESCRIPTION
Changes proposed in this pull request:

Add the recently-added (see #505) `DD_DOTNET_TRACER_HOME` environment variable to a few files used for local testing where it is still missing.