### PR TITLE
[ClrProfiler] Fix DbCommand.xxxAsync failures on 32-bit .NET Framework

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -120,12 +120,14 @@ jobs:
     condition: succeededOrFailed()
 
 - job: Windows
-
+  strategy:
+    matrix:
+      x64:
+        buildPlatform: x64
+      x86:
+        buildPlatform: x86
   pool:
     vmImage: windows-2019
-
-  variables:
-    buildPlatform: 'x64'
 
   steps:
   - task: UseDotNet@2

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
@@ -153,7 +153,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -167,13 +167,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         public static object ExecuteReaderAsync(
             object command,
             int behavior,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteReaderAsyncInternal(
                 command as DbCommand,
@@ -288,7 +287,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for <see cref="DbCommand.ExecuteNonQueryAsync(CancellationToken)"/>
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -301,13 +300,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteNonQueryAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteNonQueryAsyncInternal(
                 command as DbCommand,
@@ -413,7 +411,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for <see cref="DbCommand.ExecuteScalarAsync(CancellationToken)"/>
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -426,13 +424,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteScalarAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteScalarAsyncInternal(
                 command as DbCommand,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -138,7 +138,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for SqlCommand.ExecuteReaderAsync().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -151,13 +151,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteReaderAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteReaderAsyncInternal(
                 (DbCommand)command,
@@ -213,7 +212,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -228,13 +227,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         public static object ExecuteReaderAsyncTwoParams(
             object command,
             int behavior,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteReaderAsyncInternalTwoParams(
                 (DbCommand)command,
@@ -346,7 +344,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for SqlCommand.ExecuteNonQueryAsync().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -359,13 +357,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteNonQueryAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteNonQueryAsyncInternal(
                 command as DbCommand,
@@ -475,7 +472,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for SqlCommand.ExecuteScalarAsync().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -488,13 +485,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteScalarAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteScalarAsyncInternal(
                 command as DbCommand,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -138,7 +138,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -152,13 +152,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         public static object ExecuteReaderAsync(
             object command,
             int behavior,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteReaderAsyncInternal(
                 (DbCommand)command,
@@ -270,7 +269,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for SqlCommand.ExecuteNonQueryAsync().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -283,13 +282,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteNonQueryAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteNonQueryAsyncInternal(
                 command as DbCommand,
@@ -399,7 +397,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// Instrumentation wrapper for SqlCommand.ExecuteScalarAsync().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationToken"/> value used in the original method call.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -412,13 +410,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMaximumVersion = Major4)]
         public static object ExecuteScalarAsync(
             object command,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             return ExecuteScalarAsyncInternal(
                 command as DbCommand,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="apiController">The Api Controller</param>
         /// <param name="controllerContext">The controller context for the call</param>
-        /// <param name="cancellationTokenSource">The cancellation token source</param>
+        /// <param name="boxedCancellationToken">The cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -46,15 +46,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object ExecuteAsync(
             object apiController,
             object controllerContext,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
             if (apiController == null) { throw new ArgumentNullException(nameof(apiController)); }
 
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
             return ExecuteAsyncInternal(apiController, controllerContext, cancellationToken, opCode, mdToken, moduleVersionPtr);
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <typeparam name="TResponse">Type type of the response</typeparam>
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
-        /// <param name="cancellationTokenSource">A cancellation token</param>
+        /// <param name="boxedCancellationToken">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -113,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object CallElasticsearchAsync<TResponse>(
             object pipeline,
             object requestData,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
@@ -123,8 +123,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw new ArgumentNullException(nameof(pipeline));
             }
 
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             var genericArgument = typeof(TResponse);
             var genericResponseType = ElasticsearchResponseType.MakeGenericType(genericArgument);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <typeparam name="TResponse">Type type of the response</typeparam>
         /// <param name="pipeline">The pipeline for the original method</param>
         /// <param name="requestData">The request data</param>
-        /// <param name="cancellationTokenSource">A cancellation token</param>
+        /// <param name="boxedCancellationToken">A cancellation token</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -113,13 +113,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object CallElasticsearchAsync<TResponse>(
             object pipeline,
             object requestData,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
             return CallElasticsearchAsyncInternal<TResponse>(pipeline, requestData, cancellationToken, opCode, mdToken, moduleVersionPtr);
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> instance to instrument.</param>
         /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object HttpMessageHandler_SendAsync(
             object handler,
             object request,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
@@ -56,8 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             // original signature:
             // Task<HttpResponseMessage> HttpMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
             var callOpCode = (OpCodeValue)opCode;
             var httpMessageHandler = handler.GetInstrumentedType(HttpMessageHandler);
 
@@ -99,7 +98,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="handler">The <see cref="HttpClientHandler"/> instance to instrument.</param>
         /// <param name="request">The <see cref="HttpRequestMessage"/> that represents the current HTTP request.</param>
-        /// <param name="cancellationTokenSource">The <see cref="CancellationTokenSource"/> that can be used to cancel this <c>async</c> operation.</param>
+        /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -114,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object HttpClientHandler_SendAsync(
             object handler,
             object request,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
@@ -126,8 +125,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             // original signature:
             // Task<HttpResponseMessage> HttpClientHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
             var callOpCode = (OpCodeValue)opCode;
             var httpClientHandler = handler.GetInstrumentedType(HttpClientHandler);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="wireProtocol">The IWireProtocol instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
-        /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="boxedCancellationToken">A cancellation token.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object Execute(
             object wireProtocol,
             object connection,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
@@ -56,8 +56,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Func<object, object, CancellationToken, object> execute;
             var wireProtocolType = wireProtocol.GetType();
 
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             try
             {
@@ -101,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="wireProtocol">The IWireProtocol`1 instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
-        /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="boxedCancellationToken">A cancellation token.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -116,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object ExecuteGeneric(
             object wireProtocol,
             object connection,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
@@ -127,8 +126,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Func<object, object, CancellationToken, object> execute;
             var wireProtocolType = wireProtocol.GetType();
 
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             try
             {
@@ -172,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="wireProtocol">The IWireProtocol instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
-        /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="boxedCancellationToken">A cancellation token.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -187,15 +185,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object ExecuteAsync(
             object wireProtocol,
             object connection,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
         {
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             const string methodName = nameof(ExecuteAsync);
             var wireProtocolType = wireProtocol.GetType();
@@ -235,7 +232,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// </summary>
         /// <param name="wireProtocol">The IWireProtocol`1 instance we are replacing.</param>
         /// <param name="connection">The connection.</param>
-        /// <param name="cancellationTokenSource">A cancellation token source.</param>
+        /// <param name="boxedCancellationToken">A cancellation token.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
         /// <param name="mdToken">The mdToken of the original method call.</param>
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
@@ -250,7 +247,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         public static object ExecuteAsyncGeneric(
             object wireProtocol,
             object connection,
-            object cancellationTokenSource,
+            object boxedCancellationToken,
             int opCode,
             int mdToken,
             long moduleVersionPtr)
@@ -258,8 +255,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             // The generic type for this method comes from the declaring type of wireProtocol
             if (wireProtocol == null) { throw new ArgumentNullException(nameof(wireProtocol)); }
 
-            var tokenSource = cancellationTokenSource as CancellationTokenSource;
-            var cancellationToken = tokenSource?.Token ?? CancellationToken.None;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
 
             var wireProtocolType = wireProtocol.GetType();
             var wireProtocolGenericArgs = GetGenericsFromWireProtocol(wireProtocolType);

--- a/src/Datadog.Trace.ClrProfiler.Native/class_factory.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/class_factory.cpp
@@ -45,7 +45,13 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown* pUnkOuter,
     return CLASS_E_NOAGGREGATION;
   }
 
-  trace::Info("Datadog CLR Profiler ", PROFILER_VERSION);
+  trace::Info("Datadog CLR Profiler ", PROFILER_VERSION,
+#ifdef BIT64
+              " 64-bit"
+#else
+              " 32-bit"
+#endif
+  );
   trace::Debug("ClassFactory::CreateInstance");
 
   auto profiler = new trace::CorProfiler();

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -835,7 +835,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(
       // the rest of our IL modifications AFTER this instruction.
       auto original_methodcall_opcode = pInstr->m_opcode;
       pInstr->m_opcode = CEE_NOP;
-      rewriter_wrapper.SetILPosition(pInstr->m_pNext);
+      pInstr = pInstr->m_pNext;
+      rewriter_wrapper.SetILPosition(pInstr);
 
       // IL Modification #2: Conditionally box System.Threading.CancellationToken
       //                     if it is the last argument in the target method.

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
@@ -116,14 +116,6 @@ void ILRewriterWrapper::CallMember(const mdMemberRef& member_ref,
   m_ILRewriter->InsertBefore(m_ILInstr, pNewInstr);
 }
 
-void ILRewriterWrapper::CallMemberAfter(const mdMemberRef& member_ref,
-                                   const bool is_virtual) const {
-  ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
-  pNewInstr->m_opcode = is_virtual ? CEE_CALLVIRT : CEE_CALL;
-  pNewInstr->m_Arg32 = member_ref;
-  m_ILRewriter->InsertAfter(m_ILInstr, pNewInstr);
-}
-
 void ILRewriterWrapper::Duplicate() const {
   ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
   pNewInstr->m_opcode = CEE_DUP;

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
@@ -26,7 +26,6 @@ class ILRewriterWrapper {
   void UnboxAnyAfter(mdTypeRef type_ref) const;
   void CreateArray(mdTypeRef type_ref, INT32 size) const;
   void CallMember(const mdMemberRef& member_ref, bool is_virtual) const;
-  void CallMemberAfter(const mdMemberRef& member_ref, bool is_virtual) const;
   void Duplicate() const;
   void BeginLoadValueIntoArray(INT32 arrayIndex) const;
   void EndLoadValueIntoArray() const;

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -169,6 +169,17 @@ struct MethodSignature {
     return false;
   }
 
+  size_t IndexOfReturnType() const {
+    if (data.size() > 2 &&
+        (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0) {
+      return 3;
+    }
+    if (data.size() > 1) {
+      return 2;
+    }
+    return 0;
+  }
+
   WSTRING str() const {
     WSTRINGSTREAM ss;
     for (auto& b : data) {


### PR DESCRIPTION
See #662

## Issue
With the way our CLR Profiler and `Datadog.Trace.ClrProfiler.Managed.dll` is set up, the integration methods that we use for automatic instrumentation must only have method arguments whose types are .NET primitive types (e.g. `int`, `long`, `byte`) or `object`. To handle `xxxAsync` methods in .NET Framework libraries and third-party libraries that take a `System.Threading.CancellationToken` argument (which is a [value type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-types), not a [reference type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types)), the instrumentation method would specify the argument type as `object`, cast it to a `System.Threading.CancellationTokenSource`, and then use the `Token` property to access the original CancellationToken. While this has silently worked for our integrations on almost all platforms, it crashes on 32-bit .NET Framework when instrumenting the `System.Data.dll` assembly.

The failure likely occurs because when the instrumentation method is called, it expects the CancellationToken argument to be populated with a reference type of type `object` that has a reference to the **real** `System.Threading.CancellationToken` value. However, since `System.Threading.CancellationToken` is a value type, the value that is passed to the method is not a reference but the data itself. When the data is interpreted to be a reference and the variable is accessed, this can cause invalid memory accesses. The fix is to always [box](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/types/boxing-and-unboxing) the `System.Threading.CancellationToken` struct so that an `object` is placed onto the stack for the method call and the instrumentation method can read it correctly.

## Changes
- Fix the CLR Profiler to add an additional `box <typeToken>` IL instruction when performing a method replacement and the last argument of the target method has the type `System.Threading.CancellationToken`
- Modify all integration methods to directly cast their cancellationToken argument to `System.Threading.CancellationToken` instead of manipulating it as a `System.Threading.CancellationTokenSource`
- Add Windows `integration-test` run for x86 (previously was only x64), which exercises this code path in the `Samples.SqlServer` application
- Add minor logging to change to log the bitness of the Profiler when it initializes
- Add further documentation in the IL Modification part of the method replacement code


@DataDog/apm-dotnet