### PR TITLE
Port files

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -142,6 +142,7 @@ namespace Datadog.Trace.Agent
                     await Task.Delay(sleepDuration).ConfigureAwait(false);
                     retryCount++;
                     sleepDuration *= 2;
+                    TracingProcessManager.TraceAgentMetadata.ForcePortFileRead();
                     continue;
                 }
 

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -122,6 +122,7 @@ namespace Datadog.Trace.Logging
             }
             finally
             {
+                Initialized = true;
                 // Log some information to correspond with the app domain
                 SharedLogger.Information(FrameworkDescription.Create().ToString());
 
@@ -153,9 +154,10 @@ namespace Datadog.Trace.Logging
                     ActionsToRunWhenLoggerReady.Enqueue(logAction);
                 }
             }
-            catch
+            catch (Exception ex)
             {
                 // ignored
+                SharedLogger.Error(ex, "Register startup log failed");
             }
         }
 

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace
 
         static Tracer()
         {
-            TracingProcessManager.StartProcesses();
+            TracingProcessManager.Initialize();
             // create the default global Tracer
             Instance = new Tracer();
         }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -336,6 +336,11 @@ namespace Datadog.Trace
 
             public void InitializePortFileWatcher()
             {
+                if (File.Exists(PortFilePath))
+                {
+                    ReadPortAndAlertSubscribers();
+                }
+
                 _portFileWatcher = new FileSystemWatcher
                 {
                     NotifyFilter = NotifyFilters.LastAccess
@@ -350,6 +355,11 @@ namespace Datadog.Trace
             }
 
             private void OnPortFileChanged(object source, FileSystemEventArgs e)
+            {
+                ReadPortAndAlertSubscribers();
+            }
+
+            private void ReadPortAndAlertSubscribers()
             {
                 var portFile = PortFilePath;
                 var portText = File.ReadAllText(portFile);

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace
 
                 if (!Directory.Exists(traceAgentDirectory))
                 {
-                    DatadogLogging.RegisterStartupLog(log => log.Debug("Directory for trace agent does not exist: {0}", traceAgentDirectory));
+                    DatadogLogging.RegisterStartupLog(log => log.Warning("Directory for trace agent does not exist: {0}", traceAgentDirectory));
                     return;
                 }
 

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace
             }
             catch (Exception ex)
             {
-                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Error when attempting to start standalone agent processes."));
+                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Error when attempting to initialize process manager."));
             }
         }
 

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -94,13 +95,15 @@ namespace Datadog.Trace
             try
             {
                 _cancellationTokenSource = new CancellationTokenSource();
-                var currentProcess = Process.GetCurrentProcess();
-                if (AzureTopLevelProcesses.Contains(currentProcess.ProcessName.ToLowerInvariant()))
+                var currentProcessName = Process.GetCurrentProcess().ProcessName.ToLowerInvariant();
+                if (AzureTopLevelProcesses.Any(name => name.Contains(currentProcessName)))
                 {
+                    DatadogLogging.RegisterStartupLog(log => log.Debug("Starting sub processes from top level process."));
                     StartProcesses();
                 }
                 else
                 {
+                    DatadogLogging.RegisterStartupLog(log => log.Debug("Initializing sub process port file watchers."));
                     foreach (var instance in Processes)
                     {
                         instance.InitializePortFileWatcher();

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -116,7 +116,7 @@ namespace Datadog.Trace
                 if (_isProcessManager)
                 {
                     var currentAppDomainName = AppDomain.CurrentDomain.FriendlyName.ToLowerInvariant();
-                    DatadogLogging.RegisterStartupLog(log => log.Debug("Starting sub-processes from top level process {0}, app domain {1}.", _processName, currentAppDomainName));
+                    DatadogLogging.RegisterStartupLog(log => log.Debug("Starting sub-processes from process {0}, app domain {1}.", _processName, currentAppDomainName));
                     StartProcesses();
                 }
                 else

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -15,42 +15,30 @@ namespace Datadog.Trace
 {
     internal class TracingProcessManager
     {
-        private static readonly ProcessMetadata TraceAgentMetadata = new ProcessMetadata()
+        private static readonly HashSet<string> AzureTopLevelProcesses = new HashSet<string>() { "w3wp.exe" };
+
+        private static readonly ProcessMetadata TraceAgentMetadata = new ProcessMetadata
         {
             Name = "datadog-trace-agent",
-            ProcessPathKey = ConfigurationKeys.TraceAgentPath,
-            ProcessArgumentsKey = ConfigurationKeys.TraceAgentArgs,
-            PreStartAction = () =>
+            ProcessPath = Environment.GetEnvironmentVariable(ConfigurationKeys.TraceAgentPath),
+            ProcessArguments = Environment.GetEnvironmentVariable(ConfigurationKeys.TraceAgentArgs),
+            RefreshPortVars = () =>
             {
-                TraceAgentMetadata.Port = GetFreeTcpPort();
-                if (TraceAgentMetadata.Port == null)
-                {
-                    throw new Exception("Unable to secure a port for dogstatsd");
-                }
-
-                var portString = TraceAgentMetadata.Port.ToString();
+                var portString = TraceAgentMetadata.Port?.ToString();
                 Environment.SetEnvironmentVariable(ConfigurationKeys.AgentPort, portString);
                 Environment.SetEnvironmentVariable(ConfigurationKeys.TraceAgentPortKey, portString);
-                DatadogLogging.RegisterStartupLog(log => log.Debug("Attempting to use port {0} for the trace agent.", portString));
             }
         };
 
-        private static readonly ProcessMetadata DogStatsDMetadata = new ProcessMetadata()
+        private static readonly ProcessMetadata DogStatsDMetadata = new ProcessMetadata
         {
             Name = "dogstatsd",
-            ProcessPathKey = ConfigurationKeys.DogStatsDPath,
-            ProcessArgumentsKey = ConfigurationKeys.DogStatsDArgs,
-            PreStartAction = () =>
+            ProcessPath = Environment.GetEnvironmentVariable(ConfigurationKeys.DogStatsDPath),
+            ProcessArguments = Environment.GetEnvironmentVariable(ConfigurationKeys.DogStatsDArgs),
+            RefreshPortVars = () =>
             {
-                DogStatsDMetadata.Port = GetFreeTcpPort();
-                if (DogStatsDMetadata.Port == null)
-                {
-                    throw new Exception("Unable to secure a port for dogstatsd");
-                }
-
-                var portString = DogStatsDMetadata.Port.ToString();
+                var portString = DogStatsDMetadata.Port?.ToString();
                 Environment.SetEnvironmentVariable(StatsdConfig.DD_DOGSTATSD_PORT_ENV_VAR, portString);
-                DatadogLogging.RegisterStartupLog(log => log.Debug("Attempting to use port {0} for dogstatsd.", portString));
             }
         };
 
@@ -99,25 +87,21 @@ namespace Datadog.Trace
             }
         }
 
-        public static void StartProcesses()
+        public static void Initialize()
         {
             try
             {
                 _cancellationTokenSource = new CancellationTokenSource();
-
-                foreach (var subProcessMetadata in Processes)
+                var currentProcess = Process.GetCurrentProcess();
+                if (AzureTopLevelProcesses.Contains(currentProcess.ProcessName.ToLowerInvariant()))
                 {
-                    var processPath = Environment.GetEnvironmentVariable(subProcessMetadata.ProcessPathKey);
-
-                    if (!string.IsNullOrWhiteSpace(processPath))
+                    StartProcesses();
+                }
+                else
+                {
+                    foreach (var instance in Processes)
                     {
-                        var processArgs = Environment.GetEnvironmentVariable(subProcessMetadata.ProcessArgumentsKey);
-                        subProcessMetadata.KeepAliveTask =
-                            StartProcessWithKeepAlive(processPath, processArgs, subProcessMetadata);
-                    }
-                    else
-                    {
-                        DatadogLogging.RegisterStartupLog(log => log.Debug("There is no path configured for {0}.", subProcessMetadata.Name));
+                        instance.InitializePortFileWatcher();
                     }
                 }
             }
@@ -127,10 +111,27 @@ namespace Datadog.Trace
             }
         }
 
+        private static void StartProcesses()
+        {
+            foreach (var metadata in Processes)
+            {
+                if (!string.IsNullOrWhiteSpace(metadata.ProcessPath))
+                {
+                    metadata.KeepAliveTask = StartProcessWithKeepAlive(metadata);
+                }
+                else
+                {
+                    DatadogLogging.RegisterStartupLog(log => log.Debug("There is no path configured for {0}.", metadata.Name));
+                }
+            }
+        }
+
         private static void SafelyKillProcess(ProcessMetadata metadata)
         {
             try
             {
+                metadata.Dispose();
+
                 if (metadata.Process != null && !metadata.Process.HasExited)
                 {
                     metadata.Process.Kill();
@@ -161,9 +162,9 @@ namespace Datadog.Trace
             return false;
         }
 
-        private static Task StartProcessWithKeepAlive(string path, string args, ProcessMetadata metadata)
+        private static Task StartProcessWithKeepAlive(ProcessMetadata metadata)
         {
-            DatadogLogging.RegisterStartupLog(log => log.Debug("Starting keep alive for {0}.", path));
+            DatadogLogging.RegisterStartupLog(log => log.Debug("Starting keep alive for {0}.", metadata.ProcessPath));
 
             return Task.Run(
                 () =>
@@ -177,7 +178,7 @@ namespace Datadog.Trace
                         {
                             if (_cancellationTokenSource.IsCancellationRequested)
                             {
-                                DatadogLogging.RegisterStartupLog(log => log.Debug("Shutdown triggered for keep alive {0}.", path));
+                                DatadogLogging.RegisterStartupLog(log => log.Debug("Shutdown triggered for keep alive {0}.", metadata.ProcessPath));
                                 return;
                             }
 
@@ -185,48 +186,45 @@ namespace Datadog.Trace
                             {
                                 if (metadata.Process != null && metadata.Process.HasExited == false)
                                 {
-                                    DatadogLogging.RegisterStartupLog(log => log.Debug("We already have an active reference to {0}.", path));
+                                    DatadogLogging.RegisterStartupLog(log => log.Debug("We already have an active reference to {0}.", metadata.ProcessPath));
                                     continue;
                                 }
 
-                                if (ProgramIsRunning(path))
+                                if (ProgramIsRunning(metadata.ProcessPath))
                                 {
-                                    DatadogLogging.RegisterStartupLog(log => log.Debug("{0} is already running.", path));
+                                    DatadogLogging.RegisterStartupLog(log => log.Debug("{0} is already running.", metadata.ProcessPath));
                                     continue;
                                 }
 
-                                var startInfo = new ProcessStartInfo { FileName = path };
+                                var startInfo = new ProcessStartInfo { FileName = metadata.ProcessPath };
 
-                                if (!string.IsNullOrWhiteSpace(args))
+                                if (!string.IsNullOrWhiteSpace(metadata.ProcessArguments))
                                 {
-                                    startInfo.Arguments = args;
+                                    startInfo.Arguments = metadata.ProcessArguments;
                                 }
 
-                                DatadogLogging.RegisterStartupLog(log => log.Debug("Starting {0}.", path));
-                                metadata.PreStartAction?.Invoke();
+                                DatadogLogging.RegisterStartupLog(log => log.Debug("Starting {0}.", metadata.ProcessPath));
+                                GrabFreePortForInstance(metadata);
                                 metadata.Process = Process.Start(startInfo);
 
                                 Thread.Sleep(200);
 
                                 if (metadata.Process == null || metadata.Process.HasExited)
                                 {
-                                    DatadogLogging.RegisterStartupLog(log => log.Error("{0} has failed to start.", path));
+                                    DatadogLogging.RegisterStartupLog(log => log.Error("{0} has failed to start.", metadata.ProcessPath));
                                     sequentialFailures++;
                                 }
                                 else
                                 {
-                                    DatadogLogging.RegisterStartupLog(log => log.Debug("Successfully started {0}.", path));
+                                    DatadogLogging.RegisterStartupLog(log => log.Debug("Successfully started {0}.", metadata.ProcessPath));
                                     sequentialFailures = 0;
-                                    foreach (var portSubscriber in metadata.PortSubscribers)
-                                    {
-                                        portSubscriber(metadata.Port.Value);
-                                    }
+                                    metadata.AlertSubscribers();
                                     DatadogLogging.RegisterStartupLog(log => log.Debug("Finished calling port subscribers for {0}.", metadata.Name));
                                 }
                             }
                             catch (Exception ex)
                             {
-                                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Exception when trying to start an instance of {0}.", path));
+                                DatadogLogging.RegisterStartupLog(log => log.Error(ex, "Exception when trying to start an instance of {0}.", metadata.ProcessPath));
                                 sequentialFailures++;
                             }
                             finally
@@ -244,7 +242,7 @@ namespace Datadog.Trace
                     }
                     finally
                     {
-                        DatadogLogging.RegisterStartupLog(log => log.Debug("Keep alive is dropping for {0}.", path));
+                        DatadogLogging.RegisterStartupLog(log => log.Debug("Keep alive is dropping for {0}.", metadata.ProcessPath));
                     }
                 });
         }
@@ -270,23 +268,99 @@ namespace Datadog.Trace
             }
         }
 
-        private class ProcessMetadata
+        private static void GrabFreePortForInstance(ProcessMetadata instance)
         {
+            instance.Port = GetFreeTcpPort();
+            if (instance.Port == null)
+            {
+                throw new Exception($"Unable to secure a port for {instance.Name}");
+            }
+
+            instance.RefreshPortVars();
+            DatadogLogging.RegisterStartupLog(log => log.Debug("Attempting to use port {0} for the {1}.", instance.Port, instance.Name));
+
+            if (instance.PortFilePath != null)
+            {
+                File.WriteAllText(instance.PortFilePath, instance.Port.Value.ToString());
+            }
+        }
+
+        private class ProcessMetadata : IDisposable
+        {
+            private string _processPath;
+            private FileSystemWatcher _portFileWatcher;
+
             public string Name { get; set; }
 
             public Process Process { get; set; }
 
             public Task KeepAliveTask { get; set; }
 
-            public string ProcessPathKey { get; set; }
+            public string PortFilePath { get; private set; }
 
-            public string ProcessArgumentsKey { get; set; }
+            public string ProcessPath
+            {
+                get => _processPath;
+                set
+                {
+                    _processPath = value;
+                    PortFilePath = !string.IsNullOrWhiteSpace(_processPath) ? $"{_processPath}-port" : null;
+                }
+            }
 
-            public Action PreStartAction { get; set; }
+            public string ProcessArguments { get; set; }
+
+            public Action RefreshPortVars { get; set; }
 
             public int? Port { get; set; }
 
             public ConcurrentBag<Action<int>> PortSubscribers { get; } = new ConcurrentBag<Action<int>>();
+
+            public void AlertSubscribers()
+            {
+                if (Port != null)
+                {
+                    foreach (var portSubscriber in PortSubscribers)
+                    {
+                        portSubscriber(Port.Value);
+                    }
+                }
+            }
+
+            public void Dispose()
+            {
+                _portFileWatcher?.Dispose();
+                Process?.Dispose();
+                KeepAliveTask?.Dispose();
+            }
+
+            public void InitializePortFileWatcher()
+            {
+                _portFileWatcher = new FileSystemWatcher
+                {
+                    NotifyFilter = NotifyFilters.LastAccess
+                                 | NotifyFilters.LastWrite,
+                    Path = Path.GetDirectoryName(PortFilePath),
+                    Filter = Path.GetFileName(PortFilePath)
+                };
+
+                _portFileWatcher.Created += OnPortFileChanged;
+                _portFileWatcher.Changed += OnPortFileChanged;
+                _portFileWatcher.EnableRaisingEvents = true;
+            }
+
+            private void OnPortFileChanged(object source, FileSystemEventArgs e)
+            {
+                var portFile = PortFilePath;
+                var portText = File.ReadAllText(portFile);
+                if (int.TryParse(portText, out var portValue))
+                {
+                    Port = portValue;
+                    RefreshPortVars();
+                }
+
+                AlertSubscribers();
+            }
         }
     }
 }


### PR DESCRIPTION
Use a convention based file to store the port for configuring client classes between processes.

![image](https://user-images.githubusercontent.com/1801443/75774854-d6100e80-5d1e-11ea-8f93-ff40eee97e9e.png)

![image](https://user-images.githubusercontent.com/1801443/75774871-e3c59400-5d1e-11ea-9705-cd410dff4fcd.png)

![image](https://user-images.githubusercontent.com/1801443/75774889-ed4efc00-5d1e-11ea-8b6b-bd823e32cbb0.png)


@DataDog/apm-dotnet