### PR TITLE
Create multiple app domains sample of SqlServer sample

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -273,6 +273,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ApplicationWithLog4Net", "r
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Core.Tools", "tools\Datadog.Core.Tools\Datadog.Core.Tools.csproj", "{3BEACB10-89FE-4F74-8022-1A52F223CE82}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.SqlServer.MultipleAppDomains", "samples\Samples.SqlServer.MultipleAppDomains\Samples.SqlServer.MultipleAppDomains.csproj", "{23B55430-5FD3-4FB7-B655-BACDCD869196}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -901,6 +903,16 @@ Global
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82}.Release|x64.Build.0 = Release|Any CPU
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82}.Release|x86.ActiveCfg = Release|Any CPU
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82}.Release|x86.Build.0 = Release|Any CPU
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Debug|x64.ActiveCfg = Debug|x64
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Debug|x64.Build.0 = Debug|x64
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Debug|x86.ActiveCfg = Debug|x86
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Debug|x86.Build.0 = Debug|x86
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Release|Any CPU.ActiveCfg = Release|x86
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Release|x64.ActiveCfg = Release|x64
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Release|x64.Build.0 = Release|x64
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Release|x86.ActiveCfg = Release|x86
+		{23B55430-5FD3-4FB7-B655-BACDCD869196}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -965,6 +977,7 @@ Global
 		{35F581E9-3D7C-4E80-8DFF-D437B0D86710} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{1C34D970-6081-4EFA-8F2F-5AD2B146AC58} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{3BEACB10-89FE-4F74-8022-1A52F223CE82} = {5D8E1F81-B820-4736-B797-271B0FE787EE}
+		{23B55430-5FD3-4FB7-B655-BACDCD869196} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/reproduction-dependencies/AppDomain.Instance/AppDomainInstanceProgram.cs
+++ b/reproduction-dependencies/AppDomain.Instance/AppDomainInstanceProgram.cs
@@ -59,6 +59,7 @@ namespace AppDomain.Instance
                 return -10;
             }
 
+            Console.ReadKey();
             return 0;
         }
     }

--- a/reproduction-dependencies/AppDomain.Instance/AppDomainInstanceProgram.cs
+++ b/reproduction-dependencies/AppDomain.Instance/AppDomainInstanceProgram.cs
@@ -59,7 +59,6 @@ namespace AppDomain.Instance
                 return -10;
             }
 
-            Console.ReadKey();
             return 0;
         }
     }

--- a/samples/Samples.SqlServer.MultipleAppDomains/Program.cs
+++ b/samples/Samples.SqlServer.MultipleAppDomains/Program.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Security;
+using System.Security.Permissions;
+using System.Threading;
+using AppDomain.Instance;
+
+namespace Samples.SqlServer.MultipleAppDomains
+{
+    public class Program
+    {
+        [LoaderOptimization(LoaderOptimization.MultiDomainHost)]
+        static void Main(string[] args)
+        {
+            List<Thread> threads = new List<Thread>();
+            int index = 0;
+
+            PermissionSet ps = new PermissionSet(PermissionState.Unrestricted);
+            System.AppDomain appDomain1 = CreateAndRunAppDomain(index++, ps);
+            System.AppDomain appDomain2 = CreateAndRunAppDomain(index++, ps);
+        }
+
+        private static System.AppDomain CreateAndRunAppDomain(int index, PermissionSet grantSet)
+        {
+            // Construct and initialize settings for a second AppDomain.
+            AppDomainSetup ads = new AppDomainSetup();
+            ads.ApplicationBase = System.AppDomain.CurrentDomain.BaseDirectory;
+
+            ads.DisallowBindingRedirects = false;
+            ads.DisallowCodeDownload = true;
+            ads.ConfigurationFile =
+                System.AppDomain.CurrentDomain.SetupInformation.ConfigurationFile;
+
+            string name = "AppDomain" + index;
+            System.AppDomain appDomain1 = System.AppDomain.CreateDomain(
+                name,
+                System.AppDomain.CurrentDomain.Evidence,
+                ads,
+                grantSet);
+
+            var argsToPass = new string[] { name, index.ToString(), "SqlServer" };
+            appDomain1.ExecuteAssemblyByName(
+                typeof(AppDomainInstanceProgram).Assembly.FullName,
+                argsToPass);
+
+            Console.WriteLine("**********************************************");
+            Console.WriteLine($"Finished executing in AppDomain {name}");
+            Console.WriteLine("**********************************************");
+            return appDomain1;
+        }
+    }
+}

--- a/samples/Samples.SqlServer.MultipleAppDomains/Properties/launchSettings.json
+++ b/samples/Samples.SqlServer.MultipleAppDomains/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "Samples.SqlServer.MultipleAppDomains": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Samples.SqlServer.MultipleAppDomains/Samples.SqlServer.MultipleAppDomains.csproj
+++ b/samples/Samples.SqlServer.MultipleAppDomains/Samples.SqlServer.MultipleAppDomains.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- override to remove net452 -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461</TargetFrameworks>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\reproduction-dependencies\AppDomain.Instance\AppDomain.Instance.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Zach and I were discussing the multiple app domain issue with `System.Data` a few weeks ago and he showed me how the `AppDomainInstanceProgram` is set up to support multiple domains for `elasticsearch` and `sqlserver` samples. This PR adds the `sqlserver` multiple apps domain sample. 

It runs without any exceptions on my local machine running through Visual Studio, and it generates traces which show up in the test organization dashboard.

I want to include this sample so that we can iterate on it to further investigate and eventually resolve any multiple app domain issues pertaining to `System.Data`.


@DataDog/apm-dotnet