### PR TITLE
Expands where the tracer gets the WCF resource string from

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -142,7 +142,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 var span = scope.Span;
 
                 span.DecorateWebServerSpan(
-                    resourceName: requestMessage.Headers.Action ?? requestMessage.Headers.To.LocalPath,
+                    resourceName: requestMessage.Headers.Action ?? requestMessage.Headers.To?.LocalPath,
                     httpMethod,
                     host,
                     httpUrl: requestMessage.Headers.To?.AbsoluteUri);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WcfIntegration.cs
@@ -139,10 +139,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
 
                 scope = tracer.StartActive("wcf.request", propagatedContext);
-                Span span = scope.Span;
+                var span = scope.Span;
 
                 span.DecorateWebServerSpan(
-                    resourceName: requestMessage.Headers.Action,
+                    resourceName: requestMessage.Headers.Action ?? requestMessage.Headers.To.LocalPath,
                     httpMethod,
                     host,
                     httpUrl: requestMessage.Headers.To?.AbsoluteUri);


### PR DESCRIPTION
### Potential fix for issue where the resource tag is not added to a WCF trace

### Changes proposed in this pull request:
When creating the scope, if no action string exists on the message header, try using localpath for wcf resource

Will be submitting this to Datadog customer to see if it fixes an intermittent problem that we cannot reproduce.

@DataDog/apm-dotnet