### PR TITLE
Improving Linux trace logging

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -305,7 +305,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Assembl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.AssemblyConflict.SdkProject", "reproductions\StackExchange.Redis.AssemblyConflict.SdkProject\StackExchange.Redis.AssemblyConflict.SdkProject.csproj", "{C41023C9-65C3-4FB3-9053-4DE963A81500}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Dapper", "samples\Samples.Dapper\Samples.Dapper.csproj", "{7E563BF6-47F2-4531-A1CE-FB9445DF3253}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "linux", "linux", "{7DB68365-AA9E-4C3E-A553-31BFB5704B01}"
+	ProjectSection(SolutionItems) = preProject
+		createLogPath.sh = createLogPath.sh
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -1184,7 +1187,6 @@ Global
 		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
-		{7E563BF6-47F2-4531-A1CE-FB9445DF3253} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -305,6 +305,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StackExchange.Redis.Assembl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StackExchange.Redis.AssemblyConflict.SdkProject", "reproductions\StackExchange.Redis.AssemblyConflict.SdkProject\StackExchange.Redis.AssemblyConflict.SdkProject.csproj", "{C41023C9-65C3-4FB3-9053-4DE963A81500}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Dapper", "samples\Samples.Dapper\Samples.Dapper.csproj", "{7E563BF6-47F2-4531-A1CE-FB9445DF3253}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "linux", "linux", "{7DB68365-AA9E-4C3E-A553-31BFB5704B01}"
 	ProjectSection(SolutionItems) = preProject
 		createLogPath.sh = createLogPath.sh
@@ -1187,6 +1189,7 @@ Global
 		{4E83BFB5-F225-4C3B-B96E-0AD1951A5630} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{7B0822F6-80DE-4B49-8125-93975678D0D5} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
 		{C41023C9-65C3-4FB3-9053-4DE963A81500} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{7E563BF6-47F2-4531-A1CE-FB9445DF3253} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/createLogPath.sh
+++ b/createLogPath.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-mkdir /var/log/datadog-dotnet
-chmod a+rwx /var/log/datadog-dotnet
+mkdir -p /var/log/datadog/dotnet
+chmod a+rwx /var/log/datadog/dotnet

--- a/createLogPath.sh
+++ b/createLogPath.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+mkdir /var/log/datadog-dotnet
+chmod a+rwx /var/log/datadog-dotnet

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -20,7 +20,7 @@ for pkgtype in $PKGTYPES ; do
         netstandard2.0/ \
         Datadog.Trace.ClrProfiler.Native.so \
         integrations.json \
-        createLogPath.sh
+        $DIR/../createLogPath.sh
 done
 
 gzip -f datadog-dotnet-apm.tar

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -6,6 +6,7 @@ VERSION=1.13.3
 
 mkdir -p $DIR/../deploy/linux
 cp $DIR/../integrations.json $DIR/../src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64/
+cp $DIR/../createLogPath.sh $DIR/../src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64/
 
 cd $DIR/../deploy/linux
 for pkgtype in $PKGTYPES ; do
@@ -20,7 +21,7 @@ for pkgtype in $PKGTYPES ; do
         netstandard2.0/ \
         Datadog.Trace.ClrProfiler.Native.so \
         integrations.json \
-        $DIR/../createLogPath.sh
+        createLogPath.sh
 done
 
 gzip -f datadog-dotnet-apm.tar

--- a/docker/package.sh
+++ b/docker/package.sh
@@ -19,7 +19,8 @@ for pkgtype in $PKGTYPES ; do
         --chdir $DIR/../src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64 \
         netstandard2.0/ \
         Datadog.Trace.ClrProfiler.Native.so \
-        integrations.json
+        integrations.json \
+        createLogPath.sh
 done
 
 gzip -f datadog-dotnet-apm.tar

--- a/docker/with-profiler-logs.bash
+++ b/docker/with-profiler-logs.bash
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euxo pipefail
 
-mkdir -p /var/log/datadog
-touch /var/log/datadog/dotnet-profiler.log
-tail -f /var/log/datadog/dotnet-profiler.log | awk '
+mkdir -p /var/log/datadog/dotnet
+touch /var/log/datadog/dotnet/dotnet-profiler.log
+tail -f /var/log/datadog/dotnet/dotnet-profiler.log | awk '
   /info/ {print "\033[32m" $0 "\033[39m"}
   /warn/ {print "\033[31m" $0 "\033[39m"}
 ' &

--- a/reproductions/AutomapperTest/Dockerfile
+++ b/reproductions/AutomapperTest/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:2.1-stretch-slim AS base
 ARG TRACER_VERSION=1.13.3
 RUN mkdir -p /opt/datadog
-RUN mkdir -p /var/log/datadog
+RUN mkdir -p /var/log/datadog/dotnet
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v$TRACER_VERSION/datadog-dotnet-apm-$TRACER_VERSION.tar.gz | tar xzf - -C /opt/datadog
 
 ENV CORECLR_ENABLE_PROFILING=1

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -57,7 +57,7 @@ const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
 // Sets the path for the profiler's log file.
 // If not set, default is
 // "%ProgramData%"\Datadog .NET Tracer\logs\dotnet-profiler.log" on Windows or
-// "/var/log/datadog/dotnet-profiler.log" on Linux.
+// "/var/log/datadog/dotnet/dotnet-profiler.log" on Linux.
 const WSTRING log_path = "DD_TRACE_LOG_PATH"_W;
 
 // Sets whether to disable all optimizations.

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -42,7 +42,7 @@ inline WSTRING DatadogLogFilePath() {
   return ToWSTRING(program_data +
                    R"(\Datadog .NET Tracer\logs\dotnet-profiler.log)");
 #else
-  return "/var/log/datadog/dotnet-profiler.log"_W;
+  return "/var/log/datadog/dotnet/dotnet-profiler.log"_W;
 #endif
 }
 

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -161,7 +161,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for setting the path to the profiler log file.
         /// Default value is "%ProgramData%"\Datadog .NET Tracer\logs\dotnet-profiler.log" on Windows
-        /// or "/var/log/datadog/dotnet-profiler.log" on Linux.
+        /// or "/var/log/datadog/dotnet/dotnet-profiler.log" on Linux.
         /// </summary>
         public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
 

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Logging
 {
     internal static class DatadogLogging
     {
-        private const string NixDefaultDirectory = "/var/log/datadog/datadog-dotnet";
+        private const string NixDefaultDirectory = "/var/log/datadog/dotnet";
 
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly LogEventLevel MinimumLogEventLevel = LogEventLevel.Information;

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Logging
 {
     internal static class DatadogLogging
     {
-        private const string NixDefaultDirectory = "/var/log/datadog/";
+        private const string NixDefaultDirectory = "/var/log/datadog/datadog-dotnet";
 
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly LogEventLevel MinimumLogEventLevel = LogEventLevel.Information;

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -176,6 +176,19 @@ namespace Datadog.Trace.Logging
                     {
                         logDirectory = NixDefaultDirectory;
                     }
+                    else
+                    {
+                        try
+                        {
+                            var di = Directory.CreateDirectory(NixDefaultDirectory);
+                            logDirectory = NixDefaultDirectory;
+                        }
+                        catch
+                        {
+                            // Unable to create the directory meaning that the user
+                            // will have to create it on their own.
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Improve the Linux user experience with trace logging. As it exists now, the .NET tracer defaults to `/var/log/datadog/` for the location of tracer log files. This is also the directory used by the DD Agent. One of the issues is that the permissions are not set on that directory for a run-of-the-mill application to write to it, and since the tracer runs within the application, the tracer cannot write to it without adequate permissions. 

This PR does a few things:

1. establishes `/var/log/datadog/dotnet` as the default tracer log directory. Having its own subdirectory for logging allows tracer users to set permissions on that directory without affecting the DD Agent. It has the additional benefit of including the tracer logs in an [Agent Flare](https://docs.datadoghq.com/agent/troubleshooting/send_a_flare/?tab=agentv6v7#pagetitle) for troubleshooting purposes.
2. deploys `createLogPath.sh` as part of the Linux packages released for the .NET tracer. This script will create the logging directory path if it does not exist and will set the appropriate permissions for accessing it so that the tracer can write files to the subdirectory.
3. Refactors out the logic to retrieve the log directory in `DatadogLogging` and doesn't call what should have been Windows-specific code when running in non-Windows environments.

In addition, there will be a PR in the `Documentation` repository for these changes.

@DataDog/apm-dotnet