### PR TITLE
Postgres Database Instrumentation Support

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -304,7 +304,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.AssemblyConflict.LegacyProject", "reproductions\StackExchange.Redis.AssemblyConflict.LegacyProject\StackExchange.Redis.AssemblyConflict.LegacyProject.csproj", "{7B0822F6-80DE-4B49-8125-93975678D0D5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.AssemblyConflict.SdkProject", "reproductions\StackExchange.Redis.AssemblyConflict.SdkProject\StackExchange.Redis.AssemblyConflict.SdkProject.csproj", "{C41023C9-65C3-4FB3-9053-4DE963A81500}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Dapper", "samples\Samples.Dapper\Samples.Dapper.csproj", "{2E064A12-B50A-4906-A93B-B6AA4677C048}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Dapper", "samples\Samples.Dapper\Samples.Dapper.csproj", "{7E563BF6-47F2-4531-A1CE-FB9445DF3253}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1094,16 +1095,16 @@ Global
 		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x64.Build.0 = Release|x64
 		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x86.ActiveCfg = Release|x86
 		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x86.Build.0 = Release|x86
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x64.ActiveCfg = Debug|x64
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x64.Build.0 = Debug|x64
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x86.ActiveCfg = Debug|x86
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x86.Build.0 = Debug|x86
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|Any CPU.ActiveCfg = Release|x86
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x64.ActiveCfg = Release|x64
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x64.Build.0 = Release|x64
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x86.ActiveCfg = Release|x86
-		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x86.Build.0 = Release|x86
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|x64.ActiveCfg = Debug|x64
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|x64.Build.0 = Debug|x64
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|x86.ActiveCfg = Debug|x86
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Debug|x86.Build.0 = Debug|x86
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|Any CPU.ActiveCfg = Release|x86
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|x64.ActiveCfg = Release|x64
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|x64.Build.0 = Release|x64
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|x86.ActiveCfg = Release|x86
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1183,7 +1184,7 @@ Global
 		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
-		{2E064A12-B50A-4906-A93B-B6AA4677C048} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -304,6 +304,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.AssemblyConflict.LegacyProject", "reproductions\StackExchange.Redis.AssemblyConflict.LegacyProject\StackExchange.Redis.AssemblyConflict.LegacyProject.csproj", "{7B0822F6-80DE-4B49-8125-93975678D0D5}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.AssemblyConflict.SdkProject", "reproductions\StackExchange.Redis.AssemblyConflict.SdkProject\StackExchange.Redis.AssemblyConflict.SdkProject.csproj", "{C41023C9-65C3-4FB3-9053-4DE963A81500}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Dapper", "samples\Samples.Dapper\Samples.Dapper.csproj", "{2E064A12-B50A-4906-A93B-B6AA4677C048}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1093,6 +1094,16 @@ Global
 		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x64.Build.0 = Release|x64
 		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x86.ActiveCfg = Release|x86
 		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x86.Build.0 = Release|x86
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x64.ActiveCfg = Debug|x64
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x64.Build.0 = Debug|x64
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x86.ActiveCfg = Debug|x86
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Debug|x86.Build.0 = Debug|x86
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|Any CPU.ActiveCfg = Release|x86
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x64.ActiveCfg = Release|x64
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x64.Build.0 = Release|x64
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x86.ActiveCfg = Release|x86
+		{2E064A12-B50A-4906-A93B-B6AA4677C048}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1172,6 +1183,7 @@ Global
 		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{2E064A12-B50A-4906-A93B-B6AA4677C048} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -34,7 +34,7 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration samples/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.MongoDB Samples.HttpMessageHandler Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.MongoDB Samples.HttpMessageHandler Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration samples/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/integrations.json
+++ b/integrations.json
@@ -738,6 +738,29 @@
       {
         "caller": {},
         "target": {
+          "assembly": "netstandard",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "System.Data.IDataReader"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteReader",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
           "assembly": "System.Data",
           "type": "System.Data.IDbCommand",
           "method": "ExecuteReader",
@@ -778,6 +801,30 @@
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.13.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteReaderWithBehavior",
+          "signature": "00 05 1C 1C 08 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "netstandard",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "System.Data.IDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteReaderWithBehavior",
           "signature": "00 05 1C 1C 08 08 08 0A"
@@ -824,6 +871,29 @@
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.13.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteNonQuery",
+          "signature": "00 04 08 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "netstandard",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteNonQuery",
+          "signature_types": [
+            "System.Int32"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteNonQuery",
           "signature": "00 04 08 1C 08 08 0A"
@@ -870,6 +940,29 @@
         },
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.13.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
+          "method": "ExecuteScalar",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "netstandard",
+          "type": "System.Data.IDbCommand",
+          "method": "ExecuteScalar",
+          "signature_types": [
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.IDbCommandIntegration",
           "method": "ExecuteScalar",
           "signature": "00 04 1C 1C 08 08 0A"

--- a/integrations.json
+++ b/integrations.json
@@ -1076,6 +1076,225 @@
     ]
   },
   {
+    "name": "NpgsqlCommand",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "Npgsql.NpgsqlDataReader"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteReader",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "Npgsql.NpgsqlDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteReaderWithBehavior",
+          "signature": "00 05 1C 1C 08 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteReaderAsync",
+          "signature_types": [
+            "Npgsql.NpgsqlDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteReaderAsync",
+          "signature": "00 05 1C 1C 08 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteReaderAsync",
+          "signature_types": [
+            "Npgsql.NpgsqlDataReader",
+            "System.Data.CommandBehavior",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteReaderAsyncTwoParams",
+          "signature": "00 06 1C 1C 08 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteNonQuery",
+          "signature_types": [
+            "System.Int32"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteNonQuery",
+          "signature": "00 04 08 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteNonQueryAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Int32>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteNonQueryAsync",
+          "signature": "00 05 1C 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Npgsql",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteScalar",
+          "signature_types": [
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteScalar",
+          "signature": "00 04 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteScalarAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Object>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteScalarAsync",
+          "signature": "00 05 1C 1C 1C 08 08 0A"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.SqlClient",
+          "type": "Npgsql.NpgsqlCommand",
+          "method": "ExecuteScalarAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Object>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
+          "method": "ExecuteScalarAsync",
+          "signature": "00 05 1C 1C 1C 08 08 0A"
+        }
+      }
+    ]
+  },
+  {
     "name": "ServiceStackRedis",
     "method_replacements": [
       {

--- a/integrations.json
+++ b/integrations.json
@@ -1132,8 +1132,8 @@
           "type": "Npgsql.NpgsqlCommand",
           "method": "ExecuteReaderAsync",
           "signature_types": [
-            "Npgsql.NpgsqlDataReader",
-            "System.Data.CommandBehavior"
+            "System.Threading.Tasks.Task`1<Npgsql.NpgsqlDataReader>",
+            "System.Threading.CancellationToken"
           ],
           "minimum_major": 4,
           "minimum_minor": 0,
@@ -1146,7 +1146,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.12.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
           "method": "ExecuteReaderAsync",
-          "signature": "00 05 1C 1C 08 08 08 0A"
+          "signature": "00 05 1C 1C 1C 08 08 0A"
         }
       },
       {
@@ -1156,7 +1156,7 @@
           "type": "Npgsql.NpgsqlCommand",
           "method": "ExecuteReaderAsync",
           "signature_types": [
-            "Npgsql.NpgsqlDataReader",
+            "System.Threading.Tasks.Task`1<Npgsql.NpgsqlDataReader>",
             "System.Data.CommandBehavior",
             "System.Threading.CancellationToken"
           ],

--- a/sample-libs/Samples.DatabaseHelper/DapperTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/DapperTestHarness.cs
@@ -1,0 +1,81 @@
+#if !NET45
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Datadog.Trace;
+using Dapper;
+
+namespace Samples.DatabaseHelper
+{
+    public class DapperTestHarness<TConnection, TCommand, TDataReader>
+        where TConnection : class, IDbConnection
+        where TCommand : class, IDbCommand
+        where TDataReader : class, IDataReader
+
+    {
+        // These sql strings are passed through a Query object on the connection object (see below)
+        // which is how Dapper shortcuts some of the steps for their users.
+        private const string DropCommandText = "DROP TABLE IF EXISTS Employees; CREATE TABLE Employees (Id int PRIMARY KEY, Name varchar(100));";
+        private const string InsertCommandText = "INSERT INTO Employees (Id, Name) VALUES (1, 'nametest');";
+        private const string SelectOneCommandText = "SELECT Name FROM Employees WHERE Id=1;";
+        private const string SelectManyCommandText = "SELECT * FROM Employees WHERE Id=1;";
+
+        private readonly TConnection _connection;
+
+        public DapperTestHarness(
+            TConnection connection)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        }
+
+        public async Task RunAsync()
+        {
+            using (var scopeAll = Tracer.Instance.StartActive("run.all"))
+            {
+                scopeAll.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                using (var scopeSync = Tracer.Instance.StartActive("run.sync"))
+                {
+                    scopeSync.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                    _connection.Open();
+                    SelectRecords(_connection);
+                    _connection.Close();
+                }
+            }
+
+            if (_connection is DbConnection connection)
+            {
+                // leave a small space between spans, for better visibility in the UI
+                await Task.Delay(TimeSpan.FromSeconds(0.1));
+
+                using (var scopeAsync = Tracer.Instance.StartActive("run.async"))
+                {
+                    scopeAsync.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                    await connection.OpenAsync();
+                    await SelectRecordsAsync(_connection);
+                    _connection.Close();
+                }
+            }
+
+        }
+
+        private void SelectRecords(IDbConnection connection)
+        {
+            connection.Execute(DropCommandText);
+            connection.Execute(InsertCommandText);
+
+            // Dapper has its own unique way of passing a query.
+            connection.Query(SelectOneCommandText);
+        }
+
+        private async Task SelectRecordsAsync(IDbConnection connection)
+        {
+            await connection.ExecuteAsync(SelectManyCommandText);
+        }
+
+    }
+}
+#endif

--- a/sample-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
+++ b/sample-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0</TargetFrameworks>
 
     <LangVersion>latest</LangVersion>
@@ -11,4 +11,7 @@
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
+    <PackageReference Include="Dapper" Version="2.0.30" />
+  </ItemGroup>
 </Project>

--- a/samples/Samples.Dapper/Program.cs
+++ b/samples/Samples.Dapper/Program.cs
@@ -1,12 +1,8 @@
-#if !NET452
-
 using System;
 using System.Data;
-using System.Data.Common;
 using System.Threading.Tasks;
-using Dapper;
 using Npgsql;
-using Datadog.Trace;
+using Samples.DatabaseHelper;
 
 namespace Samples.Dapper
 {
@@ -34,86 +30,4 @@ namespace Samples.Dapper
             return new NpgsqlConnection(connectionString);
         }
     }
-
-    public class DapperTestHarness<TConnection, TCommand, TDataReader>
-        where TConnection : class, IDbConnection
-        where TCommand : class, IDbCommand
-        where TDataReader : class, IDataReader
-
-    {
-        // These sql strings are passed through a Query object on the connection object (see below)
-        // which is how Dapper shortcuts some of the steps for their users.
-        private const string DropCommandText = "DROP TABLE IF EXISTS Employees; CREATE TABLE Employees (Id int PRIMARY KEY, Name varchar(100));";
-        private const string InsertCommandText = "INSERT INTO Employees (Id, Name) VALUES (1, 'nametest');";
-        private const string SelectOneCommandText = "SELECT Name FROM Employees WHERE Id=1;";
-        private const string SelectManyCommandText = "SELECT * FROM Employees WHERE Id=1;";
-
-        private readonly TConnection _connection;
-
-        public DapperTestHarness(
-            TConnection connection)
-        {
-            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
-        }
-
-        public async Task RunAsync()
-        {
-            using (var scopeAll = Tracer.Instance.StartActive("run.all"))
-            {
-                scopeAll.Span.SetTag("command-type", typeof(TCommand).FullName);
-
-                using (var scopeSync = Tracer.Instance.StartActive("run.sync"))
-                {
-                    scopeSync.Span.SetTag("command-type", typeof(TCommand).FullName);
-
-                    _connection.Open();
-                    SelectRecords(_connection);
-                    _connection.Close();
-                }
-            }
-
-            if (_connection is DbConnection connection)
-            {
-                // leave a small space between spans, for better visibility in the UI
-                await Task.Delay(TimeSpan.FromSeconds(0.1));
-
-                using (var scopeAsync = Tracer.Instance.StartActive("run.async"))
-                {
-                    scopeAsync.Span.SetTag("command-type", typeof(TCommand).FullName);
-
-                    await connection.OpenAsync();
-                    await SelectRecordsAsync(_connection);
-                    _connection.Close();
-                }
-            }
-
-        }
-
-        private void SelectRecords(IDbConnection connection)
-        {
-            connection.Execute(DropCommandText);
-            connection.Execute(InsertCommandText);
-
-            // Dapper has its own unique way of passing a query.
-            connection.Query(SelectOneCommandText);
-        }
-
-        private async Task SelectRecordsAsync(IDbConnection connection)
-        {
-            await connection.ExecuteAsync(SelectManyCommandText);
-        }
-
-    }
-
 }
-#else
-namespace Samples.Dapper
-{
-    internal static class Program
-    {
-        private static void Main()
-        { }
-    }
-}
-#endif
-

--- a/samples/Samples.Dapper/Program.cs
+++ b/samples/Samples.Dapper/Program.cs
@@ -41,6 +41,8 @@ namespace Samples.Dapper
         where TDataReader : class, IDataReader
 
     {
+        // These sql strings are passed through a Query object on the connection object (see below)
+        // which is how Dapper shortcuts some of the steps for their users.
         private const string DropCommandText = "DROP TABLE IF EXISTS Employees; CREATE TABLE Employees (Id int PRIMARY KEY, Name varchar(100));";
         private const string InsertCommandText = "INSERT INTO Employees (Id, Name) VALUES (1, 'nametest');";
         private const string SelectOneCommandText = "SELECT Name FROM Employees WHERE Id=1;";

--- a/samples/Samples.Dapper/Program.cs
+++ b/samples/Samples.Dapper/Program.cs
@@ -1,0 +1,174 @@
+#if !NET452
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Dapper;
+using Npgsql;
+using Samples.DatabaseHelper;
+using Datadog.Trace;
+
+namespace Samples.Dapper
+{
+    internal static class Program
+    {
+        private static async Task Main()
+        {
+            using (var connection = CreateConnection())
+            {
+                var testQueries = new DapperTestHarness<DbConnection, DbCommand, DbDataReader>(
+                    connection,
+                    command => command.ExecuteNonQuery(),
+                    command => command.ExecuteScalar(),
+                    command => command.ExecuteReader(),
+                    (command, behavior) => command.ExecuteReader(behavior),
+                    command => command.ExecuteNonQueryAsync(),
+                    command => command.ExecuteScalarAsync(),
+                    command => command.ExecuteReaderAsync(),
+                    (command, behavior) => command.ExecuteReaderAsync(behavior)
+                );
+
+                await testQueries.RunAsync();
+            }
+
+            using (var connection = CreateConnection())
+            {
+                var testQueries = new RelationalDatabaseTestHarness<IDbConnection, IDbCommand, IDataReader>(
+                    connection,
+                    command => command.ExecuteNonQuery(),
+                    command => command.ExecuteScalar(),
+                    command => command.ExecuteReader(),
+                    (command, behavior) => command.ExecuteReader(behavior),
+                    executeNonQueryAsync: null,
+                    executeScalarAsync: null,
+                    executeReaderAsync: null,
+                    executeReaderWithBehaviorAsync: null
+                );
+
+                await testQueries.RunAsync();
+            }
+        }
+
+        private static NpgsqlConnection CreateConnection()
+        {
+            var connectionString = Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING");
+
+            if (connectionString == null)
+            {
+                var host = Environment.GetEnvironmentVariable("POSTGRES_HOST") ?? "localhost";
+                connectionString = $"Host={host};Username=postgres;Password=postgres;Database=postgres";
+            }
+
+            return new NpgsqlConnection(connectionString);
+        }
+    }
+
+    public class DapperTestHarness<TConnection, TCommand, TDataReader>
+        where TConnection : class, IDbConnection
+        where TCommand : class, IDbCommand
+        where TDataReader : class, IDataReader
+
+    {
+        private const string DropCommandText = "DROP TABLE IF EXISTS Employees; CREATE TABLE Employees (Id int PRIMARY KEY, Name varchar(100));";
+        private const string InsertCommandText = "INSERT INTO Employees (Id, Name) VALUES (1, 'nametest');";
+        private const string SelectOneCommandText = "SELECT Name FROM Employees WHERE Id=1;";
+        private const string SelectManyCommandText = "SELECT * FROM Employees WHERE Id=1;";
+
+        private readonly TConnection _connection;
+
+        private readonly Func<TCommand, int> _executeNonQuery;
+        private readonly Func<TCommand, object> _executeScalar;
+        private readonly Func<TCommand, TDataReader> _executeReader;
+        private readonly Func<TCommand, CommandBehavior, TDataReader> _executeReaderWithBehavior;
+
+        private readonly Func<TCommand, Task<int>> _executeNonQueryAsync;
+        private readonly Func<TCommand, Task<object>> _executeScalarAsync;
+        private readonly Func<TCommand, Task<TDataReader>> _executeReaderAsync;
+        private readonly Func<TCommand, CommandBehavior, Task<TDataReader>> _executeReaderWithBehaviorAsync;
+
+        public DapperTestHarness(
+            TConnection connection,
+            Func<TCommand, int> executeNonQuery,
+            Func<TCommand, object> executeScalar,
+            Func<TCommand, TDataReader> executeReader,
+            Func<TCommand, CommandBehavior, TDataReader> executeReaderWithBehavior,
+            Func<TCommand, Task<int>> executeNonQueryAsync,
+            Func<TCommand, Task<object>> executeScalarAsync,
+            Func<TCommand, Task<TDataReader>> executeReaderAsync,
+            Func<TCommand, CommandBehavior, Task<TDataReader>> executeReaderWithBehaviorAsync)
+        {
+            _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+
+            _executeNonQuery = executeNonQuery ?? throw new ArgumentNullException(nameof(executeNonQuery));
+            _executeScalar = executeScalar ?? throw new ArgumentNullException(nameof(executeScalar));
+            _executeReader = executeReader ?? throw new ArgumentNullException(nameof(executeReader));
+            _executeReaderWithBehavior = executeReaderWithBehavior ?? throw new ArgumentNullException(nameof(executeReaderWithBehavior));
+
+            // async methods are not implemented by all ADO.NET providers, so they can be null
+            _executeNonQueryAsync = executeNonQueryAsync;
+            _executeScalarAsync = executeScalarAsync;
+            _executeReaderAsync = executeReaderAsync;
+            _executeReaderWithBehaviorAsync = executeReaderWithBehaviorAsync;
+        }
+
+        public async Task RunAsync()
+        {
+            using (var scopeAll = Tracer.Instance.StartActive("run.all"))
+            {
+                scopeAll.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                using (var scopeSync = Tracer.Instance.StartActive("run.sync"))
+                {
+                    scopeSync.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                    _connection.Open();
+                    SelectRecords(_connection);
+                    _connection.Close();
+                }
+            }
+
+            if (_connection is DbConnection connection)
+            {
+                // leave a small space between spans, for better visibility in the UI
+                await Task.Delay(TimeSpan.FromSeconds(0.1));
+
+                using (var scopeAsync = Tracer.Instance.StartActive("run.async"))
+                {
+                    scopeAsync.Span.SetTag("command-type", typeof(TCommand).FullName);
+
+                    await connection.OpenAsync();
+                    await SelectRecordsAsync(_connection);
+                    _connection.Close();
+                }
+            }
+
+        }
+
+        private void SelectRecords(IDbConnection connection)
+        {
+            connection.Execute(DropCommandText);
+            connection.Execute(InsertCommandText);
+            var r = connection.Query(SelectOneCommandText);
+            Console.WriteLine("result: {0}", r == null ? "null result" : r.ToString());
+        }
+
+        private async Task SelectRecordsAsync(IDbConnection connection)
+        {
+            await connection.ExecuteAsync(SelectManyCommandText);
+        }
+
+    }
+
+}
+#else
+namespace Samples.Dapper
+{
+    internal static class Program
+    {
+        private static void Main()
+        { }
+    }
+}
+#endif
+

--- a/samples/Samples.Dapper/Properties/launchSettings.json
+++ b/samples/Samples.Dapper/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "Samples.Dapper": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Samples.Dapper/Samples.Dapper.csproj
+++ b/samples/Samples.Dapper/Samples.Dapper.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.30" />
     <PackageReference Include="Npgsql" Version="4.1.1" />
   </ItemGroup>
 

--- a/samples/Samples.Dapper/Samples.Dapper.csproj
+++ b/samples/Samples.Dapper/Samples.Dapper.csproj
@@ -2,51 +2,21 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+     <!-- override to remove net452 -->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-    <PackageReference Include="Dapper">
-      <Version>2.0.30</Version>
-    </PackageReference>
-    <PackageReference Include="Npgsql">
-      <Version>4.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Dapper">
-      <Version>2.0.30</Version>
-    </PackageReference>
-    <PackageReference Include="Npgsql">
-      <Version>4.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
-    <PackageReference Include="Dapper">
-      <Version>2.0.30</Version>
-    </PackageReference>
-    <PackageReference Include="Npgsql">
-      <Version>4.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Dapper">
-      <Version>2.0.30</Version>
-    </PackageReference>
-    <PackageReference Include="Npgsql">
-      <Version>4.1.1</Version>
-    </PackageReference>
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.60.6" />
+    <PackageReference Include="Dapper" Version="2.0.30" />
+    <PackageReference Include="Npgsql" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sample-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/Samples.Dapper/Samples.Dapper.csproj
+++ b/samples/Samples.Dapper/Samples.Dapper.csproj
@@ -1,0 +1,56 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Dapper">
+      <Version>2.0.30</Version>
+    </PackageReference>
+    <PackageReference Include="Npgsql">
+      <Version>4.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Dapper">
+      <Version>2.0.30</Version>
+    </PackageReference>
+    <PackageReference Include="Npgsql">
+      <Version>4.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <PackageReference Include="Dapper">
+      <Version>2.0.30</Version>
+    </PackageReference>
+    <PackageReference Include="Npgsql">
+      <Version>4.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Dapper">
+      <Version>2.0.30</Version>
+    </PackageReference>
+    <PackageReference Include="Npgsql">
+      <Version>4.1.1</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" Version="1.60.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\sample-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Samples.Dapper/Samples.Dapper.csproj
+++ b/samples/Samples.Dapper/Samples.Dapper.csproj
@@ -46,10 +46,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\sample-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/samples/Samples.Npgsql/Program.cs
+++ b/samples/Samples.Npgsql/Program.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Data;
-using System.Data.Common;
 using System.Threading.Tasks;
 using Npgsql;
 using Samples.DatabaseHelper;
@@ -11,7 +9,6 @@ namespace Samples.Npgsql
     {
         private static async Task Main()
         {
-            /* TODO: enable this after adding a Npgsql-specific integration
             using (var connection = CreateConnection())
             {
                 var testQueries = new RelationalDatabaseTestHarness<NpgsqlConnection, NpgsqlCommand, NpgsqlDataReader>(
@@ -26,45 +23,9 @@ namespace Samples.Npgsql
                     executeReaderWithBehaviorAsync: null
                 );
 
-
                 await testQueries.RunAsync();
             }
-            */
-
-            using (var connection = CreateConnection())
-            {
-                var testQueries = new RelationalDatabaseTestHarness<DbConnection, DbCommand, DbDataReader>(
-                    connection,
-                    command => command.ExecuteNonQuery(),
-                    command => command.ExecuteScalar(),
-                    command => command.ExecuteReader(),
-                    (command, behavior) => command.ExecuteReader(behavior),
-                    command => command.ExecuteNonQueryAsync(),
-                    command => command.ExecuteScalarAsync(),
-                    command => command.ExecuteReaderAsync(),
-                    (command, behavior) => command.ExecuteReaderAsync(behavior)
-                );
-
-                await testQueries.RunAsync();
-            }
-
-            using (var connection = CreateConnection())
-            {
-                var testQueries = new RelationalDatabaseTestHarness<IDbConnection, IDbCommand, IDataReader>(
-                    connection,
-                    command => command.ExecuteNonQuery(),
-                    command => command.ExecuteScalar(),
-                    command => command.ExecuteReader(),
-                    (command, behavior) => command.ExecuteReader(behavior),
-                    executeNonQueryAsync: null,
-                    executeScalarAsync: null,
-                    executeReaderAsync: null,
-                    executeReaderWithBehaviorAsync: null
-                );
-
-                await testQueries.RunAsync();
-            }
-        }
+       }
 
         private static NpgsqlConnection CreateConnection()
         {

--- a/samples/Samples.Npgsql/Program.cs
+++ b/samples/Samples.Npgsql/Program.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Data;
+using System.Data.Common;
 using System.Threading.Tasks;
 using Npgsql;
 using Samples.DatabaseHelper;
@@ -25,7 +27,41 @@ namespace Samples.Npgsql
 
                 await testQueries.RunAsync();
             }
-       }
+
+            using (var connection = CreateConnection())
+            {
+                var testQueries = new RelationalDatabaseTestHarness<DbConnection, DbCommand, DbDataReader>(
+                    connection,
+                    command => command.ExecuteNonQuery(),
+                    command => command.ExecuteScalar(),
+                    command => command.ExecuteReader(),
+                    (command, behavior) => command.ExecuteReader(behavior),
+                    command => command.ExecuteNonQueryAsync(),
+                    command => command.ExecuteScalarAsync(),
+                    command => command.ExecuteReaderAsync(),
+                    (command, behavior) => command.ExecuteReaderAsync(behavior)
+                );
+
+                await testQueries.RunAsync();
+            }
+
+            using (var connection = CreateConnection())
+            {
+                var testQueries = new RelationalDatabaseTestHarness<IDbConnection, IDbCommand, IDataReader>(
+                    connection,
+                    command => command.ExecuteNonQuery(),
+                    command => command.ExecuteScalar(),
+                    command => command.ExecuteReader(),
+                    (command, behavior) => command.ExecuteReader(behavior),
+                    executeNonQueryAsync: null,
+                    executeScalarAsync: null,
+                    executeReaderAsync: null,
+                    executeReaderWithBehaviorAsync: null
+                );
+
+                await testQueries.RunAsync();
+            }
+        }
 
         private static NpgsqlConnection CreateConnection()
         {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Datadog.Trace.ClrProfiler</RootNamespace>
@@ -32,7 +32,7 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="' $(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -36,7 +36,7 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -24,7 +24,7 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the
        to test the loading of managed profiler assemblies from disk -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true' and (( '$(TargetFramework)' == 'netstandard2.0' ) or (( '$(TargetFramework)' == 'netstandard2.1' ))) ">
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true' and '$(TargetFramework)' == 'netstandard2.0'">
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -32,11 +32,11 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(TargetFramework)' == 'netstandard2.0') or ('$(TargetFramework)' == 'netstandard2.1') ">
+  <ItemGroup Condition="' $(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(TargetFramework)' != 'netstandard2.0') and ('$(TargetFramework)' != 'netstandard2.1') ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -24,7 +24,7 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the
        to test the loading of managed profiler assemblies from disk -->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true' and '$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true' and (( '$(TargetFramework)' == 'netstandard2.0' ) or (( '$(TargetFramework)' == 'netstandard2.1' ))) ">
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -32,11 +32,11 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' == 'netstandard2.0') or ('$(TargetFramework)' == 'netstandard2.1') ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+  <ItemGroup Condition=" ('$(TargetFramework)' != 'netstandard2.0') and ('$(TargetFramework)' != 'netstandard2.1') ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/AdoNetConstants.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/AdoNetConstants.cs
@@ -10,6 +10,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             // .NET Core
             public const string SystemDataCommon = "System.Data.Common";
             public const string SystemDataSqlClient = "System.Data.SqlClient";
+
+            // .NET Standard
+            public const string NetStandard = "netstandard";
         }
 
         public static class TypeNames

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon, AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { DataReaderTypeName },
             TargetMinimumVersion = Major4,
@@ -89,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon, AdoNetConstants.AssemblyNames.NetStandard },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { DataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
@@ -153,7 +153,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon, AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
@@ -206,7 +206,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon, AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -1,0 +1,545 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
+{
+    /// <summary>
+    /// Instrumentation wrappers for <see cref="NpgsqlCommandIntegration"/>.
+    /// </summary>
+    public static class NpgsqlCommandIntegration
+    {
+        private const string IntegrationName = "AdoNet";
+        private const string Major4 = "4";
+
+        private const string NpgsqlAssemblyName = "Npgsql";
+        private const string NpgsqlCommandTypeName = "Npgsql.NpgsqlCommand";
+        private const string NpgsqlDataReaderTypeName = "Npgsql.NpgsqlDataReader";
+
+        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
+
+        /// <summary>
+        /// Instrumentation wrapper for NpgsqlCommand />
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetSignatureTypes = new[] { NpgsqlDataReaderTypeName },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteReader(
+            object command,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<object, object> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<object, object>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteReader)
+                       .WithConcreteType(targetType)
+                       .WithNamespaceAndNameFilters(NpgsqlDataReaderTypeName)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)", ex);
+                throw;
+            }
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command as DbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(command);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteReader().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetSignatureTypes = new[] { NpgsqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteReaderWithBehavior(
+            object command,
+            int behavior,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<object, CommandBehavior, object> instrumentedMethod;
+            var commandBehavior = (CommandBehavior)behavior;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<object, CommandBehavior, object>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteReader)
+                       .WithConcreteType(targetType)
+                       .WithParameters(commandBehavior)
+                       .WithNamespaceAndNameFilters(NpgsqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)", ex);
+                throw;
+            }
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command as DbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(command, commandBehavior);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteReaderAsync().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetSignatureTypes = new[] { NpgsqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteReaderAsync(
+            object command,
+            int behavior,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            return ExecuteReaderAsyncInternal(
+                (DbCommand)command,
+                (CommandBehavior)behavior,
+                opCode,
+                mdToken,
+                moduleVersionPtr);
+        }
+
+        private static async Task<DbDataReader> ExecuteReaderAsyncInternal(
+            DbCommand command,
+            CommandBehavior commandBehavior,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<DbCommand, CommandBehavior, Task<DbDataReader>> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<DbCommand, CommandBehavior, Task<DbDataReader>>>
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(ExecuteReaderAsync))
+                       .WithConcreteType(targetType)
+                       .WithParameters(commandBehavior)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, AdoNetConstants.TypeNames.CommandBehavior)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)", ex);
+                throw;
+            }
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command, IntegrationName))
+            {
+                try
+                {
+                    return await instrumentedMethod(command, commandBehavior).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteReaderAsync().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
+        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReaderAsync,
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetSignatureTypes = new[] { NpgsqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteReaderAsyncTwoParams(
+            object command,
+            int behavior,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            var tokenSource = cancellationTokenSource as CancellationTokenSource;
+            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+
+            return ExecuteReaderAsyncInternalTwoParams(
+                (DbCommand)command,
+                (CommandBehavior)behavior,
+                cancellationToken,
+                opCode,
+                mdToken,
+                moduleVersionPtr);
+        }
+
+        private static async Task<DbDataReader> ExecuteReaderAsyncInternalTwoParams(
+            DbCommand command,
+            CommandBehavior commandBehavior,
+            CancellationToken cancellationToken,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<DbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<DbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>>>
+                       .Start(moduleVersionPtr, mdToken, opCode, nameof(ExecuteReaderAsync))
+                       .WithConcreteType(targetType)
+                       .WithParameters(commandBehavior, cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)", ex);
+                throw;
+            }
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command, IntegrationName))
+            {
+                try
+                {
+                    return await instrumentedMethod(command, commandBehavior, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteNonQuery().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Int32 },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static int ExecuteNonQuery(
+            object command,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<DbCommand, int> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<DbCommand, int>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteNonQuery)
+                       .WithConcreteType(targetType)
+                       .WithNamespaceAndNameFilters(ClrNames.Int32)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)", ex);
+                throw;
+            }
+
+            var dbCommand = command as DbCommand;
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, dbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(dbCommand);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteNonQueryAsync().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteNonQueryAsync(
+            object command,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            var tokenSource = cancellationTokenSource as CancellationTokenSource;
+            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+
+            return ExecuteNonQueryAsyncInternal(
+                command as DbCommand,
+                cancellationToken,
+                opCode,
+                mdToken,
+                moduleVersionPtr);
+        }
+
+        private static async Task<int> ExecuteNonQueryAsyncInternal(
+            DbCommand command,
+            CancellationToken cancellationToken,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<DbCommand, CancellationToken, Task<int>> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<DbCommand, CancellationToken, Task<int>>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteNonQueryAsync)
+                       .WithConcreteType(targetType)
+                       .WithParameters(cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQueryAsync}(...)", ex);
+                throw;
+            }
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command, IntegrationName))
+            {
+                try
+                {
+                    return await instrumentedMethod(command, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteScalar().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
+            TargetType = NpgsqlCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Object },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteScalar(
+            object command,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<DbCommand, object> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<DbCommand, object>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteScalar)
+                       .WithConcreteType(targetType)
+                       .WithNamespaceAndNameFilters(ClrNames.Object)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)", ex);
+                throw;
+            }
+
+            var dbCommand = command as DbCommand;
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, dbCommand, IntegrationName))
+            {
+                try
+                {
+                    return instrumentedMethod(dbCommand);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Instrumentation wrapper for SqlCommand.ExecuteScalarAsync().
+        /// </summary>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The value returned by the instrumented method.</returns>
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataSqlClient },
+            TargetType = NpgsqlCommandTypeName,
+            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
+            TargetMinimumVersion = Major4,
+            TargetMaximumVersion = Major4)]
+        public static object ExecuteScalarAsync(
+            object command,
+            object cancellationTokenSource,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            var tokenSource = cancellationTokenSource as CancellationTokenSource;
+            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+
+            return ExecuteScalarAsyncInternal(
+                command as DbCommand,
+                cancellationToken,
+                opCode,
+                mdToken,
+                moduleVersionPtr);
+        }
+
+        private static async Task<object> ExecuteScalarAsyncInternal(
+            DbCommand command,
+            CancellationToken cancellationToken,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            Func<DbCommand, CancellationToken, Task<object>> instrumentedMethod;
+
+            try
+            {
+                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+
+                instrumentedMethod =
+                    MethodBuilder<Func<DbCommand, CancellationToken, Task<object>>>
+                       .Start(moduleVersionPtr, mdToken, opCode, AdoNetConstants.MethodNames.ExecuteScalarAsync)
+                       .WithConcreteType(targetType)
+                       .WithParameters(cancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalarAsync}(...)", ex);
+                throw;
+            }
+
+            using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command, IntegrationName))
+            {
+                try
+                {
+                    return await instrumentedMethod(command, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    scope?.Span.SetException(ex);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -31,11 +31,9 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto debug_enabled_value =
       GetEnvironmentValue(environment::debug_enabled);
 
-  //if (debug_enabled_value == "1"_W || debug_enabled_value == "true"_W) {
-  //  debug_logging_enabled = true;
-  //}
-
-  debug_logging_enabled = true;
+  if (debug_enabled_value == "1"_W || debug_enabled_value == "true"_W) {
+    debug_logging_enabled = true;
+  }
 
   CorProfilerBase::Initialize(cor_profiler_info_unknown);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -31,9 +31,11 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto debug_enabled_value =
       GetEnvironmentValue(environment::debug_enabled);
 
-  if (debug_enabled_value == "1"_W || debug_enabled_value == "true"_W) {
-    debug_logging_enabled = true;
-  }
+  //if (debug_enabled_value == "1"_W || debug_enabled_value == "true"_W) {
+  //  debug_logging_enabled = true;
+  //}
+
+  debug_logging_enabled = true;
 
   CorProfilerBase::Initialize(cor_profiler_info_unknown);
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
@@ -1,0 +1,45 @@
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
+{
+    public class DapperCommandTests : TestHelper
+    {
+        public DapperCommandTests(ITestOutputHelper output)
+            : base("Dapper", output)
+        {
+        }
+
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        public void SubmitsTraces()
+        {
+            // In .NET Framework, the Npgsql client injects
+            // a few extra queries the first time it connects to a database
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 21 : 22;
+            const string dbType = "postgres";
+            const string expectedOperationName = dbType + ".query";
+            const string expectedServiceName = "Samples.Dapper-" + dbType;
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
+
+                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                Assert.Equal(expectedSpanCount, spans.Count);
+
+                foreach (var span in spans)
+                {
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(SpanTypes.Sql, span.Type);
+                    Assert.Equal(dbType, span.Tags[Tags.DbType]);
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             // In .NET Framework, the Npgsql client injects
             // a few extra queries the first time it connects to a database
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 21 : 22;
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 7 : 8;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Dapper-" + dbType;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
@@ -1,3 +1,4 @@
+#if !NET452
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,9 +16,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            // In .NET Framework, the Npgsql client injects
-            // a few extra queries the first time it connects to a database
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 7 : 8;
+            var expectedSpanCount = 2;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Dapper-" + dbType;
@@ -43,3 +42,4 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
     }
 }
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             // In .NET Framework, the Npgsql client injects
             // a few extra queries the first time it connects to a database
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 21 : 22;
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 33 : 34;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Npgsql-" + dbType;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -15,9 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            // In .NET Framework, the Npgsql client injects
-            // a few extra queries the first time it connects to a database
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 33 : 34;
+            var expectedSpanCount = 34;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Npgsql-" + dbType;


### PR DESCRIPTION
### NOTE: Intended to be Pre-Released to verify with users after 1.13.0 is released

Fixes loss of `postgres` instrumentation.

Changes proposed in this pull request:
- Adds support for the .NET Postgres library named `Npgsql`.
- Instrumented methods are:
   1. `NpgsqlCommand.ExecuteReader` (two overloads)
   2. `NpgsqlCommand.ExecuteReaderAsync` (two overloads)
   3. `NpgsqlCommand.ExecuteNonQuery`
   4. `NpgsqlCommand.ExecuteNonQueryAsync`
   5. `NpgsqlCommand.ExecuteScalar`
   6. `NpgsqlCommand.ExecuteScalarAsync`

#### TO-DO
 - [ ] Test integration for memory and performance in APM Integrations Reliability Environment

#### Notes

*Note* about an unsupported overload of `NpgsqlCommand.ExecuteReaderAsync`:
A third overload that takes three arguments and returns a `ValueTask<Npgsql.NpgsqlDataReader>` is not being instrumented because to use a `ValueTask<T>` would require support for [`.NET Standard 2.1`](https://github.com/dotnet/standard/milestone/3). This version of .NET Standard is supported in .NET Core 3.0 and later but uses a different runtime and would require, IMO, a fair amount of plumbing to get it working in our complex build and test environment. That said, we definitely want to migrate to `netstandard2.1` at some point in the future.

*Testing Note*
Some of the users reported not getting `postgres` traces when they used `Dapper`, a lightweight ORM. Dapper accesses the underlying database provider library (e.g., `Npgsql`) in a way that is not captured by our `IDbCommand` and `DbCommand` integrations. By supporting the `Npgsql` Postgres library directly, we provide support for applications that use `Dapper`. A new sample called `Samples.Dapper` can be found in the `samples` folder in this repository.

@DataDog/apm-dotnet