### PR TITLE
Refactor CI pipelines

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -1,4 +1,11 @@
-trigger: none
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    exclude:
+      - docs/*
+      - .github/*
 pr:
   branches:
     include:
@@ -11,10 +18,51 @@ pr:
 variables:
   buildConfiguration: Debug
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
+  dotnetCoreSdkVersion: 3.1.x
 
 jobs:
 
+- job: build_linux_profiler
+  pool:
+    vmImage: ubuntu-16.04
+  variables:
+    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
+
+  steps:
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+    inputs:
+      command: build
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      arguments: --configuration $(buildConfiguration)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
+    inputs:
+      command: publish
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
+      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Profiler
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run Profiler
+
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+    artifact: linux-tracer-home
+
 - job: Linux
+  dependsOn: build_linux_profiler
+  condition: succeeded()
   strategy:
     matrix:
       netcoreapp2_1:
@@ -34,17 +82,19 @@ jobs:
     TestAllPackageVersions: true
 
   steps:
+  - download: current
+    artifact: linux-tracer-home
+
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/linux-tracer-home
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+
   - task: DockerCompose@0
     displayName: docker-compose run build
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) build
-
-  - task: DockerCompose@0
-    displayName: docker-compose run Profiler
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
 
   - task: DockerCompose@0
     displayName: docker-compose run IntegrationTests
@@ -59,7 +109,47 @@ jobs:
       testResultsFiles: test/**/*.trx
     condition: succeededOrFailed()
 
+- job: build_alpine_linux_profiler
+  pool:
+    vmImage: ubuntu-16.04
+  variables:
+    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
+
+  steps:
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk
+    inputs:
+      version: $(dotnetCoreSdkVersion)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+    inputs:
+      command: build
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      arguments: --configuration $(buildConfiguration)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
+    inputs:
+      command: publish
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
+      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Profiler.Alpine
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run Profiler.Alpine
+
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+    artifact: alpine-linux-tracer-home
+
 - job: Alpine_Linux
+  dependsOn: build_alpine_linux_profiler
+  condition: succeeded()
   strategy:
     matrix:
       netcoreapp2_1:
@@ -79,17 +169,19 @@ jobs:
     TestAllPackageVersions: true
 
   steps:
+  - download: current
+    artifact: alpine-linux-tracer-home
+
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/alpine-linux-tracer-home
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+
   - task: DockerCompose@0
     displayName: docker-compose run build
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) build
-
-  - task: DockerCompose@0
-    displayName: docker-compose run Profiler.Alpine
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler.Alpine
 
   - task: DockerCompose@0
     displayName: docker-compose run IntegrationTests.Alpine.Core21
@@ -157,59 +249,23 @@ jobs:
       restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net45
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework net45 --output $(publishOutput)/net45
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework net461
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework net461 --output $(publishOutput)/net461
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
-    inputs:
-      command: build
-      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-      arguments: --configuration $(buildConfiguration)
-
+  # this triggers a dependency chain that builds all the managed and native dlls
   - task: MSBuild@1
-    displayName: msbuild native
+    displayName: msbuild tracer-home
     inputs:
       solution: Datadog.Trace.proj
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp
+      msbuildArguments: /t:CreateHomeDirectory /p:TracerHomeDirectory=$(publishOutput)
       maximumCpuCount: true
 
   - task: MSBuild@1
-    displayName: 'Build .NET Framework projects (not SDK-based projects)'
+    displayName: Build .NET Framework projects (not SDK-based projects)
     inputs:
       solution: Datadog.Trace.proj
-      platform: '$(buildPlatform)'
-      configuration: '$(buildConfiguration)'
-      msbuildArguments: '/t:BuildFrameworkReproductions'
+      platform: $(buildPlatform)
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:BuildFrameworkReproductions
       maximumCpuCount: true
 
   - powershell: |
@@ -225,9 +281,7 @@ jobs:
       projects: |
         reproductions/**/*.csproj
         samples/**/*.csproj
-        test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
-        test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-        test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+        test/*.IntegrationTests/*.IntegrationTests.csproj
         !reproductions/**/ExpenseItDemo*.csproj
         !reproductions/**/EntityFramework6x*.csproj
         !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
@@ -241,7 +295,7 @@ jobs:
       projects: |
         test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
         test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
-      arguments: '-p:Platform=$(buildPlatform)'
+      arguments: -p:Platform=$(buildPlatform)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -249,4 +303,4 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: '--filter "RunOnWindows=True|Category=Smoke" -p:Platform=$(buildPlatform)'
+      arguments: --filter "RunOnWindows=True|Category=Smoke" -p:Platform=$(buildPlatform)

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -55,7 +55,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run Profiler
 
-  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: linux-tracer-home
 
 - job: Linux
@@ -83,7 +83,7 @@ jobs:
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/linux-tracer-home
-      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
 
   - task: DockerCompose@0
     displayName: docker-compose run build
@@ -135,7 +135,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run Profiler.Alpine
 
-  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: alpine-linux-tracer-home
 
 - job: Alpine_Linux
@@ -163,7 +163,7 @@ jobs:
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Pipeline.Workspace)/alpine-linux-tracer-home
-      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
 
   - task: DockerCompose@0
     displayName: docker-compose run build

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -15,18 +15,16 @@ pr:
       - docs/*
       - .github/*
 
+pool:
+  vmImage: ubuntu-18.04
 variables:
   buildConfiguration: Debug
-  publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
+  publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.x
 
 jobs:
 
 - job: build_linux_profiler
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -74,10 +72,7 @@ jobs:
       netcoreapp3_1:
         dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
-
-  pool:
-    vmImage: ubuntu-16.04
-  
+ 
   variables:
     TestAllPackageVersions: true
 
@@ -110,10 +105,6 @@ jobs:
     condition: succeededOrFailed()
 
 - job: build_alpine_linux_profiler
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -161,9 +152,6 @@ jobs:
       netcoreapp3_1:
         dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
-
-  pool:
-    vmImage: ubuntu-16.04
   
   variables:
     TestAllPackageVersions: true

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -2,7 +2,6 @@ trigger:
   branches:
     include:
       - master
-      - refs/tags/*
 pr: none
 
 variables:
@@ -165,7 +164,7 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+  condition: and(succeeded(), eq(variables['push_to_s3'], 'true'))
 
   dependsOn:
     - windows_packages_and_nuget

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -63,7 +63,6 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: dotnet pack
-    condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
     inputs:
       command: pack
       packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
       - master
+      - refs/tags/*
 pr: none
 
 variables:
@@ -163,7 +164,7 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  condition: and(succeeded(), eq(variables['push_to_s3'], 'true'))
+  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')), eq(variables['push_to_s3'], 'true'))
 
   dependsOn:
     - windows_packages_and_nuget

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -168,7 +168,7 @@ jobs:
   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
 
   dependsOn:
-    - nuget_and_windows_msi_and_home
+    - windows_packages_and_nuget
     - linux_packages
 
   pool:

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -78,7 +78,7 @@ jobs:
 
 - job: linux_packages
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   variables:
     tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
@@ -122,7 +122,7 @@ jobs:
 
 - job: linux_alpine_packages
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
   variables:
     tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -164,7 +164,7 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')), eq(variables['push_to_s3'], 'true'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['push_to_s3'], 'true'))
 
   dependsOn:
     - windows_packages_and_nuget

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -12,20 +12,16 @@ variables:
 
 jobs:
 
-#### NuGet packages and Windows msi installer
+#### Windows and NuGet packages
 
-- job: nuget_and_windows_msi_and_home
-  strategy:
-    matrix:
-      x64:
-        buildPlatform: x64
-        nugetPack: true
-      x86:
-        buildPlatform: x86
-        nugetPack: false
-
+- job: windows_packages_and_nuget
   pool:
     vmImage: windows-2019
+  variables:
+    tracerHomeName: windows-tracer-home
+    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/$(tracerHomeName)
+    msiHome: $(System.DefaultWorkingDirectory)/src/bin/msi
+    nuget_packages: $(Pipeline.Workspace)/.nuget/packages
 
   steps:
 
@@ -38,24 +34,33 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
-  - task: NuGetCommand@2
-    displayName: nuget restore native
-    inputs:
-      restoreSolution: Datadog.Trace.Native.sln
-      verbosityRestore: Normal
-
   - task: DotNetCoreCLI@2
     displayName: dotnet restore
     inputs:
       command: restore
       projects: src/**/*.csproj
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
+  # native projects must be restored with nuget.exe
+  - task: NuGetCommand@2
+    displayName: nuget restore native
     inputs:
-      command: build
-      projects: src/**/*.csproj
-      arguments: --configuration $(buildConfiguration)
+      restoreSolution: Datadog.Trace.Native.sln
+      verbosityRestore: Normal
+
+  # this triggers a dependency chain that builds all the managed, x64, and x86 dlls, and the zip and msi files
+  - task: MSBuild@1
+    displayName: build both msi
+    inputs:
+      solution: Datadog.Trace.proj
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:msi /p:Platform=All;ZipHomeDirectory=true;TracerHomeDirectory=$(tracerHome);RunWixToolsOutOfProc=true;MsiOutputPath=$(msiHome)
+      maximumCpuCount: true
+
+  - publish: $(msiHome)/en-us
+    artifact: windows-msi
+
+  - publish: $(tracerHome).zip
+    artifact: $(tracerHomeName)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet pack
@@ -63,54 +68,19 @@ jobs:
     inputs:
       command: pack
       packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
-      packDirectory: nuget-output
+      packDirectory: $(System.DefaultWorkingDirectory)/nuget-output
       configuration: $(buildConfiguration)
 
-  - task: PublishPipelineArtifact@0
-    displayName: publish nuget artifacts
-    condition: and(succeeded(), eq(variables['nugetPack'], 'true'))
-    inputs:
-      artifactName: nuget-packages
-      targetPath: nuget-output
-
-  - task: MSBuild@1
-    displayName: msbuild msi
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:msi /p:RunWixToolsOutOfProc=true
-      maximumCpuCount: true
-      
-  - task: MSBuild@1
-    displayName: msbuild tracer-home
-    condition: eq(variables['buildPlatform'], 'x64')
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:CreateHomeDirectory
-      maximumCpuCount: true
-
-  - task: PublishPipelineArtifact@0
-    displayName: publish msi artifact
-    inputs:
-      artifactName: windows-msi-$(buildPlatform)
-      targetPath: deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/bin/$(buildConfiguration)/$(buildPlatform)/en-us
-
-  - task: PublishPipelineArtifact@0
-    displayName: publish tracerhome artifact
-    condition: eq(variables['buildPlatform'], 'x64')
-    inputs:
-      artifactName: windows-tracer-home
-      targetPath: src/bin/windows-tracer-home.zip
+  - publish: $(System.DefaultWorkingDirectory)/nuget-output
+    artifact: nuget-packages
 
 #### Linux packages
 
 - job: linux_packages
-
   pool:
     vmImage: ubuntu-16.04
+  variables:
+    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -119,27 +89,21 @@ jobs:
       version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/**/*.csproj
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
     inputs:
       command: build
-      projects: src/**/*.csproj
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
       arguments: --configuration $(buildConfiguration)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
     inputs:
       command: publish
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
 
   - task: DockerCompose@0
     displayName: docker-compose run Profiler
@@ -153,16 +117,14 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run package
 
-  - task: PublishPipelineArtifact@0
-    displayName: publish artifacts
-    inputs:
-      artifactName: linux-packages
-      targetPath: deploy/linux
+  - publish: deploy/linux
+    artifact: linux-packages
 
 - job: linux_alpine_packages
-
   pool:
     vmImage: ubuntu-16.04
+  variables:
+    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
   steps:
   - task: UseDotNet@2
@@ -171,27 +133,21 @@ jobs:
       version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/**/*.csproj
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
     inputs:
       command: build
-      projects: src/**/*.csproj
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
       arguments: --configuration $(buildConfiguration)
 
   - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed --framework netstandard2.0
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
     inputs:
       command: publish
       publishWebProjects: false
       modifyOutputPath: false
       zipAfterPublish: false
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
 
   - task: DockerCompose@0
     displayName: docker-compose run Profiler.Alpine
@@ -205,11 +161,8 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run package.alpine
 
-  - task: PublishPipelineArtifact@0
-    displayName: publish artifacts
-    inputs:
-      artifactName: linux-alpine-packages
-      targetPath: deploy/linux
+  - publish: deploy/linux
+    artifact: linux-alpine-packages
 
 - job: s3_upload
   condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -21,7 +21,6 @@ jobs:
         imageName: windows-2019
       linux:
         imageName: ubuntu-16.04
-
   pool:
     vmImage: $(imageName)
 
@@ -43,14 +42,6 @@ jobs:
     inputs:
       packageType: sdk
       version: 3.1.x
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: |
-        src/**/*.csproj
-        test/**/*.Tests.csproj
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -75,7 +66,6 @@ jobs:
         buildPlatform: x64
       x86:
         buildPlatform: x86
-
   pool:
     vmImage: windows-2019
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
       windows:
         imageName: windows-2019
       linux:
-        imageName: ubuntu-16.04
+        imageName: ubuntu-18.04
   pool:
     vmImage: $(imageName)
 

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -1,6 +1,8 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)src\bin\tracer-home</TracerHomeDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -55,11 +57,11 @@
   </Target>
 
   <Target Name="BuildCpp">
-    <MSBuild Targets="Build" Projects="@(CppProject)">
+    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'" Properties="Platform=x64">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
 
-    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(BuildAdditionalx86Profiler)' == 'true'" Properties="Platform=x86">
+    <MSBuild Targets="Build" Projects="@(CppProject)" Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'All' OR '$(Buildx86Profiler)' == 'true'" Properties="Platform=x86">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
@@ -109,24 +111,18 @@
     </MSBuild>
   </Target>
 
-  <Target Name="SetMsiProperties">
-    <PropertyGroup>
-      <BuildAdditionalx86Profiler Condition="'$(Platform)' == 'x64'">true</BuildAdditionalx86Profiler>
-    </PropertyGroup>
-  </Target>
-
   <Target Name="PublishManagedProfilerOnDisk">
     <ItemGroup>
       <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-        <Properties>TargetFramework=net45;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\net45</Properties>
+        <Properties>TargetFramework=net45;PublishDir=$(TracerHomeDirectory)\net45</Properties>
       </ManagedProfilerPublishProject>
 
       <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-        <Properties>TargetFramework=net461;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\net461</Properties>
+        <Properties>TargetFramework=net461;PublishDir=$(TracerHomeDirectory)\net461</Properties>
       </ManagedProfilerPublishProject>
 
       <ManagedProfilerPublishProject Include="src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-        <Properties>TargetFramework=netstandard2.0;PublishDir=$(MSBuildThisFileDirectory)\src\bin\managed-publish\netstandard2.0</Properties>
+        <Properties>TargetFramework=netstandard2.0;PublishDir=$(TracerHomeDirectory)\netstandard2.0</Properties>
       </ManagedProfilerPublishProject>
     </ItemGroup>
 
@@ -135,46 +131,69 @@
     </MSBuild>
   </Target>
 
-  <Target Name="Msi" DependsOnTargets="SetMsiProperties;BuildCsharp;BuildCpp;PublishManagedProfilerOnDisk">
-    <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)">
+  <Target Name="BuildLoader">
+    <ItemGroup>
+      <ManagedLoaderProject Include="src\Datadog.Trace.ClrProfiler.Managed.Loader\Datadog.Trace.ClrProfiler.Managed.Loader.csproj"/>
+    </ItemGroup>
+
+    <MSBuild Targets="Build" Projects="@(ManagedLoaderProject)" RemoveProperties="Platform">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
-  
-  <Target Name="CreateHomeDirectory" DependsOnTargets="BuildCsharp;BuildCpp;PublishManagedProfilerOnDisk">
-      <ItemGroup>
-	    <PublishedManagedTracerFiles Include="$(MSBuildThisFileDirectory)src\bin\managed-publish\**\*.*" />
-      </ItemGroup>
-	  <PropertyGroup>
-	    <WindowsHomeOutput>$(MSBuildThisFileDirectory)src\bin\windows-tracer-home</WindowsHomeOutput>
-	  </PropertyGroup>
-      <Copy 
-        SourceFiles="$(MSBuildThisFileDirectory)integrations.json" 
-        DestinationFolder="$(WindowsHomeOutput)" 
-		SkipUnchangedFiles="true"
+
+  <Target Name="PublishNativeProfilerOnDisk" DependsOnTargets="BuildLoader;BuildCpp">
+    <Copy Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'"
+        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\x64\Datadog.Trace.ClrProfiler.Native.dll"
+        DestinationFolder="$(TracerHomeDirectory)\win-x64"
+        SkipUnchangedFiles="true"
         Retries="3"
         RetryDelayMilliseconds="300"/>
-      <Copy 
-	    SourceFiles="@(PublishedManagedTracerFiles)"
-        DestinationFiles="@(PublishedManagedTracerFiles->'$(WindowsHomeOutput)\%(RecursiveDir)%(Filename)%(Extension)')"
-		SkipUnchangedFiles="true"
+    <Copy Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'All' OR '$(Buildx86Profiler)' == 'true'"
+        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\x86\Datadog.Trace.ClrProfiler.Native.dll"
+        DestinationFolder="$(TracerHomeDirectory)\win-x86"
+        SkipUnchangedFiles="true"
         Retries="3"
         RetryDelayMilliseconds="300"/>
-      <Copy 
-        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\Release\x64\Datadog.Trace.ClrProfiler.Native.dll" 
-        DestinationFolder="$(WindowsHomeOutput)\x64" 
-		SkipUnchangedFiles="true"
-        Retries="3"
-        RetryDelayMilliseconds="300"/>
-      <Copy 
-        SourceFiles="$(MSBuildThisFileDirectory)src\Datadog.Trace.ClrProfiler.Native\bin\Release\x86\Datadog.Trace.ClrProfiler.Native.dll" 
-        DestinationFolder="$(WindowsHomeOutput)\x86" 
-		SkipUnchangedFiles="true"
-        Retries="3"
-        RetryDelayMilliseconds="300"/>
-	  <Delete Files="$(WindowsHomeOutput).zip" />
-	  <ZipDirectory
-        SourceDirectory="$(WindowsHomeOutput)"
-        DestinationFile="$(WindowsHomeOutput).zip" />
+  </Target>
+
+  <Target Name="SetMsiProperties">
+    <PropertyGroup>
+      <!-- we need to build both x64 and x86 profilers to build the x64 msi -->
+      <Buildx86Profiler Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'">true</Buildx86Profiler>
+
+      <!-- disable zip by default when building msi, unless explicitly enabled -->
+      <ZipHomeDirectory Condition="'$(ZipHomeDirectory)' == ''">false</ZipHomeDirectory>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="Msi" DependsOnTargets="SetMsiProperties;CreateHomeDirectory">
+    <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)" Condition="'$(Platform)' == 'x64' OR '$(Platform)' == 'All'" Properties="Platform=x64">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+    </MSBuild>
+
+    <MSBuild Targets="Build" Projects="@(WindowsInstallerProject)" Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'All'" Properties="Platform=x86">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
+    </MSBuild>
+  </Target>
+
+  <Target Name="CreateHomeDirectory" DependsOnTargets="PublishNativeProfilerOnDisk;PublishManagedProfilerOnDisk">
+    <PropertyGroup>
+      <!-- enable zip by default to keep current behavior-->
+      <ZipHomeDirectory Condition="'$(ZipHomeDirectory)' == ''">true</ZipHomeDirectory>
+    </PropertyGroup>
+
+    <Copy
+      SourceFiles="$(MSBuildThisFileDirectory)integrations.json"
+      DestinationFolder="$(TracerHomeDirectory)"
+      SkipUnchangedFiles="true"
+      Retries="3"
+      RetryDelayMilliseconds="300"/>
+
+    <Delete Condition="'$(ZipHomeDirectory)' == 'true'" Files="$(TracerHomeDirectory).zip" />
+
+    <ZipDirectory
+        Condition="'$(ZipHomeDirectory)' == 'true'"
+        SourceDirectory="$(TracerHomeDirectory)"
+        DestinationFile="$(TracerHomeDirectory).zip" />
   </Target>
 </Project>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Config.wxi
@@ -5,9 +5,6 @@
   <?define ArpManufacturer = "Datadog, Inc." ?>
   <?define Company = "Datadog" ?>
   <?define ProductNamePlatformAgnostic = "Datadog $(var.BaseProductName)" ?>
-  <?define ManagedDllPath = "$(sys.CURRENTDIR)..\..\src\bin\managed-publish" ?>
-  <?define NativeDllPath = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\$(var.Platform)" ?>
-  <?define NativeDll32Path = "$(sys.CURRENTDIR)..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(var.Configuration)\x86" ?>
   <?define ProfilerCLSID = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}" ?>
 
   <?if $(var.Platform) = x64 ?>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -10,15 +10,16 @@
     <ProjectGuid>3054de0e-f140-4758-b2da-0b9470c6ede1</ProjectGuid>
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Package</OutputType>
-    <OutputPath>bin\$(Configuration)\$(Platform)\</OutputPath>
+    <!-- use a unique property to allow changing OutputPath
+         for this project without changing it for other projects -->
+    <MsiOutputPath Condition="'$(MsiOutputPath)' == ''">bin\$(Configuration)\$(Platform)\</MsiOutputPath>
+    <OutputPath>$(MsiOutputPath)</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
     <OutputName>datadog-dotnet-apm-1.16.1-$(Platform)</OutputName>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DefineConstants>InstallerVersion=1.16.1</DefineConstants>
+    <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\src\bin\tracer-home</TracerHomeDirectory>
+    <DefineConstants>InstallerVersion=1.16.1&#59;TracerHomeDirectory=$(TracerHomeDirectory)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Datadog.Trace.ClrProfiler.WindowsInstaller.wixproj
@@ -19,7 +19,7 @@
     <DefineSolutionProperties>false</DefineSolutionProperties>
     <OutputName>datadog-dotnet-apm-1.16.1-$(Platform)</OutputName>
     <TracerHomeDirectory Condition="'$(TracerHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\src\bin\tracer-home</TracerHomeDirectory>
-    <DefineConstants>InstallerVersion=1.16.1&#59;TracerHomeDirectory=$(TracerHomeDirectory)</DefineConstants>
+    <DefineConstants>InstallerVersion=1.16.1;TracerHomeDirectory=$(TracerHomeDirectory)</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
@@ -7,62 +7,62 @@
     <ComponentGroup Id="Files.Managed.Net45.GAC" Directory="net45.GAC">
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.AspNet.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.AspNet.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.AspNet.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.ClrProfiler.Managed.Core.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.Core.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.ClrProfiler.Managed.Core.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_MessagePack.dll"
-              Source="$(var.ManagedDllPath)\net45\MessagePack.dll"
+              Source="$(var.TracerHomeDirectory)\net45\MessagePack.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\net45\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net45\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.Runtime.CompilerServices.Unsafe.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Runtime.CompilerServices.Unsafe.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.CompilerServices.Unsafe.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.Threading.Tasks.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Threading.Tasks.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Threading.Tasks.Extensions.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_GAC_System.ValueTuple.dll"
-              Source="$(var.ManagedDllPath)\net45\System.ValueTuple.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.ValueTuple.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
@@ -7,62 +7,62 @@
     <ComponentGroup Id="Files.Managed.Net45" Directory="net45">
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.AspNet.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.AspNet.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.AspNet.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.ClrProfiler.Managed.Core.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.Core.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.ClrProfiler.Managed.Core.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\net45\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_MessagePack.dll"
-              Source="$(var.ManagedDllPath)\net45\MessagePack.dll"
+              Source="$(var.TracerHomeDirectory)\net45\MessagePack.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\net45\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net45\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Runtime.CompilerServices.Unsafe.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Runtime.CompilerServices.Unsafe.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.CompilerServices.Unsafe.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.Threading.Tasks.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net45\System.Threading.Tasks.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.Threading.Tasks.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net45_System.ValueTuple.dll"
-              Source="$(var.ManagedDllPath)\net45\System.ValueTuple.dll"
+              Source="$(var.TracerHomeDirectory)\net45\System.ValueTuple.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.GAC.wxs
@@ -7,7 +7,7 @@
     <ComponentGroup Id="Files.Managed.Net461.GAC" Directory="net461.GAC">
       <Component Win64="$(var.Win64)">
         <File Id="net461_GAC_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net461\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Sigil.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
@@ -7,532 +7,532 @@
     <ComponentGroup Id="Files.Managed.Net461" Directory="net461">
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.AspNet.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.AspNet.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.AspNet.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.ClrProfiler.Managed.Core.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.ClrProfiler.Managed.Core.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.ClrProfiler.Managed.Core.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\net461\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_MessagePack.dll"
-              Source="$(var.ManagedDllPath)\net461\MessagePack.dll"
+              Source="$(var.TracerHomeDirectory)\net461\MessagePack.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Microsoft.Win32.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\Microsoft.Win32.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Microsoft.Win32.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_netstandard.dll"
-              Source="$(var.ManagedDllPath)\net461\netstandard.dll"
+              Source="$(var.TracerHomeDirectory)\net461\netstandard.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\net461\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_Sigil.dll"
-              Source="$(var.ManagedDllPath)\net461\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\net461\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.AppContext.dll"
-              Source="$(var.ManagedDllPath)\net461\System.AppContext.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.AppContext.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Collections.Concurrent.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Collections.Concurrent.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Collections.Concurrent.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Collections.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Collections.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Collections.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Collections.NonGeneric.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Collections.NonGeneric.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Collections.NonGeneric.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Collections.Specialized.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Collections.Specialized.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Collections.Specialized.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.ComponentModel.dll"
-              Source="$(var.ManagedDllPath)\net461\System.ComponentModel.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.ComponentModel.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.ComponentModel.EventBasedAsync.dll"
-              Source="$(var.ManagedDllPath)\net461\System.ComponentModel.EventBasedAsync.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.ComponentModel.EventBasedAsync.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.ComponentModel.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.ComponentModel.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.ComponentModel.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.ComponentModel.TypeConverter.dll"
-              Source="$(var.ManagedDllPath)\net461\System.ComponentModel.TypeConverter.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.ComponentModel.TypeConverter.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Console.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Console.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Console.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Data.Common.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Data.Common.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Data.Common.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.Contracts.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.Contracts.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.Contracts.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.Debug.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.Debug.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.Debug.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.FileVersionInfo.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.FileVersionInfo.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.FileVersionInfo.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.Process.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.Process.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.Process.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.StackTrace.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.StackTrace.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.StackTrace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.TextWriterTraceListener.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.TextWriterTraceListener.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.TextWriterTraceListener.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.Tools.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.Tools.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.Tools.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.TraceSource.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.TraceSource.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.TraceSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Diagnostics.Tracing.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Diagnostics.Tracing.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.Tracing.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Drawing.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Drawing.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Drawing.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Dynamic.Runtime.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Dynamic.Runtime.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Dynamic.Runtime.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Globalization.Calendars.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Globalization.Calendars.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Globalization.Calendars.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Globalization.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Globalization.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Globalization.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Globalization.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Globalization.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Globalization.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.Compression.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.Compression.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.Compression.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.Compression.ZipFile.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.Compression.ZipFile.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.Compression.ZipFile.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.FileSystem.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.FileSystem.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.FileSystem.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.FileSystem.DriveInfo.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.FileSystem.DriveInfo.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.FileSystem.DriveInfo.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.FileSystem.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.FileSystem.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.FileSystem.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.FileSystem.Watcher.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.FileSystem.Watcher.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.FileSystem.Watcher.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.IsolatedStorage.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.IsolatedStorage.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.IsolatedStorage.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.MemoryMappedFiles.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.MemoryMappedFiles.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.MemoryMappedFiles.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.Pipes.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.Pipes.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.Pipes.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.IO.UnmanagedMemoryStream.dll"
-              Source="$(var.ManagedDllPath)\net461\System.IO.UnmanagedMemoryStream.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.IO.UnmanagedMemoryStream.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Linq.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Linq.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Linq.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Linq.Expressions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Linq.Expressions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Linq.Expressions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Linq.Parallel.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Linq.Parallel.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Linq.Parallel.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Linq.Queryable.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Linq.Queryable.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Linq.Queryable.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.Http.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.Http.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.Http.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.NameResolution.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.NameResolution.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.NameResolution.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.NetworkInformation.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.NetworkInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.NetworkInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.Ping.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.Ping.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.Ping.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.Requests.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.Requests.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.Requests.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.Security.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.Security.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.Security.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.Sockets.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.Sockets.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.Sockets.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.WebHeaderCollection.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.WebHeaderCollection.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.WebHeaderCollection.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.WebSockets.Client.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.WebSockets.Client.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.WebSockets.Client.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Net.WebSockets.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Net.WebSockets.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Net.WebSockets.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.ObjectModel.dll"
-              Source="$(var.ManagedDllPath)\net461\System.ObjectModel.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.ObjectModel.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Reflection.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Reflection.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Reflection.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Reflection.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Reflection.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Reflection.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Reflection.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Reflection.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Reflection.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Resources.Reader.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Resources.Reader.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Resources.Reader.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Resources.ResourceManager.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Resources.ResourceManager.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Resources.ResourceManager.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Resources.Writer.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Resources.Writer.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Resources.Writer.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.CompilerServices.Unsafe.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.CompilerServices.Unsafe.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.CompilerServices.Unsafe.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.CompilerServices.VisualC.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.CompilerServices.VisualC.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.CompilerServices.VisualC.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Handles.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Handles.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Handles.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.InteropServices.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.InteropServices.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.InteropServices.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Numerics.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Numerics.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Numerics.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Serialization.Formatters.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Serialization.Formatters.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Serialization.Formatters.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Serialization.Json.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Serialization.Json.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Serialization.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Serialization.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Serialization.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Serialization.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Runtime.Serialization.Xml.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Runtime.Serialization.Xml.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.Serialization.Xml.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Claims.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Claims.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Claims.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Cryptography.Algorithms.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Cryptography.Algorithms.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Cryptography.Algorithms.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Cryptography.Csp.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Cryptography.Csp.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Cryptography.Csp.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Cryptography.Encoding.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Cryptography.Encoding.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Cryptography.Encoding.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Cryptography.Primitives.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Cryptography.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Cryptography.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Cryptography.X509Certificates.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Cryptography.X509Certificates.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Cryptography.X509Certificates.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.Principal.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.Principal.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.Principal.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Security.SecureString.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Security.SecureString.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Security.SecureString.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Text.Encoding.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Text.Encoding.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Text.Encoding.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Text.Encoding.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Text.Encoding.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Text.Encoding.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Text.RegularExpressions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Text.RegularExpressions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Text.RegularExpressions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.Overlapped.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.Overlapped.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.Overlapped.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.Tasks.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.Tasks.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.Tasks.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.Tasks.Extensions.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.Tasks.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.Tasks.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.Tasks.Parallel.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.Tasks.Parallel.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.Tasks.Parallel.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.Thread.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.Thread.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.Thread.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.ThreadPool.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.ThreadPool.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.ThreadPool.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Threading.Timer.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Threading.Timer.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Threading.Timer.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.ValueTuple.dll"
-              Source="$(var.ManagedDllPath)\net461\System.ValueTuple.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.ValueTuple.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Xml.ReaderWriter.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Xml.ReaderWriter.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Xml.ReaderWriter.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Xml.XDocument.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Xml.XDocument.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Xml.XDocument.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Xml.XmlDocument.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Xml.XmlDocument.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Xml.XmlDocument.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Xml.XmlSerializer.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Xml.XmlSerializer.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Xml.XmlSerializer.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Xml.XPath.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Xml.XPath.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Xml.XPath.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="net461_System.Xml.XPath.XDocument.dll"
-              Source="$(var.ManagedDllPath)\net461\System.Xml.XPath.XDocument.dll"
+              Source="$(var.TracerHomeDirectory)\net461\System.Xml.XPath.XDocument.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -7,132 +7,132 @@
     <ComponentGroup Id="Files.Managed.NetStandard20" Directory="netstandard2.0">
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Datadog.Trace.ClrProfiler.Managed.Core.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Datadog.Trace.ClrProfiler.Managed.Core.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Datadog.Trace.ClrProfiler.Managed.Core.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Datadog.Trace.ClrProfiler.Managed.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Datadog.Trace.ClrProfiler.Managed.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Datadog.Trace.ClrProfiler.Managed.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Datadog.Trace.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Datadog.Trace.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Datadog.Trace.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_MessagePack.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\MessagePack.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\MessagePack.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Microsoft.CSharp.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Microsoft.CSharp.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Microsoft.CSharp.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Newtonsoft.Json.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Newtonsoft.Json.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Sigil.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\Sigil.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.Concurrent.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Collections.Concurrent.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.Concurrent.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.Immutable.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Collections.Immutable.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.Immutable.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.NonGeneric.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Collections.NonGeneric.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.NonGeneric.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Diagnostics.DiagnosticSource.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.IO.FileSystem.Primitives.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.IO.FileSystem.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.IO.FileSystem.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Linq.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Linq.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Linq.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Emit.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.ILGeneration.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Emit.ILGeneration.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.ILGeneration.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.Lightweight.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Emit.Lightweight.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.Lightweight.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Metadata.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.Metadata.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Metadata.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.TypeExtensions.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Reflection.TypeExtensions.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.TypeExtensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Runtime.CompilerServices.Unsafe.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Runtime.InteropServices.RuntimeInformation.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.InteropServices.RuntimeInformation.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Runtime.Numerics.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Runtime.Numerics.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.Numerics.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Runtime.Serialization.Primitives.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Runtime.Serialization.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.Serialization.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Security.Cryptography.OpenSsl.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Security.Cryptography.OpenSsl.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Security.Cryptography.OpenSsl.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Security.Cryptography.Primitives.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Security.Cryptography.Primitives.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Security.Cryptography.Primitives.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Threading.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Threading.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Threading.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Threading.Tasks.Extensions.dll"
-              Source="$(var.ManagedDllPath)\netstandard2.0\System.Threading.Tasks.Extensions.dll"
+              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Threading.Tasks.Extensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
     </ComponentGroup>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Product.wxs
@@ -34,7 +34,6 @@
 
     <Feature Id="ProductFeature" Title="Datadog.Trace.ClrProfiler" Level="1">
       <ComponentGroupRef Id="Files"/>
-      <ComponentGroupRef Id="Files.Native"/>
       <ComponentGroupRef Id="Files.Managed.Net45.GAC"/>
       <ComponentGroupRef Id="Files.Managed.Net461.GAC"/>
       <ComponentGroupRef Id="Files.Managed.Net45"/>
@@ -45,10 +44,12 @@
       <ComponentGroupRef Id="EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="EnvironmentVariables.IIS"/>
 
-      <!-- For the 64-bit installer, also install the 32-bit profiler -->
       <?if $(var.Win64) = yes ?>
-      <ComponentGroupRef Id="Files.Native.32"/>
+      <ComponentGroupRef Id="Files.Native.64"/>
       <?endif ?>
+
+      <!-- The 32-bit profiler is always included, even in 64-bit builds -->
+      <ComponentGroupRef Id="Files.Native.32"/>
     </Feature>
 
     <!-- Use Quiet Execution Custom Action which will redirect standard out to the MSI log (see: https://wixtoolset.org/documentation/manual/v3/customactions/qtexec.html) -->
@@ -139,14 +140,15 @@
       </Component>
 
       <Component Win64="$(var.Win64)">
-        <File Id="integrations.json" Source="..\..\integrations.json" />
+        <File Id="integrations.json" Source="$(var.TracerHomeDirectory)\integrations.json" />
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="Files.Native" Directory="INSTALLFOLDER">
-      <Component Win64="$(var.Win64)">
+    <?if $(var.Win64) = yes ?>
+    <ComponentGroup Id="Files.Native.64" Directory="INSTALLFOLDER">
+      <Component Win64="yes">
         <File Id="Datadog.Trace.ClrProfiler.Native"
-              Source="$(var.NativeDllPath)\Datadog.Trace.ClrProfiler.Native.dll"
+              Source="$(var.TracerHomeDirectory)\win-x64\Datadog.Trace.ClrProfiler.Native.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
         </File>
@@ -154,16 +156,29 @@
     </ComponentGroup>
 
     <!-- For the 64-bit installer, also install the 32-bit profiler -->
-    <?if $(var.Win64) = yes ?>
     <ComponentGroup Id="Files.Native.32" Directory="INSTALLFOLDER.32">
       <Component Win64="no" Id="Datadog.Trace.ClrProfiler.Native.32">
         <File Id="Datadog.Trace.ClrProfiler.Native.32"
-              Source="$(var.NativeDll32Path)\Datadog.Trace.ClrProfiler.Native.dll"
+              Source="$(var.TracerHomeDirectory)\win-x86\Datadog.Trace.ClrProfiler.Native.dll"
               Checksum="yes">
           <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
         </File>
       </Component>
     </ComponentGroup>
+
+    <?else ?>
+
+    <!-- note that for the 32-bit build, we need to install into INSTALLFOLDER instead of INSTALLFOLDER.32 -->
+    <ComponentGroup Id="Files.Native.32" Directory="INSTALLFOLDER">
+      <Component Win64="no" Id="Datadog.Trace.ClrProfiler.Native.32">
+        <File Id="Datadog.Trace.ClrProfiler.Native.32"
+              Source="$(var.TracerHomeDirectory)\win-x86\Datadog.Trace.ClrProfiler.Native.dll"
+              Checksum="yes">
+          <Class Id="$(var.ProfilerCLSID)" Context="InprocServer32" ThreadingModel="both" Description="$(var.ProductNamePlatformAgnostic)"/>
+        </File>
+      </Component>
+    </ComponentGroup>
+
     <?endif ?>
 
     <ComponentGroup Id="EmptyFolders" Directory="CommonAppDataFolder.DatadogDotNetTracer.logs">

--- a/tools/PrepareRelease/SyncMsiContent.cs
+++ b/tools/PrepareRelease/SyncMsiContent.cs
@@ -18,7 +18,7 @@ namespace PrepareRelease
         private static readonly string Gac45ItemTemplate = $@"
       <Component Win64=""$(var.Win64)"">
         <File Id=""{FileIdPrefixTemplate}{FileNameTemplate}""
-              Source=""$(var.ManagedDllPath)\{FrameworkMonikerTemplate}\{FileNameTemplate}""
+              Source=""$(var.TracerHomeDirectory)\{FrameworkMonikerTemplate}\{FileNameTemplate}""
               KeyPath=""yes"" Checksum=""yes"" Assembly="".net""/>
       </Component>";
 


### PR DESCRIPTION
(obsoletes #658)
Refactor CI yaml pipelines to make leaner by reducing some of the redundant build.

- `Datadog.Trace.proj`
  - refactor targets so `msi` and `CreateHomeDirectory` share more outputs without building or copying files multiple times
  - target `CreateHomeDirectory` uses new property `ZipHomeDirectory` to create zip file (defaults to `true` to keep current behavior)
  - add a special `Platform=All` which build both `x64` and `x86`
- all CI pipelines
  - reduce number of steps by skipping `dotnet restore` if not needed
  - update `nuget.exe` if used (we require 5.3+ to restore the entire solution)
  - bump to Ubuntu 18.04
  - standardize to `$(System.DefaultWorkingDirectory)` everywhere (some places used `$(Build.SourcesDirectory)`)
- `integration-tests.yml` pipeline
  - run on `master` after a PR is merged (in addition to running on the PR commits)
  - compile the Tracer (C++ and C#) only once each for Linux and Alpine Linux, share as pipeline artifacts with the 6 parallel jobs that follow (3 on Linux and 3 on Alpine Linux)
  - on Windows, use `msbuild /t:CreateHomeDirectory` to build tracer directory
- `packages.yml` pipeline
  - don't build on tags since we already build on every commit to `master` (avoid double build)
  - on Windows, use `msbuild /t:msi /p:Platform=All` to build both msi installers and the zip file in a single job
  - add `push_to_s3` CI variable to optionally skip pushing packages to S3 (while testing, for example)

----

#### `packages.yml` before (4 jobs)
![image](https://user-images.githubusercontent.com/1851278/80407802-2f666b00-8894-11ea-85ec-6fa13f821d42.png)

----

#### `packages.yml` after (3 jobs)
![image](https://user-images.githubusercontent.com/1851278/80407813-342b1f00-8894-11ea-9ce2-a9f2d856e5f5.png)

----

#### `integration-tests.yml` before
![image](https://user-images.githubusercontent.com/1851278/80407896-54f37480-8894-11ea-955a-f0513110588c.png)

----

#### `integration-tests.yml` after
![image](https://user-images.githubusercontent.com/1851278/80405254-5e7add80-8890-11ea-966c-41056b188653.png)
