### PR TITLE
clean up project settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,6 +3,7 @@
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <LangVersion>latest</LangVersion>
 
     <!-- Strong name signature -->
     <SignAssembly>true</SignAssembly>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,7 +5,6 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>7.3</LangVersion>
 
     <!-- NuGet packages -->
     <IsPackable>true</IsPackable>

--- a/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
+++ b/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
+++ b/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
@@ -4,8 +4,4 @@
     <TargetFrameworks>net452;net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Linq" Version="4.3.0" />
-  </ItemGroup>
-
 </Project>

--- a/tools/GeneratePackageVersions/GeneratePackageVersions.csproj
+++ b/tools/GeneratePackageVersions/GeneratePackageVersions.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/GeneratePackageVersions/GeneratePackageVersions.csproj
+++ b/tools/GeneratePackageVersions/GeneratePackageVersions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/SynchronizeInstaller/SynchronizeInstaller.csproj
+++ b/tools/SynchronizeInstaller/SynchronizeInstaller.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/SynchronizeVersions/SynchronizeVersions.csproj
+++ b/tools/SynchronizeVersions/SynchronizeVersions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes proposed in this pull request:
- set C# version to `latest` in root props file (replacing several instances for `7.2` and `7.3`)
- target `netstandard2.0` in library projects
- target `netcoreapp3.0` in tool projects (executables)
- remove redundant `System.Linq` package reference
