### PR TITLE
Make timing and statistics tests less flaky

### DIFF
--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Tests
             sw.Stop();
 
             Assert.Equal(5, handler.RequestsCount);
-            Assert.InRange(sw.ElapsedMilliseconds, 1500, 10000); // should be ~ 1600ms
+            Assert.InRange(sw.ElapsedMilliseconds, 1000, 12000); // should be ~ 1600ms
 
             // TODO:bertrand check that it's properly logged
         }

--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -74,9 +74,9 @@ namespace Datadog.Trace.Tests.Sampling
             var totalMilliseconds = result.TimeElapsed.TotalMilliseconds;
 
             var expectedLimit = totalMilliseconds * actualIntervalLimit / 1_000;
-
-            var upperLimit = expectedLimit + (actualIntervalLimit * 0.8);
-            var lowerLimit = expectedLimit - (actualIntervalLimit * 0.8);
+            var acceptableDifference = (actualIntervalLimit * 0.80);
+            var upperLimit = expectedLimit + acceptableDifference;
+            var lowerLimit = expectedLimit - acceptableDifference;
 
             Assert.True(
                 result.TotalAllowed >= lowerLimit && result.TotalAllowed <= upperLimit,
@@ -88,7 +88,7 @@ namespace Datadog.Trace.Tests.Sampling
             var totalExpectedAllowed = 2 * actualIntervalLimit;
             var expectedRate = totalExpectedAllowed / (float)totalExpectedSent;
 
-            var maxPercentVariance = 0.20f;
+            var maxPercentVariance = 0.35f;
             var lowestRate = expectedRate - maxPercentVariance;
             var highestRate = expectedRate + maxPercentVariance;
 


### PR DESCRIPTION
Reduce flakiness of timing tests.

@DataDog/apm-dotnet