### PR TITLE
Reduce number of heap allocations per trace

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Agent
             _client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
         }
 
-        public async Task SendTracesAsync(IList<List<Span>> traces)
+        public async Task SendTracesAsync(Span[][] traces)
         {
             // retry up to 5 times with exponential back-off
             var retryLimit = 5;
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Agent
                     var traceIds = GetUniqueTraceIds(traces);
 
                     // re-create content on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
-                    using (var content = new MsgPackContent<IList<List<Span>>>(traces, SerializationContext))
+                    using (var content = new MsgPackContent<Span[][]>(traces, SerializationContext))
                     {
                         content.Headers.Add(AgentHttpHeaderNames.TraceCount, traceIds.Count.ToString());
 
@@ -167,7 +167,7 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        private static HashSet<ulong> GetUniqueTraceIds(IList<List<Span>> traces)
+        private static HashSet<ulong> GetUniqueTraceIds(Span[][] traces)
         {
             var uniqueTraceIds = new HashSet<ulong>();
 

--- a/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -1,11 +1,10 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
     internal interface IAgentWriter
     {
-        void WriteTrace(List<Span> trace);
+        void WriteTrace(Span[] trace);
 
         Task FlushAndCloseAsync();
 

--- a/src/Datadog.Trace/Agent/IApi.cs
+++ b/src/Datadog.Trace/Agent/IApi.cs
@@ -1,10 +1,9 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
     internal interface IApi
     {
-        Task SendTracesAsync(IList<List<Span>> traces);
+        Task SendTracesAsync(Span[][] traces);
     }
 }

--- a/src/Datadog.Trace/IDatadogTracer.cs
+++ b/src/Datadog.Trace/IDatadogTracer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 
@@ -21,7 +20,7 @@ namespace Datadog.Trace
 
         Span StartSpan(string operationName, ISpanContext parent, string serviceName, DateTimeOffset? startTime, bool ignoreActiveScope);
 
-        void Write(List<Span> span);
+        void Write(Span[] span);
 
         /// <summary>
         /// Make a span the active span and return its new scope.

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -113,7 +113,7 @@ namespace Datadog.Trace
             sb.AppendLine($"Error: {Error}");
             sb.AppendLine("Meta:");
 
-            if (_tags != null)
+            if (_tags?.Count > 0)
             {
                 foreach (var kv in _tags)
                 {
@@ -123,7 +123,7 @@ namespace Datadog.Trace
 
             sb.AppendLine("Metrics:");
 
-            if (_metrics != null && _metrics.Count > 0)
+            if (_metrics?.Count > 0)
             {
                 foreach (var kv in _metrics)
                 {
@@ -356,10 +356,7 @@ namespace Datadog.Trace
         {
             if (value == null)
             {
-                if (_metrics != null)
-                {
-                    _metrics.TryRemove(key, out _);
-                }
+                _metrics?.TryRemove(key, out _);
             }
             else
             {

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace
                 }
             }
 
-            List<Span> spansToWrite = null;
+            Span[] spansToWrite = null;
 
             lock (_lock)
             {
@@ -106,8 +106,8 @@ namespace Datadog.Trace
 
                 if (_openSpans == 0)
                 {
-                    spansToWrite = _spans;
-                    _spans = new List<Span>();
+                    spansToWrite = _spans.ToArray();
+                    _spans.Clear();
                 }
             }
 

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -10,11 +10,10 @@ namespace Datadog.Trace
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<TraceContext>();
 
-        private readonly object _lock = new object();
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
         private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private readonly List<Span> _spans = new List<Span>();
 
-        private List<Span> _spans = new List<Span>();
         private int _openSpans;
         private SamplingPriority? _samplingPriority;
         private bool _samplingPriorityLocked;
@@ -49,7 +48,7 @@ namespace Datadog.Trace
 
         public void AddSpan(Span span)
         {
-            lock (_lock)
+            lock (_spans)
             {
                 if (RootSpan == null)
                 {
@@ -100,7 +99,7 @@ namespace Datadog.Trace
 
             Span[] spansToWrite = null;
 
-            lock (_lock)
+            lock (_spans)
             {
                 _openSpans--;
 

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -9,7 +9,6 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
-using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -353,7 +352,7 @@ namespace Datadog.Trace
         /// Writes the specified <see cref="Span"/> collection to the agent writer.
         /// </summary>
         /// <param name="trace">The <see cref="Span"/> collection to write.</param>
-        void IDatadogTracer.Write(List<Span> trace)
+        void IDatadogTracer.Write(Span[] trace)
         {
             _agentWriter.WriteTrace(trace);
         }

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
@@ -31,15 +30,15 @@ namespace Datadog.Trace.Tests
         public async Task WriteTrace_2Traces_SendToApi()
         {
             // TODO:bertrand it is too complicated to setup such a simple test
-            var trace = new List<Span> { new Span(_spanContext, start: null) };
+            var trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
             await Task.Delay(TimeSpan.FromSeconds(2));
-            _api.Verify(x => x.SendTracesAsync(It.Is<List<List<Span>>>(y => y.Single().Equals(trace))), Times.Once);
+            _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
 
-            trace = new List<Span> { new Span(_spanContext, start: null) };
+            trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
             await Task.Delay(TimeSpan.FromSeconds(2));
-            _api.Verify(x => x.SendTracesAsync(It.Is<List<List<Span>>>(y => y.Single().Equals(trace))), Times.Once);
+            _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests
             var api = new Api(new Uri("http://localhost:1234"), handler, statsd: null);
 
             var span = _tracer.StartSpan("Operation");
-            var traces = new List<List<Span>> { new List<Span> { span } };
+            var traces = new[] { new[] { span } };
             await api.SendTracesAsync(traces);
 
             Assert.Equal(1, handler.RequestsCount);
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests
             var sw = new Stopwatch();
             sw.Start();
             var span = _tracer.StartSpan("Operation");
-            var traces = new List<List<Span>> { new List<Span> { span } };
+            var traces = new[] { new[] { span } };
             await api.SendTracesAsync(traces);
             sw.Stop();
 

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,7 +38,7 @@ namespace Datadog.Trace.Tests
 
             span.SetTag(key, value);
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<List<Span>>()), Times.Never);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<Span[]>()), Times.Never);
             Assert.Equal(span.GetTag(key), value);
         }
 
@@ -62,7 +61,7 @@ namespace Datadog.Trace.Tests
             await Task.Delay(TimeSpan.FromMilliseconds(1));
             span.Finish();
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<List<Span>>()), Times.Once);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<Span[]>()), Times.Once);
             Assert.True(span.Duration > TimeSpan.Zero);
         }
 


### PR DESCRIPTION
## Changes

This PR reduces the number of heap allocation we make for every trace and every span. See #634.

- refactor most uses of `List<Span>` to `Span[]` (and the one `IList<List<Span>>` into `Span[][]` so we're not fooled into using `List<T>.Add()` which will allocate a new internal array and copy items over every time it needs to double in size
- allocate and reuse a single `T` array using the buffer's max size in `AgentWriterBuffer` and keep track of count ourselves
  - avoids creating a new `List<T>` every time time we flush the buffer to the Agent (every second by default)
  - avoids the internal `T[]` allocations every the time the buffer needs to double in size
- use `Dictionary` (and locks) instead of `ConcurrentDictionary` for `Span.Tags` and `Span.Metrics`
- defer the creation of aforementioned `Dictionary` in `Span.Tags` and `Span.Metrics` until they are needed (in most cases we can avoid allocating one of them entirely)

## Benchmarks

### GC metrics

Average overhead (values with tracer enabled vs baseline values with tracer disabled) of ASP.NET Core 3.1 app with 300 requests per second. Mix of traces with 1 span per trace and 10 spans per trace. Left column is current release (1.15.0), right column has the changes in this PR.

![image](https://user-images.githubusercontent.com/1851278/77961798-6acb4500-72a8-11ea-8ee5-d1fbe987a984.png)

### BenchmarkDotNet
These are benchmark tests which create a single trace with the specified number of spans, and pushes them through to the Agent (i.e. they do through the MsgPack serializer). The memory allocated when from from about 2KB per span to about half, 1KB per span.

| Spans | Release 1.15.0 |   Latest |
|------ |---------------:|---------:|
|     1 |        2.83 KB |  1.84 KB |
|     5 |       10.76 KB |   5.7 KB |
|    10 |       20.71 KB | 10.58 KB |
|    20 |       40.88 KB | 20.59 KB |
|    40 |       81.24 KB | 40.64 KB |
