### PR TITLE
Restore ProjectReference to Datadog.Trace.AspNet

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -41,6 +41,8 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.ServiceModel" />
+
+    <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Put Datadog.Trace.AspNet project reference back in Datadog.Trace.ClrProfiler.Managed.csproj.

This allows the AspNet dll to be produced alongside the manage profiler assets for simpler logic in the windows-tracer-home setup and MSI installation.

@DataDog/apm-dotnet