### PR TITLE
[CLR Profiler] Fix InvalidProgramException: Ensure we always run argument-loading instructions before calling instrumentation wrapper methods, even after branches

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -686,27 +686,16 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
 
       // insert the opcode and signature token as
       // additional arguments for the wrapper method
-      //
-      // IMPORTANT: Conditional branches may jump to this call instruction, so
-      // we cannot add the argument-loading instructions BEFORE this instruction,
-      // otherwise this will surface in an InvalidProgramException.
-      // Either begin loading the additional arguments starting with this ILInstr
-      // structure or make the current ILInstr a no-op and do all of the argument
-      // loading after this instruction.
       ILRewriterWrapper rewriter_wrapper(&rewriter);
       rewriter_wrapper.SetILPosition(pInstr);
-      auto original_methodcall_opcode = pInstr->m_opcode;
-      pInstr->m_opcode = CEE_NOP;
-
-      // replace with a non-virtual call (CALL) to the instrumentation wrapper
-      // always use CALL because the wrappers methods are all static
-      rewriter_wrapper.CallMemberAfter(wrapper_method_ref, false);
-      rewriter_wrapper.SetILPosition(pInstr->m_pNext);
-
-      // add the additional arguments before calling the wrapper method, in order
-      rewriter_wrapper.LoadInt32(original_methodcall_opcode);
+      rewriter_wrapper.LoadInt32(pInstr->m_opcode);
       rewriter_wrapper.LoadInt32(method_def_md_token);
       rewriter_wrapper.LoadInt64(reinterpret_cast<INT64>(module_version_id_ptr));
+
+      // always use CALL because the wrappers methods are all static
+      pInstr->m_opcode = CEE_CALL;
+      // replace with a call to the instrumentation wrapper
+      pInstr->m_Arg32 = wrapper_method_ref;
 
       modified = true;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
@@ -109,14 +109,6 @@ void ILRewriterWrapper::CallMember(const mdMemberRef& member_ref,
   m_ILRewriter->InsertBefore(m_ILInstr, pNewInstr);
 }
 
-void ILRewriterWrapper::CallMemberAfter(const mdMemberRef& member_ref,
-                                   const bool is_virtual) const {
-  ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
-  pNewInstr->m_opcode = is_virtual ? CEE_CALLVIRT : CEE_CALL;
-  pNewInstr->m_Arg32 = member_ref;
-  m_ILRewriter->InsertAfter(m_ILInstr, pNewInstr);
-}
-
 void ILRewriterWrapper::Duplicate() const {
   ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
   pNewInstr->m_opcode = CEE_DUP;

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
@@ -109,6 +109,14 @@ void ILRewriterWrapper::CallMember(const mdMemberRef& member_ref,
   m_ILRewriter->InsertBefore(m_ILInstr, pNewInstr);
 }
 
+void ILRewriterWrapper::CallMemberAfter(const mdMemberRef& member_ref,
+                                   const bool is_virtual) const {
+  ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
+  pNewInstr->m_opcode = is_virtual ? CEE_CALLVIRT : CEE_CALL;
+  pNewInstr->m_Arg32 = member_ref;
+  m_ILRewriter->InsertAfter(m_ILInstr, pNewInstr);
+}
+
 void ILRewriterWrapper::Duplicate() const {
   ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
   pNewInstr->m_opcode = CEE_DUP;

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
@@ -25,6 +25,7 @@ class ILRewriterWrapper {
   void UnboxAny(mdTypeRef type_ref) const;
   void CreateArray(mdTypeRef type_ref, INT32 size) const;
   void CallMember(const mdMemberRef& member_ref, bool is_virtual) const;
+  void CallMemberAfter(const mdMemberRef& member_ref, bool is_virtual) const;
   void Duplicate() const;
   void BeginLoadValueIntoArray(INT32 arrayIndex) const;
   void EndLoadValueIntoArray() const;

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
@@ -25,7 +25,6 @@ class ILRewriterWrapper {
   void UnboxAny(mdTypeRef type_ref) const;
   void CreateArray(mdTypeRef type_ref, INT32 size) const;
   void CallMember(const mdMemberRef& member_ref, bool is_virtual) const;
-  void CallMemberAfter(const mdMemberRef& member_ref, bool is_virtual) const;
   void Duplicate() const;
   void BeginLoadValueIntoArray(INT32 arrayIndex) const;
   void EndLoadValueIntoArray() const;


### PR DESCRIPTION
Fixes #541

The issue:
IL methods may have jump or branch instructions that go directly to the IL instruction that calls the target method we intend to instrument. Previously, we would replace the metadata token in that call instruction to the MethodRef token that points to our instrumentation wrapper method and we would insert IL instructions before the method call to load additional arguments we need for proper instrumentation. But in this particular branching scenario, we encounter an `InvalidProgramException` because the branching operation jumped past the argument-loading instructions and straight to the method call.

The fix:
Make the original method call instruction a no-op, add the argument-loading instructions after this instruction, and finally add an instruction to call our wrapper method. This ensures the above scenario cannot happen by guaranteeing that argument-loading instructions will be executed before calling the instrumentation wrapper method.

Changes proposed in this pull request:
- Add the above fix in the profiler
- Add the bad code path to an existing and running reproduction case

@DataDog/apm-dotnet