### PR TITLE
When URL is empty, AspNetMVC scope creation fails

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                         if (route != null)
                         {
-                            var resourceUrl = (route.Url ?? string.Empty).ToLowerInvariant();
+                            var resourceUrl = route.Url?.ToLowerInvariant() ?? string.Empty;
                             if (resourceUrl.FirstOrDefault() != '/')
                             {
                                 resourceUrl = string.Concat("/", resourceUrl);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                         if (route != null)
                         {
-                            var resourceUrl = route.Url.ToLowerInvariant();
+                            var resourceUrl = (route.Url ?? string.Empty).ToLowerInvariant();
                             if (resourceUrl.FirstOrDefault() != '/')
                             {
                                 resourceUrl = string.Concat("/", resourceUrl);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         if (route != null)
                         {
                             var resourceUrl = route.Url.ToLowerInvariant();
-                            if (resourceUrl.First() != '/')
+                            if (resourceUrl.FirstOrDefault() != '/')
                             {
                                 resourceUrl = string.Concat("/", resourceUrl);
                             }


### PR DESCRIPTION
When URL is empty, AspNetMVC scope creation fails

@DataDog/apm-dotnet