### PR TITLE
Fix assembly and nuget metadata

### DIFF
--- a/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -6,7 +6,7 @@
     <!-- NuGet -->
     <Version>1.15.1-prerelease</Version>
     <Title>Datadog APM Tracing for ASP.NET</Title>
-    <Description>
+    <PackageDescription>
 DEPRECATED. This package exists only for backwards compatibility. If your project references this package ("Datadog.Trace.AspNet") or "Datadog.Trace.ClrProfiler.Managed", you can remove them both.
 
 .NET Core applications no longer require any NuGet package to enable automatic instrumentation.
@@ -14,7 +14,7 @@ DEPRECATED. This package exists only for backwards compatibility. If your projec
 Automatic instrumentation for both ASP.NET and ASP.NET Core is now automatically enabled.
 
 Users who need manual instrumentation should reference the "Datadog.Trace" package.
-    </Description>
+    </PackageDescription>
     <!-- Allow the GenerateAssemblyInfo task in the .NET SDK to generate all
          assembly attributes except for the AssemblyVersionAttribute. This will
          be locked at Major.0.0.0 and is defined in AssemblyInfo.cs -->

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -15,7 +15,6 @@ Automatic instrumentation for both ASP.NET and ASP.NET Core is now automatically
 
 Users who need manual instrumentation should reference the "Datadog.Trace" package.
     </PackageDescription>
-    <Authors>lucas.pimentel.datadog;colinhigginsdatadog;zachmontoyadd</Authors>
 
     <!-- Remove the Datadog.Trace.ClrProfiler.Managed.dll assembly from the output and hide inapplicable warning (https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) -->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -6,7 +6,7 @@
     <!-- NuGet -->
     <Version>1.15.1-prerelease</Version>
     <Title>Datadog APM - ClrProfiler</Title>
-    <Description>
+    <PackageDescription>
 DEPRECATED. This package exists only for backwards compatibility. If your project references this package ("Datadog.Trace.ClrProfiler.Managed") or "Datadog.Trace.AspNet", you can remove them both.
 
 .NET Core applications no longer require any NuGet package to enable automatic instrumentation.
@@ -14,7 +14,7 @@ DEPRECATED. This package exists only for backwards compatibility. If your projec
 Automatic instrumentation for both ASP.NET and ASP.NET Core is now automatically enabled.
 
 Users who need manual instrumentation should reference the "Datadog.Trace" package.
-    </Description>
+    </PackageDescription>
     <Authors>lucas.pimentel.datadog;colinhigginsdatadog;zachmontoyadd</Authors>
 
     <!-- Remove the Datadog.Trace.ClrProfiler.Managed.dll assembly from the output and hide inapplicable warning (https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128) -->

--- a/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -5,7 +5,6 @@
     <Version>1.15.1-prerelease</Version>
     <Title>Datadog APM - OpenTracing</Title>
     <Description>Provides OpenTracing support for Datadog APM</Description>
-    <Authors>lucas.pimentel.datadog;colinhigginsdatadog;zachmontoyadd</Authors>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>
   </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
     <PackageTags>Datadog;APM;tracing;profiling;instrumentation</PackageTags>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/DataDog/dd-trace-dotnet.git</RepositoryUrl>
-    <Copyright>Datadog, Inc. 2017-2019</Copyright>
+    <Copyright>Datadog, Inc. 2017-2020</Copyright>
     <Company>Datadog</Company>
     <Authors>lucas.pimentel.datadog;colinhigginsdatadog;zachmontoyadd;bobuva</Authors>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,6 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/DataDog/dd-trace-dotnet.git</RepositoryUrl>
     <Copyright>Datadog, Inc. 2017-2019</Copyright>
+    <Company>Datadog</Company>
     <Authors>lucas.pimentel.datadog;colinhigginsdatadog;zachmontoyadd;bobuva</Authors>
   </PropertyGroup>
 


### PR DESCRIPTION
- use `<PackageDescription>` instead of `<Description>` when we want the text to go into the nuget package but not into the assembly attribute
- add `<Company>` for assembly company attribute (otherwise `<Authors>` is used)
- remove `<Authors>` from specific projects so they use the shared properties (which include @bobuva!)
- fix dates in `<Copyright>`

