### PR TITLE
Kill sub processes on process exit

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -444,17 +444,23 @@ namespace Datadog.Trace
 
         private void CurrentDomain_ProcessExit(object sender, EventArgs e)
         {
-            _agentWriter.FlushAndCloseAsync().Wait();
+            RunShutdownTasks();
         }
 
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            _agentWriter.FlushAndCloseAsync().Wait();
+            RunShutdownTasks();
         }
 
         private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
         {
+            RunShutdownTasks();
+        }
+
+        private void RunShutdownTasks()
+        {
             _agentWriter.FlushAndCloseAsync().Wait();
+            TracerSubProcessManager.StopSubProcesses();
         }
 
         private void HeartbeatCallback(object state)

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -474,7 +474,7 @@ namespace Datadog.Trace
                 DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Error flushing traces on shutdown."));
             }
 
-            TracingProcessManager.StopSubProcesses();
+            TracingProcessManager.StopProcesses();
         }
 
         private void HeartbeatCallback(object state)

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace
 
         static Tracer()
         {
-            TracerSubProcessManager.StartStandaloneAgentProcessesWhenConfigured();
+            TracingProcessManager.StartProcesses();
             // create the default global Tracer
             Instance = new Tracer();
         }
@@ -474,7 +474,7 @@ namespace Datadog.Trace
                 DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Error flushing traces on shutdown."));
             }
 
-            TracerSubProcessManager.StopSubProcesses();
+            TracingProcessManager.StopSubProcesses();
         }
 
         private void HeartbeatCallback(object state)

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace
             }
         };
 
-        public static void StopSubProcesses()
+        public static void StopProcesses()
         {
             foreach (var subProcessMetadata in Processes)
             {


### PR DESCRIPTION
Attempt to kill sub processes like the trace agent or stats on exit in order to deal with recycles and restarts.

@DataDog/apm-dotnet