### PR TITLE
remove unused project reference

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -35,6 +35,9 @@ jobs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
 
+  - task: NuGetToolInstaller@1
+    displayName: install nuget
+
   - task: NuGetCommand@2
     displayName: nuget restore native
     inputs:

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -96,6 +96,9 @@ jobs:
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
         sample-libs/**/Samples.ExampleLibrary*.csproj
 
+  - task: NuGetToolInstaller@1
+    displayName: install nuget
+
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -41,8 +41,6 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.ServiceModel" />
-
-    <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Remove reference from `Datadog.Trace.ClrProfiler.Managed` to `Datadog.Trace.AspNet`. No longer needed due to #684.