### PR TITLE
ASP.NET Core Integration: Get MVC route from the ActionDescriptor abstraction

### DIFF
--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -26,7 +26,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461'">
     <!-- Instrumented libraries -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -8,7 +8,6 @@ using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
-using Microsoft.AspNetCore.Mvc.Controllers;
 
 namespace Datadog.Trace.DiagnosticListeners
 {
@@ -195,12 +194,11 @@ namespace Datadog.Trace.DiagnosticListeners
                     // NOTE: This event is the start of the action pipeline. The action has been selected, the route
                     //       has been selected but no filters have run and model binding hasn't occured.
                     var actionDescriptor = (ActionDescriptor)BeforeActionActionDescriptorFetcher.Fetch(arg);
-                    var controllerActionDescriptor = actionDescriptor as ControllerActionDescriptor;
                     HttpRequest request = httpContext.Request;
 
                     string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
-                    string controllerName = controllerActionDescriptor?.ControllerName;
-                    string actionName = controllerActionDescriptor?.ActionName;
+                    string controllerName = actionDescriptor.RouteValues["controller"];
+                    string actionName = actionDescriptor.RouteValues["action"];
                     string routeTemplate = actionDescriptor.AttributeRouteInfo?.Template ?? $"{controllerName}/{actionName}";
                     string resourceName = $"{httpMethod} {routeTemplate}";
 


### PR DESCRIPTION
Changes proposed in this pull request:
Use `Microsoft.AspNetCore.Mvc.Abstractions.ActionDescriptor.RouteValues` to extract the controller name and action. This avoids using the implementation type `Microsoft.AspNetCore.Mvc.Controllers.ControllerActionDescriptor` which pulls in the `Microsoft.AspNetCore.Mvc.Core` and adds a huge number of dependencies.

The resulting `net461` publish contains far fewer assemblies than before:

![tada](https://user-images.githubusercontent.com/13769665/73801456-53bc1b00-476f-11ea-804c-d1724e7d9b9b.JPG)


@DataDog/apm-dotnet