### PR TITLE
AspNetCoreMvc3 Integration

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -273,6 +273,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationWithLog4Net", "r
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Core.Tools", "tools\Datadog.Core.Tools\Datadog.Core.Tools.csproj", "{3BEACB10-89FE-4F74-8022-1A52F223CE82}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreMvc.Netcore3", "samples\Samples.AspNetCoreMvc.Netcore3\Samples.AspNetCoreMvc.Netcore3.csproj", "{64235C59-8EAB-401A-86B0-C41E513F0AE8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -901,6 +903,16 @@ Global
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82}.Release|x64.Build.0 = Release|Any CPU
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82}.Release|x86.ActiveCfg = Release|Any CPU
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82}.Release|x86.Build.0 = Release|Any CPU
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Debug|x64.ActiveCfg = Debug|x64
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Debug|x64.Build.0 = Debug|x64
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Debug|x86.ActiveCfg = Debug|x86
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Debug|x86.Build.0 = Debug|x86
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Release|Any CPU.ActiveCfg = Release|x86
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Release|x64.ActiveCfg = Release|x64
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Release|x64.Build.0 = Release|x64
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Release|x86.ActiveCfg = Release|x86
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -965,6 +977,7 @@ Global
 		{35F581E9-3D7C-4E80-8DFF-D437B0D86710} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{1C34D970-6081-4EFA-8F2F-5AD2B146AC58} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82} = {5D8E1F81-B820-4736-B797-271B0FE787EE}
+		{64235C59-8EAB-401A-86B0-C41E513F0AE8} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -22,6 +22,12 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration samples/Samples.AspNetCoreMvc2/Samples.AspNetCoreMvc2.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
+# Only build Samples.AspNetCoreMvc2 for netcoreapp3.0
+if [ "$publishTargetFramework" == "netcoreapp3.0" ]
+then
+    dotnet publish -f $publishTargetFramework -c $buildConfiguration samples/Samples.AspNetCoreMvc.Netcore3/Samples.AspNetCoreMvc.Netcore3.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
+fi
+
 for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.MongoDB Samples.HttpMessageHandler Samples.Npgsql Samples.MySql Samples.GraphQL ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration samples/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done

--- a/integrations.json
+++ b/integrations.json
@@ -144,6 +144,84 @@
           "method": "AfterAction",
           "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
         }
+      },
+      {
+        "caller": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core"
+        },
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker",
+          "method": "Rethrow",
+          "signature_types": [
+            "System.Void",
+            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResourceExecutedContextSealed"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "Rethrow_ResourceExecutedContextSealed",
+          "signature": "00 04 01 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core"
+        },
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker",
+          "method": "Rethrow",
+          "signature_types": [
+            "System.Void",
+            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ExceptionContextSealed"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "Rethrow_ExceptionContextSealed",
+          "signature": "00 04 01 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core"
+        },
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker",
+          "method": "Rethrow",
+          "signature_types": [
+            "System.Void",
+            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultExecutedContextSealed"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "Rethrow_ResultExecutedContextSealed",
+          "signature": "00 04 01 1C 08 08 0A"
+        }
       }
     ]
   },

--- a/integrations.json
+++ b/integrations.json
@@ -99,8 +99,8 @@
           "method": "BeforeAction",
           "signature_types": [
             "System.Void",
-            "_",
-            "Microsoft.AspNetCore.Http.DefaultHttpContext",
+            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
             "Microsoft.AspNetCore.Http.DefaultHttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
           ],
@@ -112,7 +112,34 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "BeforeAction",
+          "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+          "method": "BeforeAction",
+          "signature_types": [
+            "System.Void",
+            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
+            "Microsoft.AspNetCore.Http.HttpContext",
+            "Microsoft.AspNetCore.Routing.RouteData"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
           "method": "BeforeAction",
           "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
@@ -126,8 +153,8 @@
           "method": "AfterAction",
           "signature_types": [
             "System.Void",
-            "_",
-            "Microsoft.AspNetCore.Http.DefaultHttpContext",
+            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
             "Microsoft.AspNetCore.Http.DefaultHttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
           ],
@@ -139,16 +166,41 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
           "method": "AfterAction",
           "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
         }
       },
       {
-        "caller": {
-          "assembly": "Microsoft.AspNetCore.Mvc.Core"
+        "caller": {},
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+          "method": "AfterAction",
+          "signature_types": [
+            "System.Void",
+            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
+            "Microsoft.AspNetCore.Http.HttpContext",
+            "Microsoft.AspNetCore.Routing.RouteData"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
         },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "AfterAction",
+          "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
         "target": {
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker",
@@ -165,16 +217,14 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
           "method": "Rethrow_ResourceExecutedContextSealed",
           "signature": "00 04 01 1C 08 08 0A"
         }
       },
       {
-        "caller": {
-          "assembly": "Microsoft.AspNetCore.Mvc.Core"
-        },
+        "caller": {},
         "target": {
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker",
@@ -191,16 +241,14 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
           "method": "Rethrow_ExceptionContextSealed",
           "signature": "00 04 01 1C 08 08 0A"
         }
       },
       {
-        "caller": {
-          "assembly": "Microsoft.AspNetCore.Mvc.Core"
-        },
+        "caller": {},
         "target": {
           "assembly": "Microsoft.AspNetCore.Mvc.Core",
           "type": "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker",
@@ -217,7 +265,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
           "method": "Rethrow_ResultExecutedContextSealed",
           "signature": "00 04 01 1C 08 08 0A"

--- a/integrations.json
+++ b/integrations.json
@@ -207,7 +207,7 @@
           "method": "Rethrow",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResourceExecutedContextSealed"
+            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ResourceExecutedContextSealed"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -231,7 +231,7 @@
           "method": "Rethrow",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ExceptionContextSealed"
+            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ExceptionContextSealed"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,
@@ -255,7 +255,7 @@
           "method": "Rethrow",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultExecutedContextSealed"
+            "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ResultExecutedContextSealed"
           ],
           "minimum_major": 1,
           "minimum_minor": 0,

--- a/integrations.json
+++ b/integrations.json
@@ -99,7 +99,7 @@
           "method": "BeforeAction",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "System.Diagnostics.DiagnosticListener",
             "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
             "Microsoft.AspNetCore.Http.DefaultHttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
@@ -126,7 +126,7 @@
           "method": "BeforeAction",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "System.Diagnostics.DiagnosticListener",
             "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
             "Microsoft.AspNetCore.Http.HttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
@@ -153,7 +153,7 @@
           "method": "AfterAction",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "System.Diagnostics.DiagnosticListener",
             "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
             "Microsoft.AspNetCore.Http.DefaultHttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
@@ -180,7 +180,7 @@
           "method": "AfterAction",
           "signature_types": [
             "System.Void",
-            "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+            "System.Diagnostics.DiagnosticListener",
             "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor",
             "Microsoft.AspNetCore.Http.HttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"

--- a/integrations.json
+++ b/integrations.json
@@ -104,10 +104,10 @@
             "Microsoft.AspNetCore.Http.DefaultHttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -131,10 +131,10 @@
             "Microsoft.AspNetCore.Http.HttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -158,10 +158,10 @@
             "Microsoft.AspNetCore.Http.DefaultHttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -185,10 +185,10 @@
             "Microsoft.AspNetCore.Http.HttpContext",
             "Microsoft.AspNetCore.Routing.RouteData"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -209,10 +209,10 @@
             "System.Void",
             "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ResourceExecutedContextSealed"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -233,10 +233,10 @@
             "System.Void",
             "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ExceptionContextSealed"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -257,10 +257,10 @@
             "System.Void",
             "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ResultExecutedContextSealed"
           ],
-          "minimum_major": 1,
+          "minimum_major": 3,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 6,
+          "maximum_major": 3,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },

--- a/integrations.json
+++ b/integrations.json
@@ -89,6 +89,65 @@
     ]
   },
   {
+    "name": "AspNetCoreMvc3",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+          "method": "BeforeAction",
+          "signature_types": [
+            "System.Void",
+            "_",
+            "Microsoft.AspNetCore.Http.DefaultHttpContext",
+            "Microsoft.AspNetCore.Http.DefaultHttpContext",
+            "Microsoft.AspNetCore.Routing.RouteData"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "BeforeAction",
+          "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Mvc.Core",
+          "type": "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions",
+          "method": "AfterAction",
+          "signature_types": [
+            "System.Void",
+            "_",
+            "Microsoft.AspNetCore.Http.DefaultHttpContext",
+            "Microsoft.AspNetCore.Http.DefaultHttpContext",
+            "Microsoft.AspNetCore.Routing.RouteData"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetCoreMvc3Integration",
+          "method": "AfterAction",
+          "signature": "00 07 01 1C 1C 1C 1C 08 08 0A"
+        }
+      }
+    ]
+  },
+  {
     "name": "AspNetMvc",
     "method_replacements": [
       {

--- a/sample-libs/Samples.ExampleLibrary/FakeClient/Biscuit.cs
+++ b/sample-libs/Samples.ExampleLibrary/FakeClient/Biscuit.cs
@@ -13,5 +13,15 @@ namespace Samples.ExampleLibrary.FakeClient
         public Guid Id { get; set; }
         public string Message { get; set; }
         public List<object> Treats { get; set; } = new List<object>();
+
+        public class Cookie
+        {
+            public bool IsYummy { get; set; }
+
+            public class Raisin
+            {
+                public bool IsPurple { get; set; }
+            }
+        }
     }
 }

--- a/sample-libs/Samples.ExampleLibrary/FakeClient/DogClient.cs
+++ b/sample-libs/Samples.ExampleLibrary/FakeClient/DogClient.cs
@@ -11,6 +11,21 @@ namespace Samples.ExampleLibrary.FakeClient
             Task.Delay(1).Wait();
         }
 
+        public string TellMeIfTheCookieIsYummy(Biscuit.Cookie cookie, Biscuit.Cookie.Raisin raisin)
+        {
+            if (cookie.IsYummy)
+            {
+                if (raisin.IsPurple)
+                {
+                    return "Yes, it is yummy, with purple raisins.";
+                }
+
+                return "Yes, it is yummy, with white raisins.";
+            }
+
+            return "No, it is not yummy";
+        }
+
         public void Sit(
             string message, 
             int howManyTimes, 

--- a/sample-libs/Samples.Shared/Samples.Shared.csproj
+++ b/sample-libs/Samples.Shared/Samples.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/sample-libs/Samples.Shared/Samples.Shared.csproj
+++ b/sample-libs/Samples.Shared/Samples.Shared.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netstandard3.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Program.cs
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Samples.AspNetCoreMvc.Netcore3
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Properties/launchSettings.json
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Properties/launchSettings.json
@@ -1,0 +1,56 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:54563/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+
+        "DD_TRACE_DEBUG": "false"
+      },
+      "use64Bit": true,
+      "nativeDebugging": true
+    },
+    "Samples.AspNetCoreMvc.Netcore3": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+
+        "DD_TRACE_DEBUG":  "false" 
+      },
+      "applicationUrl": "http://localhost:54567/",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Properties/launchSettings.json
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Properties/launchSettings.json
@@ -10,7 +10,7 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
 
@@ -32,7 +32,7 @@
     },
     "Samples.AspNetCoreMvc.Netcore3": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
 
@@ -47,7 +47,7 @@
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
 
-        "DD_TRACE_DEBUG":  "false" 
+        "DD_TRACE_DEBUG": "false"
       },
       "applicationUrl": "http://localhost:54567/",
       "nativeDebugging": true

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Samples.AspNetCoreMvc.Netcore3.csproj
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Samples.AspNetCoreMvc.Netcore3.csproj
@@ -1,0 +1,47 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
+
+    <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <!--Implicitly referenced through "Microsoft.NET.Sdk.Web"-->
+  <!--<ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>-->
+
+  <!--Begin linked files section (Shared code with AspNetCoreMvc2 -->
+  <ItemGroup>
+    <Compile Include="..\Samples.AspNetCoreMvc2\Attributes\StackTraceHelper.cs" Link="Attributes\StackTraceHelper.cs" />
+    <Compile Include="..\Samples.AspNetCoreMvc2\Controllers\ApiController.cs" Link="Controllers\ApiController.cs" />
+    <Compile Include="..\Samples.AspNetCoreMvc2\Controllers\DistributedTracingApiController.cs" Link="Controllers\DistributedTracingApiController.cs" />
+    <Compile Include="..\Samples.AspNetCoreMvc2\Controllers\DistributedTracingMvcController.cs" Link="Controllers\DistributedTracingMvcController.cs" />
+    <Compile Include="..\Samples.AspNetCoreMvc2\Controllers\HomeController.cs" Link="Controllers\HomeController.cs" />
+    <Compile Include="..\Samples.AspNetCoreMvc2\Extensions\HeaderDictionaryExtensions.cs" Link="Extensions\HeaderDictionaryExtensions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Attributes\" />
+    <Folder Include="Extensions\" />
+    <Folder Include="Models\" />
+    <Folder Include="Controllers\" />
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+  <!--End linked files section-->
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sample-libs\Samples.Shared\Samples.Shared.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+</Project>

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Samples.AspNetCoreMvc.Netcore3.csproj
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Samples.AspNetCoreMvc.Netcore3.csproj
@@ -13,7 +13,7 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>-->
 
-  <!--Begin linked files section (Shared code with AspNetCoreMvc2 -->
+  <!--Begin linked files section (Shared code with AspNetCoreMvc2) -->
   <ItemGroup>
     <Compile Include="..\Samples.AspNetCoreMvc2\Attributes\StackTraceHelper.cs" Link="Attributes\StackTraceHelper.cs" />
     <Compile Include="..\Samples.AspNetCoreMvc2\Controllers\ApiController.cs" Link="Controllers\ApiController.cs" />

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Startup.cs
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Startup.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Samples.AspNetCoreMvc.Netcore3
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllersWithViews();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Home/Error");
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Views/Home/Delay.cshtml
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Views/Home/Delay.cshtml
@@ -1,0 +1,9 @@
+﻿@model int
+
+@{
+    ViewData["Title"] = "Delay";
+    ViewData["Description"] = "This page has a built-in delay";
+}
+
+<h1>Hello, world!</h1>
+<h2>Delayed @Html.FormatValue(Model, "{0:N0}") seconds</h2>

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Views/Home/Index.cshtml
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Views/Home/Index.cshtml
@@ -1,0 +1,59 @@
+﻿@model List<KeyValuePair<string, string>>
+
+@{
+    ViewData["Title"] = "Home Page";
+    ViewData["Description"] = "The home page of my website";
+}
+
+<div class="container">
+    <table class="table table-striped table-hover">
+        <tbody>
+            <tr>
+                <th scope="row">Application bitness</th>
+                <td>@(Environment.Is64BitProcess ? "64-bit" : "32-bit")</td>
+            </tr>
+            <tr>
+                <th scope="row">Profiler attached</th>
+                <td>@Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached</td>
+            </tr>
+            <tr>
+                <th scope="row">Datadog.Trace.dll path</th>
+                <td>@typeof(Datadog.Trace.Tracer).Assembly.Location</td>
+            </tr>
+            <tr>
+                <th scope="row">Datadog.Trace.ClrProfiler.Managed.dll</th>
+                <td>@typeof(Datadog.Trace.ClrProfiler.Instrumentation).Assembly.Location</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<div class="container">
+    <div>Environment Variables:</div>
+    <table class="table table-striped table-hover">
+        <thead>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            @if (Model.Any())
+            {
+                foreach (var envVar in Model)
+                {
+                    <tr>
+                        <th scope="row">@envVar.Key</th>
+                        <td>@envVar.Value</td>
+                    </tr>
+                }
+            }
+            else
+            {
+                <tr>
+                    <td colspan="2">(empty)</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Views/_Layout.cshtml
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Views/_Layout.cshtml
@@ -1,0 +1,27 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Samples.AspNetCoreMvc2</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+</head>
+<body>
+    <div>
+        @RenderBody()
+    </div>
+    @if (ViewBag.StackTrace != null)
+    {
+        <h3>Stack trace: </h3>
+        <div style="padding-left: 10px;">
+            <pre>
+                @foreach (string entry in ViewBag.StackTrace)
+                {
+                    @(entry)
+                }
+            </pre>
+        </div>
+    }
+</body>
+</html>

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Views/_ViewImports.cshtml
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+﻿@using Samples.AspNetCoreMvc2
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/samples/Samples.AspNetCoreMvc.Netcore3/Views/_ViewStart.cshtml
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout.cshtml";
+}

--- a/samples/Samples.AspNetCoreMvc.Netcore3/appsettings.Development.json
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/samples/Samples.AspNetCoreMvc.Netcore3/appsettings.json
+++ b/samples/Samples.AspNetCoreMvc.Netcore3/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/Samples.AspNetCoreMvc2/Controllers/HomeController.cs
+++ b/samples/Samples.AspNetCoreMvc2/Controllers/HomeController.cs
@@ -55,5 +55,11 @@ namespace Samples.AspNetCoreMvc2.Controllers
             HttpContext.Response.StatusCode = statusCode;
             return $"Status code has been set to {statusCode}";
         }
+
+        [Route("alive-check")]
+        public string IsAlive()
+        {
+            return "Yes";
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -71,6 +71,15 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return new MethodBuilder<TDelegate>(moduleVersionId, mdToken, opCode, methodName);
         }
 
+        public static MethodBuilder<TDelegate> Start(Module module, int mdToken, int opCode, string methodName)
+        {
+            return new MethodBuilder<TDelegate>(
+                module,
+                mdToken,
+                opCode,
+                methodName);
+        }
+
         public static MethodBuilder<TDelegate> Start(long moduleVersionPtr, int mdToken, int opCode, string methodName)
         {
             return new MethodBuilder<TDelegate>(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ModuleLookup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ModuleLookup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading;
+using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Emit
@@ -20,6 +21,11 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         private static int _failures = 0;
         private static bool _shortCircuitLogicHasLogged = false;
+
+        public static Module GetByPointer(long moduleVersionPointer)
+        {
+            return Get(PointerHelpers.GetGuidFromNativePointer(moduleVersionPointer));
+        }
 
         public static Module Get(Guid moduleVersionId)
         {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc2Integration.cs
@@ -254,8 +254,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             Action<object, object, object, object> instrumentedMethod = null;
 
-            string methodDef = $"{DiagnosticSourceTypeName}.{nameof(AfterAction)}(...)";
-
             try
             {
                 instrumentedMethod =

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -17,8 +17,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string IntegrationName = "AspNetCoreMvc3";
         private const string OperationName = "aspnet-coremvc.request";
         private const string AspnetMvcCore = "Microsoft.AspNetCore.Mvc.Core";
-        private const string MinimumVersion = "1";
-        private const string MaximumVersion = "6";
+        private const string MinimumVersion = "3";
+        private const string MaximumVersion = "3";
 
         /// <summary>
         /// Type for unobtrusive hooking into Microsoft.AspNetCore.Mvc pipeline.

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.ClrProfiler.ExtensionMethods;
+using Datadog.Trace.Headers;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Integrations
+{
+    /// <summary>
+    /// The ASP.NET Core MVC 3 integration.
+    /// </summary>
+    public static class AspNetCoreMvc3Integration
+    {
+        private const string HttpContextKey = "__Datadog.Trace.ClrProfiler.Integrations." + nameof(AspNetCoreMvc3Integration);
+        private const string IntegrationName = "AspNetCoreMvc3";
+        private const string OperationName = "aspnet-coremvc.request";
+        private const string AspnetMvcCore = "Microsoft.AspNetCore.Mvc.Core";
+        private const string MinimumVersion = "1";
+        private const string MaximumVersion = "6";
+
+        /// <summary>
+        /// Type for unobtrusive hooking into Microsoft.AspNetCore.Mvc pipeline.
+        /// </summary>
+        private const string DiagnosticListenerTypeName = "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions";
+
+        /// <summary>
+        /// Base type used for traversing the pipeline in Microsoft.AspNetCore.Mvc.Core.
+        /// </summary>
+        private const string ResourceInvokerTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker";
+
+        private const string ControllerActionDescriptorTypeName = "Microsoft.AspNetCore.Http.DefaultHttpContext";
+
+        private const string DefaultHttpContextTypeName = "Microsoft.AspNetCore.Http.DefaultHttpContext";
+
+        private const string RouteDataTypeName = "Microsoft.AspNetCore.Routing.RouteData";
+
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(AspNetCoreMvc3Integration));
+
+        private static AspNetCoreMvcContext CreateContext(object actionDescriptor, object httpContext)
+        {
+            var context = new AspNetCoreMvcContext();
+
+            try
+            {
+                var request = httpContext.GetProperty("Request").GetValueOrDefault();
+
+                GetTagValues(
+                    actionDescriptor,
+                    request,
+                    out string httpMethod,
+                    out string host,
+                    out string resourceName,
+                    out string url,
+                    out string controllerName,
+                    out string actionName);
+
+                SpanContext propagatedContext = null;
+                var tracer = Tracer.Instance;
+
+                if (tracer.ActiveScope == null)
+                {
+                    try
+                    {
+                        // extract propagated http headers
+                        var requestHeaders = request.GetProperty<IEnumerable>("Headers").GetValueOrDefault();
+
+                        if (requestHeaders != null)
+                        {
+                            var headersCollection = new DictionaryHeadersCollection();
+
+                            foreach (object header in requestHeaders)
+                            {
+                                var key = header.GetProperty<string>("Key").GetValueOrDefault();
+                                var values = header.GetProperty<IList<string>>("Value").GetValueOrDefault();
+
+                                if (key != null && values != null)
+                                {
+                                    headersCollection.Add(key, values);
+                                }
+                            }
+
+                            propagatedContext = SpanContextPropagator.Instance.Extract(headersCollection);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error extracting propagated HTTP headers.");
+                    }
+                }
+
+                var scope = tracer.StartActive(OperationName, propagatedContext);
+                context.Scope = scope;
+                var span = scope.Span;
+
+                span.DecorateWebServerSpan(
+                    resourceName: resourceName,
+                    method: httpMethod,
+                    host: host,
+                    httpUrl: url);
+
+                span.SetTag(Tags.AspNetController, controllerName);
+                span.SetTag(Tags.AspNetAction, actionName);
+
+                var analyticsSampleRate = tracer.Settings.GetIntegrationAnalyticsSampleRate(IntegrationName, enabledWithGlobalSetting: true);
+                span.SetMetric(Tags.Analytics, analyticsSampleRate);
+            }
+            catch (Exception ex)
+            {
+                context.ShouldInstrument = false;
+                context.Scope.Dispose();
+                Log.Error(
+                    ex,
+                    "An exception occurred when trying to initialize a Scope for {0}",
+                    nameof(AspNetCoreMvc3Integration));
+                throw;
+            }
+
+            return context;
+        }
+
+        /// <summary>
+        /// Wrapper method used to instrument Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticSourceExtensions.BeforeAction(...)
+        /// </summary>
+        /// <param name="diagnosticListener">The diagnostic listener that this extension method was called on.</param>
+        /// <param name="controllerActionDescriptor">An descriptor with information about the current controller and action.</param>
+        /// <param name="httpContext">The HttpContext for the current request.</param>
+        /// <param name="routeData">Any relevant data from routing.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        [InterceptMethod(
+            TargetAssembly = AspnetMvcCore,
+            TargetType = DiagnosticListenerTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
+            TargetMinimumVersion = MinimumVersion,
+            TargetMaximumVersion = MaximumVersion)]
+        public static void BeforeAction(
+            object diagnosticListener,
+            object controllerActionDescriptor,
+            object httpContext,
+            object routeData,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            AspNetCoreMvcContext context = null;
+
+            try
+            {
+                context = CreateContext(controllerActionDescriptor, httpContext);
+
+                if (context.ShouldInstrument
+                 && httpContext.TryGetPropertyValue("Items", out IDictionary<object, object> contextItems))
+                {
+                    contextItems[HttpContextKey] = context;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Error creating {nameof(AspNetCoreMvcContext)}.");
+            }
+
+            Action<object, object, object, object> instrumentedMethod = null;
+            Type concreteType = null;
+
+            try
+            {
+                var module = ModuleLookup.GetByPointer(moduleVersionPtr);
+                concreteType = module.GetType(DiagnosticListenerTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Action<object, object, object, object>>
+                       .Start(module, mdToken, opCode, nameof(BeforeAction))
+                       .WithConcreteType(concreteType)
+                       .WithParameters(diagnosticListener, controllerActionDescriptor, httpContext, routeData)
+                       .WithNamespaceAndNameFilters(
+                            ClrNames.Void,
+                            ClrNames.Ignore,
+                            ClrNames.Ignore,
+                            ClrNames.Ignore,
+                            ClrNames.Ignore)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorRetrievingMethod(
+                    exception: ex,
+                    moduleVersionPointer: moduleVersionPtr,
+                    mdToken: mdToken,
+                    opCode: opCode,
+                    instrumentedType: DiagnosticListenerTypeName,
+                    methodName: nameof(BeforeAction),
+                    instanceType: null,
+                    relevantArguments: new[] { concreteType?.AssemblyQualifiedName });
+                throw;
+            }
+
+            try
+            {
+                // call the original method, catching and rethrowing any unhandled exceptions
+                instrumentedMethod.Invoke(diagnosticListener, controllerActionDescriptor, httpContext, routeData);
+            }
+            catch (Exception ex)
+            {
+                context?.Scope?.Span?.SetException(ex);
+                throw;
+            }
+            finally
+            {
+                context?.Scope?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Wrapper method used to instrument Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticSourceExtensions.AfterAction(...)
+        /// </summary>
+        /// <param name="diagnosticListener">The diagnostic listener that this extension method was called on.</param>
+        /// <param name="controllerActionDescriptor">An descriptor with information about the current controller and action.</param>
+        /// <param name="httpContext">The HttpContext for the current request.</param>
+        /// <param name="routeData">Any relevant data from routing.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        [InterceptMethod(
+            TargetAssembly = AspnetMvcCore,
+            TargetType = DiagnosticListenerTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
+            TargetMinimumVersion = MinimumVersion,
+            TargetMaximumVersion = MaximumVersion)]
+        public static void AfterAction(
+            object diagnosticListener,
+            object controllerActionDescriptor,
+            object httpContext,
+            object routeData,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            AspNetCoreMvcContext context = null;
+
+            try
+            {
+                if (httpContext.TryGetPropertyValue("Items", out IDictionary<object, object> contextItems))
+                {
+                    context = contextItems?[HttpContextKey] as AspNetCoreMvcContext;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Error accessing {nameof(AspNetCoreMvcContext)}.");
+            }
+
+            Action<object, object, object, object> instrumentedMethod = null;
+            Type concreteType = null;
+
+            try
+            {
+                var module = ModuleLookup.GetByPointer(moduleVersionPtr);
+                concreteType = module.GetType(DiagnosticListenerTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Action<object, object, object, object>>
+                       .Start(module, mdToken, opCode, nameof(AfterAction))
+                       .WithConcreteType(concreteType)
+                       .WithParameters(diagnosticListener, controllerActionDescriptor, httpContext, routeData)
+                       .WithNamespaceAndNameFilters(
+                            ClrNames.Void,
+                            ClrNames.Ignore,
+                            ClrNames.Ignore,
+                            ClrNames.Ignore,
+                            ClrNames.Ignore)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorRetrievingMethod(
+                    exception: ex,
+                    moduleVersionPointer: moduleVersionPtr,
+                    mdToken: mdToken,
+                    opCode: opCode,
+                    instrumentedType: DiagnosticListenerTypeName,
+                    methodName: nameof(AfterAction),
+                    instanceType: null,
+                    relevantArguments: new[] { concreteType?.AssemblyQualifiedName });
+                throw;
+            }
+
+            try
+            {
+                // call the original method, catching and rethrowing any unhandled exceptions
+                instrumentedMethod.Invoke(diagnosticListener, controllerActionDescriptor, httpContext, routeData);
+            }
+            catch (Exception ex)
+            {
+                context?.Scope?.Span?.SetException(ex);
+                throw;
+            }
+            finally
+            {
+                context?.Scope?.Dispose();
+            }
+        }
+
+        private static void GetTagValues(
+            object actionDescriptor,
+            object request,
+            out string httpMethod,
+            out string host,
+            out string resourceName,
+            out string url,
+            out string controllerName,
+            out string actionName)
+        {
+            controllerName = actionDescriptor.GetProperty<string>("ControllerName").GetValueOrDefault()?.ToLowerInvariant();
+
+            actionName = actionDescriptor.GetProperty<string>("ActionName").GetValueOrDefault()?.ToLowerInvariant();
+
+            host = request.GetProperty("Host").GetProperty<string>("Value").GetValueOrDefault();
+
+            httpMethod = request.GetProperty<string>("Method").GetValueOrDefault()?.ToUpperInvariant() ?? "UNKNOWN";
+
+            string pathBase = request.GetProperty("PathBase").GetProperty<string>("Value").GetValueOrDefault();
+
+            string path = request.GetProperty("Path").GetProperty<string>("Value").GetValueOrDefault();
+
+            string queryString = request.GetProperty("QueryString").GetProperty<string>("Value").GetValueOrDefault();
+
+            url = $"{pathBase}{path}{queryString}";
+
+            string resourceUrl = actionDescriptor.GetProperty("AttributeRouteInfo").GetProperty<string>("Template").GetValueOrDefault() ??
+                                 UriHelpers.GetRelativeUrl(new Uri($"https://{host}{url}"), tryRemoveIds: true).ToLowerInvariant();
+
+            resourceName = $"{httpMethod} {resourceUrl}";
+        }
+
+        private class AspNetCoreMvcContext
+        {
+            public AspNetCoreMvcContext()
+            {
+                if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationName))
+                {
+                    // integration disabled
+                    ShouldInstrument = false;
+                }
+            }
+
+            public bool ShouldInstrument { get; set; } = true;
+
+            public Scope Scope { get; set; }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -38,9 +38,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string RouteDataTypeName = "Microsoft.AspNetCore.Routing.RouteData";
 
         private const string DiagnosticListenerTypeName = "System.Diagnostics.DiagnosticListener";
-        private const string ResourceExecutedContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResourceExecutedContextSealed";
-        private const string ExceptionContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ExceptionContextSealed";
-        private const string ResultExecutedContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultExecutedContextSealed";
+        private const string ResourceExecutedContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ResourceExecutedContextSealed";
+        private const string ExceptionContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ExceptionContextSealed";
+        private const string ResultExecutedContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker+ResultExecutedContextSealed";
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(AspNetCoreMvc3Integration));
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -30,9 +30,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         private const string ResourceInvokerTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker";
 
-        private const string ControllerActionDescriptorTypeName = "Microsoft.AspNetCore.Http.DefaultHttpContext";
+        private const string ControllerActionDescriptorTypeName = "Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor";
 
         private const string DefaultHttpContextTypeName = "Microsoft.AspNetCore.Http.DefaultHttpContext";
+        private const string HttpContextTypeName = "Microsoft.AspNetCore.Http.HttpContext";
 
         private const string RouteDataTypeName = "Microsoft.AspNetCore.Routing.RouteData";
 
@@ -137,7 +138,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = AspnetMvcCore,
             TargetType = DiagnosticListenerTypeName,
-            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
+            TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
+            TargetMinimumVersion = MinimumVersion,
+            TargetMaximumVersion = MaximumVersion)]
+        [InterceptMethod(
+            TargetAssembly = AspnetMvcCore,
+            TargetType = DiagnosticListenerTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, HttpContextTypeName, RouteDataTypeName },
             TargetMinimumVersion = MinimumVersion,
             TargetMaximumVersion = MaximumVersion)]
         public static void BeforeAction(
@@ -230,7 +237,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         [InterceptMethod(
             TargetAssembly = AspnetMvcCore,
             TargetType = DiagnosticListenerTypeName,
-            TargetSignatureTypes = new[] { ClrNames.Void, ClrNames.Ignore, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
+            TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
+            TargetMinimumVersion = MinimumVersion,
+            TargetMaximumVersion = MaximumVersion)]
+        [InterceptMethod(
+            TargetAssembly = AspnetMvcCore,
+            TargetType = DiagnosticListenerTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, HttpContextTypeName, RouteDataTypeName },
             TargetMinimumVersion = MinimumVersion,
             TargetMaximumVersion = MaximumVersion)]
         public static void AfterAction(
@@ -315,7 +328,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
-            CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
             TargetType = ResourceInvokerTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, ResourceExecutedContextSealedTypeName },
@@ -335,7 +347,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
-            CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
             TargetType = ResourceInvokerTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, ExceptionContextSealedTypeName },
@@ -355,7 +366,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
-            CallerAssembly = AspnetMvcCore,
             TargetAssembly = AspnetMvcCore,
             TargetType = ResourceInvokerTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, ResultExecutedContextSealedTypeName },

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <summary>
         /// Type for unobtrusive hooking into Microsoft.AspNetCore.Mvc pipeline.
         /// </summary>
-        private const string DiagnosticListenerTypeName = "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions";
+        private const string DiagnosticListenerExtensionsTypeName = "Microsoft.AspNetCore.Mvc.MvcCoreDiagnosticListenerExtensions";
 
         /// <summary>
         /// Base type used for traversing the pipeline in Microsoft.AspNetCore.Mvc.Core.
@@ -37,6 +37,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private const string RouteDataTypeName = "Microsoft.AspNetCore.Routing.RouteData";
 
+        private const string DiagnosticListenerTypeName = "System.Diagnostics.DiagnosticListener";
         private const string ResourceExecutedContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResourceExecutedContextSealed";
         private const string ExceptionContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ExceptionContextSealed";
         private const string ResultExecutedContextSealedTypeName = "Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.ResultExecutedContextSealed";
@@ -137,13 +138,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
             TargetAssembly = AspnetMvcCore,
-            TargetType = DiagnosticListenerTypeName,
+            TargetType = DiagnosticListenerExtensionsTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
             TargetMinimumVersion = MinimumVersion,
             TargetMaximumVersion = MaximumVersion)]
         [InterceptMethod(
             TargetAssembly = AspnetMvcCore,
-            TargetType = DiagnosticListenerTypeName,
+            TargetType = DiagnosticListenerExtensionsTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, HttpContextTypeName, RouteDataTypeName },
             TargetMinimumVersion = MinimumVersion,
             TargetMaximumVersion = MaximumVersion)]
@@ -179,7 +180,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 var module = ModuleLookup.GetByPointer(moduleVersionPtr);
-                concreteType = module.GetType(DiagnosticListenerTypeName);
+                concreteType = module.GetType(DiagnosticListenerExtensionsTypeName);
 
                 instrumentedMethod =
                     MethodBuilder<Action<object, object, object, object>>
@@ -201,7 +202,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     moduleVersionPointer: moduleVersionPtr,
                     mdToken: mdToken,
                     opCode: opCode,
-                    instrumentedType: DiagnosticListenerTypeName,
+                    instrumentedType: DiagnosticListenerExtensionsTypeName,
                     methodName: nameof(BeforeAction),
                     instanceType: null,
                     relevantArguments: new[] { concreteType?.AssemblyQualifiedName });
@@ -236,13 +237,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         [InterceptMethod(
             TargetAssembly = AspnetMvcCore,
-            TargetType = DiagnosticListenerTypeName,
+            TargetType = DiagnosticListenerExtensionsTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, DefaultHttpContextTypeName, RouteDataTypeName },
             TargetMinimumVersion = MinimumVersion,
             TargetMaximumVersion = MaximumVersion)]
         [InterceptMethod(
             TargetAssembly = AspnetMvcCore,
-            TargetType = DiagnosticListenerTypeName,
+            TargetType = DiagnosticListenerExtensionsTypeName,
             TargetSignatureTypes = new[] { ClrNames.Void, DiagnosticListenerTypeName, ControllerActionDescriptorTypeName, HttpContextTypeName, RouteDataTypeName },
             TargetMinimumVersion = MinimumVersion,
             TargetMaximumVersion = MaximumVersion)]
@@ -275,7 +276,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 var module = ModuleLookup.GetByPointer(moduleVersionPtr);
-                concreteType = module.GetType(DiagnosticListenerTypeName);
+                concreteType = module.GetType(DiagnosticListenerExtensionsTypeName);
 
                 instrumentedMethod =
                     MethodBuilder<Action<object, object, object, object>>
@@ -297,7 +298,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     moduleVersionPointer: moduleVersionPtr,
                     mdToken: mdToken,
                     opCode: opCode,
-                    instrumentedType: DiagnosticListenerTypeName,
+                    instrumentedType: DiagnosticListenerExtensionsTypeName,
                     methodName: nameof(AfterAction),
                     instanceType: null,
                     relevantArguments: new[] { concreteType?.AssemblyQualifiedName });

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -189,10 +189,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithParameters(diagnosticListener, controllerActionDescriptor, httpContext, routeData)
                        .WithNamespaceAndNameFilters(
                             ClrNames.Void,
+                            DiagnosticListenerTypeName,
+                            ControllerActionDescriptorTypeName,
                             ClrNames.Ignore,
-                            ClrNames.Ignore,
-                            ClrNames.Ignore,
-                            ClrNames.Ignore)
+                            RouteDataTypeName)
                        .Build();
             }
             catch (Exception ex)
@@ -285,10 +285,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithParameters(diagnosticListener, controllerActionDescriptor, httpContext, routeData)
                        .WithNamespaceAndNameFilters(
                             ClrNames.Void,
+                            DiagnosticListenerTypeName,
+                            ControllerActionDescriptorTypeName,
                             ClrNames.Ignore,
-                            ClrNames.Ignore,
-                            ClrNames.Ignore,
-                            ClrNames.Ignore)
+                            RouteDataTypeName)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetCoreMvc3Integration.cs
@@ -216,12 +216,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
             catch (Exception ex)
             {
-                context?.Scope?.Span?.SetException(ex);
+                // BeforeAction should never throw exceptions as it is diagnostic only.
+                // If we are here, it means we've likely messed up.
+                // Set an exception and close our span
+                if (context?.Scope != null)
+                {
+                    context.Scope?.Span?.SetException(ex);
+                    context.Scope?.Dispose();
+                    context.ShouldInstrument = false;
+                    context.Scope = null;
+                }
+
                 throw;
-            }
-            finally
-            {
-                context?.Scope?.Dispose();
             }
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -541,7 +541,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
             examined_type_token = nesting_type.id;
             examined_type_name = nesting_type.name;
 
-            ongoing_type_name = examined_type_name + "."_W + ongoing_type_name;
+            ongoing_type_name = examined_type_name + "+"_W + ongoing_type_name;
           }
 
           // index will be moved up one on every loop

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc2Tests.cs
@@ -1,166 +1,24 @@
-#if NETCOREAPP2_1
-
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Threading;
-using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
-    public class AspNetCoreMvc2Tests : TestHelper
+    public class AspNetCoreMvc2Tests : AspNetCoreMvcTestBase
     {
-        private static readonly string _topLevelOperationName = "aspnet-coremvc.request";
-
-        private static readonly List<WebServerSpanExpectation> _expectations = new List<WebServerSpanExpectation>()
-        {
-            CreateTopLevelExpectation(url: "/", httpMethod: "GET", httpStatus: "200", resourceUrl: "/"),
-            CreateTopLevelExpectation(url: "/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "delay/{seconds}"),
-            CreateTopLevelExpectation(url: "/api/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "api/delay/{seconds}"),
-            CreateTopLevelExpectation(url: "/status-code/203", httpMethod: "GET", httpStatus: "203", resourceUrl: "status-code/{statusCode}"),
-            // TODO: The below test succeeds in IISExpress, but fails in self host when expecting a status code of 500.
-            CreateTopLevelExpectation(
-                url: "/bad-request",
-                httpMethod: "GET",
-                httpStatus: null,
-                resourceUrl: "bad-request",
-                additionalCheck: span =>
-                {
-                    var failures = new List<string>();
-                    if (span.Tags[Tags.ErrorMsg] != "This was a bad request.")
-                    {
-                        failures.Add($"Expected specific exception within {span.Resource}");
-                    }
-
-                    return failures;
-                }),
-        };
-
         public AspNetCoreMvc2Tests(ITestOutputHelper output)
             : base("AspNetCoreMvc2", output)
         {
         }
 
+#if NETCOREAPP2_1
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(PackageVersions.AspNetCoreMvc2), MemberType = typeof(PackageVersions))]
-        public void SubmitsTracesSelfHosted(string packageVersion)
+        public void MeetsAllAspNetCoreMvcExpectations(string packageVersion)
         {
-            int agentPort = TcpPortProvider.GetOpenPort();
-            int aspNetCorePort = TcpPortProvider.GetOpenPort();
-
-            using (var agent = new MockTracerAgent(agentPort))
-            using (Process process = StartSample(agent.Port, arguments: null, packageVersion: packageVersion, aspNetCorePort: aspNetCorePort))
-            {
-                var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
-
-                process.OutputDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                    {
-                        if (args.Data.Contains("Now listening on:") || args.Data.Contains("Unable to start Kestrel"))
-                        {
-                            wh.Set();
-                        }
-
-                        Output.WriteLine($"[webserver][stdout] {args.Data}");
-                    }
-                };
-                process.BeginOutputReadLine();
-
-                process.ErrorDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                    {
-                        Output.WriteLine($"[webserver][stderr] {args.Data}");
-                    }
-                };
-                process.BeginErrorReadLine();
-
-                // wait for server to start
-                wh.WaitOne(5000);
-
-                var paths = _expectations.Select(e => e.OriginalUri).ToArray();
-                SubmitRequests(aspNetCorePort, paths);
-                var spans = agent.WaitForSpans(_expectations.Count, operationName: _topLevelOperationName, returnAllOperations: true)
-                                 .OrderBy(s => s.Start)
-                                 .ToList();
-
-                if (!process.HasExited)
-                {
-                    process.Kill();
-                }
-
-                SpanTestHelpers.AssertExpectationsMet(_expectations, spans);
-            }
+            RunTraceTestOnSelfHosted(packageVersion);
         }
-
-        private static WebServerSpanExpectation CreateTopLevelExpectation(
-            string url,
-            string httpMethod,
-            string httpStatus,
-            string resourceUrl,
-            Func<MockTracerAgent.Span, List<string>> additionalCheck = null)
-        {
-            var expectation = new WebServerSpanExpectation("Samples.AspNetCoreMvc2", _topLevelOperationName)
-            {
-                OriginalUri = url,
-                HttpMethod = httpMethod,
-                ResourceName = $"{httpMethod.ToUpper()} {resourceUrl}",
-                StatusCode = httpStatus,
-            };
-
-            expectation.RegisterDelegateExpectation(additionalCheck);
-
-            return expectation;
-        }
-
-        private void SubmitRequests(int aspNetCorePort, string[] paths)
-        {
-            foreach (string path in paths)
-            {
-                try
-                {
-                    var request = WebRequest.Create($"http://localhost:{aspNetCorePort}{path}");
-                    using (var response = (HttpWebResponse)request.GetResponse())
-                    using (var stream = response.GetResponseStream())
-                    using (var reader = new StreamReader(stream))
-                    {
-                        string responseText;
-                        try
-                        {
-                            responseText = reader.ReadToEnd();
-                        }
-                        catch (Exception ex)
-                        {
-                            responseText = "ENCOUNTERED AN ERROR WHEN READING RESPONSE.";
-                            Output.WriteLine(ex.ToString());
-                        }
-
-                        Output.WriteLine($"[http] {response.StatusCode} {responseText}");
-                    }
-                }
-                catch (WebException wex)
-                {
-                    Output.WriteLine($"[http] exception: {wex}");
-                    if (wex.Response is HttpWebResponse response)
-                    {
-                        using (var stream = response.GetResponseStream())
-                        using (var reader = new StreamReader(stream))
-                        {
-                            Output.WriteLine($"[http] {response.StatusCode} {reader.ReadToEnd()}");
-                        }
-                    }
-                }
-            }
-        }
+#endif
     }
 }
-
-#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc3Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc3Tests.cs
@@ -1,0 +1,25 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    public class AspNetCoreMvc3Tests : AspNetCoreMvcTestBase
+    {
+        public AspNetCoreMvc3Tests(ITestOutputHelper output)
+            : base("AspNetCoreMvc.Netcore3", output)
+        {
+            EnableDebugMode();
+        }
+
+#if NETCOREAPP3_0
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void MeetsAllAspNetCoreMvcExpectations()
+        {
+            // No package versions are relevant because this is built-in
+            RunTraceTestOnSelfHosted(string.Empty);
+        }
+#endif
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc3Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc3Tests.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         public AspNetCoreMvc3Tests(ITestOutputHelper output)
             : base("AspNetCoreMvc.Netcore3", output)
         {
-            EnableDebugMode();
+            // EnableDebugMode();
         }
 
 #if NETCOREAPP3_0

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -47,6 +47,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             using (var agent = new MockTracerAgent(agentPort))
             using (var process = StartSample(agent.Port, arguments: null, packageVersion: packageVersion, aspNetCorePort: aspNetCorePort))
             {
+                agent.Filters.Add(IsNotServerLifeCheck);
+
                 var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 
                 process.OutputDataReceived += (sender, args) =>
@@ -186,6 +188,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             }
 
             return true;
+        }
+
+        private bool IsNotServerLifeCheck(MockTracerAgent.Span span)
+        {
+            var url = SpanExpectation.GetTag(span, Tags.HttpUrl);
+            if (url == null)
+            {
+                return true;
+            }
+
+            return !url.Contains("alive-check");
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -99,7 +99,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                     agent.WaitForSpans(
                               Expectations.Count,
                               operationName: TopLevelOperationName,
-                              returnAllOperations: true,
                               minDateTime: testStart)
                          .OrderBy(s => s.Start)
                          .ToList();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
                     var ready = SubmitRequest(aspNetCorePort, "/alive-check");
 
-                    Thread.Sleep(300);
+                    Thread.Sleep(500);
 
                     if (ready)
                     {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                 var maxTimesToCheck = 20;
 
                 // wait for server to be ready to receive requests
-                while (!SubmitRequest(aspNetCorePort, "/alive-check"))
+                while (true)
                 {
                     maxTimesToCheck--;
 
@@ -87,7 +87,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                         throw new Exception("Unable to verify whether the server is ready to receive requests.");
                     }
 
-                    Thread.Sleep(500);
+                    var ready = SubmitRequest(aspNetCorePort, "/alive-check");
+
+                    Thread.Sleep(300);
+
+                    if (ready)
+                    {
+                        break;
+                    }
                 }
 
                 var testStart = DateTime.Now;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using Datadog.Trace.TestHelpers;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    public abstract class AspNetCoreMvcTestBase : TestHelper
+    {
+        protected static readonly string TopLevelOperationName = "aspnet-coremvc.request";
+
+        protected AspNetCoreMvcTestBase(string sampleAppName, ITestOutputHelper output)
+            : base(sampleAppName, output)
+        {
+            CreateTopLevelExpectation(url: "/", httpMethod: "GET", httpStatus: "200", resourceUrl: "/");
+            CreateTopLevelExpectation(url: "/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "delay/{seconds}");
+            CreateTopLevelExpectation(url: "/api/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "api/delay/{seconds}");
+            CreateTopLevelExpectation(url: "/status-code/203", httpMethod: "GET", httpStatus: "203", resourceUrl: "status-code/{statusCode}");
+            // TODO: The below test succeeds in IISExpress, but fails in self host when expecting a status code of 500.
+            CreateTopLevelExpectation(
+                url: "/bad-request",
+                httpMethod: "GET",
+                httpStatus: null,
+                resourceUrl: "bad-request",
+                additionalCheck: span =>
+                {
+                    var failures = new List<string>();
+                    if (SpanExpectation.GetTag(span, Tags.ErrorMsg) != "This was a bad request.")
+                    {
+                        failures.Add($"Expected specific exception within {span.Resource}");
+                    }
+
+                    return failures;
+                });
+        }
+
+        protected List<AspNetCoreMvcSpanExpectation> Expectations { get; set; } = new List<AspNetCoreMvcSpanExpectation>();
+
+        public void RunTraceTestOnSelfHosted(string packageVersion)
+        {
+            var agentPort = TcpPortProvider.GetOpenPort();
+            var aspNetCorePort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (var process = StartSample(agent.Port, arguments: null, packageVersion: packageVersion, aspNetCorePort: aspNetCorePort))
+            {
+                var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
+
+                process.OutputDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                    {
+                        if (args.Data.Contains("Now listening on:") || args.Data.Contains("Unable to start Kestrel"))
+                        {
+                            wh.Set();
+                        }
+
+                        Output.WriteLine($"[webserver][stdout] {args.Data}");
+                    }
+                };
+                process.BeginOutputReadLine();
+
+                process.ErrorDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                    {
+                        Output.WriteLine($"[webserver][stderr] {args.Data}");
+                    }
+                };
+                process.BeginErrorReadLine();
+
+                // wait for server to start
+                wh.WaitOne(5000);
+
+                var paths = Expectations.Select(e => e.OriginalUri).ToArray();
+                SubmitRequests(aspNetCorePort, paths);
+                var spans = agent.WaitForSpans(Expectations.Count, operationName: TopLevelOperationName, returnAllOperations: true)
+                                 .OrderBy(s => s.Start)
+                                 .ToList();
+
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+
+                SpanTestHelpers.AssertExpectationsMet(Expectations, spans);
+            }
+        }
+
+        protected void CreateTopLevelExpectation(
+            string url,
+            string httpMethod,
+            string httpStatus,
+            string resourceUrl,
+            Func<MockTracerAgent.Span, List<string>> additionalCheck = null)
+        {
+            var expectation = new AspNetCoreMvcSpanExpectation(EnvironmentHelper.FullSampleName, TopLevelOperationName)
+            {
+                OriginalUri = url,
+                HttpMethod = httpMethod,
+                ResourceName = $"{httpMethod.ToUpper()} {resourceUrl}",
+                StatusCode = httpStatus,
+            };
+
+            expectation.RegisterDelegateExpectation(additionalCheck);
+
+            Expectations.Add(expectation);
+        }
+
+        protected void SubmitRequests(int aspNetCorePort, string[] paths)
+        {
+            foreach (var path in paths)
+            {
+                try
+                {
+                    var request = WebRequest.Create($"http://localhost:{aspNetCorePort}{path}");
+                    using (var response = (HttpWebResponse)request.GetResponse())
+                    using (var stream = response.GetResponseStream())
+                    using (var reader = new StreamReader(stream))
+                    {
+                        string responseText;
+                        try
+                        {
+                            responseText = reader.ReadToEnd();
+                        }
+                        catch (Exception ex)
+                        {
+                            responseText = "ENCOUNTERED AN ERROR WHEN READING RESPONSE.";
+                            Output.WriteLine(ex.ToString());
+                        }
+
+                        Output.WriteLine($"[http] {response.StatusCode} {responseText}");
+                    }
+                }
+                catch (WebException wex)
+                {
+                    Output.WriteLine($"[http] exception: {wex}");
+                    if (wex.Response is HttpWebResponse response)
+                    {
+                        using (var stream = response.GetResponseStream())
+                        using (var reader = new StreamReader(stream))
+                        {
+                            Output.WriteLine($"[http] {response.StatusCode} {reader.ReadToEnd()}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
@@ -1,0 +1,10 @@
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class AspNetCoreMvcSpanExpectation : WebServerSpanExpectation
+    {
+        public AspNetCoreMvcSpanExpectation(string serviceName, string operationName)
+            : base(serviceName, operationName)
+        {
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
@@ -1,3 +1,5 @@
+using Datadog.Trace.TestHelpers;
+
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class AspNetCoreMvcSpanExpectation : WebServerSpanExpectation
@@ -5,6 +7,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public AspNetCoreMvcSpanExpectation(string serviceName, string operationName)
             : base(serviceName, operationName)
         {
+        }
+
+        public override bool Matches(MockTracerAgent.Span span)
+        {
+            var spanUri = GetTag(span, Tags.HttpUrl);
+            if (spanUri == null || !spanUri.Contains(OriginalUri))
+            {
+                return false;
+            }
+
+            return base.Matches(span);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
@@ -44,6 +44,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public string ServiceName { get; set; }
 
+        public static string GetTag(MockTracerAgent.Span span, string tag)
+        {
+            span.Tags.TryGetValue(tag, out var value);
+            return value;
+        }
+
         public virtual string Detail()
         {
             return $"service={ServiceName}, operation={OperationName}, type={Type}, resource={ResourceName}";
@@ -170,12 +176,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         protected string FailureMessage(string name, string actual, string expected)
         {
             return $"({name} mismatch: actual: {actual ?? "NULL"}, expected: {expected ?? "NULL"})";
-        }
-
-        protected string GetTag(MockTracerAgent.Span span, string tag)
-        {
-            span.Tags.TryGetValue(tag, out var value);
-            return value;
         }
 
         private IEnumerable<string> ExpectBasicSpanDataExists(MockTracerAgent.Span span)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -17,8 +17,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public abstract class TestHelper
     {
-        private readonly EnvironmentHelper _environmentHelper;
-
         protected TestHelper(string sampleAppName, string samplePathOverrides, ITestOutputHelper output, string disabledIntegrations = null)
             : this(new EnvironmentHelper(sampleAppName, typeof(TestHelper), output, samplePathOverrides, disabledIntegrations), output)
         {
@@ -31,20 +29,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected TestHelper(EnvironmentHelper environmentHelper, ITestOutputHelper output)
         {
-            _environmentHelper = environmentHelper;
-            SampleAppName = _environmentHelper.SampleName;
+            EnvironmentHelper = environmentHelper;
+            SampleAppName = EnvironmentHelper.SampleName;
             Output = output;
 
-            PathToSample = _environmentHelper.GetSampleApplicationOutputDirectory();
+            PathToSample = EnvironmentHelper.GetSampleApplicationOutputDirectory();
             Output.WriteLine($"Platform: {EnvironmentHelper.GetPlatform()}");
             Output.WriteLine($"Configuration: {EnvironmentHelper.GetBuildConfiguration()}");
-            Output.WriteLine($"TargetFramework: {_environmentHelper.GetTargetFramework()}");
+            Output.WriteLine($"TargetFramework: {EnvironmentHelper.GetTargetFramework()}");
             Output.WriteLine($".NET Core: {EnvironmentHelper.IsCoreClr()}");
             Output.WriteLine($"Application: {GetSampleApplicationPath()}");
-            Output.WriteLine($"Profiler DLL: {_environmentHelper.GetProfilerPath()}");
+            Output.WriteLine($"Profiler DLL: {EnvironmentHelper.GetProfilerPath()}");
         }
 
-        protected string TestPrefix => $"{EnvironmentHelper.GetBuildConfiguration()}.{_environmentHelper.GetTargetFramework()}";
+        protected EnvironmentHelper EnvironmentHelper { get; set; }
+
+        protected string TestPrefix => $"{EnvironmentHelper.GetBuildConfiguration()}.{EnvironmentHelper.GetTargetFramework()}";
 
         protected string SampleAppName { get; }
 
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public string GetSampleApplicationPath(string packageVersion = "")
         {
-            return _environmentHelper.GetSampleApplicationPath(packageVersion);
+            return EnvironmentHelper.GetSampleApplicationPath(packageVersion);
         }
 
         public Process StartSample(int traceAgentPort, string arguments, string packageVersion, int aspNetCorePort)
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
 
             return ProfilerHelper.StartProcessWithProfiler(
-                _environmentHelper,
+                EnvironmentHelper,
                 integrationPaths,
                 arguments,
                 traceAgentPort: traceAgentPort,
@@ -104,11 +104,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // get full paths to integration definitions
             IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
 
-            var exe = _environmentHelper.GetSampleExecutionSource();
+            var exe = EnvironmentHelper.GetSampleExecutionSource();
             var args = new string[]
                 {
                     $"/clr:v4.0",
-                    $"/path:{_environmentHelper.GetSampleProjectDirectory()}",
+                    $"/path:{EnvironmentHelper.GetSampleProjectDirectory()}",
                     $"/systray:false",
                     $"/port:{iisPort}",
                     $"/trace:info",
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"[webserver] starting {exe} {string.Join(" ", args)}");
 
             var process = ProfilerHelper.StartProcessWithProfiler(
-                _environmentHelper,
+                EnvironmentHelper,
                 integrationPaths,
                 arguments: string.Join(" ", args),
                 redirectStandardInput: true,
@@ -217,7 +217,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected void EnableDebugMode()
         {
-            _environmentHelper.DebugModeEnabled = true;
+            EnvironmentHelper.DebugModeEnabled = true;
         }
 
         protected async Task AssertHttpSpan(

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
@@ -1,5 +1,3 @@
-using Datadog.Trace.TestHelpers;
-
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class WebServerSpanExpectation : SpanExpectation
@@ -22,16 +20,5 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public string StatusCode { get; set; }
 
         public string HttpMethod { get; set; }
-
-        public override bool Matches(MockTracerAgent.Span span)
-        {
-            var spanUri = GetTag(span, Tags.HttpUrl);
-            if (spanUri == null || !spanUri.Contains(OriginalUri))
-            {
-                return false;
-            }
-
-            return base.Matches(span);
-        }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
@@ -1,3 +1,5 @@
+using Datadog.Trace.TestHelpers;
+
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class WebServerSpanExpectation : SpanExpectation
@@ -20,5 +22,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public string StatusCode { get; set; }
 
         public string HttpMethod { get; set; }
+
+        public override bool Matches(MockTracerAgent.Span span)
+        {
+            var spanUri = GetTag(span, Tags.HttpUrl);
+            if (spanUri == null || !spanUri.Contains(OriginalUri))
+            {
+                return false;
+            }
+
+            return base.Matches(span);
+        }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -12,7 +12,13 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
              typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.BeforeAction)),
              typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.AfterAction)),
-             typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.Rethrow))
+             typeof(AspNetCoreMvc2Integration).GetMethod(nameof(AspNetCoreMvc2Integration.Rethrow)),
+
+             typeof(AspNetCoreMvc3Integration).GetMethod(nameof(AspNetCoreMvc3Integration.BeforeAction)),
+             typeof(AspNetCoreMvc3Integration).GetMethod(nameof(AspNetCoreMvc3Integration.AfterAction)),
+             typeof(AspNetCoreMvc3Integration).GetMethod(nameof(AspNetCoreMvc3Integration.Rethrow_ExceptionContextSealed)),
+             typeof(AspNetCoreMvc3Integration).GetMethod(nameof(AspNetCoreMvc3Integration.Rethrow_ResourceExecutedContextSealed)),
+             typeof(AspNetCoreMvc3Integration).GetMethod(nameof(AspNetCoreMvc3Integration.Rethrow_ResultExecutedContextSealed)),
         };
 
         public static IEnumerable<object[]> GetWrapperMethodWithInterceptionAttributes()

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -16,7 +16,9 @@ TEST_F(CLRHelperTest, EnumeratesTypeDefs) {
       L"Samples.ExampleLibrary.FakeClient.DogTrick`1",
       L"Samples.ExampleLibrary.FakeClient.DogTrick",
       L"<>c",
-      L"<StayAndLayDown>d__3`2"};
+      L"Cookie",
+      L"<StayAndLayDown>d__4`2",
+      L"Raisin"};
 
   std::vector<std::wstring> actual_types;
 
@@ -155,6 +157,8 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromTypeDefs) {
   std::set<std::wstring> expected = {
       L"<>c",
       L"<StayAndLayDown>d__3`2",
+      L"Cookie",
+      L"Raisin",
       L"Samples.ExampleLibrary.Class1",
       L"Samples.ExampleLibrary.FakeClient.Biscuit",
       L"Samples.ExampleLibrary.FakeClient.Biscuit`1",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -236,6 +236,8 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromMethods) {
   std::set<std::wstring> expected = {
       L"<>c",
       L"<StayAndLayDown>d__3`2",
+      L"Cookie",
+      L"Raisin"
       L"Samples.ExampleLibrary.Class1",
       L"Samples.ExampleLibrary.FakeClient.Biscuit",
       L"Samples.ExampleLibrary.FakeClient.Biscuit`1",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -156,7 +156,7 @@ TEST_F(CLRHelperTest, FiltersFlattenedIntegrationMethodsByTarget) {
 TEST_F(CLRHelperTest, GetsTypeInfoFromTypeDefs) {
   std::set<std::wstring> expected = {
       L"<>c",
-      L"<StayAndLayDown>d__3`2",
+      L"<StayAndLayDown>d__4`2",
       L"Cookie",
       L"Raisin",
       L"Samples.ExampleLibrary.Class1",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -237,7 +237,7 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromMethods) {
       L"<>c",
       L"<StayAndLayDown>d__3`2",
       L"Cookie",
-      L"Raisin"
+      L"Raisin",
       L"Samples.ExampleLibrary.Class1",
       L"Samples.ExampleLibrary.FakeClient.Biscuit",
       L"Samples.ExampleLibrary.FakeClient.Biscuit`1",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -235,7 +235,7 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromModuleRefs) {
 TEST_F(CLRHelperTest, GetsTypeInfoFromMethods) {
   std::set<std::wstring> expected = {
       L"<>c",
-      L"<StayAndLayDown>d__3`2",
+      L"<StayAndLayDown>d__4`2",
       L"Cookie",
       L"Raisin",
       L"Samples.ExampleLibrary.Class1",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
@@ -47,6 +47,24 @@ TEST_F(CLRHelperTypeCheckTest, GetsVeryComplexNestedGenericTypeStrings) {
   EXPECT_EQ(expected, actual);
 }
 
+
+TEST_F(CLRHelperTypeCheckTest, SimpleStringReturnWithNestedTypeParamsNoGenerics) {
+  std::vector<WSTRING> expected = {
+      L"System.String", L"Samples.ExampleLibrary.FakeClient.Biscuit.Cookie",
+      L"Samples.ExampleLibrary.FakeClient.Biscuit.Cookie.Raisin"};
+  std::vector<std::wstring> actual;
+
+  const auto target = FunctionToTest(
+      "Samples.ExampleLibrary.FakeClient.DogClient`2"_W, "TellMeIfTheCookieIsYummy"_W);
+
+  EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
+
+  TryParseSignatureTypes(metadata_import_, target, actual);
+
+  EXPECT_EQ(expected, actual);
+}
+
+
 TEST_F(CLRHelperTypeCheckTest, SimpleClassReturnWithSimpleParamsNoGenerics) {
   std::vector<WSTRING> expected = {L"Samples.ExampleLibrary.FakeClient.Biscuit",
                                  L"System.Guid", L"System.Int16",

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
@@ -50,8 +50,8 @@ TEST_F(CLRHelperTypeCheckTest, GetsVeryComplexNestedGenericTypeStrings) {
 
 TEST_F(CLRHelperTypeCheckTest, SimpleStringReturnWithNestedTypeParamsNoGenerics) {
   std::vector<WSTRING> expected = {
-      L"System.String", L"Samples.ExampleLibrary.FakeClient.Biscuit.Cookie",
-      L"Samples.ExampleLibrary.FakeClient.Biscuit.Cookie.Raisin"};
+      L"System.String", L"Samples.ExampleLibrary.FakeClient.Biscuit+Cookie",
+      L"Samples.ExampleLibrary.FakeClient.Biscuit+Cookie+Raisin"};
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -77,6 +77,8 @@ namespace Datadog.Trace.TestHelpers
 
         public string SampleName { get; }
 
+        public string FullSampleName => $"{_appNamePrepend}{SampleName}";
+
         public static EnvironmentHelper NonProfiledHelper(Type anchor, string appName, string directory)
         {
             return new EnvironmentHelper(
@@ -339,7 +341,7 @@ namespace Datadog.Trace.TestHelpers
                 extension = "dll";
             }
 
-            var appFileName = $"{_appNamePrepend}{SampleName}.{extension}";
+            var appFileName = $"{FullSampleName}.{extension}";
             var sampleAppPath = Path.Combine(GetSampleApplicationOutputDirectory(packageVersion), appFileName);
             return sampleAppPath;
         }
@@ -358,7 +360,7 @@ namespace Datadog.Trace.TestHelpers
             }
             else
             {
-                var appFileName = $"{_appNamePrepend}{SampleName}.exe";
+                var appFileName = $"{FullSampleName}.exe";
                 executor = Path.Combine(GetSampleApplicationOutputDirectory(), appFileName);
 
                 if (!File.Exists(executor))
@@ -376,7 +378,7 @@ namespace Datadog.Trace.TestHelpers
             var projectDir = Path.Combine(
                 solutionDirectory,
                 _samplesDirectory,
-                $"{_appNamePrepend}{SampleName}");
+                $"{FullSampleName}");
             return projectDir;
         }
 

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -129,6 +129,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 relevantSpans =
                     relevantSpans
+                       .Where(s => s.Start > minimumOffset)
                        .Where(s => operationName == null || s.Name == operationName)
                        .ToImmutableList();
             }

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -68,6 +68,8 @@ namespace Datadog.Trace.TestHelpers
         /// </summary>
         public int Port { get; }
 
+        public List<Func<Span, bool>> Filters { get; private set; } = new List<Func<Span, bool>>();
+
         public IImmutableList<Span> Spans { get; private set; } = ImmutableList<Span>.Empty;
 
         public IImmutableList<NameValueCollection> RequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
@@ -97,6 +99,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 relevantSpans =
                     Spans
+                       .Where(s => Filters.All(shouldReturn => shouldReturn(s)))
                        .Where(s => s.Start > minimumOffset)
                        .ToImmutableList();
 
@@ -129,7 +132,6 @@ namespace Datadog.Trace.TestHelpers
             {
                 relevantSpans =
                     relevantSpans
-                       .Where(s => s.Start > minimumOffset)
                        .Where(s => operationName == null || s.Name == operationName)
                        .ToImmutableList();
             }

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -68,7 +68,10 @@ namespace Datadog.Trace.TestHelpers
         /// </summary>
         public int Port { get; }
 
-        public List<Func<Span, bool>> Filters { get; private set; } = new List<Func<Span, bool>>();
+        /// <summary>
+        /// Gets the filters used to filter out spans we don't want to look at for a test.
+        /// </summary>
+        public List<Func<Span, bool>> SpanFilters { get; private set; } = new List<Func<Span, bool>>();
 
         public IImmutableList<Span> Spans { get; private set; } = ImmutableList<Span>.Empty;
 
@@ -99,7 +102,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 relevantSpans =
                     Spans
-                       .Where(s => Filters.All(shouldReturn => shouldReturn(s)))
+                       .Where(s => SpanFilters.All(shouldReturn => shouldReturn(s)))
                        .Where(s => s.Start > minimumOffset)
                        .ToImmutableList();
 


### PR DESCRIPTION
Changes proposed in this pull request:
 - [x] Create shared tests for v2 and v3
 - [x] Create v3 integration based on v2
 - [x] Introduce module lookup for types
 - [x] Introduce proper filtering on nested classes
 - [x] Make core mvc tests less flaky by using a health check before running the test

@DataDog/apm-dotnet