### PR TITLE
Add automatic instrumentation for SocketsHttpHandler

### DIFF
--- a/samples/Samples.HttpMessageHandler/Program.cs
+++ b/samples/Samples.HttpMessageHandler/Program.cs
@@ -105,6 +105,30 @@ namespace Samples.HttpMessageHandler
                     }
                 }
             }
+
+#if NETCOREAPP
+            using (var client = new HttpClient(new SocketsHttpHandler()))
+            {
+                if (tracingDisabled)
+                {
+                    client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                }
+
+                using (var responseMessage = await client.PostAsync(Url, clientRequestContent))
+                {
+                    // read response content and headers
+                    var responseContent = await responseMessage.Content.ReadAsStringAsync();
+                    Console.WriteLine($"[HttpClient] response content: {responseContent}");
+
+                    foreach (var header in responseMessage.Headers)
+                    {
+                        var name = header.Key;
+                        var values = string.Join(",", header.Value);
+                        Console.WriteLine($"[HttpClient] response header: {name}={values}");
+                    }
+                }
+            }
+#endif
         }
 
         private static void SendWebClientRequest(bool tracingDisabled)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -171,7 +171,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (!(handler is HttpClientHandler) || !IsTracingEnabled(request))
+            if (!(handler is HttpClientHandler || reportedType.FullName.Equals("System.Net.Http.SocketsHttpHandler", StringComparison.OrdinalIgnoreCase)) ||
+                !IsTracingEnabled(request))
             {
                 // skip instrumentation
                 return await sendAsync(handler, request, cancellationToken).ConfigureAwait(false);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -22,6 +22,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void HttpClient()
         {
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 3 : 1;
+            const string expectedOperationName = "http.request";
+            const string expectedServiceName = "Samples.HttpMessageHandler-http-client";
+
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();
 
@@ -33,21 +37,24 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
-                var spans = agent.WaitForSpans(1);
-                Assert.True(spans.Count > 0, "expected at least one span." + System.Environment.NewLine + "IMPORTANT: Make sure Datadog.Trace.ClrProfiler.Managed.dll and its dependencies are in the GAC.");
+                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                Assert.True(spans.Count >= expectedSpanCount, $"Expected at least {expectedSpanCount} span, only received {spans.Count}" + System.Environment.NewLine + "IMPORTANT: Make sure Datadog.Trace.ClrProfiler.Managed.dll and its dependencies are in the GAC.");
 
+                foreach (var span in spans)
+                {
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(SpanTypes.Http, span.Type);
+                    Assert.Equal(nameof(HttpMessageHandler), span.Tags[Tags.InstrumentationName]);
+                }
+
+                var firstSpan = spans.First();
+                var lastSpanInFirstTrace = spans.Where(s => s.TraceId == firstSpan.TraceId).Last();
                 var traceId = GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                 var parentSpanId = GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
 
-                var firstSpan = spans.First();
-                Assert.Equal("http.request", firstSpan.Name);
-                Assert.Equal("Samples.HttpMessageHandler-http-client", firstSpan.Service);
-                Assert.Equal(SpanTypes.Http, firstSpan.Type);
-                Assert.Equal(nameof(HttpMessageHandler), firstSpan.Tags[Tags.InstrumentationName]);
-
-                var lastSpan = spans.Last();
-                Assert.Equal(lastSpan.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
-                Assert.Equal(lastSpan.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
+                Assert.Equal(lastSpanInFirstTrace.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
+                Assert.Equal(lastSpanInFirstTrace.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
             }
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void HttpClient()
         {
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 3 : 1;
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 2 : 1;
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "Samples.HttpMessageHandler-http-client";
 
@@ -49,12 +49,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
 
                 var firstSpan = spans.First();
-                var lastSpanInFirstTrace = spans.Where(s => s.TraceId == firstSpan.TraceId).Last();
                 var traceId = GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                 var parentSpanId = GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);
 
-                Assert.Equal(lastSpanInFirstTrace.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
-                Assert.Equal(lastSpanInFirstTrace.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
+                Assert.Equal(firstSpan.TraceId.ToString(CultureInfo.InvariantCulture), traceId);
+                Assert.Equal(firstSpan.SpanId.ToString(CultureInfo.InvariantCulture), parentSpanId);
             }
         }
 

--- a/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.IntegrationTests
                     actualContainerId = args.Value.Request.Headers[AgentHttpHeaderNames.ContainerId];
                 };
 
-                var settings = new TracerSettings { AgentUri = new Uri($"http://localhost:{agentPort}") };
+                var settings = new TracerSettings { AgentUri = new Uri($"http://localhost:{agent.Port}") };
                 var tracer = new Tracer(settings);
 
                 using (var scope = tracer.StartActive("operationName"))

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Tests
             {
                 var settings = new TracerSettings
                                {
-                                   AgentUri = new Uri($"http://localhost:{agentPort}"),
+                                   AgentUri = new Uri($"http://localhost:{agent.Port}"),
                                    TracerMetricsEnabled = tracerMetricsEnabled
                                };
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Add automatic instrumentation to create a span when SocketsHttpHandler is used as the HttpHandler implementation for HttpClient
- Additionally, prevent the creation of consecutive `http.request` spans that share the same resource
- Modify sample and test to expect one new span in the .NET Core Samples.HttpMessageHandler program where the user can populate the HttpClient's HttpMessageHandler with a user-provided SocketsHttpHandler instance

See #668

@DataDog/apm-dotnet