### PR TITLE
[Build,Test] Fix compiler warnings and resource name checking

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -830,7 +830,7 @@ bool ReturnTypeIsValueTypeOrGeneric(
       }
 
       size_t length = p_end_byte - p_start_byte;
-      HRESULT hr = metadata_emit->GetTokenFromTypeSpec(p_start_byte, length, ret_type_token);
+      HRESULT hr = metadata_emit->GetTokenFromTypeSpec(p_start_byte, (ULONG) length, ret_type_token);
       return SUCCEEDED(hr);
     }
 
@@ -963,7 +963,7 @@ bool ReturnTypeIsValueTypeOrGeneric(
           }
 
           size_t length = p_end_byte - p_start_byte;
-          HRESULT hr = metadata_emit->GetTokenFromTypeSpec(p_start_byte, length,
+          HRESULT hr = metadata_emit->GetTokenFromTypeSpec(p_start_byte, (ULONG) length,
                                                            ret_type_token);
           return SUCCEEDED(hr);
         } else {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -165,6 +165,8 @@ struct MethodSignature {
     if (data.size() > 1) {
       return data[2] == ELEMENT_TYPE_OBJECT;
     }
+
+    return false;
   }
 
   WSTRING str() const {

--- a/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.cpp
@@ -107,7 +107,7 @@ bool ParseMethod(PCCOR_SIGNATURE* p_sig) {
   }
 
   bool sentinel_found = false;
-  for (int i = 0; i < param_count; i++) {
+  for (ULONG i = 0; i < param_count; i++) {
     if (**p_sig == ELEMENT_TYPE_SENTINEL) {
       if (sentinel_found) {
         return false;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -16,10 +16,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         protected AspNetCoreMvcTestBase(string sampleAppName, ITestOutputHelper output)
             : base(sampleAppName, output)
         {
-            CreateTopLevelExpectation(url: "/", httpMethod: "GET", httpStatus: "200", resourceUrl: "/");
+            CreateTopLevelExpectation(url: "/", httpMethod: "GET", httpStatus: "200", resourceUrl: "Home/Index");
             CreateTopLevelExpectation(url: "/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "delay/{seconds}");
             CreateTopLevelExpectation(url: "/api/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "api/delay/{seconds}");
-            CreateTopLevelExpectation(url: "/not-found", httpMethod: "GET", httpStatus: "404", resourceUrl: "not-found");
+            CreateTopLevelExpectation(url: "/not-found", httpMethod: "GET", httpStatus: "404", resourceUrl: "/not-found");
             CreateTopLevelExpectation(url: "/status-code/203", httpMethod: "GET", httpStatus: "203", resourceUrl: "status-code/{statusCode}");
             CreateTopLevelExpectation(
                 url: "/bad-request",

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -152,10 +152,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             string resourceUrl,
             Func<MockTracerAgent.Span, List<string>> additionalCheck = null)
         {
-            var expectation = new AspNetCoreMvcSpanExpectation(EnvironmentHelper.FullSampleName, TopLevelOperationName, httpStatus, httpMethod)
+            var resourceName = $"{httpMethod.ToUpper()} {resourceUrl}";
+            var expectation = new AspNetCoreMvcSpanExpectation(EnvironmentHelper.FullSampleName, TopLevelOperationName, resourceName, httpStatus, httpMethod)
             {
                 OriginalUri = url,
-                ResourceName = $"{httpMethod.ToUpper()} {resourceUrl}",
             };
 
             expectation.RegisterDelegateExpectation(additionalCheck);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -31,24 +31,24 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _expectedGraphQLExecuteSpanCount = 0;
 
             // SUCCESS: query using GET
-            CreateGraphQLRequestsAndExpectations(url: "/graphql?query=" + WebUtility.UrlEncode("query{hero{name appearsIn}}"), httpMethod: "GET", graphQLRequestBody: null, graphQLOperationType: "Query", graphQLOperationName: null, graphQLSource: "query{hero{name appearsIn} }");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql?query=" + WebUtility.UrlEncode("query{hero{name appearsIn}}"), httpMethod: "GET", resourceName: "query operation", graphQLRequestBody: null, graphQLOperationType: "Query", graphQLOperationName: null, graphQLSource: "query{hero{name appearsIn} }");
 
             // SUCCESS: query using POST (default)
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""query HeroQuery{hero {name appearsIn}}"",""operationName"": ""HeroQuery""}", graphQLOperationType: "Query", graphQLOperationName: "HeroQuery", graphQLSource: "query HeroQuery{hero{name appearsIn}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "query HeroQuery", graphQLRequestBody: @"{""query"":""query HeroQuery{hero {name appearsIn}}"",""operationName"": ""HeroQuery""}", graphQLOperationType: "Query", graphQLOperationName: "HeroQuery", graphQLSource: "query HeroQuery{hero{name appearsIn}}");
 
             // SUCCESS: mutation
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}"",""variables"":{""human"":{""name"": ""Boba Fett""}}}", graphQLOperationType: "Mutation", graphQLOperationName: "AddBobaFett", graphQLSource: "mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "mutation AddBobaFett", graphQLRequestBody: @"{""query"":""mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}"",""variables"":{""human"":{""name"": ""Boba Fett""}}}", graphQLOperationType: "Mutation", graphQLOperationName: "AddBobaFett", graphQLSource: "mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}");
 
             // SUCCESS: subscription
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""subscription HumanAddedSub{humanAdded{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "HumanAddedSub", graphQLSource: "subscription HumanAddedSub{humanAdded{name}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "subscription HumanAddedSub", graphQLRequestBody: @"{ ""query"":""subscription HumanAddedSub{humanAdded{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "HumanAddedSub", graphQLSource: "subscription HumanAddedSub{humanAdded{name}}");
 
             // TODO: When parse is implemented, add a test that fails 'parse' step
 
             // FAILURE: query fails 'validate' step
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""query HumanError{human(id:1){name apearsIn}}""}", graphQLOperationType: "Query", graphQLOperationName: null, failsValidation: true, graphQLSource: "query HumanError{human(id:1){name apearsIn}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "query HumanError", graphQLRequestBody: @"{""query"":""query HumanError{human(id:1){name apearsIn}}""}", graphQLOperationType: "Query", graphQLOperationName: null, failsValidation: true, graphQLSource: "query HumanError{human(id:1){name apearsIn}}");
 
             // FAILURE: query fails 'execute' step
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", graphQLRequestBody: @"{""query"":""subscription NotImplementedSub{throwNotImplementedException{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "NotImplementedSub", graphQLSource: "subscription NotImplementedSub{throwNotImplementedException{name}}", failsExecution: true);
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "subscription NotImplementedSub", graphQLRequestBody: @"{""query"":""subscription NotImplementedSub{throwNotImplementedException{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "NotImplementedSub", graphQLSource: "subscription NotImplementedSub{throwNotImplementedException{name}}", failsExecution: true);
 
             // TODO: When parse is implemented, add a test that fails 'resolve' step
         }
@@ -120,6 +120,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private static void CreateGraphQLRequestsAndExpectations(
             string url,
             string httpMethod,
+            string resourceName,
             string graphQLRequestBody,
             string graphQLOperationType,
             string graphQLOperationName,
@@ -149,7 +150,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (failsValidation) { return; }
 
             // Expect an 'execute' span
-            _expectations.Add(new GraphQLSpanExpectation("Samples.GraphQL-graphql", _graphQLExecuteOperationName, _graphQLExecuteOperationName)
+            _expectations.Add(new GraphQLSpanExpectation("Samples.GraphQL-graphql", _graphQLExecuteOperationName, resourceName)
             {
                 OriginalUri = url,
                 GraphQLRequestBody = graphQLRequestBody,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -31,24 +31,24 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _expectedGraphQLExecuteSpanCount = 0;
 
             // SUCCESS: query using GET
-            CreateGraphQLRequestsAndExpectations(url: "/graphql?query=" + WebUtility.UrlEncode("query{hero{name appearsIn}}"), httpMethod: "GET", resourceName: "query operation", graphQLRequestBody: null, graphQLOperationType: "Query", graphQLOperationName: null, graphQLSource: "query{hero{name appearsIn} }");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql?query=" + WebUtility.UrlEncode("query{hero{name appearsIn}}"), httpMethod: "GET", resourceName: "Query operation", graphQLRequestBody: null, graphQLOperationType: "Query", graphQLOperationName: null, graphQLSource: "query{hero{name appearsIn} }");
 
             // SUCCESS: query using POST (default)
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "query HeroQuery", graphQLRequestBody: @"{""query"":""query HeroQuery{hero {name appearsIn}}"",""operationName"": ""HeroQuery""}", graphQLOperationType: "Query", graphQLOperationName: "HeroQuery", graphQLSource: "query HeroQuery{hero{name appearsIn}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "Query HeroQuery", graphQLRequestBody: @"{""query"":""query HeroQuery{hero {name appearsIn}}"",""operationName"": ""HeroQuery""}", graphQLOperationType: "Query", graphQLOperationName: "HeroQuery", graphQLSource: "query HeroQuery{hero{name appearsIn}}");
 
             // SUCCESS: mutation
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "mutation AddBobaFett", graphQLRequestBody: @"{""query"":""mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}"",""variables"":{""human"":{""name"": ""Boba Fett""}}}", graphQLOperationType: "Mutation", graphQLOperationName: "AddBobaFett", graphQLSource: "mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "Mutation AddBobaFett", graphQLRequestBody: @"{""query"":""mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}"",""variables"":{""human"":{""name"": ""Boba Fett""}}}", graphQLOperationType: "Mutation", graphQLOperationName: "AddBobaFett", graphQLSource: "mutation AddBobaFett($human:HumanInput!){createHuman(human: $human){id name}}");
 
             // SUCCESS: subscription
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "subscription HumanAddedSub", graphQLRequestBody: @"{ ""query"":""subscription HumanAddedSub{humanAdded{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "HumanAddedSub", graphQLSource: "subscription HumanAddedSub{humanAdded{name}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "Subscription HumanAddedSub", graphQLRequestBody: @"{ ""query"":""subscription HumanAddedSub{humanAdded{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "HumanAddedSub", graphQLSource: "subscription HumanAddedSub{humanAdded{name}}");
 
             // TODO: When parse is implemented, add a test that fails 'parse' step
 
             // FAILURE: query fails 'validate' step
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "query HumanError", graphQLRequestBody: @"{""query"":""query HumanError{human(id:1){name apearsIn}}""}", graphQLOperationType: "Query", graphQLOperationName: null, failsValidation: true, graphQLSource: "query HumanError{human(id:1){name apearsIn}}");
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "Query HumanError", graphQLRequestBody: @"{""query"":""query HumanError{human(id:1){name apearsIn}}""}", graphQLOperationType: "Query", graphQLOperationName: null, failsValidation: true, graphQLSource: "query HumanError{human(id:1){name apearsIn}}");
 
             // FAILURE: query fails 'execute' step
-            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "subscription NotImplementedSub", graphQLRequestBody: @"{""query"":""subscription NotImplementedSub{throwNotImplementedException{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "NotImplementedSub", graphQLSource: "subscription NotImplementedSub{throwNotImplementedException{name}}", failsExecution: true);
+            CreateGraphQLRequestsAndExpectations(url: "/graphql", httpMethod: "POST", resourceName: "Subscription NotImplementedSub", graphQLRequestBody: @"{""query"":""subscription NotImplementedSub{throwNotImplementedException{name}}""}", graphQLOperationType: "Subscription", graphQLOperationName: "NotImplementedSub", graphQLSource: "subscription NotImplementedSub{throwNotImplementedException{name}}", failsExecution: true);
 
             // TODO: When parse is implemented, add a test that fails 'resolve' step
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -135,10 +135,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             });
 
             // Expect a 'validate' span
-            _expectations.Add(new GraphQLSpanExpectation("Samples.GraphQL-graphql", _graphQLValidateOperationName)
+            _expectations.Add(new GraphQLSpanExpectation("Samples.GraphQL-graphql", _graphQLValidateOperationName, _graphQLValidateOperationName)
             {
                 OriginalUri = url,
-                ResourceName = _graphQLValidateOperationName,
                 GraphQLRequestBody = graphQLRequestBody,
                 GraphQLOperationType = null,
                 GraphQLOperationName = graphQLOperationName,
@@ -150,10 +149,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (failsValidation) { return; }
 
             // Expect an 'execute' span
-            _expectations.Add(new GraphQLSpanExpectation("Samples.GraphQL-graphql", _graphQLExecuteOperationName)
+            _expectations.Add(new GraphQLSpanExpectation("Samples.GraphQL-graphql", _graphQLExecuteOperationName, _graphQLExecuteOperationName)
             {
                 OriginalUri = url,
-                ResourceName = _graphQLExecuteOperationName,
                 GraphQLRequestBody = graphQLRequestBody,
                 GraphQLOperationType = graphQLOperationType,
                 GraphQLOperationName = graphQLOperationName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/AspNetCoreMvcSpanExpectation.cs
@@ -4,8 +4,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class AspNetCoreMvcSpanExpectation : WebServerSpanExpectation
     {
-        public AspNetCoreMvcSpanExpectation(string serviceName, string operationName, string statusCode, string httpMethod)
-            : base(serviceName, operationName, SpanTypes.Web, statusCode, httpMethod)
+        public AspNetCoreMvcSpanExpectation(string serviceName, string operationName, string resourceName, string statusCode, string httpMethod)
+            : base(serviceName, operationName, resourceName, SpanTypes.Web, statusCode, httpMethod)
         {
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GraphQLSpanExpectation.cs
@@ -5,8 +5,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class GraphQLSpanExpectation : WebServerSpanExpectation
     {
-        public GraphQLSpanExpectation(string serviceName, string operationName)
-            : base(serviceName, operationName, SpanTypes.GraphQL)
+        public GraphQLSpanExpectation(string serviceName, string operationName, string resourceName)
+            : base(serviceName, operationName, resourceName, SpanTypes.GraphQL)
         {
             RegisterDelegateExpectation(ExpectErrorMatch);
             RegisterTagExpectation(nameof(Tags.GraphQLSource), expected: GraphQLSource);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/SpanExpectation.cs
@@ -10,10 +10,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     /// </summary>
     public class SpanExpectation
     {
-        public SpanExpectation(string serviceName, string operationName, string type)
+        public SpanExpectation(string serviceName, string operationName, string resourceName, string type)
         {
             ServiceName = serviceName;
             OperationName = operationName;
+            ResourceName = resourceName;
             Type = type;
 
             // Expectations for all spans regardless of type should go here
@@ -21,8 +22,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             RegisterCustomExpectation(nameof(OperationName), actual: s => s.Name, expected: OperationName);
             RegisterCustomExpectation(nameof(ServiceName), actual: s => s.Service, expected: ServiceName);
-            RegisterCustomExpectation(nameof(Type), actual: s => s.Type, expected: Type);
             RegisterCustomExpectation(nameof(ResourceName), actual: s => s.Resource.TrimEnd(), expected: ResourceName);
+            RegisterCustomExpectation(nameof(Type), actual: s => s.Type, expected: Type);
 
             RegisterTagExpectation(
                 key: Tags.Language,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/WebServerSpanExpectation.cs
@@ -2,8 +2,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class WebServerSpanExpectation : SpanExpectation
     {
-        public WebServerSpanExpectation(string serviceName, string operationName, string type = SpanTypes.Web, string statusCode = null, string httpMethod = null)
-        : base(serviceName, operationName, type)
+        public WebServerSpanExpectation(string serviceName, string operationName, string resourceName, string type = SpanTypes.Web, string statusCode = null, string httpMethod = null)
+        : base(serviceName, operationName, resourceName, type)
         {
             StatusCode = statusCode;
             HttpMethod = httpMethod;


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix profiler compiler warnings
- Fix the integration tests so the `ResourceName` is actually checked by the `SpanExpectation` framework

@DataDog/apm-dotnet