### PR TITLE
AspNetWebApi2: Update span information after exception

### DIFF
--- a/samples-aspnet/Samples.AspNetMvc5/Controllers/ApiController.cs
+++ b/samples-aspnet/Samples.AspNetMvc5/Controllers/ApiController.cs
@@ -29,5 +29,18 @@ namespace Samples.AspNetMvc5.Controllers
         {
             return Json(System.Environment.GetEnvironmentVariables());
         }
+
+        [HttpGet]
+        [Route("api/transient-failure/{value}")]
+        public IHttpActionResult TransientFailure(string value)
+        {
+            bool success = bool.TryParse(value, out bool result) && result;
+            if (success)
+            {
+                return Json(System.Environment.GetEnvironmentVariables());
+            }
+
+            throw new ArgumentException($"Passed in value was not 'true': {value}");
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -122,6 +122,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
                 catch (Exception ex)
                 {
+                    if (scope != null)
+                    {
+                        // some fields aren't set till after execution, so populate anything missing
+                        UpdateSpan(controllerContext, scope.Span);
+                    }
+
                     scope?.Span.SetException(ex);
                     throw;
                 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -25,6 +25,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [InlineData("/api/environment", "GET api/environment")]
         [InlineData("/api/delay/0", "GET api/delay/{seconds}")]
         [InlineData("/api/delay-async/0", "GET api/delay-async/{seconds}")]
+        [InlineData("/api/transient-failure/true", "GET api/delay-async/{value}")]
+        [InlineData("/api/transient-failure/false", "GET api/delay-async/{value}")]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName)


### PR DESCRIPTION
Changes proposed in this pull request:
Fix an issue in the AspNetWebApi2 integration where we do not update fields, such as the route, when the controller throws an exception. Regardless if an exception is thrown, try to get information from the controller and add it to the span.

@DataDog/apm-dotnet