### PR TITLE
remove package feed dependency from CI builds

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -10,7 +10,6 @@ pr:
 
 variables:
   buildConfiguration: Debug
-  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
 jobs:
@@ -154,7 +153,6 @@ jobs:
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.sln
-      vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
   - task: DotNetCoreCLI@2

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -6,7 +6,6 @@ pr: none
 
 variables:
   buildConfiguration: release
-  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
   dotnetCoreSdkVersion: 3.1.x
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
@@ -44,7 +43,6 @@ jobs:
     displayName: nuget restore native
     inputs:
       restoreSolution: Datadog.Trace.Native.sln
-      vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
   - task: DotNetCoreCLI@2
@@ -52,7 +50,6 @@ jobs:
     inputs:
       command: restore
       projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -127,7 +124,6 @@ jobs:
     inputs:
       command: restore
       projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -180,7 +176,6 @@ jobs:
     inputs:
       command: restore
       projects: src/**/*.csproj
-      vstsFeed: $(packageFeed)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -11,7 +11,6 @@ trigger:
 
 variables:
   buildConfiguration: Debug
-  packageFeed: /ffc32c57-3e0e-4e8f-8633-a7ad01df2e45
 
 jobs:
 
@@ -52,7 +51,6 @@ jobs:
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj
-      vstsFeed: $(packageFeed)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -102,7 +100,6 @@ jobs:
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.Native.sln
-      vstsFeed: $(packageFeed)
       verbosityRestore: Normal
 
   - task: MSBuild@1


### PR DESCRIPTION
This PR removes the NuGet package feed we use in CI builds
- all the package we have here come from nuget.org, these feed feature is really meant for hosting our own packages
- it's a legacy "org scope" feed, new feeds on public projects are always project -scoped
- it causes community PR builds to fail due to authentication issues

If we need to bring feeds back, we should create a new project-scope feed (which may or may not fix the authentication issue on community PR builds).