### PR TITLE
Add test for valid json that has wrong dictionary entry types

### DIFF
--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -123,12 +124,10 @@ namespace Datadog.Trace.Configuration
                 return null;
             }
 
-            // Presence of a curly brace indicates that this is likely a JSON string. An exception will be thrown
-            // if it fails to parse or convert to a dictionary.
             if (token.Type == JTokenType.Object)
             {
                 var dictionary = token
-                    ?.ToObject<ConcurrentDictionary<string, string>>() as ConcurrentDictionary<string, string>;
+                    ?.ToObject<ConcurrentDictionary<string, string>>();
                 return dictionary;
             }
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Tests.Configuration
         public static IEnumerable<object[]> GetBadJsonTestData3()
         {
             // Json doesn't represent dictionary of string to string
-            yield return new object[] { @"{ ""DD_TRACE_GLOBAL_TAGS"": { ""name1"": { ""name2"": [ ""vers"" ] } } }" };
+            yield return new object[] { @"{ ""DD_TRACE_GLOBAL_TAGS"": { ""name1"": { ""name2"": [ ""vers"" ] } } }", CreateFunc(s => s.GlobalTags.Count), 0 };
         }
 
         public static Func<TracerSettings, object> CreateFunc(Func<TracerSettings, object> settingGetter)
@@ -148,10 +148,15 @@ namespace Datadog.Trace.Tests.Configuration
         [Theory]
         [MemberData(nameof(GetBadJsonTestData3))]
         public void JsonConfigurationSource_BadData3(
-            string value)
+            string value,
+            Func<TracerSettings, object> settingGetter,
+            object expectedValue)
         {
             IConfigurationSource source = new JsonConfigurationSource(value);
-            Assert.Throws<JsonReaderException>(() => { new TracerSettings(source); });
+            var settings = new TracerSettings(source);
+
+            var actualValue = settingGetter(settings);
+            Assert.Equal(expectedValue, actualValue);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -59,6 +59,12 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { @"{ ""DD_TRACE_GLOBAL_TAGS"": { ""name1"":""value1"", ""name2"": ""value2"" }" };
         }
 
+        public static IEnumerable<object[]> GetBadJsonTestData3()
+        {
+            // Json doesn't represent dictionary of string to string
+            yield return new object[] { @"{ ""DD_TRACE_GLOBAL_TAGS"": { ""name1"": { ""name2"": [ ""vers"" ] } } }" };
+        }
+
         public static Func<TracerSettings, object> CreateFunc(Func<TracerSettings, object> settingGetter)
         {
             return settingGetter;
@@ -137,6 +143,15 @@ namespace Datadog.Trace.Tests.Configuration
             string value)
         {
             Assert.Throws<JsonSerializationException>(() => { new JsonConfigurationSource(value); });
+        }
+
+        [Theory]
+        [MemberData(nameof(GetBadJsonTestData3))]
+        public void JsonConfigurationSource_BadData3(
+            string value)
+        {
+            IConfigurationSource source = new JsonConfigurationSource(value);
+            Assert.Throws<JsonReaderException>(() => { new TracerSettings(source); });
         }
     }
 }


### PR DESCRIPTION
Follow-up to #533.

Changes proposed in this pull request:

* Removes the `as ConcurrentDictionary<string, string>`.

* A test for the case where JSON is valid but not in the correct format for `IDictionary<string, string>`.

* Removed old comment.

Note: ignore name of branch -- originally I was going to catch a JSON exception but given that the user would be adding configuration in JSON format, e.g., for Global Tags, then it is preferable to let the JSON exceptions bubble up to them.

@DataDog/apm-dotnet