### PR TITLE
resource name: allow larger ids in URL segments

### DIFF
--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Util
             }
 
             // remove path segments that look like int or guid (with or without dashes)
-            segment = int.TryParse(segment, out _) ||
+            segment = long.TryParse(segment, out _) ||
                       Guid.TryParseExact(segment, "N", out _) ||
                       Guid.TryParseExact(segment, "D", out _)
                           ? UrlIdPlaceholder

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -14,6 +14,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("users", "users")]
         [InlineData("123/", Id + "/")]
         [InlineData("123", Id)]
+        [InlineData("4294967294/", Id + "/")]
+        [InlineData("4294967294", Id)]
         [InlineData("E653C852-227B-4F0C-9E48-D30D83C68BF3/", Id + "/")]
         [InlineData("E653C852-227B-4F0C-9E48-D30D83C68BF3", Id)]
         [InlineData("E653C852227B4F0C9E48D30D83C68BF3/", Id + "/")]

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("https://example.com/path/123/file.aspx", "example.com/path/" + Id + "/file.aspx")]
         [InlineData("https://example.com/path/123/", "example.com/path/" + Id + "/")]
         [InlineData("https://example.com/path/123", "example.com/path/" + Id)]
+        [InlineData("https://example.com/path/4294967294/file.aspx", "example.com/path/" + Id + "/file.aspx")]
+        [InlineData("https://example.com/path/4294967294/", "example.com/path/" + Id + "/")]
+        [InlineData("https://example.com/path/4294967294", "example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/" + Id)]
         [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/" + Id)]
         public void CleanUri_ResourceName(string uri, string expected)


### PR DESCRIPTION
Try to parse URL path segments as `Int64` instead of `Int32` to allow for larger values when removing IDs from resource names.

For example, for the URL
```
/users/4294967294/edit
```
the resource name should be something like
```
GET /users/?/edit
```
but `4294967294` is too big for `Int32.TryParse()`.