### PR TITLE
S3 Upload: Rename deb package to include prerelease version

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -250,6 +250,7 @@ jobs:
       echo $(GitVersion.Sha) >> $INDEX_FILE
       pushd s3_upload && name=$(ls *.deb) && echo "${name::-7}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
+      cat $INDEX_FILE
     displayName: Write index.txt
 
   - script: sudo apt-get install -y awscli
@@ -265,5 +266,5 @@ jobs:
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-  - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
+  - script: aws s3 cp --dryrun s3_upload s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb, MSI, index.txt to s3

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -266,3 +266,6 @@ jobs:
     displayName: Authenticate aws_secret_access_key
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
+
+  - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
+    displayName: Upload deb, MSI, index.txt to s3

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -239,9 +239,9 @@ jobs:
     displayName: Move deb package and MSI to s3_upload folder
 
   - script: |
-      MSI_NAME=$(ls s3_upload/windows-msi-x64/*.msi)
+      MSI_NAME=$(ls s3_upload/*.msi)
       PACKAGE_NAME=${MSI_NAME::-4}
-      mv $(Pipeline.Workspace)/linux-packages/*.deb $PACKAGE_NAME.deb
+      mv s3_upload/*.deb $PACKAGE_NAME.deb
     displayName: Rename deb package name to match MSI name
 
   - script: |

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -250,8 +250,6 @@ jobs:
       echo $(GitVersion.Sha) >> $INDEX_FILE
       pushd s3_upload && name=$(ls *.deb) && echo "${name::-7}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
-      cat $INDEX_FILE
-      ls -l s3_upload
     displayName: Write index.txt
 
   - script: sudo apt-get install -y awscli

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -242,7 +242,7 @@ jobs:
       INDEX_FILE=$(pwd)/index.txt
       echo $(GitVersion.BranchName) >> $INDEX_FILE
       echo $(GitVersion.Sha) >> $INDEX_FILE
-      echo "${PACKAGE_NAME}*" >> $INDEX_FILE
+      pushd $(Pipeline.Workspace)/linux-packages && name=$(ls *.deb) && echo "${name::-3}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
       cat $INDEX_FILE
       ls -l $(Pipeline.Workspace)/linux-packages/

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -250,7 +250,6 @@ jobs:
       echo $(GitVersion.Sha) >> $INDEX_FILE
       pushd s3_upload && name=$(ls *.deb) && echo "${name::-7}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
-      cat $INDEX_FILE
     displayName: Write index.txt
 
   - script: sudo apt-get install -y awscli
@@ -266,5 +265,5 @@ jobs:
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-  - script: aws s3 cp --dryrun s3_upload s3://datadog-reliability-env/dotnet/ --recursive
+  - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb, MSI, index.txt to s3

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -233,20 +233,25 @@ jobs:
     patterns: '**/*amd64.deb'
 
   - script: |
-      MSI_NAME=$(ls $(Pipeline.Workspace)/windows-msi-x64/*.msi)
+      mkdir s3_upload
+      mv $(Pipeline.Workspace)/windows-msi-x64/*.msi s3_upload/
+      mv $(Pipeline.Workspace)/linux-packages/*.deb s3_upload/
+    displayName: Move deb package and MSI to s3_upload folder
+
+  - script: |
+      MSI_NAME=$(ls s3_upload/windows-msi-x64/*.msi)
       PACKAGE_NAME=${MSI_NAME::-4}
       mv $(Pipeline.Workspace)/linux-packages/*.deb $PACKAGE_NAME.deb
     displayName: Rename deb package name to match MSI name
 
   - script: |
-      INDEX_FILE=$(pwd)/index.txt
+      INDEX_FILE=$(pwd)/s3_upload/index.txt
       echo $(GitVersion.BranchName) >> $INDEX_FILE
       echo $(GitVersion.Sha) >> $INDEX_FILE
-      pushd $(Pipeline.Workspace)/linux-packages && name=$(ls *.deb) && echo "${name::-3}*" >> $INDEX_FILE && popd
+      pushd s3_upload && name=$(ls *.deb) && echo "${name::-3}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
       cat $INDEX_FILE
-      ls -l $(Pipeline.Workspace)/linux-packages/
-      ls -l $(Pipeline.Workspace)/windows-msi-x64/
+      ls -l s3_upload
     displayName: Write index.txt
 
   - script: sudo apt-get install -y awscli

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -233,15 +233,20 @@ jobs:
     patterns: '**/*amd64.deb'
 
   - script: |
-      rename 's/_/-/g' $(Pipeline.Workspace)/linux-packages/*.deb -v
-    displayName: Rename deb package to use dashes
+      MSI_NAME=$(ls $(Pipeline.Workspace)/windows-msi-x64/*.msi)
+      PACKAGE_NAME=${MSI_NAME::-4}
+      mv $(Pipeline.Workspace)/linux-packages/*.deb $PACKAGE_NAME.deb
+    displayName: Rename deb package name to match MSI name
 
   - script: |
       INDEX_FILE=$(pwd)/index.txt
       echo $(GitVersion.BranchName) >> $INDEX_FILE
       echo $(GitVersion.Sha) >> $INDEX_FILE
-      pushd $(Pipeline.Workspace)/linux-packages && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
+      echo "${PACKAGE_NAME}*" >> $INDEX_FILE
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
+      cat $INDEX_FILE
+      ls -l $(Pipeline.Workspace)/linux-packages/
+      ls -l $(Pipeline.Workspace)/windows-msi-x64/
     displayName: Write index.txt
 
   - script: sudo apt-get install -y awscli
@@ -256,12 +261,3 @@ jobs:
     displayName: Authenticate aws_secret_access_key
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
-
-  - script: aws s3 cp $(Pipeline.Workspace)/linux-packages s3://datadog-reliability-env/dotnet/ --recursive
-    displayName: Upload deb package to s3
-
-  - script: aws s3 cp $(Pipeline.Workspace)/windows-msi-x64 s3://datadog-reliability-env/dotnet/ --recursive
-    displayName: Upload MSI to s3
-
-  - script: aws s3 cp index.txt s3://datadog-reliability-env/dotnet/index.txt
-    displayName: Upload index.txt to s3

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -248,7 +248,7 @@ jobs:
       INDEX_FILE=$(pwd)/s3_upload/index.txt
       echo $(GitVersion.BranchName) >> $INDEX_FILE
       echo $(GitVersion.Sha) >> $INDEX_FILE
-      pushd s3_upload && name=$(ls *.deb) && echo "${name::-3}*" >> $INDEX_FILE && popd
+      pushd s3_upload && name=$(ls *.deb) && echo "${name::-7}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
       cat $INDEX_FILE
       ls -l s3_upload


### PR DESCRIPTION
Motivation:
The motivation for this change is that the $tracer_version on our dashboards is determined by the filenames of the artifacts, so this ensures matching version numbers for both Linux and Windows deployments. Before, the deb file did not include any prerelease labels. After this change, it will.

Here is an example set of files produced when the version is `1.15.1-prerelease`:
- `datadog-dotnet-apm-1.15.1-prerelease-x64.msi`
- `datadog-dotnet-apm-1.15.1-prerelease-x64.deb`
- `index.txt` with the following lines:

```
zach/pipelines/s3-filename
b0a2b072e52a13d4fe52c83b23a1b4d0d0a63548
datadog-dotnet-apm-1.15.1-prerelease-*
zach.montoya@datadoghq.com
```

@DataDog/apm-dotnet