### PR TITLE
Prevent an unhandled SecurityException in DatadogLogging

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Configuration key for the DogStatsd port where the Tracer can send metrics.
-        /// Default value is 8125/
+        /// Default value is 8125.
         /// </summary>
         public const string DogStatsdPort = "DD_DOGSTATSD_PORT";
 
@@ -142,6 +142,20 @@ namespace Datadog.Trace.Configuration
         /// Default value is <c>false</c> (disabled).
         /// </summary>
         public const string TracerMetricsEnabled = "DD_TRACE_METRICS_ENABLED";
+
+        /// <summary>
+        /// Configuration key for setting the approximate maximum size,
+        /// in bytes, for Tracer log files.
+        /// Default value is 10 MB.
+        /// </summary>
+        public const string MaxLogFileSize = "DD_MAX_LOGFILE_SIZE";
+
+        /// <summary>
+        /// Configuration key for setting the path to the profiler log file.
+        /// Default value is "%ProgramData%"\Datadog .NET Tracer\logs\dotnet-profiler.log" on Windows
+        /// or "/var/log/datadog/dotnet-profiler.log" on Linux.
+        /// </summary>
+        public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
 
         /// <summary>
         /// String format patterns used to match integration-specific configuration keys.

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -11,7 +11,8 @@ namespace Datadog.Trace.Logging
     internal static class DatadogLogging
     {
         private const string NixDefaultDirectory = "/var/log/datadog/";
-        private static readonly string WindowsDefaultDirectory;
+        private static readonly string WindowsDefaultDirectory =
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
 
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly LogEventLevel MinimumLogEventLevel = LogEventLevel.Warning;
@@ -50,13 +51,8 @@ namespace Datadog.Trace.Logging
                     logDirectory = Path.GetDirectoryName(nativeLogFile);
                 }
 
-                // This entire block may throw a SecurityException if not granted the System.Security.Permissions.FileIOPermission because of the following API calls
-                //   - Directory.Exists
-                //   - Environment.GetFolderPath
-                //   - Path.GetTempPath
                 if (logDirectory == null)
                 {
-                    WindowsDefaultDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
                     if (Directory.Exists(WindowsDefaultDirectory))
                     {
                         logDirectory = WindowsDefaultDirectory;

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -11,8 +11,7 @@ namespace Datadog.Trace.Logging
     internal static class DatadogLogging
     {
         private const string NixDefaultDirectory = "/var/log/datadog/";
-        private static readonly string WindowsDefaultDirectory =
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
+        private static readonly string WindowsDefaultDirectory;
 
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly LogEventLevel MinimumLogEventLevel = LogEventLevel.Warning;
@@ -51,8 +50,13 @@ namespace Datadog.Trace.Logging
                     logDirectory = Path.GetDirectoryName(nativeLogFile);
                 }
 
+                // This entire block may throw a SecurityException if not granted the System.Security.Permissions.FileIOPermission because of the following API calls
+                //   - Directory.Exists
+                //   - Environment.GetFolderPath
+                //   - Path.GetTempPath
                 if (logDirectory == null)
                 {
+                    WindowsDefaultDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
                     if (Directory.Exists(WindowsDefaultDirectory))
                     {
                         logDirectory = WindowsDefaultDirectory;

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Vendors.Serilog;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.Serilog.Sinks.File;
@@ -36,14 +37,14 @@ namespace Datadog.Trace.Logging
                     MinimumLogEventLevel = LogEventLevel.Verbose;
                 }
 
-                var maxLogSizeVar = Environment.GetEnvironmentVariable("DD_MAX_LOGFILE_SIZE");
+                var maxLogSizeVar = Environment.GetEnvironmentVariable(ConfigurationKeys.MaxLogFileSize);
                 if (long.TryParse(maxLogSizeVar, out var maxLogSize))
                 {
                     // No verbose or debug logs
                     MaxLogFileSize = maxLogSize;
                 }
 
-                var nativeLogFile = Environment.GetEnvironmentVariable("DD_TRACE_LOG_PATH");
+                var nativeLogFile = Environment.GetEnvironmentVariable(ConfigurationKeys.ProfilerLogPath);
                 string logDirectory = null;
 
                 if (!string.IsNullOrEmpty(nativeLogFile))

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -12,8 +12,7 @@ namespace Datadog.Trace.Logging
     internal static class DatadogLogging
     {
         private const string NixDefaultDirectory = "/var/log/datadog/";
-        private static readonly string WindowsDefaultDirectory =
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
+        private static readonly string WindowsDefaultDirectory;
 
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly LogEventLevel MinimumLogEventLevel = LogEventLevel.Warning;
@@ -52,8 +51,13 @@ namespace Datadog.Trace.Logging
                     logDirectory = Path.GetDirectoryName(nativeLogFile);
                 }
 
+                // This entire block may throw a SecurityException if not granted the System.Security.Permissions.FileIOPermission because of the following API calls
+                //   - Directory.Exists
+                //   - Environment.GetFolderPath
+                //   - Path.GetTempPath
                 if (logDirectory == null)
                 {
+                    WindowsDefaultDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
                     if (Directory.Exists(WindowsDefaultDirectory))
                     {
                         logDirectory = WindowsDefaultDirectory;


### PR DESCRIPTION
Move initialization of the WindowsDefaultDirectory field in DatadogLogging to the constructor to catch possible SecurityExceptions.

@DataDog/apm-dotnet