### PR TITLE
fix threading issue in TracingHttpModule

### DIFF
--- a/samples-aspnet/Samples.AspNetMvc5/Web.config
+++ b/samples-aspnet/Samples.AspNetMvc5/Web.config
@@ -56,18 +56,19 @@
       <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
-  
+
   <system.codedom>
     <compilers>
       <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
       <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
-<system.webServer>
+  <system.webServer>
     <handlers>
       <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
       <remove name="OPTIONSVerbHandler" />
       <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
-  </system.webServer></configuration>
+  </system.webServer>
+</configuration>

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Web;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -20,6 +20,8 @@ namespace Datadog.Trace.AspNet
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(TracingHttpModule));
 
+        // there is no ConcurrentHashSet, so use a ConcurrentDictionary
+        // where we only care about the key, not the value
         private static ConcurrentDictionary<HttpApplication, byte> registeredEventHandlers = new ConcurrentDictionary<HttpApplication, byte>();
 
         private readonly string _httpContextScopeKey;

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -71,9 +71,13 @@ namespace Datadog.Trace.AspNet
         /// <inheritdoc />
         public void Dispose()
         {
-            // Remove the HttpApplication mapping so we don't keep the object alive
-            registeredEventHandlers.TryRemove(_httpApplication, out var _);
-            _httpApplication = null;
+            // defend against multiple calls to Dispose()
+            if (_httpApplication != null)
+            {
+                // Remove the HttpApplication mapping so we don't keep the object alive
+                registeredEventHandlers.TryRemove(_httpApplication, out var _);
+                _httpApplication = null;
+            }
         }
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)


### PR DESCRIPTION
Replace the static `HashTag`  in `TracingHttpModule` with `ConcurrentDictionary` since it can be written to from multiple threads, causing an exception.

See #653