### PR TITLE
Add calls to Dapper's QueryAsync and correct span counts in Dapper tests

### DIFF
--- a/sample-libs/Samples.DatabaseHelper/DapperTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/DapperTestHarness.cs
@@ -5,6 +5,7 @@ using System.Data.Common;
 using System.Threading.Tasks;
 using Datadog.Trace;
 using Dapper;
+using System.Collections.Generic;
 
 namespace Samples.DatabaseHelper
 {
@@ -60,6 +61,12 @@ namespace Samples.DatabaseHelper
                 }
             }
 
+            var t1 = CallQueryAsync(_connection, SelectOneCommandText);
+
+            // To avoid "Npgsql.NpgsqlOperationInProgressException: A command is already in progress" error
+            await Task.Delay(TimeSpan.FromSeconds(0.3));
+
+            t1 = CallQueryAsync(_connection, SelectManyCommandText);
         }
 
         private void SelectRecords(IDbConnection connection)
@@ -76,6 +83,10 @@ namespace Samples.DatabaseHelper
             await connection.ExecuteAsync(SelectManyCommandText);
         }
 
+        private async Task<IEnumerable<dynamic>> CallQueryAsync(IDbConnection connection, string sql)
+        {
+            return await connection.QueryAsync<dynamic>(sql);
+        }
     }
 }
 #endif

--- a/sample-libs/Samples.DatabaseHelper/DapperTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/DapperTestHarness.cs
@@ -61,12 +61,8 @@ namespace Samples.DatabaseHelper
                 }
             }
 
-            var t1 = CallQueryAsync(_connection, SelectOneCommandText);
-
-            // To avoid "Npgsql.NpgsqlOperationInProgressException: A command is already in progress" error
-            await Task.Delay(TimeSpan.FromSeconds(0.3));
-
-            t1 = CallQueryAsync(_connection, SelectManyCommandText);
+            var t1 = await CallQueryAsync(_connection, SelectOneCommandText);
+            t1 = await CallQueryAsync(_connection, SelectManyCommandText);
         }
 
         private void SelectRecords(IDbConnection connection)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperCommandTests.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTraces()
         {
-            var expectedSpanCount = 2;
+            var expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 4 : 7;
             const string dbType = "postgres";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.Dapper-" + dbType;


### PR DESCRIPTION
This PR validates that, when user code calls Dapper's `QueryAsync`, which calls down to `DbCommand.ExecuteReaderAsync`, it generates an appropriate Span.

Further testing also uncovered that `.NET Framework` and `.NET Core` produce different numbers of Spans. I had in a prior PR, removed that distinction but it should be there and is here corrected.

@DataDog/apm-dotnet