### PR TITLE
[WIP] Refactor CI pipelines

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -15,20 +15,18 @@ pr:
       - docs/*
       - .github/*
 
+pool:
+  vmImage: ubuntu-18.04
 variables:
   buildConfiguration: Debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
   #NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
-  publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
+  publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.x
 
 jobs:
 
 - job: build_linux_profiler
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -76,10 +74,7 @@ jobs:
       netcoreapp3_1:
         dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
-
-  pool:
-    vmImage: ubuntu-16.04
-  
+ 
   variables:
     TestAllPackageVersions: true
 
@@ -112,10 +107,6 @@ jobs:
     condition: succeededOrFailed()
 
 - job: build_alpine_linux_profiler
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -163,9 +154,6 @@ jobs:
       netcoreapp3_1:
         dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
-
-  pool:
-    vmImage: ubuntu-16.04
   
   variables:
     TestAllPackageVersions: true

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -1,4 +1,11 @@
-trigger: none
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
+      - .github/*
 pr:
   branches:
     include:
@@ -11,11 +18,53 @@ pr:
 variables:
   buildConfiguration: Debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+  #NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
+  dotnetCoreSdkVersion: 3.1.x
 
 jobs:
 
+- job: build_linux_profiler
+  pool:
+    vmImage: ubuntu-16.04
+  variables:
+    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
+
+  steps:
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+    inputs:
+      command: build
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      arguments: --configuration $(buildConfiguration)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
+    inputs:
+      command: publish
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
+      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Profiler
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run Profiler
+
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+    artifact: linux-tracer-home
+
 - job: Linux
+  dependsOn: build_linux_profiler
+  condition: succeeded()
   strategy:
     matrix:
       netcoreapp2_1:
@@ -35,17 +84,19 @@ jobs:
     TestAllPackageVersions: true
 
   steps:
+  - download: current
+    artifact: linux-tracer-home
+
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/linux-tracer-home
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+
   - task: DockerCompose@0
     displayName: docker-compose run build
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) build
-
-  - task: DockerCompose@0
-    displayName: docker-compose run Profiler
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
 
   - task: DockerCompose@0
     displayName: docker-compose run IntegrationTests
@@ -60,7 +111,47 @@ jobs:
       testResultsFiles: test/**/*.trx
     condition: succeededOrFailed()
 
+- job: build_alpine_linux_profiler
+  pool:
+    vmImage: ubuntu-16.04
+  variables:
+    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
+
+  steps:
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+    inputs:
+      command: build
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      arguments: --configuration $(buildConfiguration)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
+    inputs:
+      command: publish
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
+      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Profiler.Alpine
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run Profiler.Alpine
+
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+    artifact: alpine-linux-tracer-home
+
 - job: Alpine_Linux
+  dependsOn: build_alpine_linux_profiler
+  condition: succeeded()
   strategy:
     matrix:
       netcoreapp2_1:
@@ -80,17 +171,19 @@ jobs:
     TestAllPackageVersions: true
 
   steps:
+  - download: current
+    artifact: alpine-linux-tracer-home
+
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/alpine-linux-tracer-home
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+
   - task: DockerCompose@0
     displayName: docker-compose run build
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) build
-
-  - task: DockerCompose@0
-    displayName: docker-compose run Profiler.Alpine
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler.Alpine
 
   - task: DockerCompose@0
     displayName: docker-compose run IntegrationTests.Alpine.Core21
@@ -126,7 +219,7 @@ jobs:
     vmImage: windows-2019
 
   variables:
-    buildPlatform: 'x64'
+    buildPlatform: x64
 
   steps:
   - task: UseDotNet@2
@@ -150,6 +243,15 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
+  #- task: Cache@2
+  #  displayName: Cache NuGet packages
+  #  inputs:
+  #    key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+  #    restoreKeys: |
+  #       nuget | "$(Agent.OS)"
+  #       nuget
+  #    path: $(NUGET_PACKAGES)
+
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
@@ -157,59 +259,23 @@ jobs:
       vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net45
+  # this triggers a dependency chain that builds all the managed, x64, and x86 dlls
+  - task: MSBuild@1
+    displayName: msbuild tracer-home
     inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework net45 --output $(publishOutput)/net45
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net461
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework net461 --output $(publishOutput)/net461
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
-    inputs:
-      command: build
-      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-      arguments: --configuration $(buildConfiguration)
+      solution: Datadog.Trace.proj
+      platform: x64
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:CreateHomeDirectory /p:TracerHomeDirectory=$(publishOutput)
+      maximumCpuCount: true
 
   - task: MSBuild@1
-    displayName: msbuild native
+    displayName: Build .NET Framework projects (not SDK-based projects)
     inputs:
       solution: Datadog.Trace.proj
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp
-      maximumCpuCount: true
-
-  - task: MSBuild@1
-    displayName: 'Build .NET Framework projects (not SDK-based projects)'
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: '$(buildPlatform)'
-      configuration: '$(buildConfiguration)'
-      msbuildArguments: '/t:BuildFrameworkReproductions'
+      msbuildArguments: /t:BuildFrameworkReproductions
       maximumCpuCount: true
 
   - task: DotNetCoreCLI@2
@@ -219,9 +285,7 @@ jobs:
       projects: |
         reproductions/**/*.csproj
         samples/**/*.csproj
-        test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
-        test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-        test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+        test/*.IntegrationTests/*.IntegrationTests.csproj
         !reproductions/**/ExpenseItDemo*.csproj
         !reproductions/**/EntityFramework6x*.csproj
         !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
@@ -235,7 +299,7 @@ jobs:
       projects: |
         test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
         test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
-      arguments: '-p:Platform=$(buildPlatform)'
+      arguments: -p:Platform=$(buildPlatform)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -243,4 +307,4 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: '--filter "RunOnWindows=True|Category=Smoke" -p:Platform=$(buildPlatform)'
+      arguments: --filter "RunOnWindows=True|Category=Smoke" -p:Platform=$(buildPlatform)

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -7,32 +7,30 @@ pr: none
 variables:
   buildConfiguration: release
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+  #NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
   dotnetCoreSdkVersion: 3.1.x
-  publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
 jobs:
 
-#### NuGet packages and Windows msi installer
-
-- job: nuget_and_windows_msi_and_home
-  strategy:
-    matrix:
-      x64:
-        buildPlatform: x64
-        nugetPack: true
-      x86:
-        buildPlatform: x86
-        nugetPack: false
-
+#### Windows msi and NuGet
+- job: windows_packages_and_nuget
   pool:
     vmImage: windows-2019
+  variables:
+    tracerHomeName: windows-tracer-home
+    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/$(tracerHomeName)
+    msiHome: $(System.DefaultWorkingDirectory)/src/bin/msi
+    nuget_packages: $(Pipeline.Workspace)/.nuget/packages
 
   steps:
-
-  - task: gittools.gitversion.gitversion-task.GitVersion@4
-    displayName: GitVersion
-    inputs:
-      preferBundledVersion: false
+  #- task: Cache@2
+  #  displayName: Cache NuGet packages
+  #  inputs:
+  #    key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+  #    restoreKeys: |
+  #       nuget | "$(Agent.OS)"
+  #       nuget
+  #    path: $(NUGET_PACKAGES)
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk
@@ -40,6 +38,17 @@ jobs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
 
+  - task: NuGetToolInstaller@1
+    displayName: install nuget
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet restore
+    inputs:
+      command: restore
+      vstsFeed: $(packageFeed)
+      projects: src/**/*.csproj
+
+  # native projects must be restored with nuget.exe
   - task: NuGetCommand@2
     displayName: nuget restore native
     inputs:
@@ -47,74 +56,39 @@ jobs:
       vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
+  # this triggers a dependency chain that builds all the managed, x64, and x86 dlls, and the zip and msi files
+  - task: MSBuild@1
+    displayName: build both msi
     inputs:
-      command: restore
-      projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
+      solution: Datadog.Trace.proj
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:msi /p:Platform=All;ZipHomeDirectory=true;TracerHomeDirectory=$(tracerHome);RunWixToolsOutOfProc=true;MsiOutputPath=$(msiHome)
+      maximumCpuCount: true
+
+  - publish: $(msiHome)/en-us
+    artifact: windows-msi
+
+  - publish: $(tracerHome).zip
+    artifact: $(tracerHomeName)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      projects: src/**/*.csproj
-      arguments: --configuration $(buildConfiguration)
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet pack
-    condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
+    displayName: build nugets
     inputs:
       command: pack
-      packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj;src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
-      packDirectory: nuget-output
+      packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+      packDirectory: $(System.DefaultWorkingDirectory)/nuget-output
       configuration: $(buildConfiguration)
 
-  - task: PublishPipelineArtifact@0
-    displayName: publish nuget artifacts
-    condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
-    inputs:
-      artifactName: nuget-packages
-      targetPath: nuget-output
-
-  - task: MSBuild@1
-    displayName: msbuild msi
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:msi /p:RunWixToolsOutOfProc=true
-      maximumCpuCount: true
-      
-  - task: MSBuild@1
-    displayName: msbuild tracer-home
-    condition: eq(variables['buildPlatform'], 'x64')
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:CreateHomeDirectory
-      maximumCpuCount: true
-
-  - task: PublishPipelineArtifact@0
-    displayName: publish msi artifact
-    inputs:
-      artifactName: windows-msi-$(buildPlatform)
-      targetPath: deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/bin/$(buildConfiguration)/$(buildPlatform)/en-us
-
-  - task: PublishPipelineArtifact@0
-    displayName: publish tracerhome artifact
-    condition: eq(variables['buildPlatform'], 'x64')
-    inputs:
-      artifactName: windows-tracer-home
-      targetPath: src/bin/windows-tracer-home.zip
+  - publish: $(System.DefaultWorkingDirectory)/nuget-output
+    artifact: nuget-packages
 
 #### Linux packages
 
 - job: linux_packages
-
   pool:
     vmImage: ubuntu-16.04
+  variables:
+    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -122,29 +96,31 @@ jobs:
     inputs:
       version: $(dotnetCoreSdkVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
+  #- task: Cache@2
+  #  displayName: Cache NuGet packages
+  #  inputs:
+  #    key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+  #    restoreKeys: |
+  #       nuget | "$(Agent.OS)"
+  #       nuget
+  #    path: $(NUGET_PACKAGES)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet build
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
     inputs:
       command: build
-      projects: src/**/*.csproj
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
       arguments: --configuration $(buildConfiguration)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
     inputs:
       command: publish
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
 
   - task: DockerCompose@0
     displayName: docker-compose run Profiler
@@ -158,16 +134,14 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run package
 
-  - task: PublishPipelineArtifact@0
-    displayName: publish artifacts
-    inputs:
-      artifactName: linux-packages
-      targetPath: deploy/linux
+  - publish: deploy/linux
+    artifact: linux-packages
 
 - job: linux_alpine_packages
-
   pool:
     vmImage: ubuntu-16.04
+  variables:
+    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -175,29 +149,31 @@ jobs:
     inputs:
       version: $(dotnetCoreSdkVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
+  #- task: Cache@2
+  #  displayName: Cache NuGet packages
+  #  inputs:
+  #    key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+  #    restoreKeys: |
+  #       nuget | "$(Agent.OS)"
+  #       nuget
+  #    path: $(NUGET_PACKAGES)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet build
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
     inputs:
       command: build
-      projects: src/**/*.csproj
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
       arguments: --configuration $(buildConfiguration)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
     inputs:
       command: publish
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
 
   - task: DockerCompose@0
     displayName: docker-compose run Profiler.Alpine
@@ -211,8 +187,5 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run package.alpine
 
-  - task: PublishPipelineArtifact@0
-    displayName: publish artifacts
-    inputs:
-      artifactName: linux-alpine-packages
-      targetPath: deploy/linux
+  - publish: deploy/linux
+    artifact: linux-alpine-packages

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -86,7 +86,7 @@ jobs:
 
 - job: linux_packages
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   variables:
     tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
@@ -139,7 +139,7 @@ jobs:
 
 - job: linux_alpine_packages
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   variables:
     tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
       windows:
         imageName: windows-2019
       linux:
-        imageName: ubuntu-16.04
+        imageName: ubuntu-18.04
   pool:
     vmImage: $(imageName)
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -12,6 +12,7 @@ trigger:
 variables:
   buildConfiguration: Debug
   packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
+  #NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
 
 jobs:
 
@@ -22,7 +23,6 @@ jobs:
         imageName: windows-2019
       linux:
         imageName: ubuntu-16.04
-
   pool:
     vmImage: $(imageName)
 
@@ -45,14 +45,14 @@ jobs:
       packageType: sdk
       version: 3.1.x
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: |
-        src/**/*.csproj
-        test/**/*.Tests.csproj
-      vstsFeed: $(packageFeed)
+  #- task: Cache@2
+  #  displayName: Cache NuGet packages
+  #  inputs:
+  #    key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+  #    restoreKeys: |
+  #       nuget | "$(Agent.OS)"
+  #       nuget
+  #    path: $(NUGET_PACKAGES)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -77,7 +77,6 @@ jobs:
         buildPlatform: x64
       x86:
         buildPlatform: x86
-
   pool:
     vmImage: windows-2019
 
@@ -89,6 +88,15 @@ jobs:
       packageType: sdk
       version: 3.1.x
 
+  #- task: Cache@2
+  #  displayName: Cache NuGet packages
+  #  inputs:
+  #    key: 'nuget | "$(Agent.OS)" | **/packages.lock.json'
+  #    restoreKeys: |
+  #       nuget | "$(Agent.OS)"
+  #       nuget
+  #    path: $(NUGET_PACKAGES)
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build
     inputs:
@@ -97,6 +105,9 @@ jobs:
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
         sample-libs/**/Samples.ExampleLibrary*.csproj
+
+  - task: NuGetToolInstaller@1
+    displayName: install nuget
 
   - task: NuGetCommand@2
     displayName: nuget restore

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -1,6 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)src\bin\tracer-home</TracerHomeDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -55,11 +57,11 @@
   </Target>
 
   <Target Name="BuildCpp">
-    <MSBuild Targets="Build" Projects="@(CppProject)">
+    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'" Properties="Platform=x64">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
 
-    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(BuildAdditionalx86Profiler)' == 'true'" Properties="Platform=x86">
+    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'All' OR '$(Buildx86Profiler)' == 'true'" Properties="Platform=x86">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
@@ -109,24 +111,18 @@
     </MSBuild>
   </Target>
 
-  <Target Name="SetMsiProperties">
-    <PropertyGroup>
-      <BuildAdditionalx86Profiler Condition="'$(Platform)' == 'x64'">true</BuildAdditionalx86Profiler>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="PublishManagedProfilerOnDisk">
     <ItemGroup>
       <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-        <Properties>TargetFramework=net45;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\net45</Properties>
+        <Properties>TargetFramework=net45;PublishDir=$(TracerHomeDirectory)\net45</Properties>
       </ManagedProfilerPublishProject>
 
       <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-        <Properties>TargetFramework=net461;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\net461</Properties>
+        <Properties>TargetFramework=net461;PublishDir=$(TracerHomeDirectory)\net461</Properties>
       </ManagedProfilerPublishProject>
 
       <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-        <Properties>TargetFramework=netstandard2.0;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\netstandard2.0</Properties>
+        <Properties>TargetFramework=netstandard2.0;PublishDir=$(TracerHomeDirectory)\netstandard2.0</Properties>
       </ManagedProfilerPublishProject>
     </ItemGroup>
 
@@ -135,46 +131,69 @@
     </MSBuild>
   </Target>
 
-  <Target Name="Msi" DependsOnTargets="SetMsiProperties;BuildCsharp;BuildCpp;PublishManagedProfilerOnDisk">
-    <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)">
+  <Target Name="BuildLoader">
+    <ItemGroup>
+      <ManagedLoaderProject Include="src\Datadog.Trace.ClrProfiler.Managed.Loader\Datadog.Trace.ClrProfiler.Managed.Loader.csproj"/>
+    </ItemGroup>
+
+    <MSBuild Targets="Build" Projects="@(ManagedLoaderProject)" RemoveProperties="Platform">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
-  
-  <Target Name="CreateHomeDirectory" DependsOnTargets="BuildCsharp;BuildCpp;PublishManagedProfilerOnDisk">
-      <ItemGroup>
-	    <PublishedManagedTracerFiles Include="$(MSBuildThisFileDirectory)src\bin\managed-publish\**\*.*" />
-      </ItemGroup>
-	  <PropertyGroup>
-	    <WindowsHomeOutput>$(MSBuildThisFileDirectory)src\bin\windows-tracer-home</WindowsHomeOutput>
-	  </PropertyGroup>
-      <Copy 
-        SourceFiles="$(MSBuildThisFileDirectory)integrations.json" 
-        DestinationFolder="$(WindowsHomeOutput)" 
-		SkipUnchangedFiles="true"
+
+  <Target Name="PublishNativeProfilerOnDisk" DependsOnTargets="BuildLoader;BuildCpp">
+    <Copy Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'"
+        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\x64\Datadog.Trace.ClrProfiler.Native.dll"
+        DestinationFolder="$(TracerHomeDirectory)\win-x64"
+        SkipUnchangedFiles="true"
         Retries="3"
         RetryDelayMilliseconds="300"/>
-      <Copy 
-	    SourceFiles="@(PublishedManagedTracerFiles)"
-        DestinationFiles="@(PublishedManagedTracerFiles->'$(WindowsHomeOutput)\%(RecursiveDir)%(Filename)%(Extension)')"
-		SkipUnchangedFiles="true"
+    <Copy Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'All' OR '$(Buildx86Profiler)' == 'true'"
+        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\x86\Datadog.Trace.ClrProfiler.Native.dll"
+        DestinationFolder="$(TracerHomeDirectory)\win-x86"
+        SkipUnchangedFiles="true"
         Retries="3"
         RetryDelayMilliseconds="300"/>
-      <Copy 
-        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\Release\x64\Datadog.Trace.ClrProfiler.Native.dll" 
-        DestinationFolder="$(WindowsHomeOutput)\x64" 
-		SkipUnchangedFiles="true"
-        Retries="3"
-        RetryDelayMilliseconds="300"/>
-      <Copy 
-        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\Release\x86\Datadog.Trace.ClrProfiler.Native.dll" 
-        DestinationFolder="$(WindowsHomeOutput)\x86" 
-		SkipUnchangedFiles="true"
-        Retries="3"
-        RetryDelayMilliseconds="300"/>
-	  <Delete Files="$(WindowsHomeOutput).zip" />
-	  <ZipDirectory
-        SourceDirectory="$(WindowsHomeOutput)"
-        DestinationFile="$(WindowsHomeOutput).zip" />
+  </Target>
+
+  <Target Name="SetMsiProperties">
+    <PropertyGroup>
+      <!-- we need to build both x64 and x86 profilers to build the x64 msi -->
+      <Buildx86Profiler Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'">true</Buildx86Profiler>
+
+      <!-- disable zip by default when building msi, unless explicitly enabled -->
+      <ZipHomeDirectory Condition="'$(ZipHomeDirectory)' == ''">false</ZipHomeDirectory>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="Msi" DependsOnTargets="SetMsiProperties;CreateHomeDirectory">
+    <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'" Properties="Platform=x64">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+    </MSBuild>
+
+    <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)" Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'All'" Properties="Platform=x86">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+    </MSBuild>
+  </Target>
+
+  <Target Name="CreateHomeDirectory" DependsOnTargets="PublishNativeProfilerOnDisk;PublishManagedProfilerOnDisk">
+    <PropertyGroup>
+      <!-- enable zip by default to keep current behavior-->
+      <ZipHomeDirectory Condition="'$(ZipHomeDirectory)' == ''">true</ZipHomeDirectory>
+    </PropertyGroup>
+
+    <Copy
+      SourceFiles="$(MSBuildThisFileDirectory)integrations.json"
+      DestinationFolder="$(TracerHomeDirectory)"
+      SkipUnchangedFiles="true"
+      Retries="3"
+      RetryDelayMilliseconds="300"/>
+
+    <Delete Condition="'$(ZipHomeDirectory)' == 'true'" Files="$(TracerHomeDirectory).zip" />
+
+    <ZipDirectory
+        Condition="'$(ZipHomeDirectory)' == 'true'"
+        SourceDirectory="$(TracerHomeDirectory)"
+        DestinationFile="$(TracerHomeDirectory).zip" />
   </Target>
 </Project>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
@@ -5,9 +5,6 @@
   <?define ArpManufacturer = "Datadog, Inc." ?>
   <?define Company = "Datadog" ?>
   <?define ProductNamePlatformAgnostic = "Datadog $(var.BaseProductName)" ?>
-  <?define ManagedDllPath = "$(sys.CURRENTDIR)..\..\src\bin\managed-publish" ?>
-  <?define NativeDllPath = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\$(var.Platform)" ?>
-  <?define NativeDll32Path = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\x86" ?>
   <?define ProfilerCLSID = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" ?>
 
   <?if $(var.Platform) = x64 ?>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -10,15 +10,16 @@
     <ProjectGuid>3054de0e-f140-4758-b2da-0b9470c6ede1</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Package</OutputType>
-    <OutputPath>bin\$(Configuration)\$(Platform)\</OutputPath>
+    <!-- use a unique property to allow changing OutputPath
+         for this project without changing it for other projects -->
+    <MsiOutputPath Condition="'$(MsiOutputPath)' == ''">bin\$(Configuration)\$(Platform)\</MsiOutputPath>
+    <OutputPath>$(MsiOutputPath)</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
     <OutputName>datadog-dotnet-apm-1.14.0-$(Platform)</OutputName>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DefineConstants>InstallerVersion=1.14.0</DefineConstants>
+    <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\src\bin\tracer-home</TracerHomeDirectory>
+    <DefineConstants>InstallerVersion=1.14.0&#59;TracerHomeDirectory=$(TracerHomeDirectory)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
@@ -7,42 +7,42 @@
     <ComponentGroup Id="Files.Managed.Net45.GAC" Directory="net45.GAC">
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.AspNet.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.AspNet.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.AspNet.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_MsgPack.dll"
-              Source="$(var.ManagedDllPath)\net45\MsgPack.dll"
+              Source="$(var.TracerHomeDirectory)\net45\MsgPack.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\net45\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net45\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
@@ -7,42 +7,42 @@
     <ComponentGroup Id="Files.Managed.Net45" Directory="net45">
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.AspNet.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.AspNet.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.AspNet.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_MsgPack.dll"
-              Source="$(var.ManagedDllPath)\net45\MsgPack.dll"
+              Source="$(var.TracerHomeDirectory)\net45\MsgPack.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\net45\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net45\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
@@ -7,42 +7,42 @@
     <ComponentGroup Id="Files.Managed.Net461" Directory="net461">
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.AspNet.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.AspNet.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.AspNet.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_MsgPack.dll"
-              Source="$(var.ManagedDllPath)\net461\MsgPack.dll"
+              Source="$(var.TracerHomeDirectory)\net461\MsgPack.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\net461\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net461\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -7,122 +7,122 @@
     <ComponentGroup Id="Files.Managed.NetStandard20" Directory="netstandard2.0">
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Microsoft.CSharp.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Microsoft.CSharp.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Microsoft.CSharp.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_MsgPack.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\MsgPack.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\MsgPack.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Sigil.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.CodeDom.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.CodeDom.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.CodeDom.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.Concurrent.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Collections.Concurrent.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.Concurrent.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.Immutable.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Collections.Immutable.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.Immutable.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.NonGeneric.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Collections.NonGeneric.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.NonGeneric.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.IO.FileSystem.Primitives.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.IO.FileSystem.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.IO.FileSystem.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Linq.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Linq.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Linq.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Numerics.Vectors.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Numerics.Vectors.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Numerics.Vectors.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Emit.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.ILGeneration.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Emit.ILGeneration.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.ILGeneration.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.Lightweight.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Emit.Lightweight.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.Lightweight.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Metadata.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Metadata.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Metadata.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.TypeExtensions.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.TypeExtensions.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.TypeExtensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Runtime.Numerics.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Runtime.Numerics.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.Numerics.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Security.Cryptography.OpenSsl.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Security.Cryptography.OpenSsl.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Security.Cryptography.OpenSsl.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Security.Cryptography.Primitives.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Security.Cryptography.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Security.Cryptography.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Threading.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Threading.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Threading.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -34,7 +34,6 @@
 
     <Feature Id="ProductFeature" Title="Datadog.Trace.ClrProfiler" Level="1">
       <ComponentGroupRef Id="Files"/>
-      <ComponentGroupRef Id="Files.Native"/>
       <ComponentGroupRef Id="Files.Managed.Net45.GAC"/>
       <ComponentGroupRef Id="Files.Managed.Net461.GAC"/>
       <ComponentGroupRef Id="Files.Managed.Net45"/>
@@ -45,10 +44,12 @@
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.IIS"/>
 
-      <!-- For the 64-bit installer, also install the 32-bit profiler -->
       <?if $(var.Win64) = yes ?>
-      <ComponentGroupRef Id="Files.Native.32"/>
+      <ComponentGroupRef Id="Files.Native.64"/>
       <?endif ?>
+
+      <!-- The 32-bit profiler is always included, even in 64-bit builds -->
+      <ComponentGroupRef Id="Files.Native.32"/>
     </Feature>
   </Product>
 
@@ -107,14 +108,15 @@
   <Fragment>
     <ComponentGroup Id="Files" Directory="INSTALLFOLDER">
       <Component Win64="$(var.Win64)">
-        <File Id="integrations.json" Source="..\..\integrations.json" />
+        <File Id="integrations.json" Source="$(var.TracerHomeDirectory)\integrations.json" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="Files.Native" Directory="INSTALLFOLDER">
-      <Component Win64="$(var.Win64)">
+    <?if $(var.Win64) = yes ?>
+    <ComponentGroup Id="Files.Native.64" Directory="INSTALLFOLDER">
+      <Component Win64="yes">
         <File Id="Datadog.Trace.ClrProfiler.Native"
-              Source="$(var.NativeDllPath)\Datadog.Trace.ClrProfiler.Native.dll"
+              Source="$(var.TracerHomeDirectory)\win-x64\Datadog.Trace.ClrProfiler.Native.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
         </File>
@@ -122,16 +124,29 @@
     </ComponentGroup>
 
     <!-- For the 64-bit installer, also install the 32-bit profiler -->
-    <?if $(var.Win64) = yes ?>
     <ComponentGroup Id="Files.Native.32" Directory="INSTALLFOLDER.32">
       <Component Win64="no" Id="Datadog.Trace.ClrProfiler.Native.32">
         <File Id="Datadog.Trace.ClrProfiler.Native.32"
-              Source="$(var.NativeDll32Path)\Datadog.Trace.ClrProfiler.Native.dll"
+              Source="$(var.TracerHomeDirectory)\win-x86\Datadog.Trace.ClrProfiler.Native.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
         </File>
       </Component>
     </ComponentGroup>
+
+    <?else ?>
+
+    <!-- note that for the 32-bit build, we need to install into INSTALLFOLDER instead of INSTALLFOLDER.32 -->
+    <ComponentGroup Id="Files.Native.32" Directory="INSTALLFOLDER">
+      <Component Win64="no" Id="Datadog.Trace.ClrProfiler.Native.32">
+        <File Id="Datadog.Trace.ClrProfiler.Native.32"
+              Source="$(var.TracerHomeDirectory)\win-x86\Datadog.Trace.ClrProfiler.Native.dll"
+              Checksum="yes">
+          <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
+        </File>
+      </Component>
+    </ComponentGroup>
+
     <?endif ?>
 
     <ComponentGroup Id="EmptyFolders" Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">


### PR DESCRIPTION
Refactor CI yaml pipelines to make leaner by reducing some of the redundant build.

- `Datadog.Trace.proj`
  - refactor targets so `msi` and `CreateHomeDirectory` share more output without building or copying files multiple times
  - add a special `Platform=All` which build both `x64` and `x86`
- all pipelines
  - reduce number of steps by skipping `dotnet restore` if not needed
  - update `nuget.exe` if used (we require 5.3+ to restore the entire solution)
  - bump to Ubuntu 18.04
  - standardize to `$(System.DefaultWorkingDirectory)` everywhere (some places used `$(Build.SourcesDirectory)`)
- `integration-tests.yml`
  - run on `master` _after_ a PR is merged (in addition to running during the PR process)
  - compile the Tracer (C++ and C#) on Linux and Alpine Linux only once and share as pipeline artifacts with the 6 parallel jobs that follow
  - use `msbuild /t:CreateHomeDirectory` to build tracer directory
- `packages.yml`
  - build nuget packages, msi x64, msi x86, and the zip file on the same VM/job to reduce the amount of code that is compiled multiple times
  - use `msbuild /t:msi /p:Platform=All` to build both msi and the zip file
