### PR TITLE
fix building OpenTracing NuGet package

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -66,7 +66,7 @@ jobs:
     condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
     inputs:
       command: pack
-      packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj;src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.csproj
+      packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj;src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
       packDirectory: nuget-output
       configuration: $(buildConfiguration)
 


### PR DESCRIPTION
- fix path to OpenTracing project in CI pipeline so the NuGet package can be built

Test build has the correct artifacts:
![image](https://user-images.githubusercontent.com/1851278/70575699-0ce9e480-1b75-11ea-8d4a-68d4ade219da.png)
