### PR TITLE
Check assembly version of Datadog assemblies

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -35,9 +35,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 // Load the main profiler and tracer into the default Assembly Load Context
                 var assembly = Assembly.LoadFrom(path);
 
-                if (assembly.GetName() == assemblyName)
+                if (assembly.GetName().Version == assemblyName.Version)
                 {
-                    // check that we loaded the exact assembly we are expecting
+                    // check that we loaded the exact version we are expecting
                     // (not a higher version, for example)
                     return assembly;
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -32,7 +32,15 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 && assemblyName.FullName.IndexOf("PublicKeyToken=def86d061d0d2eeb", StringComparison.OrdinalIgnoreCase) >= 0
                 && File.Exists(path))
             {
-                return Assembly.LoadFrom(path); // Load the main profiler and tracer into the default Assembly Load Context
+                // Load the main profiler and tracer into the default Assembly Load Context
+                var assembly = Assembly.LoadFrom(path);
+
+                if (assembly.GetName() == assemblyName)
+                {
+                    // check that we loaded the exact assembly we are expecting
+                    // (not a higher version, for example)
+                    return assembly;
+                }
             }
             else if (File.Exists(path))
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -37,9 +37,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             {
                 var assembly = Assembly.LoadFrom(path);
 
-                if (assembly.GetName() == assemblyName)
+                if (assembly.GetName().Version == assemblyName.Version)
                 {
-                    // check that we loaded the exact assembly we are expecting
+                    // check that we loaded the exact version we are expecting
                     // (not a higher version, for example)
                     return assembly;
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -30,12 +30,19 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
         private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
         {
-            string assemblyName = new AssemblyName(args.Name).Name;
-            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName}.dll");
+            var assemblyName = new AssemblyName(args.Name);
+            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
 
             if (File.Exists(path))
             {
-                return Assembly.LoadFrom(path);
+                var assembly = Assembly.LoadFrom(path);
+
+                if (assembly.GetName() == assemblyName)
+                {
+                    // check that we loaded the exact assembly we are expecting
+                    // (not a higher version, for example)
+                    return assembly;
+                }
             }
 
             return null;

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -25,8 +25,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         {
             try
             {
-                Assembly.Load(new AssemblyName("Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"));
-                return true;
+                var assemblyName = new AssemblyName("Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+                var assembly = Assembly.Load(assemblyName);
+
+                // check that we loaded the exact assembly we are expecting
+                // (not a higher version, for example)
+                return assembly.GetName() == assemblyName;
             }
             catch
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -28,9 +28,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 var assemblyName = new AssemblyName("Datadog.Trace.ClrProfiler.Managed, Version=1.9.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
                 var assembly = Assembly.Load(assemblyName);
 
-                // check that we loaded the exact assembly we are expecting
+                // check that we loaded the exact version we are expecting
                 // (not a higher version, for example)
-                return assembly.GetName() == assemblyName;
+                return assembly.GetName().Version == assemblyName.Version;
             }
             catch
             {


### PR DESCRIPTION
Changes proposed in this pull request:
- check that the assembly we tried to load has the exact version we are expecting

This fixes an issue (see #550) where the CLR profiler could load a newer version of Datadog assemblies that could in turn have breaking changes.
