### PR TITLE
Implement global sample rate config

### DIFF
--- a/samples/Samples.TracingWithoutLimits/Program.cs
+++ b/samples/Samples.TracingWithoutLimits/Program.cs
@@ -45,7 +45,7 @@ namespace Samples.TracingWithoutLimits
             PrepKeys(ServiceCatRunner, RootRunOperation, total * 0.1m);
             PrepKeys(ServiceRatRunner, RootRunOperation, total * 0.0m);
 
-            PrepKeys(UnknownService, UnknownOperation, null);
+            PrepKeys(UnknownService, UnknownOperation, total * 0.6m);
 
             // Configured rules:
             // [{"service":"rat.*","name":".*run.*","sample_rate":0},{"service":"dog.*","name":".+walk","sample_rate":1.0},{"service":"cat.*","name":".+walk","sample_rate":0.8},{"name":".+walk","sample_rate":0.5},{"service":"dog.*","sample_rate":0.2},{"service":"cat.*","sample_rate":0.1}]
@@ -133,14 +133,7 @@ namespace Samples.TracingWithoutLimits
             var limitPsrKey = "_dd.limit_psr";
             var priorityKey = "_sampling_priority_v1";
 
-            if (serviceName == UnknownService)
-            {
-                if (metrics.ContainsKey(rulePsrKey))
-                {
-                    throw new Exception($"{rulePsrKey} should not be set in the fallback behavior.");
-                }
-            }
-            else if (!metrics.ContainsKey(rulePsrKey))
+            if (!metrics.ContainsKey(rulePsrKey))
             {
                 throw new Exception($"{rulePsrKey} must be set in a user defined rule.");
             }

--- a/samples/Samples.TracingWithoutLimits/Properties/launchSettings.json
+++ b/samples/Samples.TracingWithoutLimits/Properties/launchSettings.json
@@ -13,7 +13,7 @@
 
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
-
+        "DD_TRACE_SAMPLE_RATE": "0.6",
         "DD_TRACE_SAMPLING_RULES": "[{\"service\":\"rat.*\", \"name\":\".*run.*\", \"sample_rate\":0}, {\"service\":\"dog.*\",\"name\":\".+walk\",\"sample_rate\":1.0},{\"service\":\"cat.*\",\"name\":\".+walk\",\"sample_rate\":0.8},{\"name\":\".+walk\",\"sample_rate\":0.5},{\"service\":\"dog.*\",\"sample_rate\":0.2},{\"service\":\"cat.*\",\"sample_rate\":0.1}]"
       },
       "nativeDebugging": true

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -127,6 +127,11 @@ namespace Datadog.Trace.Configuration
         public const string CustomSamplingRules = "DD_TRACE_SAMPLING_RULES";
 
         /// <summary>
+        /// Configuration key for setting the global rate for the sampler.
+        /// </summary>
+        public const string GlobalSamplingRate = "DD_TRACE_SAMPLE_RATE";
+
+        /// <summary>
         /// Configuration key for the DogStatsd port where the Tracer can send metrics.
         /// Default value is 8125/
         /// </summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -111,8 +111,12 @@ namespace Datadog.Trace.Configuration
                                    false;
 
             CustomSamplingRules = source?.GetString(ConfigurationKeys.CustomSamplingRules) ??
-                                   // default value
-                                   null;
+                                  // default value
+                                  null;
+
+            GlobalSamplingRate = source?.GetDouble(ConfigurationKeys.GlobalSamplingRate) ??
+                                  // default value
+                                  null;
         }
 
         /// <summary>
@@ -185,6 +189,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.CustomSamplingRules"/>
         public string CustomSamplingRules { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating a global rate for sampling.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.GlobalSamplingRate"/>
+        public double? GlobalSamplingRate { get; set; }
 
         /// <summary>
         /// Gets a collection of <see cref="Integrations"/> keyed by integration name.

--- a/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Sampling
 
         public float GetSamplingRate(Span span)
         {
-            span.SetMetric(Metrics.SamplingAgentDecision, _samplingRate);
+            span.SetMetric(Metrics.SamplingRuleDecision, _samplingRate);
             return _samplingRate;
         }
 

--- a/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Sampling
         /// <summary>
         /// Gets the priority which is one beneath custom rules.
         /// </summary>
-        public int Priority => 2;
+        public int Priority => 0;
 
         public bool IsMatch(Span span)
         {

--- a/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Sampling
+{
+    internal class GlobalSamplingRule : ISamplingRule
+    {
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<GlobalSamplingRule>();
+
+        private readonly float _globalRate;
+
+        public GlobalSamplingRule(float rate)
+        {
+            _globalRate = rate;
+        }
+
+        public string RuleName => "global-rate-rule";
+
+        /// <summary>
+        /// Gets the priority which is one beneath custom rules.
+        /// </summary>
+        public int Priority => 2;
+
+        public bool IsMatch(Span span)
+        {
+            return true;
+        }
+
+        public float GetSamplingRate(Span span)
+        {
+            Log.Debug("Using the global sampling rate: {0}", _globalRate);
+            span.SetMetric(Metrics.SamplingRuleDecision, _globalRate);
+            return _globalRate;
+        }
+    }
+}

--- a/src/Datadog.Trace/Sampling/ISamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/ISamplingRule.cs
@@ -2,8 +2,16 @@ namespace Datadog.Trace.Sampling
 {
     internal interface ISamplingRule
     {
+        /// <summary>
+        /// Gets the rule name.
+        /// Used for debugging purposes mostly.
+        /// </summary>
         string RuleName { get; }
 
+        /// <summary>
+        /// Gets the priority.
+        /// Higher number means higher priority.
+        /// </summary>
         int Priority { get; }
 
         bool IsMatch(Span span);

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -95,6 +95,19 @@ namespace Datadog.Trace
                 }
             }
 
+            if (Settings.GlobalSamplingRate != null)
+            {
+                var globalRate = (float)Settings.GlobalSamplingRate;
+                if (globalRate < 0f || globalRate > 1f)
+                {
+                    Log.Warning("{0} configuration of {1} is out of range", ConfigurationKeys.GlobalSamplingRate, Settings.GlobalSamplingRate);
+                }
+                else
+                {
+                    Sampler.RegisterRule(new GlobalSamplingRule(globalRate));
+                }
+            }
+
             // Register callbacks to make sure we flush the traces before exiting
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;


### PR DESCRIPTION
Changes proposed in this pull request:
Implements `DD_TRACE_SAMPLE_RATE`

@DataDog/apm-dotnet