### PR TITLE
add tracer metrics

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -43,6 +43,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		PackageVersionsGeneratorDefinitions.json = PackageVersionsGeneratorDefinitions.json
 		docs\README.md = docs\README.md
 		stylecop.json = stylecop.json
+		Test.Common.props = Test.Common.props
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9E5F0022-0A50-40BF-AC6A-C3078585ECAB}"

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetStartup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetStartup.cs
@@ -14,7 +14,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         public static void Register()
         {
-            Tracer.Instance = new Tracer(null, null, null, new AspNetScopeManager());
+            Tracer.Instance = new Tracer(
+                settings: null,
+                agentWriter: null,
+                sampler: null,
+                scopeManager: new AspNetScopeManager(),
+                statsd: null);
 
             if (Tracer.Instance.Settings.IsIntegrationEnabled(AspNetHttpModule.IntegrationName))
             {

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Agent
             {
                 _statsd.AppendSetGauge(TracerMetricNames.Queue.DequeuedTraces, traces.Count);
                 _statsd.AppendSetGauge(TracerMetricNames.Queue.DequeuedSpans, spanCount);
-                _statsd.AppendSetGauge(TracerMetricNames.Queue.TraceQueueMaxCapacity, TraceBufferSize);
+                _statsd.AppendSetGauge(TracerMetricNames.Queue.MaxCapacity, TraceBufferSize);
                 _statsd.Send();
             }
 

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -31,12 +31,12 @@ namespace Datadog.Trace.Agent
         {
             var success = _tracesBuffer.Push(trace);
 
-            _dogStatsdClient.Increment(TracerMetricNames.Queue.PushedTraces);
-            _dogStatsdClient.Increment(TracerMetricNames.Queue.PushedSpans, trace.Count);
+            _dogStatsdClient?.Increment(TracerMetricNames.Queue.PushedTraces);
+            _dogStatsdClient?.Increment(TracerMetricNames.Queue.PushedSpans, trace.Count);
 
             if (!success)
             {
-                _dogStatsdClient.Increment(TracerMetricNames.Queue.DroppedTraces);
+                _dogStatsdClient?.Increment(TracerMetricNames.Queue.DroppedTraces);
                 Log.Debug("Trace buffer is full, dropping it.");
             }
         }
@@ -62,9 +62,9 @@ namespace Datadog.Trace.Agent
             var traces = _tracesBuffer.Pop();
             var spanCount = traces.Sum(t => t.Count);
 
-            _dogStatsdClient.Gauge(TracerMetricNames.Queue.PoppedTraces, traces.Count);
-            _dogStatsdClient.Gauge(TracerMetricNames.Queue.PoppedSpans, spanCount);
-            _dogStatsdClient.Gauge(TracerMetricNames.Queue.BufferedTracesLimit, TraceBufferSize);
+            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.PoppedTraces, traces.Count);
+            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.PoppedSpans, spanCount);
+            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.BufferedTracesLimit, TraceBufferSize);
 
             if (traces.Any())
             {

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Datadog.Trace.DogStatsD;
+using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.StatsdClient;
 

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -31,8 +31,8 @@ namespace Datadog.Trace.Agent
         {
             var success = _tracesBuffer.Push(trace);
 
-            _dogStatsdClient?.Increment(TracerMetricNames.Queue.PushedTraces);
-            _dogStatsdClient?.Increment(TracerMetricNames.Queue.PushedSpans, trace.Count);
+            _dogStatsdClient?.Increment(TracerMetricNames.Queue.EnqueuedTraces);
+            _dogStatsdClient?.Increment(TracerMetricNames.Queue.EnqueuedSpans, trace.Count);
 
             if (!success)
             {
@@ -62,9 +62,9 @@ namespace Datadog.Trace.Agent
             var traces = _tracesBuffer.Pop();
             var spanCount = traces.Sum(t => t.Count);
 
-            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.PoppedTraces, traces.Count);
-            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.PoppedSpans, spanCount);
-            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.BufferedTracesLimit, TraceBufferSize);
+            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.DequeuedTraces, traces.Count);
+            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.DequeuedSpans, spanCount);
+            _dogStatsdClient?.Gauge(TracerMetricNames.Queue.TraceQueueMaxCapacity, TraceBufferSize);
 
             if (traces.Any())
             {

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Datadog.Trace.DogStatsD;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.Agent
 {
@@ -12,12 +14,14 @@ namespace Datadog.Trace.Agent
 
         private readonly AgentWriterBuffer<List<Span>> _tracesBuffer = new AgentWriterBuffer<List<Span>>(1000);
         private readonly IApi _api;
+        private readonly IDogStatsd _dogStatsdClient;
         private readonly Task _flushTask;
         private readonly TaskCompletionSource<bool> _processExit = new TaskCompletionSource<bool>();
 
-        public AgentWriter(IApi api)
+        public AgentWriter(IApi api, IDogStatsd dogStatsdClient)
         {
             _api = api;
+            _dogStatsdClient = dogStatsdClient;
             _flushTask = Task.Run(FlushTracesTaskLoopAsync);
         }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.Agent
                         }
                         catch
                         {
-                            // count the exceptions throw by the HttpClient,
+                            // count the exceptions thrown by the HttpClient,
                             // not responses with 5xx status codes
                             // (which cause EnsureSuccessStatusCode() to throw below)
                             _dogStatsdClient?.Increment(TracerMetricNames.Api.Errors);

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Agent
 
                 try
                 {
-                    _dogStatsdClient.Increment(TracerMetricNames.Api.RequestCount);
+                    _dogStatsdClient?.Increment(TracerMetricNames.Api.RequestCount);
                     var traceIds = GetUniqueTraceIds(traces);
 
                     // re-create content on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
@@ -107,20 +107,20 @@ namespace Datadog.Trace.Agent
                         {
                             // count the exceptions caused by the http request itself,
                             // but not caused by 5xx status codes in EnsureSuccessStatusCode() below
-                            _dogStatsdClient.Increment(TracerMetricNames.Api.ErrorCount);
+                            _dogStatsdClient?.Increment(TracerMetricNames.Api.ErrorCount);
                             throw;
                         }
 
                         // count every response's status code, regardless of value
                         string[] tags = { $"status: {(int)responseMessage.StatusCode}" };
-                        _dogStatsdClient.Increment(TracerMetricNames.Api.ResponseCountByStatusCode, tags: tags);
+                        _dogStatsdClient?.Increment(TracerMetricNames.Api.ResponseCountByStatusCode, tags: tags);
 
                         responseMessage.EnsureSuccessStatusCode();
                     }
                 }
                 catch (Exception ex)
                 {
-                    _dogStatsdClient.Increment(TracerMetricNames.Api.ErrorCount);
+                    _dogStatsdClient?.Increment(TracerMetricNames.Api.ErrorCount);
 
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -116,7 +116,7 @@ namespace Datadog.Trace.Agent
                             string[] tags = { $"status:{(int)responseMessage.StatusCode}" };
 
                             // count every response, grouped by status code
-                            _statsd.AppendIncrementCount(TracerMetricNames.Api.ResponsesByStatusCode, tags: tags);
+                            _statsd.AppendIncrementCount(TracerMetricNames.Api.Responses, tags: tags);
                         }
 
                         responseMessage.EnsureSuccessStatusCode();

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.Containers;
 using Datadog.Trace.DogStatsD;
@@ -63,8 +62,7 @@ namespace Datadog.Trace.Agent
             }
 
             // report Tracer version
-            var tracerVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, tracerVersion);
+            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, TracerConstants.AssemblyVersion);
 
             // report container id (only Linux containers supported for now)
             var containerId = ContainerInfo.GetContainerId();

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -110,9 +110,14 @@ namespace Datadog.Trace.Agent
                             throw;
                         }
 
-                        // count every response's status code
-                        string[] tags = { $"status:{(int)responseMessage.StatusCode}" };
-                        _statsd?.AppendIncrementCount(TracerMetricNames.Api.ResponsesByStatusCode, tags: tags);
+                        if (_statsd != null)
+                        {
+                            // don't bother creating the tags array if trace metrics are disabled
+                            string[] tags = { $"status:{(int)responseMessage.StatusCode}" };
+
+                            // count every response, grouped by status code
+                            _statsd.AppendIncrementCount(TracerMetricNames.Api.ResponsesByStatusCode, tags: tags);
+                        }
 
                         responseMessage.EnsureSuccessStatusCode();
                     }

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Agent
             };
         }
 
-        public Api(Uri baseEndpoint, IDogStatsd dogStatsdClient, DelegatingHandler delegatingHandler)
+        public Api(Uri baseEndpoint, DelegatingHandler delegatingHandler, IDogStatsd dogStatsdClient)
         {
             _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
             _dogStatsdClient = dogStatsdClient;

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -121,8 +121,6 @@ namespace Datadog.Trace.Agent
                 }
                 catch (Exception ex)
                 {
-                    _dogStatsdClient?.Increment(TracerMetricNames.Api.Errors);
-
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)
                     {

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Datadog.Trace.Containers;
-using Datadog.Trace.DogStatsD;
+using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.StatsdClient;
 using MsgPack.Serialization;

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Agent
 
                         try
                         {
-                            _dogStatsdClient?.Increment(TracerMetricNames.Api.RequestCount);
+                            _dogStatsdClient?.Increment(TracerMetricNames.Api.Requests);
                             responseMessage = await _client.PostAsync(_tracesEndpoint, content).ConfigureAwait(false);
                         }
                         catch
@@ -108,20 +108,20 @@ namespace Datadog.Trace.Agent
                             // count the exceptions throw by the HttpClient,
                             // not responses with 5xx status codes
                             // (which cause EnsureSuccessStatusCode() to throw below)
-                            _dogStatsdClient?.Increment(TracerMetricNames.Api.ErrorCount);
+                            _dogStatsdClient?.Increment(TracerMetricNames.Api.Errors);
                             throw;
                         }
 
                         // count every response's status code
                         string[] tags = { $"status:{(int)responseMessage.StatusCode}" };
-                        _dogStatsdClient?.Increment(TracerMetricNames.Api.ResponseCountByStatusCode, tags: tags);
+                        _dogStatsdClient?.Increment(TracerMetricNames.Api.ResponsesByStatusCode, tags: tags);
 
                         responseMessage.EnsureSuccessStatusCode();
                     }
                 }
                 catch (Exception ex)
                 {
-                    _dogStatsdClient?.Increment(TracerMetricNames.Api.ErrorCount);
+                    _dogStatsdClient?.Increment(TracerMetricNames.Api.Errors);
 
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Datadog.Trace.Containers;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.StatsdClient;
 using MsgPack.Serialization;
 using Newtonsoft.Json;
 
@@ -20,6 +21,7 @@ namespace Datadog.Trace.Agent
 
         private readonly Uri _tracesEndpoint;
         private readonly HttpClient _client;
+        private readonly IDogStatsd _dogStatsdClient;
 
         static Api()
         {
@@ -32,13 +34,14 @@ namespace Datadog.Trace.Agent
             };
         }
 
-        public Api(Uri baseEndpoint, DelegatingHandler delegatingHandler = null)
+        public Api(Uri baseEndpoint, IDogStatsd dogStatsdClient, DelegatingHandler delegatingHandler)
         {
+            _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
+            _dogStatsdClient = dogStatsdClient;
+
             _client = delegatingHandler == null
                           ? new HttpClient()
                           : new HttpClient(delegatingHandler);
-
-            _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
 
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");
 

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.Configuration
         /// Configuration key for enabling or disabling internal metrics sent to DogStatsD.
         /// Default value is <c>false</c> (disabled).
         /// </summary>
-        public const string InternalMetricsEnabled = "DD_INTERNAL_METRICS_ENABLED";
+        public const string TracerMetricsEnabled = "DD_TRACER_METRICS_ENABLED";
 
         /// <summary>
         /// String format patterns used to match integration-specific configuration keys.

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -127,6 +127,18 @@ namespace Datadog.Trace.Configuration
         public const string CustomSamplingRules = "DD_CUSTOM_SAMPLING_RULES";
 
         /// <summary>
+        /// Configuration key for the DogStatsd port where the Tracer can send metrics.
+        /// Default value is 8125/
+        /// </summary>
+        public const string DogStatsdPort = "DD_DOGSTATSD_PORT";
+
+        /// <summary>
+        /// Configuration key for enabling or disabling internal metrics sent to DogStatsD.
+        /// Default value is <c>false</c> (disabled).
+        /// </summary>
+        public const string InternalMetricsEnabled = "DD_INTERNAL_METRICS_ENABLED";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -85,6 +85,14 @@ namespace Datadog.Trace.Configuration
 
             GlobalTags = source?.GetDictionary(ConfigurationKeys.GlobalTags) ??
                          new ConcurrentDictionary<string, string>();
+
+            DogStatsdPort = source?.GetInt32(ConfigurationKeys.DogStatsdPort) ??
+                            // default value
+                            8125;
+
+            InternalMetricsEnabled = source?.GetBool(ConfigurationKeys.InternalMetricsEnabled) ??
+                                     // default value
+                                     false;
         }
 
         /// <summary>
@@ -167,6 +175,19 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets the global tags, which are applied to all <see cref="Span"/>s.
         /// </summary>
         public IDictionary<string, string> GlobalTags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the port where the DogStatsd server is listening for connections.
+        /// Default is <c>8125</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DogStatsdPort"/>
+        public int DogStatsdPort { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether internal metrics
+        /// are enabled and send to DogStatsd.
+        /// </summary>
+        public bool InternalMetricsEnabled { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Configuration
                             // default value
                             8125;
 
-            InternalMetricsEnabled = source?.GetBool(ConfigurationKeys.InternalMetricsEnabled) ??
+            TracerMetricsEnabled = source?.GetBool(ConfigurationKeys.TracerMetricsEnabled) ??
                                      // default value
                                      false;
         }
@@ -187,7 +187,7 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether internal metrics
         /// are enabled and send to DogStatsd.
         /// </summary>
-        public bool InternalMetricsEnabled { get; set; }
+        public bool TracerMetricsEnabled { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Newtonsoft.Json;
 
 namespace Datadog.Trace.Configuration
 {
@@ -72,10 +71,12 @@ namespace Datadog.Trace.Configuration
             AgentUri = new Uri(agentUri);
 
             AnalyticsEnabled = source?.GetBool(ConfigurationKeys.GlobalAnalyticsEnabled) ??
+                               // default value
                                false;
 
             LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled) ??
-                               false;
+                                   // default value
+                                   false;
 
             MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
                                100;
@@ -83,7 +84,7 @@ namespace Datadog.Trace.Configuration
             Integrations = new IntegrationSettingsCollection(source);
 
             GlobalTags = source?.GetDictionary(ConfigurationKeys.GlobalTags) ??
-                new ConcurrentDictionary<string, string>();
+                         new ConcurrentDictionary<string, string>();
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -58,14 +58,17 @@ namespace Datadog.Trace.Configuration
                             // backwards compatibility for names used in the past
                             source?.GetString("DD_TRACE_AGENT_HOSTNAME") ??
                             source?.GetString("DATADOG_TRACE_AGENT_HOSTNAME") ??
+                            // default value
                             DefaultAgentHost;
 
             var agentPort = source?.GetInt32(ConfigurationKeys.AgentPort) ??
                             // backwards compatibility for names used in the past
                             source?.GetInt32("DATADOG_TRACE_AGENT_PORT") ??
+                            // default value
                             DefaultAgentPort;
 
             var agentUri = source?.GetString(ConfigurationKeys.AgentUri) ??
+                           // default value
                            $"http://{agentHost}:{agentPort}";
 
             AgentUri = new Uri(agentUri);
@@ -79,11 +82,13 @@ namespace Datadog.Trace.Configuration
                                    false;
 
             MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
-                               100;
+                                          // default value
+                                          100;
 
             Integrations = new IntegrationSettingsCollection(source);
 
             GlobalTags = source?.GetDictionary(ConfigurationKeys.GlobalTags) ??
+                         // default value (empty)
                          new ConcurrentDictionary<string, string>();
 
             DogStatsdPort = source?.GetInt32(ConfigurationKeys.DogStatsdPort) ??
@@ -91,8 +96,8 @@ namespace Datadog.Trace.Configuration
                             8125;
 
             TracerMetricsEnabled = source?.GetBool(ConfigurationKeys.TracerMetricsEnabled) ??
-                                     // default value
-                                     false;
+                                   // default value
+                                   false;
         }
 
         /// <summary>

--- a/src/Datadog.Trace/DogStatsD/StatsdExtensions.cs
+++ b/src/Datadog.Trace/DogStatsD/StatsdExtensions.cs
@@ -1,0 +1,19 @@
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.DogStatsD
+{
+    internal static class StatsdExtensions
+    {
+        public static IStatsd AppendIncrementCount(this IStatsd statsd, string name, int value = 1, double sampleRate = 1, string[] tags = null)
+        {
+            statsd.Add<Statsd.Counting, int>(name, value, sampleRate, tags);
+            return statsd;
+        }
+
+        public static IStatsd AppendSetGauge(this IStatsd statsd, string name, int value, double sampleRate = 1, string[] tags = null)
+        {
+            statsd.Add<Statsd.Gauge, int>(name, value, sampleRate, tags);
+            return statsd;
+        }
+    }
+}

--- a/src/Datadog.Trace/DogStatsD/TracerMetricNames.cs
+++ b/src/Datadog.Trace/DogStatsD/TracerMetricNames.cs
@@ -7,22 +7,22 @@ namespace Datadog.Trace.DogStatsD
             /// <summary>
             /// Count: Total number of API requests made
             /// </summary>
-            public const string RequestCount = "datadog.tracer.api.requests";
+            public const string Requests = "datadog.tracer.api.requests";
 
             /// <summary>
             /// Count: Count of API responses.
             /// This metric has an additional tag of "status: {code}" to group the responses by the HTTP response code.
-            /// This is different from <seealso cref="ErrorCount"/> in that this is all HTTP responses
-            /// regardless of status code, and <seealso cref="ErrorCount"/> is exceptions raised from making an API call.
+            /// This is different from <seealso cref="Errors"/> in that this is all HTTP responses
+            /// regardless of status code, and <seealso cref="Errors"/> is exceptions raised from making an API call.
             /// </summary>
-            public const string ResponseCountByStatusCode = "datadog.tracer.api.responses";
+            public const string ResponsesByStatusCode = "datadog.tracer.api.responses";
 
             /// <summary>
             /// Count: Total number of exceptions raised by API calls.
             /// This is different from receiving a 4xx or 5xx response.
             /// It is a "timeout error" or something from making the API call.
             /// </summary>
-            public const string ErrorCount = "datadog.tracer.api.errors";
+            public const string Errors = "datadog.tracer.api.errors";
         }
 
         public static class Queue
@@ -30,17 +30,17 @@ namespace Datadog.Trace.DogStatsD
             /// <summary>
             /// Count: Total number of traces pushed into the queue, where "accepted - dropped = total to be flushed"
             /// </summary>
-            public const string PushedTraces = "datadog.tracer.queue.accepted";
+            public const string EnqueuedTraces = "datadog.tracer.queue.accepted";
 
             /// <summary>
             /// Count: Total number of spans pushed into the queue
             /// </summary>
-            public const string PushedSpans = "datadog.tracer.queue.accepted_lengths";
+            public const string EnqueuedSpans = "datadog.tracer.queue.accepted_lengths";
 
             /// <summary>
             /// Count: Total size in bytes of traces pushed into the queue
             /// </summary>
-            public const string PushedBytes = "datadog.tracer.queue.accepted_size";
+            public const string EnqueuedBytes = "datadog.tracer.queue.accepted_size";
 
             /// <summary>
             /// Count: Total number of traces dropped by the queue.
@@ -52,22 +52,22 @@ namespace Datadog.Trace.DogStatsD
             /// <summary>
             /// Gauge: Number of traces pulled from the queue for flushing (should be between zero and queue.max_length)
             /// </summary>
-            public const string PoppedTraces = "datadog.tracer.queue.length";
+            public const string DequeuedTraces = "datadog.tracer.queue.length";
 
             /// <summary>
             /// Gauge: Total number of spans pulled from the queue for flushing
             /// </summary>
-            public const string PoppedSpans = "datadog.tracer.queue.spans";
+            public const string DequeuedSpans = "datadog.tracer.queue.spans";
 
             /// <summary>
             /// Gauge: Size in bytes of traces pulled from the queue for flushing
             /// </summary>
-            public const string PoppedBytes = "datadog.tracer.queue.size";
+            public const string DequeuedBytes = "datadog.tracer.queue.size";
 
             /// <summary>
             /// Gauge: The maximum number of traces buffered by the background writer (this is static at 1k for now)
             /// </summary>
-            public const string BufferedTracesLimit = "datadog.tracer.queue.max_length";
+            public const string TraceQueueMaxCapacity = "datadog.tracer.queue.max_length";
         }
     }
 }

--- a/src/Datadog.Trace/DogStatsD/TracerMetricNames.cs
+++ b/src/Datadog.Trace/DogStatsD/TracerMetricNames.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.DogStatsD
             /// This is different from <seealso cref="Errors"/> in that this is all HTTP responses
             /// regardless of status code, and <seealso cref="Errors"/> is exceptions raised from making an API call.
             /// </summary>
-            public const string ResponsesByStatusCode = "datadog.tracer.api.responses";
+            public const string Responses = "datadog.tracer.api.responses";
 
             /// <summary>
             /// Count: Total number of exceptions raised by API calls.

--- a/src/Datadog.Trace/DogStatsD/TracerMetricNames.cs
+++ b/src/Datadog.Trace/DogStatsD/TracerMetricNames.cs
@@ -1,0 +1,73 @@
+namespace Datadog.Trace.DogStatsD
+{
+    internal static class TracerMetricNames
+    {
+        public static class Api
+        {
+            /// <summary>
+            /// Count: Total number of API requests made
+            /// </summary>
+            public const string RequestCount = "datadog.tracer.api.requests";
+
+            /// <summary>
+            /// Count: Count of API responses.
+            /// This metric has an additional tag of "status: {code}" to group the responses by the HTTP response code.
+            /// This is different from <seealso cref="ErrorCount"/> in that this is all HTTP responses
+            /// regardless of status code, and <seealso cref="ErrorCount"/> is exceptions raised from making an API call.
+            /// </summary>
+            public const string ResponseCountByStatusCode = "datadog.tracer.api.responses";
+
+            /// <summary>
+            /// Count: Total number of exceptions raised by API calls.
+            /// This is different from receiving a 4xx or 5xx response.
+            /// It is a "timeout error" or something from making the API call.
+            /// </summary>
+            public const string ErrorCount = "datadog.tracer.api.errors";
+        }
+
+        public static class Queue
+        {
+            /// <summary>
+            /// Count: Total number of traces pushed into the queue, where "accepted - dropped = total to be flushed"
+            /// </summary>
+            public const string PushedTraces = "datadog.tracer.queue.accepted";
+
+            /// <summary>
+            /// Count: Total number of spans pushed into the queue
+            /// </summary>
+            public const string PushedSpans = "datadog.tracer.queue.accepted_lengths";
+
+            /// <summary>
+            /// Count: Total size in bytes of traces pushed into the queue
+            /// </summary>
+            public const string PushedBytes = "datadog.tracer.queue.accepted_size";
+
+            /// <summary>
+            /// Count: Total number of traces dropped by the queue.
+            /// This is the number of traces attempted to write into the queue above the max
+            /// (e.g. more than 1k traces, we start dropping traces)
+            /// </summary>
+            public const string DroppedTraces = "datadog.tracer.queue.dropped";
+
+            /// <summary>
+            /// Gauge: Number of traces pulled from the queue for flushing (should be between zero and queue.max_length)
+            /// </summary>
+            public const string PoppedTraces = "datadog.tracer.queue.length";
+
+            /// <summary>
+            /// Gauge: Total number of spans pulled from the queue for flushing
+            /// </summary>
+            public const string PoppedSpans = "datadog.tracer.queue.spans";
+
+            /// <summary>
+            /// Gauge: Size in bytes of traces pulled from the queue for flushing
+            /// </summary>
+            public const string PoppedBytes = "datadog.tracer.queue.size";
+
+            /// <summary>
+            /// Gauge: The maximum number of traces buffered by the background writer (this is static at 1k for now)
+            /// </summary>
+            public const string BufferedTracesLimit = "datadog.tracer.queue.max_length";
+        }
+    }
+}

--- a/src/Datadog.Trace/DogStatsd/StatsdExtensions.cs
+++ b/src/Datadog.Trace/DogStatsd/StatsdExtensions.cs
@@ -1,6 +1,6 @@
 using Datadog.Trace.Vendors.StatsdClient;
 
-namespace Datadog.Trace.DogStatsD
+namespace Datadog.Trace.DogStatsd
 {
     internal static class StatsdExtensions
     {

--- a/src/Datadog.Trace/DogStatsd/TracerMetricNames.cs
+++ b/src/Datadog.Trace/DogStatsd/TracerMetricNames.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.DogStatsd
             /// <summary>
             /// Gauge: The maximum number of traces buffered by the background writer (this is static at 1k for now)
             /// </summary>
-            public const string TraceQueueMaxCapacity = "datadog.tracer.queue.max_length";
+            public const string MaxCapacity = "datadog.tracer.queue.max_length";
         }
     }
 }

--- a/src/Datadog.Trace/DogStatsd/TracerMetricNames.cs
+++ b/src/Datadog.Trace/DogStatsd/TracerMetricNames.cs
@@ -1,4 +1,4 @@
-namespace Datadog.Trace.DogStatsD
+namespace Datadog.Trace.DogStatsd
 {
     internal static class TracerMetricNames
     {

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -55,8 +55,8 @@ namespace Datadog.Trace
             // fall back to default implementations of each dependency if not provided
             Settings = settings ?? TracerSettings.FromDefaultSources();
 
-            // only set DogStatsdClient if internal metrics are enabled
-            if (Settings.InternalMetricsEnabled)
+            // only set DogStatsdClient if tracer metrics are enabled
+            if (Settings.TracerMetricsEnabled)
             {
                 if (dogStatsdClient == null)
                 {

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace
                 }
             }
 
-            IApi apiClient = new Api(Settings.AgentUri, DogStatsdClient, delegatingHandler: null);
+            IApi apiClient = new Api(Settings.AgentUri, delegatingHandler: null, dogStatsdClient: DogStatsdClient);
             _agentWriter = agentWriter ?? new AgentWriter(apiClient, DogStatsdClient);
             _scopeManager = scopeManager ?? new AsyncLocalScopeManager();
             Sampler = sampler ?? new RuleBasedSampler(new RateLimiter(Settings.MaxTracesSubmittedPerSecond));

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace
             {
                 if (dogStatsdClient == null)
                 {
-                    var config = new StatsdConfig { StatsdServerName = Settings.AgentUri.Authority, StatsdPort = Settings.DogStatsdPort };
+                    var config = new StatsdConfig { StatsdServerName = Settings.AgentUri.DnsSafeHost, StatsdPort = Settings.DogStatsdPort };
                     DogStatsdClient = new DogStatsdService();
                     DogStatsdClient.Configure(config);
                 }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -306,7 +306,6 @@ namespace Datadog.Trace
         private static DogStatsdService CreateDogStatsdClient(TracerSettings settings)
         {
             var frameworkDescription = FrameworkDescription.Create();
-            var tracerVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 
             var config = new StatsdConfig
                          {
@@ -317,7 +316,7 @@ namespace Datadog.Trace
                                                 "lang:.NET",
                                                 $"lang_interpreter:{frameworkDescription.Name}",
                                                 $"lang_version:{frameworkDescription.ProductVersion}",
-                                                $"tracer_version:{tracerVersion}"
+                                                $"tracer_version:{TracerConstants.AssemblyVersion}"
                                             }
                          };
 

--- a/src/Datadog.Trace/TracerConstants.cs
+++ b/src/Datadog.Trace/TracerConstants.cs
@@ -8,5 +8,7 @@ namespace Datadog.Trace
         /// 2^63-1
         /// </summary>
         public const ulong MaxTraceId = 9_223_372_036_854_775_807;
+
+        public static readonly string AssemblyVersion = typeof(Tracer).Assembly.GetName().Version.ToString();
     }
 }

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
@@ -20,10 +20,10 @@ namespace Datadog.Trace.IntegrationTests
 
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
-            var api = new Api(endpoint, _httpRecorder);
-            var agentWriter = new AgentWriter(api);
+            var api = new Api(endpoint, _httpRecorder, dogStatsdClient: null);
+            var agentWriter = new AgentWriter(api, dogStatsdClient: null);
 
-            _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null);
+            _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, dogStatsdClient: null);
         }
 
         [Fact(Skip = "Run manually")]

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
@@ -20,10 +20,10 @@ namespace Datadog.Trace.IntegrationTests
 
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
-            var api = new Api(endpoint, _httpRecorder, dogStatsdClient: null);
-            var agentWriter = new AgentWriter(api, dogStatsdClient: null);
+            var api = new Api(endpoint, _httpRecorder, statsd: null);
+            var agentWriter = new AgentWriter(api, statsd: null);
 
-            _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, dogStatsdClient: null);
+            _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }
 
         [Fact(Skip = "Run manually")]

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
@@ -20,10 +20,10 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
 
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
-            var api = new Api(endpoint, _httpRecorder);
-            var agentWriter = new AgentWriter(api);
+            var api = new Api(endpoint, _httpRecorder, statsd: null);
+            var agentWriter = new AgentWriter(api, statsd: null);
 
-            var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null);
+            var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(tracer);
         }
 

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             var writerMock = new Mock<IAgentWriter>(MockBehavior.Strict);
             var samplerMock = new Mock<ISampler>();
 
-            var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null);
+            var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(datadogTracer);
         }
 

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, null);
+            var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(datadogTracer);
         }
 

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.OpenTracing.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, null);
+            var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
             _tracer = new OpenTracingTracer(datadogTracer);
         }

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tests
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");
 
             _api = new Mock<IApi>();
-            _agentWriter = new AgentWriter(_api.Object);
+            _agentWriter = new AgentWriter(_api.Object, dogStatsdClient: null);
 
             var parentSpanContext = new Mock<ISpanContext>();
             var traceContext = new Mock<ITraceContext>();
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task FlushTwice()
         {
-            var w = new AgentWriter(_api.Object);
+            var w = new AgentWriter(_api.Object, dogStatsdClient: null);
             await w.FlushAndCloseAsync();
             await w.FlushAndCloseAsync();
         }

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tests
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");
 
             _api = new Mock<IApi>();
-            _agentWriter = new AgentWriter(_api.Object, dogStatsdClient: null);
+            _agentWriter = new AgentWriter(_api.Object, statsd: null);
 
             var parentSpanContext = new Mock<ISpanContext>();
             var traceContext = new Mock<ITraceContext>();
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task FlushTwice()
         {
-            var w = new AgentWriter(_api.Object, dogStatsdClient: null);
+            var w = new AgentWriter(_api.Object, statsd: null);
             await w.FlushAndCloseAsync();
             await w.FlushAndCloseAsync();
         }

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests
                 StatusCode = HttpStatusCode.OK
             };
             var handler = new SetResponseHandler(response);
-            var api = new Api(new Uri("http://localhost:1234"), dogStatsdClient: null, handler);
+            var api = new Api(new Uri("http://localhost:1234"), handler, dogStatsdClient: null);
 
             var span = _tracer.StartSpan("Operation");
             var traces = new List<List<Span>> { new List<Span> { span } };
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Tests
                 StatusCode = HttpStatusCode.InternalServerError
             };
             var handler = new SetResponseHandler(response);
-            var api = new Api(new Uri("http://localhost:1234"), dogStatsdClient: null, handler);
+            var api = new Api(new Uri("http://localhost:1234"), handler, dogStatsdClient: null);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, null);
+            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests
                 StatusCode = HttpStatusCode.OK
             };
             var handler = new SetResponseHandler(response);
-            var api = new Api(new Uri("http://localhost:1234"), handler);
+            var api = new Api(new Uri("http://localhost:1234"), dogStatsdClient: null, handler);
 
             var span = _tracer.StartSpan("Operation");
             var traces = new List<List<Span>> { new List<Span> { span } };
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Tests
                 StatusCode = HttpStatusCode.InternalServerError
             };
             var handler = new SetResponseHandler(response);
-            var api = new Api(new Uri("http://localhost:1234"), handler);
+            var api = new Api(new Uri("http://localhost:1234"), dogStatsdClient: null, handler);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
+            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests
                 StatusCode = HttpStatusCode.OK
             };
             var handler = new SetResponseHandler(response);
-            var api = new Api(new Uri("http://localhost:1234"), handler, dogStatsdClient: null);
+            var api = new Api(new Uri("http://localhost:1234"), handler, statsd: null);
 
             var span = _tracer.StartSpan("Operation");
             var traces = new List<List<Span>> { new List<Span> { span } };
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Tests
                 StatusCode = HttpStatusCode.InternalServerError
             };
             var handler = new SetResponseHandler(response);
-            var api = new Api(new Uri("http://localhost:1234"), handler, dogStatsdClient: null);
+            var api = new Api(new Uri("http://localhost:1234"), handler, statsd: null);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -109,15 +109,17 @@ namespace Datadog.Trace.Tests.Configuration
             Func<TracerSettings, object> settingGetter,
             object expectedValue)
         {
+            // save original value so we can restore later
             var originalValue = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
 
+            Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
             IConfigurationSource source = new EnvironmentConfigurationSource();
             var settings = new TracerSettings(source);
-            object actualValue = settingGetter(settings);
 
+            object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
 
+            // restore original value
             Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
         }
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -22,6 +22,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
             yield return new object[] { CreateFunc(s => s.CustomSamplingRules), null };
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
+            yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
+            yield return new object[] { CreateFunc(s => s.DogStatsdPort), 8125 };
         }
 
         public static IEnumerable<object[]> GetTestData()

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -122,8 +122,26 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(GetJsonTestData))]
+        [MemberData(nameof(GetTestData))]
         public void JsonConfigurationSource(
+            string key,
+            string value,
+            Func<TracerSettings, object> settingGetter,
+            object expectedValue)
+        {
+            var config = new Dictionary<string, string> { [key] = value };
+            string json = JsonConvert.SerializeObject(config);
+            IConfigurationSource source = new JsonConfigurationSource(json);
+            var settings = new TracerSettings(source);
+
+            object actualValue = settingGetter(settings);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        // Special case for dictionary-typed settings in JSON
+        [Theory]
+        [MemberData(nameof(GetJsonTestData))]
+        public void JsonConfigurationSourceWithJsonTypedSetting(
             string value,
             Func<TracerSettings, object> settingGetter,
             object expectedValue)

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -19,6 +19,9 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
             yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
+            yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
+            yield return new object[] { CreateFunc(s => s.CustomSamplingRules), null };
+            yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
         }
 
         public static IEnumerable<object[]> GetTestData()
@@ -39,6 +42,9 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
 
             yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags.Count), 2 };
+
+            yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "true", CreateFunc(s => s.AnalyticsEnabled), true };
+            yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "false", CreateFunc(s => s.AnalyticsEnabled), false };
         }
 
         // JsonConfigurationSource needs to be tested with JSON data, which cannot be used with the other IConfigurationSource implementations.

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -40,6 +40,7 @@ namespace Datadog.Trace.Tests
                 agent.WaitForSpans(1);
             }
 
+            // for a single trace, these methods are called once with a value of "1"
             dogStatsD.Verify(
                 statsd => statsd.Increment(TracerMetricNames.Queue.PushedTraces, 1, 1D, null),
                 Times.Once());
@@ -56,6 +57,7 @@ namespace Datadog.Trace.Tests
                 statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedSpans, 1, 1D, null),
                 Times.Once());
 
+            // these methods can be called multiple times with a "0" value (no more traces left)
             dogStatsD.Verify(
                 statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedTraces, 0, 1D, null),
                 Times.AtLeastOnce);
@@ -64,6 +66,7 @@ namespace Datadog.Trace.Tests
                 statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedSpans, 0, 1D, null),
                 Times.AtLeastOnce());
 
+            // these methods can be called multiple times with a "1000" value (the max buffer size, constant)
             dogStatsD.Verify(
                 statsd => statsd.Gauge(TracerMetricNames.Queue.BufferedTracesLimit, 1000, 1D, null),
                 Times.AtLeastOnce());

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -22,15 +22,15 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void SendMetrics()
         {
-            var dogStatsD = new Mock<IDogStatsd>();
+            var statsd = new Mock<IStatsd>();
             var api = new Mock<IApi>();
             var agentPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
             {
                 var settings = new TracerSettings();
-                var agentWriter = new AgentWriter(api.Object, dogStatsD.Object);
-                var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, dogStatsdClient: null);
+                var agentWriter = new AgentWriter(api.Object, statsd.Object);
+                var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
                 using (var rootScope = tracer.StartActive("root"))
                 {

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.DogStatsD;
+using Datadog.Trace.DogStatsd;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Vendors.StatsdClient;
 using Moq;

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -42,33 +42,33 @@ namespace Datadog.Trace.Tests
 
             // for a single trace, these methods are called once with a value of "1"
             dogStatsD.Verify(
-                statsd => statsd.Increment(TracerMetricNames.Queue.PushedTraces, 1, 1D, null),
+                statsd => statsd.Increment(TracerMetricNames.Queue.EnqueuedTraces, 1, 1D, null),
                 Times.Once());
 
             dogStatsD.Verify(
-                statsd => statsd.Increment(TracerMetricNames.Queue.PushedSpans, 1, 1D, null),
+                statsd => statsd.Increment(TracerMetricNames.Queue.EnqueuedSpans, 1, 1D, null),
                 Times.Once());
 
             dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedTraces, 1, 1D, null),
+                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedTraces, 1, 1D, null),
                 Times.Once());
 
             dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedSpans, 1, 1D, null),
+                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedSpans, 1, 1D, null),
                 Times.Once());
 
             // these methods can be called multiple times with a "0" value (no more traces left)
             dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedTraces, 0, 1D, null),
+                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedTraces, 0, 1D, null),
                 Times.AtLeastOnce);
 
             dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedSpans, 0, 1D, null),
+                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedSpans, 0, 1D, null),
                 Times.AtLeastOnce());
 
             // these methods can be called multiple times with a "1000" value (the max buffer size, constant)
             dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.BufferedTracesLimit, 1000, 1D, null),
+                statsd => statsd.Gauge(TracerMetricNames.Queue.TraceQueueMaxCapacity, 1000, 1D, null),
                 Times.AtLeastOnce());
         }
     }

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -41,35 +41,41 @@ namespace Datadog.Trace.Tests
             }
 
             // for a single trace, these methods are called once with a value of "1"
-            dogStatsD.Verify(
-                statsd => statsd.Increment(TracerMetricNames.Queue.EnqueuedTraces, 1, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Counting, int>(TracerMetricNames.Queue.EnqueuedTraces, 1, 1, null),
                 Times.Once());
 
-            dogStatsD.Verify(
-                statsd => statsd.Increment(TracerMetricNames.Queue.EnqueuedSpans, 1, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Counting, int>(TracerMetricNames.Queue.EnqueuedSpans, 1, 1D, null),
                 Times.Once());
 
-            dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedTraces, 1, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedTraces, 1, 1D, null),
                 Times.Once());
 
-            dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedSpans, 1, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedSpans, 1, 1D, null),
                 Times.Once());
 
             // these methods can be called multiple times with a "0" value (no more traces left)
-            dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedTraces, 0, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedTraces, 0, 1D, null),
                 Times.AtLeastOnce);
 
-            dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.DequeuedSpans, 0, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedSpans, 0, 1D, null),
                 Times.AtLeastOnce());
 
             // these methods can be called multiple times with a "1000" value (the max buffer size, constant)
-            dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.MaxCapacity, 1000, 1D, null),
+            statsd.Verify(
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.MaxCapacity, 1000, 1D, null),
                 Times.AtLeastOnce());
+
+            statsd.Verify(
+                s => s.Send(),
+                Times.AtLeastOnce());
+
+            statsd.VerifyNoOtherCalls();
         }
     }
 }

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
 
             // these methods can be called multiple times with a "1000" value (the max buffer size, constant)
             dogStatsD.Verify(
-                statsd => statsd.Gauge(TracerMetricNames.Queue.TraceQueueMaxCapacity, 1000, 1D, null),
+                statsd => statsd.Gauge(TracerMetricNames.Queue.MaxCapacity, 1000, 1D, null),
                 Times.AtLeastOnce());
         }
     }

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -1,0 +1,72 @@
+using System.Threading;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DogStatsD;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.StatsdClient;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Tests
+{
+    public class DogStatsDTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DogStatsDTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void SendMetrics()
+        {
+            var dogStatsD = new Mock<IDogStatsd>();
+            var api = new Mock<IApi>();
+            var agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            {
+                var settings = new TracerSettings();
+                var agentWriter = new AgentWriter(api.Object, dogStatsD.Object);
+                var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, dogStatsdClient: null);
+
+                using (var rootScope = tracer.StartActive("root"))
+                {
+                    Thread.Sleep(5);
+                }
+
+                agent.WaitForSpans(1);
+            }
+
+            dogStatsD.Verify(
+                statsd => statsd.Increment(TracerMetricNames.Queue.PushedTraces, 1, 1D, null),
+                Times.Once());
+
+            dogStatsD.Verify(
+                statsd => statsd.Increment(TracerMetricNames.Queue.PushedSpans, 1, 1D, null),
+                Times.Once());
+
+            dogStatsD.Verify(
+                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedTraces, 1, 1D, null),
+                Times.Once());
+
+            dogStatsD.Verify(
+                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedSpans, 1, 1D, null),
+                Times.Once());
+
+            dogStatsD.Verify(
+                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedTraces, 0, 1D, null),
+                Times.AtLeastOnce);
+
+            dogStatsD.Verify(
+                statsd => statsd.Gauge(TracerMetricNames.Queue.PoppedSpans, 0, 1D, null),
+                Times.AtLeastOnce());
+
+            dogStatsD.Verify(
+                statsd => statsd.Gauge(TracerMetricNames.Queue.BufferedTracesLimit, 1000, 1D, null),
+                Times.AtLeastOnce());
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Immutable;
 using System.Threading;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
@@ -20,25 +22,24 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void SendMetrics()
+        public void Dont_send_metrics_when_disabled()
         {
             var statsd = new Mock<IStatsd>();
-            var api = new Mock<IApi>();
-            var agentPort = TcpPortProvider.GetOpenPort();
+            var spans = SendSpan(tracerMetricsEnabled: false, statsd);
 
-            using (var agent = new MockTracerAgent(agentPort))
-            {
-                var settings = new TracerSettings();
-                var agentWriter = new AgentWriter(api.Object, statsd.Object);
-                var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
+            Assert.True(spans.Count == 1, "Expected one span");
 
-                using (var rootScope = tracer.StartActive("root"))
-                {
-                    Thread.Sleep(5);
-                }
+            // no methods should be called on the IStatsd
+            statsd.VerifyNoOtherCalls();
+        }
 
-                agent.WaitForSpans(1);
-            }
+        [Fact]
+        public void Send_metrics_when_enabled()
+        {
+            var statsd = new Mock<IStatsd>();
+            var spans = SendSpan(tracerMetricsEnabled: true, statsd);
+
+            Assert.True(spans.Count == 1, "Expected one span");
 
             // for a single trace, these methods are called once with a value of "1"
             statsd.Verify(
@@ -46,36 +47,74 @@ namespace Datadog.Trace.Tests
                 Times.Once());
 
             statsd.Verify(
-                s => s.Add<Statsd.Counting, int>(TracerMetricNames.Queue.EnqueuedSpans, 1, 1D, null),
+                s => s.Add<Statsd.Counting, int>(TracerMetricNames.Queue.EnqueuedSpans, 1, 1, null),
                 Times.Once());
 
             statsd.Verify(
-                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedTraces, 1, 1D, null),
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedTraces, 1, 1, null),
                 Times.Once());
 
             statsd.Verify(
-                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedSpans, 1, 1D, null),
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedSpans, 1, 1, null),
+                Times.Once());
+
+            statsd.Verify(
+                s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Requests, 1, 1, null),
+                Times.Once());
+
+            statsd.Verify(
+                s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, "status:200"),
                 Times.Once());
 
             // these methods can be called multiple times with a "0" value (no more traces left)
+            /*
             statsd.Verify(
-                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedTraces, 0, 1D, null),
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedTraces, 0, 1, null),
                 Times.AtLeastOnce);
 
             statsd.Verify(
-                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedSpans, 0, 1D, null),
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.DequeuedSpans, 0, 1, null),
                 Times.AtLeastOnce());
+            */
 
-            // these methods can be called multiple times with a "1000" value (the max buffer size, constant)
+            // these method can be called multiple times with a "1000" value (the max buffer size, constant)
             statsd.Verify(
-                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.MaxCapacity, 1000, 1D, null),
+                s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Queue.MaxCapacity, 1000, 1, null),
                 Times.AtLeastOnce());
 
             statsd.Verify(
                 s => s.Send(),
                 Times.AtLeastOnce());
 
+            // no other methods should be called on the IStatsd
             statsd.VerifyNoOtherCalls();
+        }
+
+        private static IImmutableList<MockTracerAgent.Span> SendSpan(bool tracerMetricsEnabled, Mock<IStatsd> statsd)
+        {
+            IImmutableList<MockTracerAgent.Span> spans;
+            var agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            {
+                var settings = new TracerSettings
+                               {
+                                   AgentUri = new Uri($"http://localhost:{agentPort}"),
+                                   TracerMetricsEnabled = tracerMetricsEnabled
+                               };
+
+                var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: statsd.Object);
+
+                using (var scope = tracer.StartActive("root"))
+                {
+                    scope.Span.ResourceName = "resource";
+                    Thread.Sleep(5);
+                }
+
+                spans = agent.WaitForSpans(1);
+            }
+
+            return spans;
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tests.Logging
 
             settings.LogsInjectionEnabled = enableLogsInjection;
 
-            return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
+            return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }
 
         internal static void PerformParentChildScopeSequence(Tracer tracer, ILog logger, Func<string, object, bool, IDisposable> openMappedContext, out Scope parentScope, out Scope childScope)

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tests.Logging
 
             settings.LogsInjectionEnabled = enableLogsInjection;
 
-            return new Tracer(settings, writerMock.Object, samplerMock.Object, null);
+            return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
         }
 
         internal static void PerformParentChildScopeSequence(Tracer tracer, ILog logger, Func<string, object, bool, IDisposable> openMappedContext, out Scope parentScope, out Scope childScope)

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Tests
             _writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, null);
+            _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Tests
             _writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
+            _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
@@ -21,7 +20,7 @@ namespace Datadog.Trace.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, null);
+            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tests
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ISampler>();
 
-            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, dogStatsdClient: null);
+            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds internal tracer metrics using the [`dogstatsd-csharp-client`](https://github.com/DataDog/dogstatsd-csharp-client). These tracer metrics are disabled by default and can be enabled with the `DD_TRACER_METRICS_ENABLED` setting.

Metrics added:
- number of traces and spans created
- number of traces and spans dropped
- number of traces and spans sent to the Agent
- number of API requests sent to the Agent
- number of successful responses from the Agent, tagged with status code
- number of failed API requests to the Agent

All metrics are tagged with:
- tracer language (`.NET`)
- tracer library version (e.g. `1.9.0`)
- runtime name (e.g. `.NET Framework`, `.NET Core`)
- runtime version (e.g. `4.6.1, `3.0.0`)
