### PR TITLE
Add CLR Profiler variable to override instrumentation behavior on domain-neutral assemblies

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -210,6 +210,12 @@ jobs:
       msbuildArguments: '/t:BuildFrameworkReproductions'
       maximumCpuCount: true
 
+  - powershell: |
+      [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
+      $publish = New-Object System.EnterpriseServices.Internal.Publish
+      Get-ChildItem $(publishOutput)/net45 -Filter *.dll | Foreach-Object { $publish.GacInstall($_.FullName) }
+    displayName: Add net45 Datadog.Trace.ClrProfiler.Managed assets to the GAC
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build integration tests
     inputs:

--- a/samples/Samples.HttpMessageHandler/Program.cs
+++ b/samples/Samples.HttpMessageHandler/Program.cs
@@ -18,6 +18,9 @@ namespace Samples.HttpMessageHandler
 
         private static string Url;
 
+#if NETFRAMEWORK
+        [LoaderOptimization(LoaderOptimization.MultiDomainHost)]
+#endif
         public static void Main(string[] args)
         {
             bool tracingDisabled = args.Any(arg => arg.Equals("TracingDisabled", StringComparison.OrdinalIgnoreCase));

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -790,8 +790,9 @@ HRESULT CorProfiler::ProcessReplacementCalls(
           method_replacement.wrapper_method.assembly.name == "Datadog.Trace.ClrProfiler.Managed"_W) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement "
-            "found but the managed profiler has not yet been loaded. "
-            "function_id=", function_id, " token=", function_token,
+            "found but the managed profiler has not yet been loaded "
+            "into AppDomain with id=", module_metadata->app_domain_id,
+            " function_id=", function_id, " token=", function_token,
             " caller_name=", caller.type.name, ".", caller.name, "()",
             " target_name=", target.type.name, ".", target.name, "()");
         continue;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -174,8 +174,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
          "=", domain_neutral_instrumentation);
     Info("Enabling automatic instrumentation of methods called from domain-neutral assemblies. ",
          "Please ensure that there is only one AppDomain or, if applications are being hosted in IIS, ",
-         "ensure that all Application Pools only have one application. ",
-         "Otherwise, a FileNotFound exception may occur.");
+         "ensure that all Application Pools have at most one application each. ",
+         "Otherwise, a sharing violation (HRESULT 0x80131401) may occur.");
     instrument_domain_neutral_assemblies = true;
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -91,6 +91,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
                      environment::service_name,
                      environment::disabled_integrations,
                      environment::clr_disable_optimizations,
+                     environment::domain_neutral_instrumentation,
                      environment::azure_app_services,
                      environment::azure_app_services_app_pool_id,
                      environment::azure_app_services_cli_telemetry_profile_value};
@@ -163,6 +164,19 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   if (DisableOptimizations()) {
     Info("Disabling all code optimizations.");
     event_mask |= COR_PRF_DISABLE_OPTIMIZATIONS;
+  }
+
+  const WSTRING domain_neutral_instrumentation =
+      GetEnvironmentValue(environment::domain_neutral_instrumentation);
+
+  if (domain_neutral_instrumentation == "1"_W || domain_neutral_instrumentation == "true"_W) {
+    Info("Detected environment variable ", environment::domain_neutral_instrumentation,
+         "=", domain_neutral_instrumentation);
+    Info("Enabling automatic instrumentation of methods called from domain-neutral assemblies. ",
+         "Please ensure that there is only one AppDomain or, if applications are being hosted in IIS, ",
+         "ensure that all Application Pools only have one application. ",
+         "Otherwise, a FileNotFound exception may occur.");
+    instrument_domain_neutral_assemblies = true;
   }
 
   // set event mask to subscribe to events and disable NGEN images
@@ -784,10 +798,12 @@ HRESULT CorProfiler::ProcessReplacementCalls(
       }
 
       // At this point we know we've hit a match. Error out if
-      //   1) The target assembly is Datadog.Trace.ClrProfiler.Managed
-      //   2) The calling assembly is domain-neutral
+      //   1) The calling assembly is domain-neutral
+      //   2) The profiler is not configured to instrument domain-neutral assemblies
+      //   3) The target assembly is Datadog.Trace.ClrProfiler.Managed
       if (runtime_information_.is_desktop() && corlib_module_loaded &&
           module_metadata->app_domain_id == corlib_app_domain_id &&
+          !instrument_domain_neutral_assemblies &&
           method_replacement.wrapper_method.assembly.name == "Datadog.Trace.ClrProfiler.Managed"_W) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement",

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -25,6 +25,7 @@ class CorProfiler : public CorProfilerBase {
   // Startup helper variables
   bool first_jit_compilation_completed = false;
 
+  bool instrument_domain_neutral_assemblies = false;
   bool corlib_module_loaded = false;
   AppDomainID corlib_app_domain_id;
   bool managed_profiler_loaded_domain_neutral = false;

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -67,13 +67,13 @@ const WSTRING log_path = "DD_TRACE_LOG_PATH"_W;
 // https://github.com/dotnet/coreclr/issues/12468
 const WSTRING clr_disable_optimizations = "DD_CLR_DISABLE_OPTIMIZATIONS"_W;
 
-// Sets whether to intercept method calls when the caller metohd is inside a
+// Sets whether to intercept method calls when the caller method is inside a
 // domain-neutral assembly. This is dangerous because the integration assembly
 // Datadog.Trace.ClrProfiler.Managed.dll must also be loaded domain-neutral,
-// otherwise a FileNotFound exception will occur. This setting should only be
+// otherwise a sharing violation (HRESULT 0x80131401) may occur. This setting should only be
 // enabled when there is only one AppDomain or, when hosting applications in IIS,
-// the user can guarantee that all Application Pools on the system only have one
-// application.
+// the user can guarantee that all Application Pools on the system have at most
+// one application.
 // Default is false.
 // https://github.com/DataDog/dd-trace-dotnet/pull/671
 const WSTRING domain_neutral_instrumentation = "DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION"_W;

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -67,6 +67,17 @@ const WSTRING log_path = "DD_TRACE_LOG_PATH"_W;
 // https://github.com/dotnet/coreclr/issues/12468
 const WSTRING clr_disable_optimizations = "DD_CLR_DISABLE_OPTIMIZATIONS"_W;
 
+// Sets whether to intercept method calls when the caller metohd is inside a
+// domain-neutral assembly. This is dangerous because the integration assembly
+// Datadog.Trace.ClrProfiler.Managed.dll must also be loaded domain-neutral,
+// otherwise a FileNotFound exception will occur. This setting should only be
+// enabled when there is only one AppDomain or, when hosting applications in IIS,
+// the user can guarantee that all Application Pools on the system only have one
+// application.
+// Default is false.
+// https://github.com/DataDog/dd-trace-dotnet/pull/671
+const WSTRING domain_neutral_instrumentation = "DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION"_W;
+
 // Indicates whether the profiler is running in the context
 // of Azure App Services
 const WSTRING azure_app_services = "DD_AZURE_APP_SERVICES"_W;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public HttpClientTests(ITestOutputHelper output)
             : base("HttpMessageHandler", output)
         {
+            SetEnvironmentVariable("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION", "true");
         }
 
         [Fact]
@@ -33,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.WaitForSpans(1);
-                Assert.True(spans.Count > 0, "expected at least one span");
+                Assert.True(spans.Count > 0, "expected at least one span." + System.Environment.NewLine + "IMPORTANT: Make sure Datadog.Trace.ClrProfiler.Managed.dll and its dependencies are in the GAC.");
 
                 var traceId = GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                 var parentSpanId = GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
@@ -90,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.WaitForSpans(1);
-                Assert.True(spans.Count > 0, "expected at least one span");
+                Assert.True(spans.Count > 0, "expected at least one span." + System.Environment.NewLine + "IMPORTANT: Make sure Datadog.Trace.ClrProfiler.Managed.dll and its dependencies are in the GAC.");
 
                 var traceId = GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                 var parentSpanId = GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.TestHelpers
                 catch (HttpListenerException) when (retries > 0)
                 {
                     // only catch the exception if there are retries left
-                    port++;
+                    port = TcpPortProvider.GetOpenPort();
                     retries--;
                 }
 


### PR DESCRIPTION
Add new CLR Profiler environment variable `DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` to override the default instrumentation behavior introduced in https://github.com/DataDog/dd-trace-dotnet/pull/671.

The default behavior refuses to instrument a method call inside a domain-neutral assembly, which completely avoids the scenario that can cause a `FileLoadException` seen in https://github.com/DataDog/dd-trace-dotnet/issues/592. However, as noted in the original PR, this can cause some callsites for the HttpMessageHandler, WebClient, and WCF integrations to not be instrumented when the application is hosted in IIS. As a temporary measure to receive the same spans before upgrading to .NET Tracer v1.14.2, this new environment variable can safely be set under one condition: **all IIS Application Pools on the machine have at most one application.**

Additional changes in this PR include:
- Test the `DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` flag by:
  - Modifying Samples.HttpMessageHandler to use `LoaderOptimization.MultiDomainHost` when run on .NET Framework. This simulates IIS where Framework assemblies in the GAC are loaded in domain-neutral.
  - Injecting the environment variable into the Samples.HttpMessageHandler integration test case
  - Adding `Datadog.Trace.ClrProfiler.Managed.dll` and its dependencies to the GAC before executing the integration tests
- Small fix in `MockTracerAgent` to always get the next port from the `TcpPortProvider` instead of incrementing the port number by 1



@DataDog/apm-dotnet