### PR TITLE
Use shortcut NETCOREAPP ifdef and fix broken build

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Datadog.Trace.ClrProfiler.Integrations;
-#if !NETCOREAPP2_1 && !NETCOREAPP3_0 && !NETCOREAPP3_1
+#if !NETCOREAPP
 using Datadog.Trace.ClrProfiler.Integrations.AspNet;
 #endif
 using Xunit;
@@ -14,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         // This is a list of instrumented methods that are static, i.e., the target method is static.
         private static readonly List<MethodInfo> StaticInstrumentations = new List<MethodInfo>()
         {
-#if !NETCOREAPP2_1 && !NETCOREAPP3_0 && !NETCOREAPP3_1
+#if !NETCOREAPP
              typeof(AspNetIntegration).GetMethod(nameof(AspNetIntegration.InvokePreStartInitMethods)),
 #endif
         };

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
@@ -6,4 +6,11 @@
     <ProjectReference Include="..\..\test\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
* Fixes broken build of OpenTracing integration tests.
* Uses `NETCOREAPP` in place of verbose usage of every .NET Core version in an `#ifdef`

@DataDog/apm-dotnet