### PR TITLE
Change minimum ASP.NET WebApi version support from 5.2 to 5.1

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -348,7 +348,7 @@
             "System.Threading.CancellationToken"
           ],
           "minimum_major": 5,
-          "minimum_minor": 2,
+          "minimum_minor": 1,
           "minimum_patch": 0,
           "maximum_major": 5,
           "maximum_minor": 65535,

--- a/samples-aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/samples-aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -55,14 +55,14 @@
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Core.5.1.2\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.Tracing, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Tracing.5.2.7\lib\net45\System.Web.Http.Tracing.dll</HintPath>
+    <Reference Include="System.Web.Http.Tracing, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.Tracing.5.1.2\lib\net45\System.Web.Http.Tracing.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
+    <Reference Include="System.Web.Http.WebHost, Version=5.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.AspNet.WebApi.WebHost.5.1.2\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>

--- a/samples-aspnet/Samples.AspNetMvc5/Web.config
+++ b/samples-aspnet/Samples.AspNetMvc5/Web.config
@@ -39,6 +39,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 
@@ -52,18 +56,18 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
-  <system.webServer>
-    <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    </handlers>
-  </system.webServer>
+  
   <system.codedom>
     <compilers>
       <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
-</configuration>
+<system.webServer>
+    <handlers>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+    </handlers>
+  </system.webServer></configuration>

--- a/samples-aspnet/Samples.AspNetMvc5/packages.config
+++ b/samples-aspnet/Samples.AspNetMvc5/packages.config
@@ -3,11 +3,11 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi" version="5.1.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.7" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Tracing" version="5.1.2" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.1.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net45" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="2.10.0" targetFramework="net45" developmentDependency="true" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
     {
         private const string IntegrationName = "AspNetWebApi2";
         private const string OperationName = "aspnet-webapi.request";
-        private const string Major5Minor2 = "5.2";
+        private const string Major5Minor1 = "5.1";
         private const string Major5 = "5";
 
         private const string SystemWebHttpAssemblyName = "System.Web.Http";
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetAssembly = SystemWebHttpAssemblyName,
             TargetType = HttpControllerTypeName,
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, HttpControllerContextTypeName, ClrNames.CancellationToken },
-            TargetMinimumVersion = Major5Minor2,
+            TargetMinimumVersion = Major5Minor1,
             TargetMaximumVersion = Major5)]
         public static object ExecuteAsync(
             object apiController,


### PR DESCRIPTION
Adds support for ASP.NET WebApi version 5.1.

Note: realized that there are some other Nuget packages that probably should be downgraded in the sample app for testing (`Microsoft.AspNet.WebApi.Client` for sure, and also `Microsoft.AspNet.Mvc` since it was originally released around same time as the `WebApi` corresponding versions. I'm testing this and will update the PR.

After installing `Microsoft.AspNet.WebApi.Client` version 5.1.2 Nuget package, there is a runtime conflict on `System.Net.Http.Formatting` assembly with the version that is referenced by `Datadog.Trace.ClrProfiler.Managed`. I guess it would be possible to put a binding redirect in the target application's `web.config` but for the purposes of this testing, I am going to stick with the `5.2.7` version of the `Microsoft.AspNet.WebApi.Client` since the core part of WebApi is covered by the `Microsoft.AspNet.WebApi` assembly.

@DataDog/apm-dotnet