### PR TITLE
AspNet HttpModule: Fix bug when adding to web.config

### DIFF
--- a/samples-aspnet/Samples.WebForms/CustomLoggingModule.cs
+++ b/samples-aspnet/Samples.WebForms/CustomLoggingModule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Web;
@@ -22,12 +23,12 @@ namespace Samples.WebForms
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            File.WriteAllText("C:\\logs\\Samples.WebForms.log", $"dd.trace_id={CorrelationIdentifier.TraceId}, dd.span_id={CorrelationIdentifier.SpanId}{Environment.NewLine}");
+            Debug.Write("\nCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + "\n");
         }
 
         private void OnEndRequest(object sender, EventArgs eventArgs)
         {
-            // Do nothing
+            Debug.Write("\nCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + "\n");
         }
     }
 }

--- a/samples-aspnet/Samples.WebForms/CustomLoggingModule.cs
+++ b/samples-aspnet/Samples.WebForms/CustomLoggingModule.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Web;
+using Datadog.Trace;
+
+namespace Samples.WebForms
+{
+    public class CustomLoggingModule : IHttpModule
+    {
+        public void Dispose()
+        {
+            // Nothing to do
+        }
+
+        public void Init(HttpApplication context)
+        {
+            context.BeginRequest += OnBeginRequest;
+            context.EndRequest += OnEndRequest;
+        }
+
+        private void OnBeginRequest(object sender, EventArgs eventArgs)
+        {
+            File.WriteAllText("C:\\logs\\Samples.WebForms.log", $"dd.trace_id={CorrelationIdentifier.TraceId}, dd.span_id={CorrelationIdentifier.SpanId}{Environment.NewLine}");
+        }
+
+        private void OnEndRequest(object sender, EventArgs eventArgs)
+        {
+            // Do nothing
+        }
+    }
+}

--- a/samples-aspnet/Samples.WebForms/DDCustomLoggingModule.cs
+++ b/samples-aspnet/Samples.WebForms/DDCustomLoggingModule.cs
@@ -23,12 +23,12 @@ namespace Samples.WebForms
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            Debug.Write("\nDDCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + "\n");
+            Debug.Write("\nDDCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + ". TraceID:" + CorrelationIdentifier.TraceId + "\n");
         }
 
         private void OnEndRequest(object sender, EventArgs eventArgs)
         {
-            Debug.Write("\nDDCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + "\n");
+            Debug.Write("\nDDCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + ". TraceID:" + CorrelationIdentifier.TraceId + "\n");
         }
     }
 }

--- a/samples-aspnet/Samples.WebForms/DDCustomLoggingModule.cs
+++ b/samples-aspnet/Samples.WebForms/DDCustomLoggingModule.cs
@@ -8,7 +8,7 @@ using Datadog.Trace;
 
 namespace Samples.WebForms
 {
-    public class CustomLoggingModule : IHttpModule
+    public class DDCustomLoggingModule : IHttpModule
     {
         public void Dispose()
         {
@@ -23,12 +23,12 @@ namespace Samples.WebForms
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            Debug.Write("\nCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + "\n");
+            Debug.Write("\nDDCustomLoggingModule: OnBeginRequest: call from: " + HttpContext.Current.Request.Path + "\n");
         }
 
         private void OnEndRequest(object sender, EventArgs eventArgs)
         {
-            Debug.Write("\nCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + "\n");
+            Debug.Write("\nDDCustomLoggingModule: OnEndRequest: call from: " + HttpContext.Current.Request.Path + "\n");
         }
     }
 }

--- a/samples-aspnet/Samples.WebForms/Samples.WebForms.csproj
+++ b/samples-aspnet/Samples.WebForms/Samples.WebForms.csproj
@@ -154,7 +154,7 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CustomLoggingModule.cs" />
+    <Compile Include="DDCustomLoggingModule.cs" />
     <Compile Include="Database\Elasticsearch.aspx.cs">
       <DependentUpon>Elasticsearch.aspx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/samples-aspnet/Samples.WebForms/Samples.WebForms.csproj
+++ b/samples-aspnet/Samples.WebForms/Samples.WebForms.csproj
@@ -197,6 +197,10 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj">
+      <Project>{f2780421-295d-4187-912c-71d34ec35c27}</Project>
+      <Name>Datadog.Trace.AspNet</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
       <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
       <Name>Datadog.Trace.ClrProfiler.Managed</Name>

--- a/samples-aspnet/Samples.WebForms/Samples.WebForms.csproj
+++ b/samples-aspnet/Samples.WebForms/Samples.WebForms.csproj
@@ -154,6 +154,7 @@
     <Content Include="Web.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomLoggingModule.cs" />
     <Compile Include="Database\Elasticsearch.aspx.cs">
       <DependentUpon>Elasticsearch.aspx</DependentUpon>
       <SubType>ASPXCodeBehind</SubType>

--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -43,7 +43,7 @@
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
       <!-- <add name="DatadogModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet"/> -->
-      <add name="DDCustomLoggingModule" type="Samples.WebForms.DDCustomLoggingModule, Samples.WebForms"/>
+      <add name="DDArbitrarynameForCustomLoggingModule" type="Samples.WebForms.DDCustomLoggingModule, Samples.WebForms"/>
     </modules>
   </system.webServer>
   <runtime>

--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -42,8 +42,8 @@
       <remove name="FormsAuthentication" />
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
-      <!-- <add name="DatadogModule" type="Datadog.Trace.ClrProfiler.Integrations.AspNetHttpModule, Datadog.Trace.ClrProfiler.Managed"/> -->
-      <add name="CustomgLoggingModule" type="Samples.WebForms.CustomLoggingModule, Samples.WebForms"/>
+      <add name="DatadogModule" type="Datadog.Trace.ClrProfiler.Integrations.AspNetHttpModule, Datadog.Trace.ClrProfiler.Managed"/>
+      <add name="CustomLoggingModule" type="Samples.WebForms.CustomLoggingModule, Samples.WebForms"/>
     </modules>
   </system.webServer>
   <runtime>

--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -42,7 +42,7 @@
       <remove name="FormsAuthentication" />
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
-      <add name="DatadogModule" type="Datadog.Trace.ClrProfiler.Integrations.AspNetHttpModule, Datadog.Trace.ClrProfiler.Managed"/>
+      <!-- <add name="DatadogModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet"/> -->
       <add name="DDCustomLoggingModule" type="Samples.WebForms.DDCustomLoggingModule, Samples.WebForms"/>
     </modules>
   </system.webServer>

--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -42,7 +42,7 @@
       <remove name="FormsAuthentication" />
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
-      <!-- <add name="DatadogModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet"/> -->
+      <add name="DatadogModule" type="Datadog.Trace.AspNet.TracingHttpModule, Datadog.Trace.AspNet"/>
       <add name="DDArbitrarynameForCustomLoggingModule" type="Samples.WebForms.DDCustomLoggingModule, Samples.WebForms"/>
     </modules>
   </system.webServer>

--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -42,6 +42,8 @@
       <remove name="FormsAuthentication" />
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
+      <!-- <add name="DatadogModule" type="Datadog.Trace.ClrProfiler.Integrations.AspNetHttpModule, Datadog.Trace.ClrProfiler.Managed"/> -->
+      <add name="CustomgLoggingModule" type="Samples.WebForms.CustomLoggingModule, Samples.WebForms"/>
     </modules>
   </system.webServer>
   <runtime>

--- a/samples-aspnet/Samples.WebForms/Web.config
+++ b/samples-aspnet/Samples.WebForms/Web.config
@@ -43,7 +43,7 @@
       <remove name="TelemetryCorrelationHttpModule" />
       <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="integratedMode,managedHandler" />
       <add name="DatadogModule" type="Datadog.Trace.ClrProfiler.Integrations.AspNetHttpModule, Datadog.Trace.ClrProfiler.Managed"/>
-      <add name="CustomLoggingModule" type="Samples.WebForms.CustomLoggingModule, Samples.WebForms"/>
+      <add name="DDCustomLoggingModule" type="Samples.WebForms.DDCustomLoggingModule, Samples.WebForms"/>
     </modules>
   </system.webServer>
   <runtime>

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -134,10 +134,8 @@ namespace Datadog.Trace.AspNet
                     return;
                 }
 
-                var httpContext = (sender as HttpApplication)?.Context;
-
-                if (httpContext != null &&
-                    httpContext.Items[_httpContextScopeKey] is Scope scope)
+                if (sender is HttpApplication app &&
+                    app.Context.Items[_httpContextScopeKey] is Scope scope)
                 {
                     scope.Dispose();
                 }

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -112,7 +112,7 @@ namespace Datadog.Trace.AspNet
                 scope.Span.SetMetric(Tags.Analytics, analyticsSampleRate);
 
                 httpContext.Items[_httpContextScopeKey] = scope;
-                // Set this HttpModule instance as the only module allowed to respond to further callbacks
+                // Register this HttpModule instance as the only one allowed to respond to further callbacks
                 httpContext.Items[_httpContextOwningModuleKey] = this;
             }
             catch (Exception ex)
@@ -161,12 +161,10 @@ namespace Datadog.Trace.AspNet
 
                 if (httpContext?.Error != null &&
                     httpContext.Items[_httpContextOwningModuleKey] is TracingHttpModule module &&
-                    ReferenceEquals(module, this))
+                    ReferenceEquals(module, this) &&
+                    httpContext.Items[_httpContextScopeKey] is Scope scope)
                 {
-                    if (httpContext.Items[_httpContextScopeKey] is Scope scope)
-                    {
-                        scope.Span.SetException(httpContext.Error);
-                    }
+                    scope.Span.SetException(httpContext.Error);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Changes proposed in this pull request:
The previous implementation of the HttpModule did not behave correctly when it was invoked more than once in one ASP.NET request. Multiple scopes would be created and only the innermost one would be closed, so the root span would not be closed and the Datadog UI would show no traces. The new implementation registers the first HttpModule to hit the event handlers as the only one allowed to create/modify `Scope` objects, so only one scope is created and closed.

This fix is important to support customers who have other HttpModules in their system `web.config` that subscribe to the `BeginRequest` and would like our Tracer to start spans before hitting them. As a result, the customer will enter our HttpModule before the other HttpModule's in their `web.config` which causes our the ASP.NET application to create and invoke two instances of our HttpModule: once from the `web.config` declaration and once from the dynamic module after referencing our NuGet package.

@DataDog/apm-dotnet