### PR TITLE
Support text map format

### DIFF
--- a/src/Datadog.Trace.OpenTracing/OpenTracingTracer.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingTracer.cs
@@ -22,7 +22,11 @@ namespace Datadog.Trace.OpenTracing
             DatadogTracer = datadogTracer;
             DefaultServiceName = datadogTracer.DefaultServiceName;
             ScopeManager = scopeManager;
-            _codecs = new Dictionary<string, ICodec> { { BuiltinFormats.HttpHeaders.ToString(), new HttpHeadersCodec() } };
+            _codecs = new Dictionary<string, ICodec>
+            {
+                { BuiltinFormats.HttpHeaders.ToString(), new HttpHeadersCodec() },
+                { BuiltinFormats.TextMap.ToString(), new HttpHeadersCodec() } // the HttpHeadersCodec can support an unconstrained ITextMap
+            };
         }
 
         public IDatadogTracer DatadogTracer { get; }

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -161,6 +161,16 @@ namespace Datadog.Trace.OpenTracing.Tests
         }
 
         [Fact]
+        public void Inject_UnknownFormat_Throws()
+        {
+            var span = (OpenTracingSpan)_tracer.BuildSpan("Span").Start();
+            var headers = new MockTextMap();
+            var mockFormat = new Mock<IFormat<ITextMap>>();
+
+            Assert.Throws<NotSupportedException>(() => _tracer.Inject(span.Context, mockFormat.Object, headers));
+        }
+
+        [Fact]
         public void Extract_HttpHeadersFormat_HeadersProperlySet_SpanContext()
         {
             const ulong parentId = 10;
@@ -188,6 +198,19 @@ namespace Datadog.Trace.OpenTracing.Tests
 
             Assert.Equal(parentId, otSpanContext.Context.SpanId);
             Assert.Equal(traceId, otSpanContext.Context.TraceId);
+        }
+
+        [Fact]
+        public void Extract_UnknownFormat_Throws()
+        {
+            const ulong parentId = 10;
+            const ulong traceId = 42;
+            var headers = new MockTextMap();
+            headers.Set(HttpHeaderNames.ParentId, parentId.ToString());
+            headers.Set(HttpHeaderNames.TraceId, traceId.ToString());
+            var mockFormat = new Mock<IFormat<ITextMap>>();
+
+            Assert.Throws<NotSupportedException>(() => _tracer.Extract(mockFormat.Object, headers));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #514 

Changes proposed in this pull request:

Using the `HttpHeadersCodec` to support `BuiltinFormats.TextMap`.  

As explained in the [documentation for the `OpenTracing` library](https://github.com/opentracing/opentracing-csharp/blob/461c6edd7b4209fe353eea7b927dd7046986e2b8/src/OpenTracing/Propagation/BuiltinFormats.cs#L7-L28), the difference between the two formats is that data written in the HttpHeaders format has to, naturally, work in an HTTP header.  TextMap format, on the other hand, has no constraints on the data.  Therefore, the `HttpHeadersCodec` should satisfy both use cases just fine.

`BuiltinFormats.HttpHeaders`
> keys written to the ITextMap MUST be suitable for HTTP header keys (which are poorly defined but certainly restricted); and similarly for values (i.e., URL-escaped and "not too long").

`BuiltinFormat.TextMap`
> the builtin 'TextMap' format expresses no constraints on keys or values.

@DataDog/apm-dotnet