### PR TITLE
Getting property values: fix potential cache key conflict, improve speed

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -187,6 +187,13 @@ jobs:
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
       arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
 
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+    inputs:
+      command: build
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      arguments: --configuration $(buildConfiguration)
+
   - task: MSBuild@1
     displayName: msbuild native
     inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -147,13 +147,12 @@ jobs:
       packageType: sdk
       version: 3.1.x
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build src/**/*.csproj
+  - task: NuGetCommand@2
+    displayName: nuget restore
     inputs:
-      command: build
-      projects: |
-        src/**/*.csproj
-      arguments: --configuration $(buildConfiguration)
+      restoreSolution: Datadog.Trace.sln
+      vstsFeed: $(packageFeed)
+      verbosityRestore: Normal
 
   - task: DotNetCoreCLI@2
     displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net45
@@ -185,13 +184,6 @@ jobs:
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
       arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
 
-  - task: NuGetCommand@2
-    displayName: nuget restore native
-    inputs:
-      restoreSolution: Datadog.Trace.Native.sln
-      vstsFeed: $(packageFeed)
-      verbosityRestore: Normal
-
   - task: MSBuild@1
     displayName: msbuild native
     inputs:
@@ -201,14 +193,6 @@ jobs:
       msbuildArguments: /t:BuildCpp
       maximumCpuCount: true
 
-  - task: NuGetCommand@2
-    displayName: 'nuget restore reproductions/**/packages.config'
-    inputs:
-      restoreSolution: reproductions/**/packages.config
-      restoreDirectory: $(Build.SourcesDirectory)/packages
-      vstsFeed: $(packageFeed)
-      verbosityRestore: Normal
-
   - task: MSBuild@1
     displayName: 'Build .NET Framework projects (not SDK-based projects)'
     inputs:
@@ -217,21 +201,6 @@ jobs:
       configuration: '$(buildConfiguration)'
       msbuildArguments: '/t:BuildFrameworkReproductions'
       maximumCpuCount: true
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: |
-        reproductions/**/*.csproj
-        samples/**/*.csproj
-        test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
-        test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-        test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
-        !reproductions/**/ExpenseItDemo*.csproj
-        !reproductions/**/EntityFramework6x*.csproj
-        !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
-      vstsFeed: $(packageFeed)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build integration tests
@@ -247,33 +216,6 @@ jobs:
         !reproductions/**/EntityFramework6x*.csproj
         !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput)
-
-#  - task: MSBuild@1
-#    displayName: 'Build sample apps (x64 or x86)'
-#    inputs:
-#      solution: Datadog.Trace.proj
-#      platform: '$(buildPlatform)'
-#      configuration: '$(buildConfiguration)'
-#      msbuildArguments: '/t:BuildSamples'
-#      maximumCpuCount: true
-
-#  - script: |
-#    choco install redis-64
-#    redis-server --service-install
-#    redis-server --service-start
-#    displayName: 'Install Redis'
-
-#  - script: |
-#    choco install elasticsearch
-#    net start elasticsearch-service-x64
-#    displayName: 'Install Elasticsearch'
-
-#  - task: PowerShell@2
-#    displayName: 'PowerShell Script'
-#    inputs:
-#      targetType: filePath
-#      filePath: './ci/install-sqlserver.ps1'
-#    enabled: false
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -230,6 +230,7 @@ jobs:
         test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
         !reproductions/**/ExpenseItDemo*.csproj
         !reproductions/**/EntityFramework6x*.csproj
+        !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
       vstsFeed: $(packageFeed)
 
   - task: DotNetCoreCLI@2
@@ -244,6 +245,7 @@ jobs:
         test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
         !reproductions/**/ExpenseItDemo*.csproj
         !reproductions/**/EntityFramework6x*.csproj
+        !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput)
 
 #  - task: MSBuild@1

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -147,6 +147,9 @@ jobs:
       packageType: sdk
       version: 3.1.x
 
+  - task: NuGetToolInstaller@1
+    displayName: install nuget
+
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <FrameworkReproduction Include="reproductions\EntityFramework6x.MdTokenLookupFailure\EntityFramework6x.MdTokenLookupFailure.csproj" />
+    <FrameworkReproduction Include="reproductions\StackExchange.Redis.AssemblyConflict.LegacyProject\StackExchange.Redis.AssemblyConflict.LegacyProject.csproj" />
   </ItemGroup>
 
   <Import Condition="'$(PerformComprehensiveTesting)'=='true'" Project="PackageVersionsComprehensive.g.props" />

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -295,6 +295,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.FakeKudu", "samples
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.FakeAzureAppServices", "samples\Samples.FakeAzureAppServices\Samples.FakeAzureAppServices.csproj", "{9A2AE41B-251F-4A21-89FA-E5C55A737BBB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.StackExchange.Redis.Abstractions", "reproduction-dependencies\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj", "{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.StackExchange.Redis", "reproduction-dependencies\Datadog.StackExchange.Redis\Datadog.StackExchange.Redis.csproj", "{EB0B88E2-589A-4F65-8F98-D5B958D8104F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.StackExchange.Redis.StrongName", "reproduction-dependencies\Datadog.StackExchange.Redis.StrongName\Datadog.StackExchange.Redis.StrongName.csproj", "{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.AssemblyConflict.LegacyProject", "reproductions\StackExchange.Redis.AssemblyConflict.LegacyProject\StackExchange.Redis.AssemblyConflict.LegacyProject.csproj", "{7B0822F6-80DE-4B49-8125-93975678D0D5}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.AssemblyConflict.SdkProject", "reproductions\StackExchange.Redis.AssemblyConflict.SdkProject\StackExchange.Redis.AssemblyConflict.SdkProject.csproj", "{C41023C9-65C3-4FB3-9053-4DE963A81500}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1025,6 +1035,64 @@ Global
 		{9A2AE41B-251F-4A21-89FA-E5C55A737BBB}.Release|x64.Build.0 = Release|x64
 		{9A2AE41B-251F-4A21-89FA-E5C55A737BBB}.Release|x86.ActiveCfg = Release|x86
 		{9A2AE41B-251F-4A21-89FA-E5C55A737BBB}.Release|x86.Build.0 = Release|x86
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|x64.Build.0 = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Debug|x86.Build.0 = Debug|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|x64.ActiveCfg = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|x64.Build.0 = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|x86.ActiveCfg = Release|Any CPU
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE}.Release|x86.Build.0 = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|x64.Build.0 = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F}.Release|x86.Build.0 = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|x64.Build.0 = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Debug|x86.Build.0 = Debug|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|x64.ActiveCfg = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|x64.Build.0 = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|x86.ActiveCfg = Release|Any CPU
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630}.Release|x86.Build.0 = Release|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|x64.ActiveCfg = Debug|x64
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|x64.Build.0 = Debug|x64
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|x86.ActiveCfg = Debug|x86
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Debug|x86.Build.0 = Debug|x86
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|x64.ActiveCfg = Release|x64
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|x64.Build.0 = Release|x64
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|x86.ActiveCfg = Release|x86
+		{7B0822F6-80DE-4B49-8125-93975678D0D5}.Release|x86.Build.0 = Release|x86
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|x64.ActiveCfg = Debug|x64
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|x64.Build.0 = Debug|x64
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|x86.ActiveCfg = Debug|x86
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Debug|x86.Build.0 = Debug|x86
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|Any CPU.ActiveCfg = Release|x86
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x64.ActiveCfg = Release|x64
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x64.Build.0 = Release|x64
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x86.ActiveCfg = Release|x86
+		{C41023C9-65C3-4FB3-9053-4DE963A81500}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1099,6 +1167,11 @@ Global
 		{DAA6B000-5BED-4081-B5E0-B698BFB89415} = {5D8E1F81-B820-4736-B797-271B0FE787EE}
 		{317D3C64-E4F6-4D77-83C0-C69FC3923471} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 		{9A2AE41B-251F-4A21-89FA-E5C55A737BBB} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
+		{24BE488C-A5F3-4228-8CAB-E60EBEA444EE} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
+		{EB0B88E2-589A-4F65-8F98-D5B958D8104F} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
+		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
+		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -38,7 +38,7 @@ for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStac
     dotnet publish -f $publishTargetFramework -c $buildConfiguration samples/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 
-for sample in OrleansCrash DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash ; do
+for sample in OrleansCrash DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration reproductions/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/reproduction-dependencies/Datadog.StackExchange.Redis.Abstractions/Datadog.StackExchange.Redis.Abstractions.csproj
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis.Abstractions/Datadog.StackExchange.Redis.Abstractions.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/reproduction-dependencies/Datadog.StackExchange.Redis.Abstractions/Directory.Build.props
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis.Abstractions/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!--
+  This file intentionally left blank...
+  to stop msbuild from looking up the folder hierarchy
+  -->
+</Project>

--- a/reproduction-dependencies/Datadog.StackExchange.Redis.Abstractions/ICache.cs
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis.Abstractions/ICache.cs
@@ -1,0 +1,9 @@
+namespace Datadog.StackExchange.Redis.Abstractions
+{
+    public interface ICache
+    {
+        string GetString(string key);
+
+        void SetString(string key, string value);
+    }
+}

--- a/reproduction-dependencies/Datadog.StackExchange.Redis.StrongName/Datadog.StackExchange.Redis.StrongName.csproj
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis.StrongName/Datadog.StackExchange.Redis.StrongName.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/reproduction-dependencies/Datadog.StackExchange.Redis.StrongName/Directory.Build.props
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis.StrongName/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!--
+  This file intentionally left blank...
+  to stop msbuild from looking up the folder hierarchy
+  -->
+</Project>

--- a/reproduction-dependencies/Datadog.StackExchange.Redis.StrongName/RedisStrongNameClient.cs
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis.StrongName/RedisStrongNameClient.cs
@@ -1,0 +1,33 @@
+using System;
+using Datadog.StackExchange.Redis.Abstractions;
+using StackExchange.Redis;
+
+namespace Datadog.StackExchange.Redis.StrongName
+{
+    public class RedisStrongNameClient : ICache, IDisposable
+    {
+        private readonly ConnectionMultiplexer _connection;
+        private readonly IDatabase _database;
+
+        public RedisStrongNameClient(string configuration)
+        {
+            _connection = ConnectionMultiplexer.Connect(configuration);
+            _database = _connection.GetDatabase();
+        }
+
+        public void SetString(string key, string value)
+        {
+            _database.StringSet(key, value);
+        }
+
+        public string GetString(string key)
+        {
+            return _database.StringGet(key);
+        }
+
+        public void Dispose()
+        {
+            _connection?.Dispose();
+        }
+    }
+}

--- a/reproduction-dependencies/Datadog.StackExchange.Redis/Datadog.StackExchange.Redis.csproj
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis/Datadog.StackExchange.Redis.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/reproduction-dependencies/Datadog.StackExchange.Redis/Directory.Build.props
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!--
+  This file intentionally left blank...
+  to stop msbuild from looking up the folder hierarchy
+  -->
+</Project>

--- a/reproduction-dependencies/Datadog.StackExchange.Redis/RedisClient.cs
+++ b/reproduction-dependencies/Datadog.StackExchange.Redis/RedisClient.cs
@@ -1,0 +1,33 @@
+using System;
+using Datadog.StackExchange.Redis.Abstractions;
+using StackExchange.Redis;
+
+namespace Datadog.StackExchange.Redis
+{
+    public class RedisClient : ICache, IDisposable
+    {
+        private readonly ConnectionMultiplexer _connection;
+        private readonly IDatabase _database;
+
+        public RedisClient(string configuration)
+        {
+            _connection = ConnectionMultiplexer.Connect(configuration);
+            _database = _connection.GetDatabase();
+        }
+
+        public void SetString(string key, string value)
+        {
+            _database.StringSet(key, value);
+        }
+
+        public string GetString(string key)
+        {
+            return _database.StringGet(key);
+        }
+
+        public void Dispose()
+        {
+            _connection?.Dispose();
+        }
+    }
+}

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/App.config
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+  </startup>
+</configuration>

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Directory.Build.props
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!--
+  This file intentionally left blank...
+  to stop msbuild from looking up the folder hierarchy
+  -->
+</Project>

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
@@ -33,7 +33,8 @@ namespace StackExchange.Redis.AssemblyConflict.LegacyProject
 
         private static void RunTest()
         {
-            const string configuration = "127.0.0.1:6389";
+            // note: STACKEXCHANGE_REDIS_HOST includes a port, despite its name
+            var configuration = Environment.GetEnvironmentVariable("STACKEXCHANGE_REDIS_HOST") ?? "localhost:6389";
 
             ICache redis = new RedisClient(configuration);
             RunTest(redis);

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Reflection;
+using Datadog.StackExchange.Redis;
+using Datadog.StackExchange.Redis.Abstractions;
+using Datadog.StackExchange.Redis.StrongName;
+
+namespace StackExchange.Redis.AssemblyConflict.LegacyProject
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            try
+            {
+                RunTest();
+            }
+            finally
+            {
+                var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace.ClrProfiler.Managed");
+                var profilerAttached = instrumentationType?.GetProperty("ProfilerAttached", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) ?? false;
+                var tracerAssemblyLocation = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace")?.Assembly.Location ?? "(none)";
+                var clrProfilerAssemblyLocation = instrumentationType?.Assembly.Location ?? "(none)";
+                var sigilAssemblyLocation = Type.GetType("Sigil.Local, Sigil")?.Assembly.Location ?? "(none)";
+
+                Console.WriteLine();
+                Console.WriteLine($"Profile attached: {profilerAttached}");
+                Console.WriteLine($"Datadog.Trace.dll path: {tracerAssemblyLocation}");
+                Console.WriteLine($"Datadog.Trace.ClrProfiler.Managed.dll path: {clrProfilerAssemblyLocation}");
+                Console.WriteLine($"Sigil.dll path: {sigilAssemblyLocation}");
+                Console.WriteLine();
+            }
+        }
+
+        private static void RunTest()
+        {
+            const string configuration = "127.0.0.1:6389";
+
+            ICache redis = new RedisClient(configuration);
+            RunTest(redis);
+
+            ICache redisStrongName = new RedisStrongNameClient(configuration);
+            RunTest(redisStrongName);
+        }
+
+        public static void RunTest(ICache cache)
+        {
+            Console.WriteLine($"Running test with {cache.GetType().Name}");
+
+            const string name = "name1";
+            const string expectedValue = "value1";
+
+            Console.WriteLine("Setting string...");
+            cache.SetString(name, expectedValue);
+
+            Console.WriteLine("Getting string...");
+            var actualValue = cache.GetString(name);
+
+            if (expectedValue == actualValue)
+            {
+                Console.WriteLine($"Values match. {expectedValue} == {actualValue}");
+                Console.WriteLine();
+            }
+            else
+            {
+                throw new Exception($"Values do NOT match. {expectedValue} == {actualValue}");
+            }
+
+        }
+    }
+}

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Properties/AssemblyInfo.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("StackExchange.Redis.AssemblyConflict")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("StackExchange.Redis.AssemblyConflict")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7b0822f6-80de-4b49-8125-93975678d0d5")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7B0822F6-80DE-4B49-8125-93975678D0D5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>StackExchange.Redis.AssemblyConflict</RootNamespace>
+    <AssemblyName>StackExchange.Redis.AssemblyConflict</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\reproduction-dependencies\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj">
+      <Project>{24be488c-a5f3-4228-8cab-e60ebea444ee}</Project>
+      <Name>Datadog.StackExchange.Redis.Abstractions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\reproduction-dependencies\Datadog.StackExchange.Redis.StrongName\Datadog.StackExchange.Redis.StrongName.csproj">
+      <Project>{4e83bfb5-f225-4c3b-b96e-0ad1951a5630}</Project>
+      <Name>Datadog.StackExchange.Redis.StrongName</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\reproduction-dependencies\Datadog.StackExchange.Redis\Datadog.StackExchange.Redis.csproj">
+      <Project>{eb0b88e2-589a-4f65-8f98-d5b958d8104f}</Project>
+      <Name>Datadog.StackExchange.Redis</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Reflection;
+using Datadog.StackExchange.Redis;
+using Datadog.StackExchange.Redis.Abstractions;
+using Datadog.StackExchange.Redis.StrongName;
+
+namespace StackExchange.Redis.AssemblyConflict.SdkProject
+{
+    public class Program
+    {
+        public static void Main()
+        {
+            try
+            {
+                RunTest();
+            }
+            finally
+            {
+                var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace.ClrProfiler.Managed");
+                var profilerAttached = instrumentationType?.GetProperty("ProfilerAttached", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) ?? false;
+                var tracerAssemblyLocation = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace")?.Assembly.Location ?? "(none)";
+                var clrProfilerAssemblyLocation = instrumentationType?.Assembly.Location ?? "(none)";
+                var sigilAssemblyLocation = Type.GetType("Sigil.Local, Sigil")?.Assembly.Location ?? "(none)";
+
+                Console.WriteLine();
+                Console.WriteLine($"Profile attached: {profilerAttached}");
+                Console.WriteLine($"Datadog.Trace.dll path: {tracerAssemblyLocation}");
+                Console.WriteLine($"Datadog.Trace.ClrProfiler.Managed.dll path: {clrProfilerAssemblyLocation}");
+                Console.WriteLine($"Sigil.dll path: {sigilAssemblyLocation}");
+                Console.WriteLine();
+            }
+        }
+
+        private static void RunTest()
+        {
+            const string configuration = "127.0.0.1:6389";
+
+            ICache redis = new RedisClient(configuration);
+            RunTest(redis);
+
+            ICache redisStrongName = new RedisStrongNameClient(configuration);
+            RunTest(redisStrongName);
+        }
+
+        public static void RunTest(ICache cache)
+        {
+            Console.WriteLine($"Running test with {cache.GetType().Name}");
+
+            const string name = "name1";
+            const string expectedValue = "value1";
+
+            Console.WriteLine("Setting string...");
+            cache.SetString(name, expectedValue);
+
+            Console.WriteLine("Getting string...");
+            var actualValue = cache.GetString(name);
+
+            if (expectedValue == actualValue)
+            {
+                Console.WriteLine($"Values match. {expectedValue} == {actualValue}");
+                Console.WriteLine();
+            }
+            else
+            {
+                throw new Exception($"Values do NOT match. {expectedValue} == {actualValue}");
+            }
+
+        }
+    }
+}

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -33,7 +33,8 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
 
         private static void RunTest()
         {
-            const string configuration = "127.0.0.1:6389";
+            // note: STACKEXCHANGE_REDIS_HOST includes a port, despite its name
+            var configuration = Environment.GetEnvironmentVariable("STACKEXCHANGE_REDIS_HOST") ?? "localhost:6389";
 
             ICache redis = new RedisClient(configuration);
             RunTest(redis);

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Properties/launchSettings.json
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "StackExchange.Redis.AssemblyConflict.SdkProject": {
+      "commandName": "Project",
+      "nativeDebugging": true,
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      }
+    }
+  }
+}

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/StackExchange.Redis.AssemblyConflict.SdkProject.csproj
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/StackExchange.Redis.AssemblyConflict.SdkProject.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net45;net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\reproduction-dependencies\Datadog.StackExchange.Redis.StrongName\Datadog.StackExchange.Redis.StrongName.csproj" />
+    <ProjectReference Include="..\..\reproduction-dependencies\Datadog.StackExchange.Redis\Datadog.StackExchange.Redis.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/StackExchange.Redis.AssemblyConflict.SdkProject.csproj
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/StackExchange.Redis.AssemblyConflict.SdkProject.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net45;net461;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -682,7 +682,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 {
                     for (var i = 0; i < methodGenerics.Length; i++)
                     {
-                        GenericSpec = string.Concat(GenericSpec, $"_{methodGenerics[i]?.FullName ?? "NULL"}_");
+                        GenericSpec = string.Concat(GenericSpec, $"_{methodGenerics[i]?.AssemblyQualifiedName ?? "NULL"}_");
                     }
                 }
 
@@ -692,7 +692,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 {
                     for (var i = 0; i < declaringTypeGenerics.Length; i++)
                     {
-                        GenericSpec = string.Concat(GenericSpec, $"_{declaringTypeGenerics[i]?.FullName ?? "NULL"}_");
+                        GenericSpec = string.Concat(GenericSpec, $"_{declaringTypeGenerics[i]?.AssemblyQualifiedName ?? "NULL"}_");
                     }
                 }
 
@@ -700,7 +700,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
                 if (explicitParameterTypes != null)
                 {
-                    ExplicitParams = string.Join("_", explicitParameterTypes.Select(ept => ept?.FullName ?? "NULL"));
+                    ExplicitParams = string.Join("_", explicitParameterTypes.Select(ept => ept?.AssemblyQualifiedName ?? "NULL"));
                 }
             }
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -183,7 +183,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         private static string GetKey<TResult>(string name, Type type)
         {
-            return $"{typeof(TResult).FullName}.{type.FullName}.{name}";
+            return $"{typeof(TResult).AssemblyQualifiedName}:{type.AssemblyQualifiedName}:{name}";
         }
 
         private static Func<object, TResult> CreatePropertyDelegate<TResult>(Type containerType, string propertyName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 var type = source.GetType();
 
                 PropertyFetcher fetcher = PropertyFetcherCache.GetOrAdd(
-                    GetKey(propertyName, type),
+                    GetKey<TResult>(propertyName, type),
                     key => new PropertyFetcher(propertyName));
 
                 if (fetcher != null)
@@ -158,7 +158,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
             var type = source.GetType();
 
             object cachedItem = Cache.GetOrAdd(
-                GetKey(fieldName, type),
+                GetKey<TResult>(fieldName, type),
                 key => CreateFieldDelegate<TResult>(type, fieldName));
 
             if (cachedItem is Func<object, TResult> func)
@@ -183,9 +183,9 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return GetField<object>(source, fieldName);
         }
 
-        private static string GetKey(string name, Type type)
+        private static string GetKey<TResult>(string name, Type type)
         {
-            return $"{type.AssemblyQualifiedName}:{name}";
+            return $"{typeof(TResult).AssemblyQualifiedName}:{type.AssemblyQualifiedName}:{name}";
         }
 
         private static Func<object, TResult> CreatePropertyDelegate<TResult>(Type containerType, string propertyName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using Datadog.Trace.ClrProfiler.Emit;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
@@ -72,17 +71,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <returns>The multiplexer</returns>
         public static object GetMultiplexer(object obj)
         {
-            object multiplexer = null;
-            try
-            {
-                var fi = obj.GetType().GetField("multiplexer", BindingFlags.NonPublic | BindingFlags.Instance);
-                multiplexer = fi.GetValue(obj);
-            }
-            catch
-            {
-            }
-
-            return multiplexer;
+            return obj.GetField("multiplexer").GetValueOrDefault();
         }
     }
 }

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -34,8 +34,8 @@ namespace Datadog.Trace.DiagnosticListeners
         private static readonly PropertyFetcher HttpRequestInStopHttpContextFetcher = new PropertyFetcher("HttpContext");
         private static readonly PropertyFetcher UnhandledExceptionHttpContextFetcher = new PropertyFetcher("HttpContext");
         private static readonly PropertyFetcher UnhandledExceptionExceptionFetcher = new PropertyFetcher("Exception");
-        private static readonly PropertyFetcher BeforeActionHttpContextFetcher = new PropertyFetcher("HttpContext");
-        private static readonly PropertyFetcher BeforeActionActionDescriptorFetcher = new PropertyFetcher("ActionDescriptor");
+        private static readonly PropertyFetcher BeforeActionHttpContextFetcher = new PropertyFetcher("httpContext");
+        private static readonly PropertyFetcher BeforeActionActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");
 
         private readonly IDatadogTracer _tracer;
         private readonly AspNetCoreDiagnosticOptions _options;

--- a/src/Datadog.Trace/Util/PropertyFetcher.cs
+++ b/src/Datadog.Trace/Util/PropertyFetcher.cs
@@ -32,8 +32,7 @@ namespace Datadog.Trace.Util
 
             if (objType != _expectedType)
             {
-                TypeInfo typeInfo = objType.GetTypeInfo();
-                var propertyInfo = typeInfo.DeclaredProperties.FirstOrDefault(p => string.Equals(p.Name, _propertyName, StringComparison.OrdinalIgnoreCase));
+                var propertyInfo = objType.GetProperty(_propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                 _fetchForExpectedType = PropertyFetch.FetcherForProperty(propertyInfo);
                 _expectedType = objType;
             }

--- a/src/Datadog.Trace/Util/PropertyFetcher.cs
+++ b/src/Datadog.Trace/Util/PropertyFetcher.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Util
 
             if (objType != _expectedType)
             {
-                var propertyInfo = objType.GetProperty(_propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                var propertyInfo = objType.GetProperty(_propertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.IgnoreCase);
                 _fetchForExpectedType = PropertyFetch.FetcherForProperty(propertyInfo);
                 _expectedType = objType;
             }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
@@ -1,0 +1,29 @@
+using Datadog.Core.Tools;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest : SmokeTestBase
+    {
+        public StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest(ITestOutputHelper output)
+            : base(output, "StackExchange.Redis.AssemblyConflict.LegacyProject", maxTestRunSeconds: 15)
+        {
+        }
+
+        [TargetFrameworkVersionsFact("net452;net461")]
+        [Trait("Category", "Smoke")]
+        public void NoExceptions()
+        {
+            if (!EnvironmentTools.IsWindows())
+            {
+                Output.WriteLine("Ignored for Linux");
+                return;
+            }
+
+            CheckForSmoke(shouldDeserializeTraces: false);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
@@ -13,16 +13,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         {
         }
 
-        [TargetFrameworkVersionsFact("net452;net461")]
+        [Fact(Skip = ".NET Framework test, but cannot run on Windows because it requires Redis")]
         [Trait("Category", "Smoke")]
         public void NoExceptions()
         {
-            if (!EnvironmentTools.IsWindows())
-            {
-                Output.WriteLine("Ignored for Linux");
-                return;
-            }
-
             CheckForSmoke(shouldDeserializeTraces: false);
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
@@ -13,10 +13,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         {
         }
 
-        [TargetFrameworkVersionsFact("net452;net461;netcoreapp2.1;netcoreapp3.1")]
+        [Fact]
         [Trait("Category", "Smoke")]
         public void NoExceptions()
         {
+            if (EnvironmentTools.IsWindows())
+            {
+                Output.WriteLine("Ignored for Windows");
+                return;
+            }
+
             CheckForSmoke(shouldDeserializeTraces: false);
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
@@ -1,0 +1,23 @@
+using Datadog.Core.Tools;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class StackExchangeRedisAssemblyConflictSdkProjectSmokeTest : SmokeTestBase
+    {
+        public StackExchangeRedisAssemblyConflictSdkProjectSmokeTest(ITestOutputHelper output)
+            : base(output, "StackExchange.Redis.AssemblyConflict.SdkProject", maxTestRunSeconds: 15)
+        {
+        }
+
+        [TargetFrameworkVersionsFact("net452;net461;netcoreapp2.1;netcoreapp3.1")]
+        [Trait("Category", "Smoke")]
+        public void NoExceptions()
+        {
+            CheckForSmoke(shouldDeserializeTraces: false);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
@@ -16,8 +16,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var objectResult = someCast.GetProperty<object>("SomeIntProperty");
             var actualResult = someCast.GetProperty<int>("SomeIntProperty");
 
-            Assert.Equal(actual: expected, expected: (int)objectResult.GetValueOrDefault());
-            Assert.Equal(actual: expected, expected: actualResult.GetValueOrDefault());
+            Assert.Equal(expected, (int)objectResult.GetValueOrDefault());
+            Assert.Equal(expected, actualResult.GetValueOrDefault());
         }
 
         [Fact]
@@ -31,8 +31,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var objectResult = someCast.GetField<object>("someIntField");
             var actualResult = someCast.GetField<int>("someIntField");
 
-            Assert.Equal(actual: expected, expected: (int)objectResult.GetValueOrDefault());
-            Assert.Equal(actual: expected, expected: actualResult.GetValueOrDefault());
+            Assert.Equal(expected, (int)objectResult.GetValueOrDefault());
+            Assert.Equal(expected, actualResult.GetValueOrDefault());
         }
 
         private class SomeClass : SomeBaseClass


### PR DESCRIPTION
TL;DR
- replace uses of `Type.FullName` with `Type.AssemblyQualifiedName` in `MethodBuilder` and `ObjectExtensions`
- use the `PropertyFetcher` helper instead of emitting IL in `ObjectExtensions.TryGetPropertyValue()`
- replace the use of reflection to access a field in the `StackExchange.Redis` instrumentation

This PR fixes an issue with the cache key used to store dynamically emitted methods. A conflict can occur when we encounter multiple classes with the same full name. We would reuse the cached dynamic method, and the emitted IL would try to cast one class into the other, but they are incompatible classes and causes an `InvalidCastException`. Using the assembly qualified name for types fixes this since includes assembly name and version to generate different cache keys.

This PR also replaces the use of dynamic methods with `PropertyFetcher` (added in #611) when getting property values. Using `PropertyFetcher` is much faster than emitting IL and doesn't allocate any memory for each fetch. These are benchmark results from testing a very simple scenario using `ObjectExtensions.GetProperty()` and `PropertyFetcher.Fetch()` to the get value of a property:

```
|                         Method |       Runtime |        Mean |     Error |    StdDev |      Median | Allocated |
|------------------------------- |-------------- |------------:|----------:|----------:|------------:|----------:|
| ObjectExtensions.GetProperty() | .NET 4.6.1    | 1,157.07 ns | 18.849 ns | 15.740 ns | 1,151.96 ns |    2392 B |
| ObjectExtensions.GetProperty() | .NET Core 2.1 | 1,141.81 ns | 11.196 ns | 10.473 ns | 1,139.89 ns |    2256 B |
| ObjectExtensions.GetProperty() | .NET Core 3.1 | 1,082.25 ns |  8.152 ns |  7.625 ns | 1,082.74 ns |    2240 B |
|------------------------------- |-------------- |------------:|----------:|----------:|------------:|----------:|
| PropertyFetcher.Fetch()        | .NET 4.6.1    |    23.31 ns |  0.317 ns |  0.297 ns |    23.32 ns |         - |
| PropertyFetcher.Fetch()        | .NET Core 2.1 |    20.61 ns |  0.207 ns |  0.193 ns |    20.54 ns |         - |
| PropertyFetcher.Fetch()        | .NET Core 3.1 |    17.99 ns |  0.392 ns |  1.060 ns |    17.58 ns |         - |
```

Bonus change: reduce number of steps in `integration-tests.yaml` pipeline

To do:
- [x] add reproduction project
- [x] test both versions of Sigil
- [x] test on .NET Framework
- [x] test on .NET Core
- [x] run regression test in CI