### PR TITLE
Enable Samples.MySql test in CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     - MYSQL_USER=mysqldb
     - MYSQL_PASSWORD=mysqldb
     ports:
-    - "127.0.0.1:3306:3306"
+    - "127.0.0.1:3307:3306"
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
     - ./:/project
     environment:
     - MYSQL_HOST=mysql
+    - MYSQL_PORT=3306
     depends_on:
     - mysql
 
@@ -216,6 +217,7 @@ services:
     - SQLSERVER_CONNECTION_STRING=Server=sqlserver;User=sa;Password=Strong!Passw0rd
     - POSTGRES_HOST=postgres
     - MYSQL_HOST=mysql
+    - MYSQL_PORT=3306
     - buildConfiguration=${buildConfiguration}
     - publishTargetFramework=${publishTargetFramework}
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -226,3 +226,4 @@ services:
     - sqlserver
     - mongo
     - postgres
+    - mysql

--- a/samples/Samples.MySql/Program.cs
+++ b/samples/Samples.MySql/Program.cs
@@ -55,7 +55,8 @@ namespace Samples.MySql
             if (connectionString == null)
             {
                 var host = Environment.GetEnvironmentVariable("MYSQL_HOST") ?? "localhost";
-                connectionString = $"server={host};user=mysqldb;password=mysqldb;port=3307;database=world";
+                var port = Environment.GetEnvironmentVariable("MYSQL_PORT") ?? "3307";
+                connectionString = $"server={host};user=mysqldb;password=mysqldb;port={port};database=world";
             }
 
             return new MySqlConnection(connectionString);

--- a/samples/Samples.MySql/Program.cs
+++ b/samples/Samples.MySql/Program.cs
@@ -55,7 +55,7 @@ namespace Samples.MySql
             if (connectionString == null)
             {
                 var host = Environment.GetEnvironmentVariable("MYSQL_HOST") ?? "localhost";
-                connectionString = $"server={host};user=mysqldb;password=mysqldb;port=3306;database=world";
+                connectionString = $"server={host};user=mysqldb;password=mysqldb;port=3307;database=world";
             }
 
             return new MySqlConnection(connectionString);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
         }
 
-        [Fact(Skip = "Need to figure out running MySQL in docker containers.")]
+        [Fact]
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {


### PR DESCRIPTION
Changes proposed in this pull request:
Enable `Samples.MySql` test in CI



@DataDog/apm-dotnet