### PR TITLE
Fix Active scope synchronization in AspNetScopeManager

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1872,6 +1872,29 @@
           "method": "GetResponseAsync",
           "signature": "00 04 1C 1C 08 08 0A"
         }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Net.Requests",
+          "type": "System.Net.WebRequest",
+          "method": "GetResponseAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Net.WebResponse>"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.11.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
+          "method": "GetResponseAsync",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
       }
     ]
   }

--- a/integrations.json
+++ b/integrations.json
@@ -1853,7 +1853,7 @@
       {
         "caller": {},
         "target": {
-          "assembly": "System.Net",
+          "assembly": "System",
           "type": "System.Net.WebRequest",
           "method": "GetResponseAsync",
           "signature_types": [

--- a/samples-aspnet/Samples.AspNetMvc5_0/Controllers/HomeController.cs
+++ b/samples-aspnet/Samples.AspNetMvc5_0/Controllers/HomeController.cs
@@ -1,9 +1,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.Mvc;
+using Datadog.Trace;
 
 namespace Samples.AspNetMvc5_0.Controllers
 {
@@ -36,6 +42,56 @@ namespace Samples.AspNetMvc5_0.Controllers
             ViewBag.Message = "Your contact page.";
 
             return View();
+        }
+
+        public async Task<ActionResult> DadJoke()
+        {
+            string responseText;
+            var request = WebRequest.Create("https://icanhazdadjoke.com/");
+            ((HttpWebRequest)request).Accept = "application/json;q=1";
+
+            using (var response = await request.GetResponseAsync())
+            using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream))
+            {
+                try
+                {
+                    responseText = reader.ReadToEnd();
+                }
+                catch (Exception)
+                {
+                    responseText = "ENCOUNTERED AN ERROR WHEN READING RESPONSE.";
+                }
+            }
+
+            using (var scope = Tracer.Instance.StartActive("not-http-request-child-first"))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(1_000));
+            }
+
+            request = WebRequest.Create("https://icanhazdadjoke.com/");
+            ((HttpWebRequest)request).Accept = "application/json;q=1";
+
+            using (var response = await request.GetResponseAsync())
+            using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream))
+            {
+                try
+                {
+                    responseText = reader.ReadToEnd();
+                }
+                catch (Exception)
+                {
+                    responseText = "ENCOUNTERED AN ERROR WHEN READING RESPONSE.";
+                }
+            }
+
+            using (var scope = Tracer.Instance.StartActive("not-http-request-child-second"))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(1_000));
+            }
+
+            return Json(responseText, JsonRequestBehavior.AllowGet);
         }
 
         public ActionResult BadRequest()

--- a/samples-aspnet/Samples.AspNetMvc5_0/Samples.AspNetMvc5_0.csproj
+++ b/samples-aspnet/Samples.AspNetMvc5_0/Samples.AspNetMvc5_0.csproj
@@ -186,6 +186,10 @@
     <Content Include="Scripts\jquery-3.3.1.min.map" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj">
+      <Project>{b34edbc7-c5fb-409d-8472-bc7469d6f2bd}</Project>
+      <Name>Datadog.Trace.AspNet</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
       <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
       <Name>Datadog.Trace.ClrProfiler.Managed</Name>

--- a/src/Datadog.Trace.AspNet/AspNetScopeManager.cs
+++ b/src/Datadog.Trace.AspNet/AspNetScopeManager.cs
@@ -13,24 +13,24 @@ namespace Datadog.Trace.AspNet
         {
             get
             {
-                var activeScope = HttpContext.Current?.Items[_name] as Scope;
+                var activeScope = _activeScopeFallback.Get();
                 if (activeScope != null)
                 {
                     return activeScope;
                 }
 
-                return _activeScopeFallback.Get();
+                return HttpContext.Current?.Items[_name] as Scope;
             }
 
             protected set
             {
+                _activeScopeFallback.Set(value);
+
                 var httpContext = HttpContext.Current;
                 if (httpContext != null)
                 {
                     httpContext.Items[_name] = value;
                 }
-
-                _activeScopeFallback.Set(value);
             }
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
-            TargetAssembly = "System.Net",
+            TargetAssembly = "System",
             TargetType = WebRequestTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Net.WebResponse>" },
             TargetMinimumVersion = Major4,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -115,7 +115,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
-            TargetAssembly = "System",
+            TargetAssembly = "System", // .NET Framework
+            TargetType = WebRequestTypeName,
+            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Net.WebResponse>" },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssembly = "System.Net.Requests", // .NET Core
             TargetType = WebRequestTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Net.WebResponse>" },
             TargetMinimumVersion = Major4,


### PR DESCRIPTION
Issue:
When using the AspNetScopeManager, the closing of a span generated by automatic instrumentation doesn't get propagated correctly to the original ASP.NET synchronization context, causing later spans to have the wrong parent.

This occurs because we use `ConfigureAwait(false)` on all of our async continuations. When we create the new span we register it to the `HttpContext.Current` of the ASP.NET synchronization context, but when we close the span during the continuation we have lost the original ASP.NET synchronization context so the `HttpContext.Current` remains unchanged. Then, later spans generated in the ASP.NET synchronization context treat that span as being active and will always be a child of that one.

![synchronizationcontext_bad](https://user-images.githubusercontent.com/13769665/72925717-08822100-3d08-11ea-86d9-80b5a0e34e15.JPG)

Solution:
When obtaining the Active scope, check the `AsyncLocalCompat` value first and then check `HttpContext.Current` as a fallback. This allows any changes to the Active scope that were made in our continuations without the ASP.NET synchronization context to be visible by later code run inside the ASP.NET synchronization context.

![synchronizationcontext_good](https://user-images.githubusercontent.com/13769665/72925732-0ddf6b80-3d08-11ea-899e-63d526733d50.JPG)

Additional fix:
Fix the System.Net.WebRequest.GetResponseAsync integration which had the wrong assembly name. In .NET Framework it is always in the `System` assembly. This was noticed while testing the modified sample. I am also adding the .NET Core integration because the change is so small.

@DataDog/apm-dotnet