### PR TITLE
Only reference Datadog.Trace.AspNet as a private reference

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -42,8 +42,6 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <Reference Include="System.Web" />
     <Reference Include="System.ServiceModel" />
 
-    <!-- include this dependency in the NuGet package for backwards compatiblity with
-         users who were using "Datadog.Trace.ClrProfiler.Managed" to instrument ASP.NET -->
     <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -44,7 +44,7 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
 
     <!-- include this dependency in the NuGet package for backwards compatiblity with
          users who were using "Datadog.Trace.ClrProfiler.Managed" to instrument ASP.NET -->
-    <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" />
+    <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
The `Datadog.Trace.AspNet` reference in `Datadog.Trace.ClrProfiler.Managed` should not  be visible as a public reference from the latter's Nuget package.

@DataDog/apm-dotnet