### PR TITLE
Publish artifacts to S3 in packaging build

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -244,13 +244,13 @@ jobs:
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-  - script: aws s3 cp linux-packages s3://datadog-reliability-env/dotnet/ --recursive
+  - script: aws s3 cp $(Pipeline.Workspace)/linux-packages s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb package to s3
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
-  - script: aws s3 cp windows-msi-x64 s3://datadog-reliability-env/dotnet/ --recursive
+  - script: aws s3 cp $(Pipeline.Workspace)/windows-msi-x64 s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload MSI to s3
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -1,6 +1,7 @@
 trigger:
   branches:
     include:
+      - master
       - refs/tags/*
 pr: none
 
@@ -211,3 +212,46 @@ jobs:
     inputs:
       artifactName: linux-alpine-packages
       targetPath: deploy/linux
+
+- job: s3_upload
+
+  dependsOn:
+    - nuget_and_windows_msi_and_home
+    - linux_packages
+
+  pool:
+    vmImage: ubuntu-16.04
+
+  steps:
+  - download: current
+    artifact: windows-msi-x64
+    patterns: '**/*x64.msi'
+
+  - download: current
+    artifact: linux-packages
+    patterns: '**/*amd64.deb'
+
+  - script: sudo apt-get install -y awscli
+    displayName: Install AWS CLI
+
+  - script: aws configure set aws_access_key_id $SECRET
+    displayName: Authenticate aws_access_key_id
+    env:
+      SECRET: $(AWS_ACCESS_KEY_ID)
+
+  - script: aws configure set aws_secret_access_key $SECRET
+    displayName: Authenticate aws_secret_access_key
+    env:
+      SECRET: $(AWS_SECRET_ACCESS_KEY)
+
+  - script: aws s3 cp linux-packages s3://datadog-reliability-env/dotnet/ --recursive
+    displayName: Upload deb package to s3
+    env:
+      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+
+  - script: aws s3 cp windows-msi-x64 s3://datadog-reliability-env/dotnet/ --recursive
+    displayName: Upload MSI to s3
+    env:
+      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -256,11 +256,11 @@ jobs:
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-  - script: aws s3 cp index.txt s3://datadog-reliability-env/dotnet/index.txt
-    displayName: Upload index.txt to s3
-
   - script: aws s3 cp $(Pipeline.Workspace)/linux-packages s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb package to s3
 
   - script: aws s3 cp $(Pipeline.Workspace)/windows-msi-x64 s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload MSI to s3
+
+  - script: aws s3 cp index.txt s3://datadog-reliability-env/dotnet/index.txt
+    displayName: Upload index.txt to s3

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -243,9 +243,6 @@ jobs:
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
     displayName: Write index.txt
 
-  - script: cat index.txt
-    displayName: cat index.txt
-
   - script: sudo apt-get install -y awscli
     displayName: Install AWS CLI
 
@@ -261,18 +258,9 @@ jobs:
 
   - script: aws s3 cp index.txt s3://datadog-reliability-env/dotnet/index.txt
     displayName: Upload index.txt to s3
-    env:
-      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
   - script: aws s3 cp $(Pipeline.Workspace)/linux-packages s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb package to s3
-    env:
-      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
   - script: aws s3 cp $(Pipeline.Workspace)/windows-msi-x64 s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload MSI to s3
-    env:
-      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
-      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -236,10 +236,11 @@ jobs:
     displayName: Rename deb package to use dashes
 
   - script: |
-      echo $(GitVersion.BranchName) >> index.txt
-      echo $(GitVersion.Sha) >> index.txt
-      pushd $(Pipeline.Workspace)/linux-packages && name=$(ls *.deb) && echo "${name::-9}*" >> index.txt && popd
-      git show -s --format='%ae' $(GitVersion.Sha) >> index.txt
+      INDEX_FILE=$(pwd)/index.txt
+      echo $(GitVersion.BranchName) >> $INDEX_FILE
+      echo $(GitVersion.Sha) >> $INDEX_FILE
+      pushd $(Pipeline.Workspace)/linux-packages && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
+      git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
     displayName: Write index.txt
 
   - script: cat index.txt

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -231,6 +231,16 @@ jobs:
     artifact: linux-packages
     patterns: '**/*amd64.deb'
 
+  - script: |
+      echo $(GitVersion.BranchName) >> index.txt
+      echo $(GitVersion.Sha) >> index.txt;
+      echo datadog-dotnet-apm-$(GitVersion.MajorMinorPatch)* >> index.txt
+      git show -s --format='%ae' $(GitVersion.Sha) >> index.txt
+    displayName: Write index.txt
+
+  - script: cat index.txt
+    displayName: cat index.txt
+
   - script: sudo apt-get install -y awscli
     displayName: Install AWS CLI
 
@@ -243,6 +253,12 @@ jobs:
     displayName: Authenticate aws_secret_access_key
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
+
+  - script: aws s3 cp index.txt s3://datadog-reliability-env/dotnet/index.txt
+    displayName: Upload index.txt to s3
+    env:
+      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
   - script: aws s3 cp $(Pipeline.Workspace)/linux-packages s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb package to s3

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -237,8 +237,8 @@ jobs:
 
   - script: |
       echo $(GitVersion.BranchName) >> index.txt
-      echo $(GitVersion.Sha) >> index.txt;
-      echo datadog-dotnet-apm-$(GitVersion.MajorMinorPatch)* >> index.txt
+      echo $(GitVersion.Sha) >> index.txt
+      pushd $(Pipeline.Workspace)/linux-packages && name=$(ls *.deb) && echo "${name::-9}*" >> index.txt && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> index.txt
     displayName: Write index.txt
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -209,6 +209,7 @@ jobs:
       targetPath: deploy/linux
 
 - job: s3_upload
+  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
 
   dependsOn:
     - nuget_and_windows_msi_and_home

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -232,6 +232,10 @@ jobs:
     patterns: '**/*amd64.deb'
 
   - script: |
+      rename 's/_/-/g' $(Pipeline.Workspace)/linux-packages/*.deb -v
+    displayName: Rename deb package to use dashes
+
+  - script: |
       echo $(GitVersion.BranchName) >> index.txt
       echo $(GitVersion.Sha) >> index.txt;
       echo datadog-dotnet-apm-$(GitVersion.MajorMinorPatch)* >> index.txt

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -29,11 +29,6 @@ jobs:
 
   steps:
 
-  - task: gittools.gitversion.gitversion-task.GitVersion@4
-    displayName: GitVersion
-    inputs:
-      preferBundledVersion: false
-
   - task: UseDotNet@2
     displayName: install dotnet core sdk
     inputs:
@@ -223,6 +218,11 @@ jobs:
     vmImage: ubuntu-16.04
 
   steps:
+  - task: GitVersion@5
+    displayName: GitVersion
+    inputs:
+      preferBundledVersion: false
+
   - download: current
     artifact: windows-msi-x64
     patterns: '**/*x64.msi'


### PR DESCRIPTION
Improve the `packaging` Azure DevOps pipeline for building/deploying/testing master:
- Run the `packaging` pipeline on each commit to master
- Upload the following files to s3 for testing:
  - `datadog-dotnet-apm-${MAJOR_MINOR_PATCH_WITH_PRERELEASE}-x64.msi`
  - `datadog-dotnet-apm-${MAJOR_MINOR_PATCH}-amd64.deb`
  - `index.txt` that has supplementary information about the latest commit

The `index.txt` file contains the branch, SHA, filename (or wildcard) for installing, and the author:
```
zach/reliability-env/packaging
4f7ebb128af5b1ec5dea07c31e73ab2dd73cfded
datadog-dotnet-apm-1.15.0-*
zach.montoya@datadoghq.com
```

@DataDog/apm-dotnet