### PR TITLE
ADO.NET: add IDbCommand instrumentation

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -930,6 +930,197 @@
     ]
   },
   {
+    "name": "IDbCommand",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "System.Data.IDataReader"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteReader",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "System.Data.IDataReader"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteReader",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "System.Data.IDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteReaderWithBehavior",
+          "signature": "00 05 1C 1C 08 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "System.Data.IDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteReaderWithBehavior",
+          "signature": "00 05 1C 1C 08 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteNonQuery",
+          "signature_types": [
+            "System.Int32"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteNonQuery",
+          "signature": "00 04 08 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteNonQuery",
+          "signature_types": [
+            "System.Int32"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteNonQuery",
+          "signature": "00 04 08 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteScalar",
+          "signature_types": [
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteScalar",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteScalar",
+          "signature_types": [
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteScalar",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      }
+    ]
+  },
+  {
     "name": "MongoDb",
     "method_replacements": [
       {

--- a/sample-libs/Samples.DatabaseHelper/Extensions.cs
+++ b/sample-libs/Samples.DatabaseHelper/Extensions.cs
@@ -1,12 +1,11 @@
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 
 namespace Samples.DatabaseHelper
 {
     public static class Extensions
     {
-        public static IEnumerable<IDataRecord> AsDataRecords(this DbDataReader reader)
+        public static IEnumerable<IDataRecord> AsDataRecords(this IDataReader reader)
         {
             while (reader.Read())
             {
@@ -14,17 +13,17 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        public static DbParameter CreateParameterWithValue(this DbCommand command, string name, object value)
+        public static IDbDataParameter CreateParameterWithValue(this IDbCommand command, string name, object value)
         {
-            var parameter = command.CreateParameter();
+            IDbDataParameter parameter = command.CreateParameter();
             parameter.ParameterName = name;
             parameter.Value = value;
             return parameter;
         }
 
-        public static DbParameter AddParameterWithValue(this DbCommand command, string name, object value)
+        public static IDbDataParameter AddParameterWithValue(this IDbCommand command, string name, object value)
         {
-            DbParameter parameter = CreateParameterWithValue(command, name, value);
+            IDbDataParameter parameter = CreateParameterWithValue(command, name, value);
             command.Parameters.Add(parameter);
             return parameter;
         }

--- a/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -246,13 +246,7 @@ namespace Samples.DatabaseHelper
                 command.AddParameterWithValue("Name", "Name2");
                 command.AddParameterWithValue("Id", 1);
 
-                if (_executeNonQueryAsync == null)
-                {
-                    // fallback to the sync version to get the side effects
-                    int records = _executeNonQuery(command);
-                    Console.WriteLine($"Updated {records} record(s).");
-                }
-                else
+                if (_executeNonQueryAsync != null)
                 {
                     int records = await _executeNonQueryAsync(command);
                     Console.WriteLine($"Updated {records} record(s).");
@@ -284,13 +278,7 @@ namespace Samples.DatabaseHelper
                 command.AddParameterWithValue("Id", 1);
                 command.AddParameterWithValue("Name", "Name1");
 
-                if (_executeNonQueryAsync == null)
-                {
-                    // fallback to the sync version to get the side effects
-                    int records = _executeNonQuery(command);
-                    Console.WriteLine($"Updated {records} record(s).");
-                }
-                else
+                if (_executeNonQueryAsync != null)
                 {
                     int records = await _executeNonQueryAsync(command);
                     Console.WriteLine($"Inserted {records} record(s).");
@@ -304,13 +292,7 @@ namespace Samples.DatabaseHelper
             {
                 command.CommandText = DropCommandText;
 
-                if (_executeNonQueryAsync == null)
-                {
-                    // fallback to the sync version to get the side effects
-                    int records = _executeNonQuery(command);
-                    Console.WriteLine($"Updated {records} record(s).");
-                }
-                else
+                if (_executeNonQueryAsync != null)
                 {
                     int records = await _executeNonQueryAsync(command);
                     Console.WriteLine($"Dropped and recreated table. {records} record(s) affected.");

--- a/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -8,9 +8,9 @@ using Datadog.Trace;
 namespace Samples.DatabaseHelper
 {
     public class RelationalDatabaseTestHarness<TConnection, TCommand, TDataReader>
-        where TConnection : DbConnection
-        where TCommand : DbCommand
-        where TDataReader : DbDataReader
+        where TConnection : class, IDbConnection
+        where TCommand : class, IDbCommand
+        where TDataReader : class, IDataReader
     {
         private const string DropCommandText = "DROP TABLE IF EXISTS Employees; CREATE TABLE Employees (Id int PRIMARY KEY, Name varchar(100));";
         private const string InsertCommandText = "INSERT INTO Employees (Id, Name) VALUES (@Id, @Name);";
@@ -49,10 +49,9 @@ namespace Samples.DatabaseHelper
             _executeReader = executeReader ?? throw new ArgumentNullException(nameof(executeReader));
             _executeReaderWithBehavior = executeReaderWithBehavior ?? throw new ArgumentNullException(nameof(executeReaderWithBehavior));
 
-            _executeNonQueryAsync = executeNonQueryAsync ?? throw new ArgumentNullException(nameof(executeNonQueryAsync));
-            _executeScalarAsync = executeScalarAsync ?? throw new ArgumentNullException(nameof(executeScalarAsync));
-
-            // these two are not implemented by all ADO.NET providers, so they can be null
+            // async methods are not implemented by all ADO.NET providers, so they can be null
+            _executeNonQueryAsync = executeNonQueryAsync;
+            _executeScalarAsync = executeScalarAsync;
             _executeReaderAsync = executeReaderAsync;
             _executeReaderWithBehaviorAsync = executeReaderWithBehaviorAsync;
         }
@@ -77,26 +76,29 @@ namespace Samples.DatabaseHelper
                     _connection.Close();
                 }
 
-                // leave a small space between spans, for better visibility in the UI
-                await Task.Delay(TimeSpan.FromSeconds(0.1));
-
-                using (var scopeAsync = Tracer.Instance.StartActive("run.async"))
+                if (_connection is DbConnection connection)
                 {
-                    scopeAsync.Span.SetTag("command-type", typeof(TCommand).FullName);
+                    // leave a small space between spans, for better visibility in the UI
+                    await Task.Delay(TimeSpan.FromSeconds(0.1));
 
-                    await _connection.OpenAsync();
-                    await CreateNewTableAsync(_connection);
-                    await InsertRowAsync(_connection);
-                    await SelectScalarAsync(_connection);
-                    await UpdateRowAsync(_connection);
-                    await SelectRecordsAsync(_connection);
-                    await DeleteRecordAsync(_connection);
-                    _connection.Close();
+                    using (var scopeAsync = Tracer.Instance.StartActive("run.async"))
+                    {
+                        scopeAsync.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                        await connection.OpenAsync();
+                        await CreateNewTableAsync(_connection);
+                        await InsertRowAsync(_connection);
+                        await SelectScalarAsync(_connection);
+                        await UpdateRowAsync(_connection);
+                        await SelectRecordsAsync(_connection);
+                        await DeleteRecordAsync(_connection);
+                        _connection.Close();
+                    }
                 }
             }
         }
 
-        private void DeleteRecord(DbConnection connection)
+        private void DeleteRecord(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -108,7 +110,7 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private void SelectRecords(DbConnection connection)
+        private void SelectRecords(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -137,7 +139,7 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private void UpdateRow(DbConnection connection)
+        private void UpdateRow(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -150,7 +152,7 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private void SelectScalar(DbConnection connection)
+        private void SelectScalar(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -162,7 +164,7 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private void InsertRow(DbConnection connection)
+        private void InsertRow(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -175,7 +177,7 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private void CreateNewTable(DbConnection connection)
+        private void CreateNewTable(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -186,19 +188,22 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private async Task DeleteRecordAsync(DbConnection connection)
+        private async Task DeleteRecordAsync(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
                 command.CommandText = DeleteCommandText;
                 command.AddParameterWithValue("Id", 1);
 
-                int records = await _executeNonQueryAsync(command);
-                Console.WriteLine($"Deleted {records} record(s).");
+                if (_executeNonQueryAsync != null)
+                {
+                    int records = await _executeNonQueryAsync(command);
+                    Console.WriteLine($"Deleted {records} record(s).");
+                }
             }
         }
 
-        private async Task SelectRecordsAsync(DbConnection connection)
+        private async Task SelectRecordsAsync(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -233,7 +238,7 @@ namespace Samples.DatabaseHelper
             }
         }
 
-        private async Task UpdateRowAsync(DbConnection connection)
+        private async Task UpdateRowAsync(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -241,25 +246,37 @@ namespace Samples.DatabaseHelper
                 command.AddParameterWithValue("Name", "Name2");
                 command.AddParameterWithValue("Id", 1);
 
-                int records = await _executeNonQueryAsync(command);
-                Console.WriteLine($"Updated {records} record(s).");
+                if (_executeNonQueryAsync == null)
+                {
+                    // fallback to the sync version to get the side effects
+                    int records = _executeNonQuery(command);
+                    Console.WriteLine($"Updated {records} record(s).");
+                }
+                else
+                {
+                    int records = await _executeNonQueryAsync(command);
+                    Console.WriteLine($"Updated {records} record(s).");
+                }
             }
         }
 
-        private async Task SelectScalarAsync(DbConnection connection)
+        private async Task SelectScalarAsync(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
                 command.CommandText = SelectOneCommandText;
                 command.AddParameterWithValue("Id", 1);
 
-                object nameObj = await _executeScalarAsync(command);
-                var name = nameObj as string;
-                Console.WriteLine($"Selected scalar `{name ?? "(null)"}`.");
+                if (_executeScalarAsync != null)
+                {
+                    object nameObj = await _executeScalarAsync(command);
+                    var name = nameObj as string;
+                    Console.WriteLine($"Selected scalar `{name ?? "(null)"}`.");
+                }
             }
         }
 
-        private async Task InsertRowAsync(DbConnection connection)
+        private async Task InsertRowAsync(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
@@ -267,19 +284,37 @@ namespace Samples.DatabaseHelper
                 command.AddParameterWithValue("Id", 1);
                 command.AddParameterWithValue("Name", "Name1");
 
-                int records = await _executeNonQueryAsync(command);
-                Console.WriteLine($"Inserted {records} record(s).");
+                if (_executeNonQueryAsync == null)
+                {
+                    // fallback to the sync version to get the side effects
+                    int records = _executeNonQuery(command);
+                    Console.WriteLine($"Updated {records} record(s).");
+                }
+                else
+                {
+                    int records = await _executeNonQueryAsync(command);
+                    Console.WriteLine($"Inserted {records} record(s).");
+                }
             }
         }
 
-        private async Task CreateNewTableAsync(DbConnection connection)
+        private async Task CreateNewTableAsync(IDbConnection connection)
         {
             using (var command = (TCommand)connection.CreateCommand())
             {
                 command.CommandText = DropCommandText;
 
-                int records = await _executeNonQueryAsync(command);
-                Console.WriteLine($"Dropped and recreated table. {records} record(s) affected.");
+                if (_executeNonQueryAsync == null)
+                {
+                    // fallback to the sync version to get the side effects
+                    int records = _executeNonQuery(command);
+                    Console.WriteLine($"Updated {records} record(s).");
+                }
+                else
+                {
+                    int records = await _executeNonQueryAsync(command);
+                    Console.WriteLine($"Dropped and recreated table. {records} record(s) affected.");
+                }
             }
         }
     }

--- a/sample-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
+++ b/sample-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Samples.MySql/Program.cs
+++ b/samples/Samples.MySql/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
@@ -42,6 +43,23 @@ namespace Samples.MySql
                     command => command.ExecuteScalarAsync(),
                     command => command.ExecuteReaderAsync(),
                     (command, behavior) => command.ExecuteReaderAsync(behavior)
+                );
+
+                await testQueries.RunAsync();
+            }
+
+            using (var connection = CreateConnection())
+            {
+                var testQueries = new RelationalDatabaseTestHarness<IDbConnection, IDbCommand, IDataReader>(
+                    connection,
+                    command => command.ExecuteNonQuery(),
+                    command => command.ExecuteScalar(),
+                    command => command.ExecuteReader(),
+                    (command, behavior) => command.ExecuteReader(behavior),
+                    executeNonQueryAsync: null,
+                    executeScalarAsync: null,
+                    executeReaderAsync: null,
+                    executeReaderWithBehaviorAsync: null
                 );
 
                 await testQueries.RunAsync();

--- a/samples/Samples.Npgsql/Program.cs
+++ b/samples/Samples.Npgsql/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Data.Common;
 using System.Threading.Tasks;
 using Npgsql;
@@ -42,6 +43,23 @@ namespace Samples.Npgsql
                     command => command.ExecuteScalarAsync(),
                     command => command.ExecuteReaderAsync(),
                     (command, behavior) => command.ExecuteReaderAsync(behavior)
+                );
+
+                await testQueries.RunAsync();
+            }
+
+            using (var connection = CreateConnection())
+            {
+                var testQueries = new RelationalDatabaseTestHarness<IDbConnection, IDbCommand, IDataReader>(
+                    connection,
+                    command => command.ExecuteNonQuery(),
+                    command => command.ExecuteScalar(),
+                    command => command.ExecuteReader(),
+                    (command, behavior) => command.ExecuteReader(behavior),
+                    executeNonQueryAsync: null,
+                    executeScalarAsync: null,
+                    executeReaderAsync: null,
+                    executeReaderWithBehaviorAsync: null
                 );
 
                 await testQueries.RunAsync();

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -71,7 +71,7 @@ namespace Samples.SqlServer
         private static SqlConnection CreateConnection()
         {
             var connectionString = Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING") ??
-                                   @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;TransparentNetworkIPResolution=false";
+                                   @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;";
 
             return new SqlConnection(connectionString);
         }

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -71,7 +71,7 @@ namespace Samples.SqlServer
         private static SqlConnection CreateConnection()
         {
             var connectionString = Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING") ??
-                                   @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;";
+                                   @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;TransparentNetworkIPResolution=false";
 
             return new SqlConnection(connectionString);
         }

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
-using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace;
 using Samples.DatabaseHelper;
@@ -46,6 +44,23 @@ namespace Samples.SqlServer
                         command => command.ExecuteScalarAsync(),
                         command => command.ExecuteReaderAsync(),
                         (command, behavior) => command.ExecuteReaderAsync(behavior)
+                    );
+
+                    await testQueries.RunAsync();
+                }
+
+                using (var connection = CreateConnection())
+                {
+                    var testQueries = new RelationalDatabaseTestHarness<IDbConnection, IDbCommand, IDataReader>(
+                        connection,
+                        command => command.ExecuteNonQuery(),
+                        command => command.ExecuteScalar(),
+                        command => command.ExecuteReader(),
+                        (command, behavior) => command.ExecuteReader(behavior),
+                        executeNonQueryAsync: null,
+                        executeScalarAsync: null,
+                        executeReaderAsync: null,
+                        executeReaderWithBehaviorAsync: null
                     );
 
                     await testQueries.RunAsync();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(DbCommandIntegration));
 
         /// <summary>
-        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteDbDataReader"/>.
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteReader()"/>.
         /// </summary>
         /// <param name="command">The object referenced "this" in the instrumented method.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteDbDataReader"/>.
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteReader(CommandBehavior)"/>.
         /// </summary>
         /// <param name="command">The object referenced "this" in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
@@ -149,7 +149,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for DbCommand.ExecuteReaderAsync().
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteReaderAsync()"/>.
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
@@ -232,7 +232,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for DbCommand.ExecuteNonQuery().
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteNonQuery"/>.
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -285,7 +285,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for DbCommand.ExecuteNonQueryAsync().
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteNonQueryAsync(CancellationToken)"/>
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
@@ -357,7 +357,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for DbCommand.ExecuteScalar().
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteScalar"/>
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -410,7 +410,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for DbCommand.ExecuteScalarAsync().
+        /// Instrumentation wrapper for <see cref="DbCommand.ExecuteScalarAsync(CancellationToken)"/>
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
+{
+    /// <summary>
+    /// Instrumentation wrappers for <see cref="IDbCommand"/>.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IDbCommandIntegration
+    {
+        private const string IntegrationName = "AdoNet";
+        private const string Major4 = "4";
+
+        // ReSharper disable InconsistentNaming
+        private const string IDbCommandTypeName = "System.Data.IDbCommand";
+        private const string IDataReaderTypeName = "System.Data.IDataReader";
+        // ReSharper restore InconsistentNaming
+
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(IDbCommandIntegration));
+
+        /// <summary>
+        /// Instrumentation wrapper for <see cref="IDbCommand.ExecuteReader()"/>.
+        /// </summary>
+        /// <param name="command">The object referenced "this" in the instrumented method.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { IDataReaderTypeName },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteReader(
+            object command,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<IDbCommand, IDataReader> instrumentedMethod;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<IDbCommand, IDataReader>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteReader)
+                       .WithConcreteType(typeof(IDbCommand))
+                       .WithNamespaceAndNameFilters(IDataReaderTypeName)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorRetrievingMethod(
+                    exception: ex,
+                    moduleVersionPointer: moduleVersionPtr,
+                    mdToken: mdToken,
+                    opCode: opCode,
+                    instrumentedType: IDbCommandTypeName,
+                    methodName: nameof(ExecuteReader),
+                    instanceType: command.GetType().AssemblyQualifiedName);
+                throw;
+            }
+
+            var dbCommand = command as IDbCommand;
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, dbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(dbCommand);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for <see cref="IDbCommand.ExecuteReader(CommandBehavior)"/>.
+        /// </summary>
+        /// <param name="command">The object referenced "this" in the instrumented method.</param>
+        /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { IDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteReaderWithBehavior(
+            object command,
+            int behavior,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<IDbCommand, CommandBehavior, IDataReader> instrumentedMethod;
+            var commandBehavior = (CommandBehavior)behavior;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<IDbCommand, CommandBehavior, IDataReader>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteReader)
+                       .WithConcreteType(typeof(IDbCommand))
+                       .WithParameters(commandBehavior)
+                       .WithNamespaceAndNameFilters(IDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorRetrievingMethod(
+                    exception: ex,
+                    moduleVersionPointer: moduleVersionPtr,
+                    mdToken: mdToken,
+                    opCode: opCode,
+                    instrumentedType: IDbCommandTypeName,
+                    methodName: nameof(ExecuteReader),
+                    instanceType: command.GetType().AssemblyQualifiedName);
+                throw;
+            }
+
+            var dbCommand = command as IDbCommand;
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, dbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(dbCommand, commandBehavior);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for IDbCommand.ExecuteNonQuery().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Int32 },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static int ExecuteNonQuery(
+            object command,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<IDbCommand, int> instrumentedMethod;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<IDbCommand, int>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteNonQuery)
+                       .WithConcreteType(typeof(IDbCommand))
+                       .WithNamespaceAndNameFilters(ClrNames.Int32)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Error resolving {IDbCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)");
+                throw;
+            }
+
+            var dbCommand = command as IDbCommand;
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, dbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(dbCommand);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for IDbCommand.ExecuteScalar().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Object },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteScalar(
+            object command,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<IDbCommand, object> instrumentedMethod;
+
+            try
+            {
+                instrumentedMethod =
+                    MethodBuilder<Func<IDbCommand, object>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteScalar)
+                       .WithConcreteType(typeof(IDbCommand))
+                       .WithNamespaceAndNameFilters(ClrNames.Object)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Error resolving {IDbCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)");
+                throw;
+            }
+
+            var dbCommand = command as IDbCommand;
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, dbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(dbCommand);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Data;
-using System.Data.Common;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Logging;
 
@@ -15,10 +14,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         private const string IntegrationName = "AdoNet";
         private const string Major4 = "4";
 
-        // ReSharper disable InconsistentNaming
-        private const string IDbCommandTypeName = "System.Data.IDbCommand";
-        private const string IDataReaderTypeName = "System.Data.IDataReader";
-        // ReSharper restore InconsistentNaming
+        private const string DbCommandTypeName = "System.Data.IDbCommand";
+        private const string DataReaderTypeName = "System.Data.IDataReader";
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(IDbCommandIntegration));
 
@@ -32,8 +29,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
-            TargetType = IDbCommandTypeName,
-            TargetSignatureTypes = new[] { IDataReaderTypeName },
+            TargetType = DbCommandTypeName,
+            TargetSignatureTypes = new[] { DataReaderTypeName },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteReader(
@@ -50,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                     MethodBuilder<Func<IDbCommand, IDataReader>>
                        .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteReader)
                        .WithConcreteType(typeof(IDbCommand))
-                       .WithNamespaceAndNameFilters(IDataReaderTypeName)
+                       .WithNamespaceAndNameFilters(DataReaderTypeName)
                        .Build();
             }
             catch (Exception ex)
@@ -60,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                     moduleVersionPointer: moduleVersionPtr,
                     mdToken: mdToken,
                     opCode: opCode,
-                    instrumentedType: IDbCommandTypeName,
+                    instrumentedType: DbCommandTypeName,
                     methodName: nameof(ExecuteReader),
                     instanceType: command.GetType().AssemblyQualifiedName);
                 throw;
@@ -94,8 +91,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
-            TargetType = IDbCommandTypeName,
-            TargetSignatureTypes = new[] { IDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetType = DbCommandTypeName,
+            TargetSignatureTypes = new[] { DataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteReaderWithBehavior(
@@ -115,7 +112,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteReader)
                        .WithConcreteType(typeof(IDbCommand))
                        .WithParameters(commandBehavior)
-                       .WithNamespaceAndNameFilters(IDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior)
+                       .WithNamespaceAndNameFilters(DataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior)
                        .Build();
             }
             catch (Exception ex)
@@ -125,7 +122,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                     moduleVersionPointer: moduleVersionPtr,
                     mdToken: mdToken,
                     opCode: opCode,
-                    instrumentedType: IDbCommandTypeName,
+                    instrumentedType: DbCommandTypeName,
                     methodName: nameof(ExecuteReader),
                     instanceType: command.GetType().AssemblyQualifiedName);
                 throw;
@@ -157,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
-            TargetType = IDbCommandTypeName,
+            TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
@@ -180,7 +177,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Error resolving {IDbCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)");
+                Log.Error(ex, $"Error resolving {DbCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)");
                 throw;
             }
 
@@ -210,7 +207,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
-            TargetType = IDbCommandTypeName,
+            TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
@@ -233,7 +230,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Error resolving {IDbCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)");
+                Log.Error(ex, $"Error resolving {DbCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)");
                 throw;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Data.Common;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
@@ -65,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler
             return scope;
         }
 
-        public static Scope CreateDbCommandScope(Tracer tracer, DbCommand command, string integrationName)
+        public static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command, string integrationName)
         {
             if (!tracer.Settings.IsIntegrationEnabled(integrationName))
             {

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Data.Common;
 
 namespace Datadog.Trace.ExtensionMethods
@@ -28,7 +29,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// </summary>
         /// <param name="span">The span to add the tags to.</param>
         /// <param name="command">The db command to get tags values from.</param>
-        public static void AddTagsFromDbCommand(this Span span, DbCommand command)
+        public static void AddTagsFromDbCommand(this Span span, IDbCommand command)
         {
             span.ResourceName = command.CommandText;
             span.Type = SpanTypes.Sql;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -15,7 +15,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            const int expectedSpanCount = 14;
+            // In .NET Framework, the MySQL client injects
+            // a few extra queries the first time it connects to a database
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 21 : 24;
             const string dbType = "mysql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.MySql-" + dbType;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -15,7 +15,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            const int expectedSpanCount = 14;
+            // In .NET Framework, the Npgsql client injects
+            // a few extra queries the first time it connects to a database
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 21 : 22;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Npgsql-" + dbType;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("RunOnWindows", "True")]
         public void SubmitsTraces(string packageVersion)
         {
-            const int expectedSpanCount = 28;
+            const int expectedSpanCount = 35;
             const string dbType = "sql-server";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.SqlServer-" + dbType;


### PR DESCRIPTION
This PR fixes a regression in release 1.8.0 caused by #516. See issue #540.

It adds instrumentation for calls to the following `IDbCommand` methods:
```csharp
IDbCommand.ExecuteReader()
IDbCommand.ExecuteNonQuery()
IDbCommand.ExecuteScalar()
```
