### PR TITLE
don't enable AspNetCoreDiagnosticObserver in net461

### DIFF
--- a/samples/Samples.AspNetCoreMvc21/Samples.AspNetCoreMvc21.csproj
+++ b/samples/Samples.AspNetCoreMvc21/Samples.AspNetCoreMvc21.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/samples/Samples.AspNetCoreMvc21/Views/Home/Index.cshtml
+++ b/samples/Samples.AspNetCoreMvc21/Views/Home/Index.cshtml
@@ -9,8 +9,12 @@
     <table class="table table-striped table-hover">
         <tbody>
             <tr>
+                <th scope="row">Runtime</th>
+                <td>@(System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription)</td>
+            </tr>
+            <tr>
                 <th scope="row">Process architecture</th>
-                <td>@(Environment.Is64BitProcess ? "x64" : "x86")</td>
+                <td>@(System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture)</td>
             </tr>
             <tr>
                 <th scope="row">Profiler attached</th>
@@ -18,11 +22,11 @@
             </tr>
             <tr>
                 <th scope="row">Datadog.Trace.dll path</th>
-                <td>@ViewBag.TracerAssemblyLocation</td>
+                <td>@(ViewBag.TracerAssemblyLocation ?? "(not found)")</td>
             </tr>
             <tr>
-                <th scope="row">Datadog.Trace.ClrProfiler.Managed.dll</th>
-                <td>@ViewBag.ClrProfilerAssemblyLocation</td>
+                <th scope="row">Datadog.Trace.ClrProfiler.Managed.dll path</th>
+                <td>@(ViewBag.ClrProfilerAssemblyLocation ?? "(not found)")</td>
             </tr>
         </tbody>
     </table>

--- a/samples/Samples.AspNetCoreMvc30/Samples.AspNetCoreMvc30.csproj
+++ b/samples/Samples.AspNetCoreMvc30/Samples.AspNetCoreMvc30.csproj
@@ -5,6 +5,10 @@
     <RootNamespace>Samples.AspNetCoreMvc</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+
   <!--Files shared with AspNetCoreMvc21 -->
   <ItemGroup>
     <Compile Include="..\Samples.AspNetCoreMvc21\Controllers\**\*.*" Link="Controllers\%(RecursiveDir)%(Filename)%(Extension)" />

--- a/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -5,6 +5,10 @@
     <RootNamespace>Samples.AspNetCoreMvc</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+
   <!--Files shared with AspNetCoreMvc21 -->
   <ItemGroup>
     <Compile Include="..\Samples.AspNetCoreMvc21\Controllers\**\*.*" Link="Controllers\%(RecursiveDir)%(Filename)%(Extension)" />

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" PrivateAssets="all" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <!-- Instrumented libraries -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" PrivateAssets="All" />

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" PrivateAssets="All" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -1,4 +1,4 @@
-#if !NET45
+#if NETSTANDARD
 using System;
 using Datadog.Trace.Abstractions;
 using Datadog.Trace.ExtensionMethods;

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticOptions.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticOptions.cs
@@ -1,4 +1,4 @@
-#if !NET45
+#if NETSTANDARD
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.Abstractions;

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -369,7 +369,7 @@ namespace Datadog.Trace
 
             var observers = new List<DiagnosticObserver>();
 
-#if !NET45
+#if NETSTANDARD
             if (Settings.IsIntegrationEnabled(AspNetCoreDiagnosticObserver.IntegrationName))
             {
                 Log.Debug("Adding AspNetCoreDiagnosticObserver");

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -379,7 +379,11 @@ namespace Datadog.Trace
             }
 #endif
 
-            if (observers.Count > 0)
+            if (observers.Count == 0)
+            {
+                Log.Debug("DiagnosticManager not started, zero observers added.");
+            }
+            else
             {
                 Log.Debug("Starting DiagnosticManager with {0} observers.", observers.Count);
 


### PR DESCRIPTION
The new ASP.NET Core integration using `DiagnosticSource` will only be enabled in .NET Core, not in .NET Framework. Even though ASP.NET Core 2.x can technically run on .NET Framework, this change avoids issues when .NET Framework's strict assembly binding kick in.