### PR TITLE
Refactor current implementations of IScopeManager

### DIFF
--- a/src/Datadog.Trace.AspNet/AspNetScopeManager.cs
+++ b/src/Datadog.Trace.AspNet/AspNetScopeManager.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.AspNet
                 return _activeScopeFallback.Get();
             }
 
-            set
+            protected set
             {
                 var httpContext = HttpContext.Current;
                 if (httpContext != null)

--- a/src/Datadog.Trace.AspNet/AspNetScopeManager.cs
+++ b/src/Datadog.Trace.AspNet/AspNetScopeManager.cs
@@ -4,24 +4,12 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.AspNet
 {
-    internal class AspNetScopeManager : IScopeManager
+    internal class AspNetScopeManager : ScopeManagerBase
     {
-        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<AspNetScopeManager>();
-
         private readonly string _name = "__Datadog_Scope_Current__" + Guid.NewGuid();
         private readonly AsyncLocalCompat<Scope> _activeScopeFallback = new AsyncLocalCompat<Scope>();
 
-        public event EventHandler<SpanEventArgs> SpanOpened;
-
-        public event EventHandler<SpanEventArgs> SpanActivated;
-
-        public event EventHandler<SpanEventArgs> SpanDeactivated;
-
-        public event EventHandler<SpanEventArgs> SpanClosed;
-
-        public event EventHandler<SpanEventArgs> TraceEnded;
-
-        public Scope Active
+        public override Scope Active
         {
             get
             {
@@ -33,66 +21,17 @@ namespace Datadog.Trace.AspNet
 
                 return _activeScopeFallback.Get();
             }
-        }
 
-        public Scope Activate(Span span, bool finishOnClose)
-        {
-            var newParent = Active;
-            var scope = new Scope(newParent, span, this, finishOnClose);
-            var scopeOpenedArgs = new SpanEventArgs(span);
-
-            SpanOpened?.Invoke(this, scopeOpenedArgs);
-
-            SetScope(scope);
-
-            if (newParent != null)
+            set
             {
-                SpanDeactivated?.Invoke(this, new SpanEventArgs(newParent.Span));
+                var httpContext = HttpContext.Current;
+                if (httpContext != null)
+                {
+                    httpContext.Items[_name] = value;
+                }
+
+                _activeScopeFallback.Set(value);
             }
-
-            SpanActivated?.Invoke(this, scopeOpenedArgs);
-
-            return scope;
-        }
-
-        public void Close(Scope scope)
-        {
-            var current = Active;
-            var isRootSpan = scope.Parent == null;
-
-            if (current == null || current != scope)
-            {
-                // This is not the current scope for this context, bail out
-                return;
-            }
-
-            // if the scope that was just closed was the active scope,
-            // set its parent as the new active scope
-            SetScope(current.Parent);
-            SpanDeactivated?.Invoke(this, new SpanEventArgs(current.Span));
-
-            if (!isRootSpan)
-            {
-                SpanActivated?.Invoke(this, new SpanEventArgs(current.Parent.Span));
-            }
-
-            SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));
-
-            if (isRootSpan)
-            {
-                TraceEnded?.Invoke(this, new SpanEventArgs(scope.Span));
-            }
-        }
-
-        private void SetScope(Scope scope)
-        {
-            var httpContext = HttpContext.Current;
-            if (httpContext != null)
-            {
-                httpContext.Items[_name] = scope;
-            }
-
-            _activeScopeFallback.Set(scope);
         }
     }
 }

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -3,71 +3,20 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace
 {
-    internal class AsyncLocalScopeManager : IScopeManager
+    internal class AsyncLocalScopeManager : ScopeManagerBase
     {
-        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(AsyncLocalScopeManager));
-
         private readonly AsyncLocalCompat<Scope> _activeScope = new AsyncLocalCompat<Scope>();
 
-        public event EventHandler<SpanEventArgs> SpanOpened;
-
-        public event EventHandler<SpanEventArgs> SpanActivated;
-
-        public event EventHandler<SpanEventArgs> SpanDeactivated;
-
-        public event EventHandler<SpanEventArgs> SpanClosed;
-
-        public event EventHandler<SpanEventArgs> TraceEnded;
-
-        public Scope Active => _activeScope.Get();
-
-        public Scope Activate(Span span, bool finishOnClose)
+        public override Scope Active
         {
-            var newParent = Active;
-            var scope = new Scope(newParent, span, this, finishOnClose);
-            var scopeOpenedArgs = new SpanEventArgs(span);
-
-            SpanOpened?.Invoke(this, scopeOpenedArgs);
-
-            _activeScope.Set(scope);
-
-            if (newParent != null)
+            get
             {
-                SpanDeactivated?.Invoke(this, new SpanEventArgs(newParent.Span));
+                return _activeScope.Get();
             }
 
-            SpanActivated?.Invoke(this, scopeOpenedArgs);
-
-            return scope;
-        }
-
-        public void Close(Scope scope)
-        {
-            var current = Active;
-            var isRootSpan = scope.Parent == null;
-
-            if (current == null || current != scope)
+            set
             {
-                // This is not the current scope for this context, bail out
-                SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));
-                return;
-            }
-
-            // if the scope that was just closed was the active scope,
-            // set its parent as the new active scope
-            _activeScope.Set(scope.Parent);
-            SpanDeactivated?.Invoke(this, new SpanEventArgs(scope.Span));
-
-            if (!isRootSpan)
-            {
-                SpanActivated?.Invoke(this, new SpanEventArgs(scope.Parent.Span));
-            }
-
-            SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));
-
-            if (isRootSpan)
-            {
-                TraceEnded?.Invoke(this, new SpanEventArgs(scope.Span));
+                _activeScope.Set(value);
             }
         }
     }

--- a/src/Datadog.Trace/AsyncLocalScopeManager.cs
+++ b/src/Datadog.Trace/AsyncLocalScopeManager.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace
                 return _activeScope.Get();
             }
 
-            set
+            protected set
             {
                 _activeScope.Set(value);
             }

--- a/src/Datadog.Trace/ScopeManagerBase.cs
+++ b/src/Datadog.Trace/ScopeManagerBase.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace
 
         public event EventHandler<SpanEventArgs> TraceEnded;
 
-        public abstract Scope Active { get; set; }
+        public abstract Scope Active { get; protected set; }
 
         public Scope Activate(Span span, bool finishOnClose)
         {

--- a/src/Datadog.Trace/ScopeManagerBase.cs
+++ b/src/Datadog.Trace/ScopeManagerBase.cs
@@ -1,0 +1,74 @@
+using System;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace
+{
+    internal abstract class ScopeManagerBase : IScopeManager
+    {
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(ScopeManagerBase));
+
+        private readonly AsyncLocalCompat<Scope> _activeScope = new AsyncLocalCompat<Scope>();
+
+        public event EventHandler<SpanEventArgs> SpanOpened;
+
+        public event EventHandler<SpanEventArgs> SpanActivated;
+
+        public event EventHandler<SpanEventArgs> SpanDeactivated;
+
+        public event EventHandler<SpanEventArgs> SpanClosed;
+
+        public event EventHandler<SpanEventArgs> TraceEnded;
+
+        public abstract Scope Active { get; set; }
+
+        public Scope Activate(Span span, bool finishOnClose)
+        {
+            var newParent = Active;
+            var scope = new Scope(newParent, span, this, finishOnClose);
+            var scopeOpenedArgs = new SpanEventArgs(span);
+
+            SpanOpened?.Invoke(this, scopeOpenedArgs);
+
+            _activeScope.Set(scope);
+
+            if (newParent != null)
+            {
+                SpanDeactivated?.Invoke(this, new SpanEventArgs(newParent.Span));
+            }
+
+            SpanActivated?.Invoke(this, scopeOpenedArgs);
+
+            return scope;
+        }
+
+        public void Close(Scope scope)
+        {
+            var current = Active;
+            var isRootSpan = scope.Parent == null;
+
+            if (current == null || current != scope)
+            {
+                // This is not the current scope for this context, bail out
+                SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));
+                return;
+            }
+
+            // if the scope that was just closed was the active scope,
+            // set its parent as the new active scope
+            Active = scope.Parent;
+            SpanDeactivated?.Invoke(this, new SpanEventArgs(scope.Span));
+
+            if (!isRootSpan)
+            {
+                SpanActivated?.Invoke(this, new SpanEventArgs(scope.Parent.Span));
+            }
+
+            SpanClosed?.Invoke(this, new SpanEventArgs(scope.Span));
+
+            if (isRootSpan)
+            {
+                TraceEnded?.Invoke(this, new SpanEventArgs(scope.Span));
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace/ScopeManagerBase.cs
+++ b/src/Datadog.Trace/ScopeManagerBase.cs
@@ -7,8 +7,6 @@ namespace Datadog.Trace
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(ScopeManagerBase));
 
-        private readonly AsyncLocalCompat<Scope> _activeScope = new AsyncLocalCompat<Scope>();
-
         public event EventHandler<SpanEventArgs> SpanOpened;
 
         public event EventHandler<SpanEventArgs> SpanActivated;
@@ -29,7 +27,7 @@ namespace Datadog.Trace
 
             SpanOpened?.Invoke(this, scopeOpenedArgs);
 
-            _activeScope.Set(scope);
+            Active = scope;
 
             if (newParent != null)
             {


### PR DESCRIPTION
Refactor current implementations of IScopeManager to inherit from ScopeManagerBase so all the implementation is identical except for how the Active scope is stored and retrieved.

@DataDog/apm-dotnet