### PR TITLE
Use Composite Settings for Log Level

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Agent
 
         public Api(Uri baseEndpoint, DelegatingHandler delegatingHandler, IStatsd statsd)
         {
-            DatadogLogging.RegisterStartupLog(log => log.Debug("Creating new Api"));
+            Log.Debug("Creating new Api");
 
             _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
             _statsd = statsd;

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -27,31 +27,20 @@ namespace Datadog.Trace.Configuration
             DebugEnabled = source?.GetBool(ConfigurationKeys.DebugEnabled) ??
                            // default value
                            false;
-
-            LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled) ??
-                                   // default value
-                                   false;
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether debug mode is enabled.
+        /// Gets a value indicating whether debug mode is enabled.
         /// Default is <c>false</c>.
+        /// Set in code via <see cref="SetDebugEnabled"/>
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
-        public bool DebugEnabled { get; set; }
+        public bool DebugEnabled { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether correlation identifiers are
-        /// automatically injected into the logging context.
-        /// Default is <c>false</c>.
+        /// Gets or sets the global settings instance.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
-        public bool LogsInjectionEnabled { get; set; }
-
-        /// <summary>
-        /// Gets the global settings instance.
-        /// </summary>
-        internal static GlobalSettings Source { get; } = FromDefaultSources();
+        internal static GlobalSettings Source { get; set; } = FromDefaultSources();
 
         /// <summary>
         /// Set whether debug mode is enabled.
@@ -70,6 +59,15 @@ namespace Datadog.Trace.Configuration
             {
                 DatadogLogging.UseDefaultLevel();
             }
+        }
+
+        /// <summary>
+        /// Used to refresh global settings when environment variables or config sources change.
+        /// This is not necessary if changes are set via code, only environment.
+        /// </summary>
+        public static void Reload()
+        {
+            Source = FromDefaultSources();
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalSettings"/> class with default values.
         /// </summary>
-        public GlobalSettings()
+        internal GlobalSettings()
             : this(null)
         {
         }
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Configuration
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
-        public GlobalSettings(IConfigurationSource source)
+        internal GlobalSettings(IConfigurationSource source)
         {
             DebugEnabled = source?.GetBool(ConfigurationKeys.DebugEnabled) ??
                            // default value

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -1,0 +1,128 @@
+using System.IO;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog.Events;
+
+namespace Datadog.Trace.Configuration
+{
+    /// <summary>
+    /// Contains global datadog settings.
+    /// </summary>
+    public class GlobalSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GlobalSettings"/> class with default values.
+        /// </summary>
+        public GlobalSettings()
+            : this(null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GlobalSettings"/> class
+        /// using the specified <see cref="IConfigurationSource"/> to initialize values.
+        /// </summary>
+        /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
+        public GlobalSettings(IConfigurationSource source)
+        {
+            DebugEnabled = source?.GetBool(ConfigurationKeys.DebugEnabled) ??
+                           // default value
+                           false;
+
+            LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled) ??
+                                   // default value
+                                   false;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether debug mode is enabled.
+        /// Default is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
+        public bool DebugEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether correlation identifiers are
+        /// automatically injected into the logging context.
+        /// Default is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
+        public bool LogsInjectionEnabled { get; set; }
+
+        /// <summary>
+        /// Gets the global settings instance.
+        /// </summary>
+        internal static GlobalSettings Source { get; } = FromDefaultSources();
+
+        /// <summary>
+        /// Set whether debug mode is enabled.
+        /// Affects the level of logs written to file.
+        /// </summary>
+        /// <param name="enabled">Whether debug is enabled.</param>
+        public static void SetDebugEnabled(bool enabled)
+        {
+            Source.DebugEnabled = enabled;
+
+            if (enabled)
+            {
+                DatadogLogging.SetLogLevel(LogEventLevel.Verbose);
+            }
+            else
+            {
+                DatadogLogging.UseDefaultLevel();
+            }
+        }
+
+        /// <summary>
+        /// Create a <see cref="GlobalSettings"/> populated from the default sources
+        /// returned by <see cref="CreateDefaultConfigurationSource"/>.
+        /// </summary>
+        /// <returns>A <see cref="TracerSettings"/> populated from the default sources.</returns>
+        public static GlobalSettings FromDefaultSources()
+        {
+            var source = CreateDefaultConfigurationSource();
+            return new GlobalSettings(source);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IConfigurationSource"/> by combining environment variables,
+        /// AppSettings where available, and a local datadog.json file, if present.
+        /// </summary>
+        /// <returns>A new <see cref="IConfigurationSource"/> instance.</returns>
+        internal static CompositeConfigurationSource CreateDefaultConfigurationSource()
+        {
+            // env > AppSettings > datadog.json
+            var configurationSource = new CompositeConfigurationSource
+            {
+                new EnvironmentConfigurationSource(),
+
+#if !NETSTANDARD2_0
+                // on .NET Framework only, also read from app.config/web.config
+                new NameValueConfigurationSource(System.Configuration.ConfigurationManager.AppSettings)
+#endif
+            };
+
+            string currentDirectory = System.Environment.CurrentDirectory;
+
+#if !NETSTANDARD2_0
+            // on .NET Framework only, use application's root folder
+            // as default path when looking for datadog.json
+            if (System.Web.Hosting.HostingEnvironment.IsHosted)
+            {
+                currentDirectory = System.Web.Hosting.HostingEnvironment.MapPath("~");
+            }
+#endif
+
+            // if environment variable is not set, look for default file name in the current directory
+            var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName) ??
+                                        Path.Combine(currentDirectory, "datadog.json");
+
+            if (Path.GetExtension(configurationFileName).ToUpperInvariant() == ".JSON" &&
+                File.Exists(configurationFileName))
+            {
+                configurationSource.Add(JsonConfigurationSource.FromFile(configurationFileName));
+            }
+
+            return configurationSource;
+        }
+    }
+}

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or null if not found.</returns>
         bool? IConfigurationSource.GetBool(string key)
         {
-            return GetValue<bool>(key);
+            return GetValue<bool?>(key);
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -85,7 +86,7 @@ namespace Datadog.Trace.Configuration
         /// <returns>The value of the setting, or null if not found.</returns>
         bool? IConfigurationSource.GetBool(string key)
         {
-            return GetValue<bool?>(key);
+            return GetValue<bool>(key);
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Configuration
 {
@@ -76,11 +77,8 @@ namespace Datadog.Trace.Configuration
         /// <inheritdoc />
         public virtual bool? GetBool(string key)
         {
-            string value = GetString(key);
-
-            return bool.TryParse(value, out bool result)
-                       ? result
-                       : (bool?)null;
+            var value = GetString(key);
+            return value?.ToBoolean();
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -134,11 +134,12 @@ namespace Datadog.Trace.Configuration
         public bool TraceEnabled { get; set; }
 
         /// <summary>
-        /// Gets a value indicating whether debug mode is enabled.
-        /// Default is <c>false</c>.
+        /// Gets or sets a value indicating whether debug is enabled for a tracer.
+        /// This property is obsolete. Manage the debug setting through GlobalSettings.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
-        public bool DebugEnabled => GlobalSettings.Source.DebugEnabled;
+        /// <seealso cref="GlobalSettings.DebugEnabled"/>
+        [Obsolete]
+        public bool DebugEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets the names of disabled integrations.

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -3,7 +3,9 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.Configuration
 {
@@ -224,6 +226,29 @@ namespace Datadog.Trace.Configuration
         /// of <see cref="System.Diagnostics.DiagnosticSource"/> is enabled.
         /// </summary>
         public bool DiagnosticSourceEnabled { get; set; }
+
+        /// <summary>
+        /// Gets the global settings instance.
+        /// </summary>
+        internal static TracerSettings GlobalSettings { get; } = FromDefaultSources();
+
+        /// <summary>
+        /// Set whether debug mode is enabled in the tracing library.
+        /// </summary>
+        /// <param name="enabled">Whether debug is enabled.</param>
+        public static void SetDebugEnabled(bool enabled)
+        {
+            GlobalSettings.DebugEnabled = enabled;
+
+            if (enabled)
+            {
+                DatadogLogging.SetLogLevel(LogEventLevel.Verbose);
+            }
+            else
+            {
+                DatadogLogging.UseDefaultLevel();
+            }
+        }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -73,6 +73,10 @@ namespace Datadog.Trace.Configuration
                                // default value
                                false;
 
+            LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled) ??
+                                   // default value
+                                   false;
+
             var maxTracesPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond);
 
             if (maxTracesPerSecond != null)
@@ -130,14 +134,19 @@ namespace Datadog.Trace.Configuration
         public bool TraceEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether debug mode is enabled.
+        /// Gets a value indicating whether debug mode is enabled.
         /// Default is <c>false</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
         public bool DebugEnabled
         {
-            get { return GlobalSettings.Source.DebugEnabled; }
-            set { GlobalSettings.Source.DebugEnabled = value; }
+            get => GlobalSettings.Source.DebugEnabled;
+            // [Obsolete("Use GlobalSettings.SetDebugEnabled(value).")] // TODO: this doesn't work on setters and getters until c#8
+            // ReSharper disable once ValueParameterNotUsed
+            set
+            {
+                // no-op to prevent signature change for this major version
+            }
         }
 
         /// <summary>
@@ -170,11 +179,7 @@ namespace Datadog.Trace.Configuration
         /// Default is <c>false</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
-        public bool LogsInjectionEnabled
-        {
-            get { return GlobalSettings.Source.LogsInjectionEnabled; }
-            set { GlobalSettings.Source.LogsInjectionEnabled = value; }
-        }
+        public bool LogsInjectionEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating the maximum number of traces set to AutoKeep (p1) per second.

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -138,16 +138,7 @@ namespace Datadog.Trace.Configuration
         /// Default is <c>false</c>.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DebugEnabled"/>
-        public bool DebugEnabled
-        {
-            get => GlobalSettings.Source.DebugEnabled;
-            // [Obsolete("Use GlobalSettings.SetDebugEnabled(value).")] // TODO: this doesn't work on setters and getters until c#8
-            // ReSharper disable once ValueParameterNotUsed
-            set
-            {
-                // no-op to prevent signature change for this major version
-            }
-        }
+        public bool DebugEnabled => GlobalSettings.Source.DebugEnabled;
 
         /// <summary>
         /// Gets or sets the names of disabled integrations.

--- a/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -34,10 +34,12 @@ namespace Datadog.Trace.ExtensionMethods
             {
                 case "TRUE":
                 case "YES":
+                case "T":
                 case "1":
                     return true;
                 case "FALSE":
                 case "NO":
+                case "F":
                 case "0":
                     return false;
                 default:

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Logging
                    .CreateLogger();
             try
             {
-                if (TracerSettings.GlobalSettings.DebugEnabled)
+                if (GlobalSettings.Source.DebugEnabled)
                 {
                     LoggingLevelSwitch.MinimumLevel = LogEventLevel.Verbose;
                 }

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -83,46 +83,8 @@ namespace Datadog.Trace.Logging
             }
             finally
             {
-                Initialized = true;
                 // Log some information to correspond with the app domain
-<<<<<<< HEAD
                 SharedLogger.Information(FrameworkDescription.Create().ToString());
-
-                // Clear the queue out regardless of exception
-                while (ActionsToRunWhenLoggerReady.TryDequeue(out var logAction))
-                {
-                    try
-                    {
-                        logAction(SharedLogger);
-                    }
-                    catch (Exception ex)
-                    {
-                        SharedLogger.Error(ex, "Failure on logger startup subscriber");
-                    }
-                }
-            }
-        }
-
-        public static void RegisterStartupLog(Action<ILogger> logAction)
-        {
-            try
-            {
-                if (Initialized)
-                {
-                    logAction(SharedLogger);
-                }
-                else
-                {
-                    ActionsToRunWhenLoggerReady.Enqueue(logAction);
-                }
-            }
-            catch (Exception ex)
-            {
-                // ignored
-                SharedLogger.Error(ex, "Register startup log failed");
-=======
-                SharedLogger.Information("New global logger instance created with {0}", FrameworkDescription.Create().ToString());
->>>>>>> Use global settings instance for configuring log level
             }
         }
 
@@ -138,7 +100,16 @@ namespace Datadog.Trace.Logging
             return GetLogger(typeof(T));
         }
 
-<<<<<<< HEAD
+        internal static void SetLogLevel(LogEventLevel logLevel)
+        {
+            LoggingLevelSwitch.MinimumLevel = logLevel;
+        }
+
+        internal static void UseDefaultLevel()
+        {
+            SetLogLevel(LogEventLevel.Information);
+        }
+
         private static string GetLogDirectory()
         {
             var nativeLogFile = Environment.GetEnvironmentVariable(ConfigurationKeys.ProfilerLogPath);
@@ -194,16 +165,6 @@ namespace Datadog.Trace.Logging
             }
 
             return logDirectory;
-=======
-        internal static void SetLogLevel(LogEventLevel logLevel)
-        {
-            LoggingLevelSwitch.MinimumLevel = logLevel;
-        }
-
-        internal static void UseDefaultLevel()
-        {
-            SetLogLevel(LogEventLevel.Information);
->>>>>>> Use global settings instance for configuring log level
         }
     }
 }

--- a/src/Datadog.Trace/PlatformHelpers/AzureAppservices.cs
+++ b/src/Datadog.Trace/PlatformHelpers/AzureAppservices.cs
@@ -28,6 +28,8 @@ namespace Datadog.Trace.PlatformHelpers
         /// </summary>
         internal static readonly string SiteNameKey = "WEBSITE_DEPLOYMENT_ID";
 
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(AzureAppServices));
+
         static AzureAppServices()
         {
             Metadata = new AzureAppServices(Environment.GetEnvironmentVariables());
@@ -67,19 +69,19 @@ namespace Datadog.Trace.PlatformHelpers
                 if (SubscriptionId == null)
                 {
                     success = false;
-                    DatadogLogging.RegisterStartupLog(log => log.Warning("Could not successfully retrieve the subscription ID from variable: {0}", WebsiteOwnerNameKey));
+                    Log.Warning("Could not successfully retrieve the subscription ID from variable: {0}", WebsiteOwnerNameKey);
                 }
 
                 if (SiteName == null)
                 {
                     success = false;
-                    DatadogLogging.RegisterStartupLog(log => log.Warning("Could not successfully retrieve the deployment ID from variable: {0}", SiteNameKey));
+                    Log.Warning("Could not successfully retrieve the deployment ID from variable: {0}", SiteNameKey);
                 }
 
                 if (ResourceGroup == null)
                 {
                     success = false;
-                    DatadogLogging.RegisterStartupLog(log => log.Warning("Could not successfully retrieve the resource group name from variable: {0}", ResourceGroupKey));
+                    Log.Warning("Could not successfully retrieve the resource group name from variable: {0}", ResourceGroupKey);
                 }
 
                 if (success)
@@ -89,7 +91,7 @@ namespace Datadog.Trace.PlatformHelpers
             }
             catch (Exception ex)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Could not successfully setup the resource id for azure app services."));
+                Log.Error(ex, "Could not successfully setup the resource id for azure app services.");
             }
 
             return resourceId;
@@ -111,7 +113,7 @@ namespace Datadog.Trace.PlatformHelpers
             }
             catch (Exception ex)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Could not successfully retrieve the subscription id for azure app services."));
+                Log.Error(ex, "Could not successfully retrieve the subscription id for azure app services.");
             }
 
             return null;

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace
             // update the count of Tracer instances
             Interlocked.Increment(ref _liveTracerCount);
 
-            Settings = settings ?? TracerSettings.GlobalSettings;
+            Settings = settings ?? TracerSettings.FromDefaultSources();
 
             // if not configured, try to determine an appropriate service name
             DefaultServiceName = Settings.ServiceName ??

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace
     public class Tracer : IDatadogTracer
     {
         private const string UnknownServiceName = "UnknownService";
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<Tracer>();
 
         /// <summary>
         /// The number of Tracer instances that have been created and not yet destroyed.
@@ -67,7 +68,7 @@ namespace Datadog.Trace
             // update the count of Tracer instances
             Interlocked.Increment(ref _liveTracerCount);
 
-            Settings = settings ?? TracerSettings.FromDefaultSources();
+            Settings = settings ?? TracerSettings.GlobalSettings;
 
             // if not configured, try to determine an appropriate service name
             DefaultServiceName = Settings.ServiceName ??
@@ -81,7 +82,7 @@ namespace Datadog.Trace
                 TracingProcessManager.SubscribeToDogStatsDPortOverride(
                     port =>
                     {
-                        DatadogLogging.RegisterStartupLog(log => log.Debug("Attempting to override dogstatsd port with {0}", port));
+                        Log.Debug("Attempting to override dogstatsd port with {0}", port);
                         Statsd = CreateDogStatsdClient(Settings, DefaultServiceName, port);
                     });
 
@@ -92,7 +93,7 @@ namespace Datadog.Trace
             TracingProcessManager.SubscribeToTraceAgentPortOverride(
                 port =>
                 {
-                    DatadogLogging.RegisterStartupLog(log => log.Debug("Attempting to override trace agent port with {0}", port));
+                    Log.Debug("Attempting to override trace agent port with {0}", port);
                     var builder = new UriBuilder(Settings.AgentUri) { Port = port };
                     var baseEndpoint = builder.Uri;
                     IApi overridingApiClient = new Api(baseEndpoint, delegatingHandler: null, Statsd);
@@ -129,7 +130,7 @@ namespace Datadog.Trace
 
                 if (globalRate < 0f || globalRate > 1f)
                 {
-                    DatadogLogging.RegisterStartupLog(log => log.Warning("{0} configuration of {1} is out of range", ConfigurationKeys.GlobalSamplingRate, Settings.GlobalSamplingRate));
+                    Log.Warning("{0} configuration of {1} is out of range", ConfigurationKeys.GlobalSamplingRate, Settings.GlobalSamplingRate);
                 }
                 else
                 {
@@ -370,7 +371,7 @@ namespace Datadog.Trace
 
             if (type == null)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Warning("DiagnosticSource type could not be loaded. Disabling diagnostic observers."));
+                Log.Warning("DiagnosticSource type could not be loaded. Disabling diagnostic observers.");
             }
             else
             {
@@ -388,7 +389,7 @@ namespace Datadog.Trace
 #if NETSTANDARD
             if (Settings.IsIntegrationEnabled(AspNetCoreDiagnosticObserver.IntegrationName))
             {
-                DatadogLogging.RegisterStartupLog(log => log.Debug("Adding AspNetCoreDiagnosticObserver"));
+                Log.Debug("Adding AspNetCoreDiagnosticObserver");
 
                 var aspNetCoreDiagnosticOptions = new AspNetCoreDiagnosticOptions();
                 observers.Add(new AspNetCoreDiagnosticObserver(this, aspNetCoreDiagnosticOptions));
@@ -397,11 +398,11 @@ namespace Datadog.Trace
 
             if (observers.Count == 0)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Debug("DiagnosticManager not started, zero observers added."));
+                Log.Debug("DiagnosticManager not started, zero observers added.");
             }
             else
             {
-                DatadogLogging.RegisterStartupLog(log => log.Debug("Starting DiagnosticManager with {0} observers.", observers.Count));
+                Log.Debug("Starting DiagnosticManager with {0} observers.", observers.Count);
 
                 var diagnosticManager = new DiagnosticManager(observers);
                 diagnosticManager.Start();
@@ -433,7 +434,7 @@ namespace Datadog.Trace
             }
             catch (Exception ex)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Error creating default service name."));
+                Log.Error(ex, "Error creating default service name.");
                 return null;
             }
         }
@@ -488,7 +489,7 @@ namespace Datadog.Trace
             }
             catch (Exception ex)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Error flushing traces on shutdown."));
+                Log.Error(ex, "Error flushing traces on shutdown.");
             }
 
             TracingProcessManager.StopProcesses();

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -212,7 +212,7 @@ namespace Datadog.Trace
             // Keep supporting this older public method by creating a TracerConfiguration
             // from default sources, overwriting the specified settings, and passing that to the constructor.
             var configuration = TracerSettings.FromDefaultSources();
-            configuration.DebugEnabled = isDebugEnabled;
+            GlobalSettings.SetDebugEnabled(isDebugEnabled);
 
             if (agentEndpoint != null)
             {

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Tests.Configuration
             var collection = new NameValueCollection { { key, value } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var settings = new TracerSettings(source);
-
+            GlobalSettings.Reload();
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
         }
@@ -140,7 +140,7 @@ namespace Datadog.Trace.Tests.Configuration
             string json = JsonConvert.SerializeObject(config);
             IConfigurationSource source = new JsonConfigurationSource(json);
             var settings = new TracerSettings(source);
-
+            GlobalSettings.Reload();
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
         }

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -118,6 +118,9 @@ namespace Datadog.Trace.Tests.Configuration
             IConfigurationSource source = new EnvironmentConfigurationSource();
             var settings = new TracerSettings(source);
 
+            // Needed because we cache global settings like DebugEnabled
+            GlobalSettings.Reload();
+
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -16,6 +16,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         public static IEnumerable<object[]> GetGlobalTestData()
         {
+            yield return new object[] { ConfigurationKeys.DebugEnabled, 1, CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, 0, CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, true, CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, false, CreateGlobalFunc(s => s.DebugEnabled), false };
             yield return new object[] { ConfigurationKeys.DebugEnabled, "true", CreateGlobalFunc(s => s.DebugEnabled), true };
             yield return new object[] { ConfigurationKeys.DebugEnabled, "false", CreateGlobalFunc(s => s.DebugEnabled), false };
             yield return new object[] { ConfigurationKeys.DebugEnabled, "tRUe", CreateGlobalFunc(s => s.DebugEnabled), true };
@@ -26,6 +30,11 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.DebugEnabled, "no", CreateGlobalFunc(s => s.DebugEnabled), false };
             yield return new object[] { ConfigurationKeys.DebugEnabled, "T", CreateGlobalFunc(s => s.DebugEnabled), true };
             yield return new object[] { ConfigurationKeys.DebugEnabled, "F", CreateGlobalFunc(s => s.DebugEnabled), false };
+
+            // garbage checks
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "what_even_is_this", CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, 42, CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, string.Empty, CreateGlobalFunc(s => s.DebugEnabled), false };
         }
 
         public static IEnumerable<object[]> GetDefaultTestData()

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -9,10 +9,28 @@ namespace Datadog.Trace.Tests.Configuration
 {
     public class ConfigurationSourceTests
     {
+        public static IEnumerable<object[]> GetGlobalDefaultTestData()
+        {
+            yield return new object[] { CreateGlobalFunc(s => s.DebugEnabled), false };
+        }
+
+        public static IEnumerable<object[]> GetGlobalTestData()
+        {
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "true", CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "false", CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "tRUe", CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "fALse", CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "1", CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "0", CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "yes", CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "no", CreateGlobalFunc(s => s.DebugEnabled), false };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "T", CreateGlobalFunc(s => s.DebugEnabled), true };
+            yield return new object[] { ConfigurationKeys.DebugEnabled, "F", CreateGlobalFunc(s => s.DebugEnabled), false };
+        }
+
         public static IEnumerable<object[]> GetDefaultTestData()
         {
             yield return new object[] { CreateFunc(s => s.TraceEnabled), true };
-            yield return new object[] { CreateFunc(s => s.DebugEnabled), false };
             yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://localhost:8126/") };
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
@@ -30,9 +48,6 @@ namespace Datadog.Trace.Tests.Configuration
         {
             yield return new object[] { ConfigurationKeys.TraceEnabled, "true", CreateFunc(s => s.TraceEnabled), true };
             yield return new object[] { ConfigurationKeys.TraceEnabled, "false", CreateFunc(s => s.TraceEnabled), false };
-
-            yield return new object[] { ConfigurationKeys.DebugEnabled, "true", CreateFunc(s => s.DebugEnabled), true };
-            yield return new object[] { ConfigurationKeys.DebugEnabled, "false", CreateFunc(s => s.DebugEnabled), false };
 
             yield return new object[] { ConfigurationKeys.AgentHost, "test-host", CreateFunc(s => s.AgentUri), new Uri("http://test-host:8126/") };
             yield return new object[] { ConfigurationKeys.AgentPort, "9000", CreateFunc(s => s.AgentUri), new Uri("http://localhost:9000/") };
@@ -78,6 +93,11 @@ namespace Datadog.Trace.Tests.Configuration
             return settingGetter;
         }
 
+        public static Func<GlobalSettings, object> CreateGlobalFunc(Func<GlobalSettings, object> settingGetter)
+        {
+            return settingGetter;
+        }
+
         [Theory]
         [MemberData(nameof(GetDefaultTestData))]
         public void DefaultSetting(Func<TracerSettings, object> settingGetter, object expectedValue)
@@ -98,7 +118,6 @@ namespace Datadog.Trace.Tests.Configuration
             var collection = new NameValueCollection { { key, value } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var settings = new TracerSettings(source);
-            GlobalSettings.Reload();
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
         }
@@ -117,9 +136,6 @@ namespace Datadog.Trace.Tests.Configuration
             Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
             IConfigurationSource source = new EnvironmentConfigurationSource();
             var settings = new TracerSettings(source);
-
-            // Needed because we cache global settings like DebugEnabled
-            GlobalSettings.Reload();
 
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
@@ -140,9 +156,51 @@ namespace Datadog.Trace.Tests.Configuration
             string json = JsonConvert.SerializeObject(config);
             IConfigurationSource source = new JsonConfigurationSource(json);
             var settings = new TracerSettings(source);
-            GlobalSettings.Reload();
+
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetGlobalDefaultTestData))]
+        public void GlobalDefaultSetting(Func<GlobalSettings, object> settingGetter, object expectedValue)
+        {
+            var settings = new GlobalSettings();
+            object actualValue = settingGetter(settings);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetGlobalTestData))]
+        public void GlobalNameValueConfigurationSource(
+            string key,
+            string value,
+            Func<GlobalSettings, object> settingGetter,
+            object expectedValue)
+        {
+            var collection = new NameValueCollection { { key, value } };
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var settings = new GlobalSettings(source);
+            object actualValue = settingGetter(settings);
+            Assert.Equal(expectedValue, actualValue);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetGlobalTestData))]
+        public void GlobalEnvironmentConfigurationSource(
+            string key,
+            string value,
+            Func<GlobalSettings, object> settingGetter,
+            object expectedValue)
+        {
+            // save original value so we can restore later
+            var originalValue = Environment.GetEnvironmentVariable(key);
+            Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
+            IConfigurationSource source = new EnvironmentConfigurationSource();
+            var settings = new GlobalSettings(source);
+            object actualValue = settingGetter(settings);
+            Assert.Equal(expectedValue, actualValue);
+            Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
         }
 
         // Special case for dictionary-typed settings in JSON


### PR DESCRIPTION
Use a global settings instance to base configuration of the logger on.
Enable code setting of debug mode in the logger with a logging level switch.
 - [x] Make Logger use all config options
 - [x] Remove RegisterStartupLog method
 - [x] Documentation update PR (https://github.com/DataDog/documentation/pull/6826)

@DataDog/apm-dotnet