### PR TITLE
[WIP] Improve profiler settings: DD_<integration>_ENABLED and DD_PROFILER_EXCLUDE_PROCESSES

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -48,7 +48,7 @@ SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Don't attach the profiler to these processes
-SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe
+SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;msbuild.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.*;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe;PerfWatson2.exe;vsls-agent.exe
 
 rem Set dotnet tracer home path
 SET DD_DOTNET_TRACER_HOME=%~dp0

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -316,6 +316,28 @@ std::vector<IntegrationMethod> FilterIntegrationsByCaller(
   return enabled;
 }
 
+bool IsCurrentProcessExcluded(const WSTRING& process_name,
+                              const std::vector<WSTRING>& excluded_processes) {
+  for (auto& excluded : excluded_processes) {
+    if (excluded == process_name) {
+      return true;
+    }
+
+    // support simple wildcards: a trailing '*' matches anything
+    if (excluded.substr(excluded.size() - 1, 1) == "*"_W &&
+        process_name.size() > excluded.size() - 1) {
+      auto excluded_prefix = excluded.substr(0, excluded.size() - 1);
+      auto current_prefix = process_name.substr(0, excluded.size() - 1);
+
+      if (excluded_prefix == current_prefix) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 bool AssemblyMeetsIntegrationRequirements(
     const AssemblyMetadata metadata,
     const MethodReplacement method_replacement) {

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -347,6 +347,9 @@ std::vector<IntegrationMethod> FilterIntegrationsByTarget(
     const std::vector<IntegrationMethod>& integrations,
     const ComPtr<IMetaDataAssemblyImport>& assembly_import);
 
+bool IsCurrentProcessExcluded(const WSTRING& process_name,
+                              const std::vector<WSTRING>& excluded_processes);
+
 mdMethodSpec DefineMethodSpec(const ComPtr<IMetaDataEmit2>& metadata_emit,
                               const mdToken& token,
                               const MethodSignature& signature);

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -329,7 +329,7 @@ mdAssemblyRef FindAssemblyRef(
 // disabled_integration_names
 std::vector<Integration> FilterIntegrationsByName(
     const std::vector<Integration>& integrations,
-    const std::vector<WSTRING>& integration_names);
+    const std::vector<WSTRING>& disabled_integration_names);
 
 // FlattenIntegrations flattens integrations to per method structures
 std::vector<IntegrationMethod> FlattenIntegrations(

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -62,8 +62,9 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto exclude_process_names =
       GetEnvironmentValues(environment::exclude_process_names);
 
-  // attach profiler only if this process's name is NOT on the list
-  if (Contains(exclude_process_names, process_name)) {
+  // attach profiler only if this process's name is NOT on the excluded process
+  // list
+  if (IsCurrentProcessExcluded(process_name, exclude_process_names)) {
     Info("Profiler disabled: ", process_name, " found in ",
          environment::exclude_process_names, ".");
     return E_FAIL;


### PR DESCRIPTION
CLR Profiler:
- check for `DD_<integration>_ENABLED` in addition to `DD_DISABLED_INTEGRATIONS` (we should probably deprecate the latter at some point)
- support simple trailing `*` wildcard in `DD_PROFILER_EXCLUDE_PROCESSES`
- in `devenv.bat`, exclude all `ServiceBus.*` (there are _many_ of these used by Visual Studio), and add a few other known processes like `msbuild.exe`