### PR TITLE
MSI: install Sigil-vNext 4.8.41 into the GAC

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <Compile Include="Files.Managed.Net45.GAC.wxs" />
     <Compile Include="Files.Managed.Net45.wxs" />
+    <Compile Include="Files.Managed.Net461.GAC.wxs" />
     <Compile Include="Files.Managed.Net461.wxs" />
     <Compile Include="Files.Managed.NetStandard20.wxs" />
     <Compile Include="Product.wxs" />

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.GAC.wxs
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+     xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+  <?include $(sys.CURRENTDIR)\Config.wxi?>
+  <Fragment>
+    <ComponentGroup Id="Files.Managed.Net461.GAC" Directory="net461.GAC">
+      <Component Win64="$(var.Win64)">
+        <File Id="net461_GAC_Sigil.dll"
+              Source="$(var.ManagedDllPath)\net461\Sigil.dll"
+              KeyPath="yes" Checksum="yes" Assembly=".net"/>
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -36,6 +36,7 @@
       <ComponentGroupRef Id="Files"/>
       <ComponentGroupRef Id="Files.Native"/>
       <ComponentGroupRef Id="Files.Managed.Net45.GAC"/>
+      <ComponentGroupRef Id="Files.Managed.Net461.GAC"/>
       <ComponentGroupRef Id="Files.Managed.Net45"/>
       <ComponentGroupRef Id="Files.Managed.Net461"/>
       <ComponentGroupRef Id="Files.Managed.NetStandard20"/>
@@ -69,6 +70,9 @@
                 <!-- ".\netstandard2.0" -->
               </Directory>
               <Directory Id="net45.GAC" Name="net45.GAC">
+                <!-- Ignored as all of its components will be installed in the GAC -->
+              </Directory>
+              <Directory Id="net461.GAC" Name="net461.GAC">
                 <!-- Ignored as all of its components will be installed in the GAC -->
               </Directory>
           </Directory>


### PR DESCRIPTION
Install Sigil-vNext 4.8.41 into the GAC in addition to Sigil 4.7.

```
C:\Windows\Microsoft.NET\assembly\GAC_MSIL\Sigil>dir

02/21/2020  08:25 AM    <DIR>          v4.0_4.7.0.0__2d06c3494341c8ab
02/21/2020  08:25 AM    <DIR>          v4.0_4.8.41.0__2d06c3494341c8ab
```

Tested with apps running on .NET Framework 4.8 and they now correctly load Sigil from the GAC.

Before:
```
Profile attached: True
Path to Datadog.Trace.dll: C:\Windows\Microsoft.Net\assembly\GAC_MSIL\Datadog.Trace\v4.0_1.13.0.0__def86d061d0d2eeb\Datadog.Trace.dll
Path to Datadog.Trace.ClrProfiler.Managed.dll: C:\Windows\Microsoft.Net\assembly\GAC_MSIL\Datadog.Trace.ClrProfiler.Managed\v4.0_1.13.0.0__def86d061d0d2eeb\Datadog.Trace.ClrProfiler.Managed.dll
Path to Sigil.dll: C:\Program Files\Datadog\.NET Tracer\net461\Sigil.dll
```

After:
```
Profile attached: True
Path to Datadog.Trace.dll: C:\Windows\Microsoft.Net\assembly\GAC_MSIL\Datadog.Trace\v4.0_1.13.0.0__def86d061d0d2eeb\Datadog.Trace.dll
Path to Datadog.Trace.ClrProfiler.Managed.dll: C:\Windows\Microsoft.Net\assembly\GAC_MSIL\Datadog.Trace.ClrProfiler.Managed\v4.0_1.13.0.0__def86d061d0d2eeb\Datadog.Trace.ClrProfiler.Managed.dll
Path to Sigil.dll: C:\Windows\Microsoft.Net\assembly\GAC_MSIL\Sigil\v4.0_4.8.41.0__2d06c3494341c8ab\Sigil.dll
```