### PR TITLE
fix integration name in SqlCommandIntegration

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     /// </summary>
     public static class SqlCommandIntegration
     {
-        private const string IntegrationName = "SqlCommand";
+        private const string IntegrationName = "AdoNet";
         private const string Major4 = "4";
 
         private const string SqlCommandTypeName = "System.Data.SqlClient.SqlCommand";


### PR DESCRIPTION
Change the integration name in `SqlCommandIntegration` to `AdoNet` to match other ADO.NET integrations, since they are all treated as a single integration for configuration purposes.