### PR TITLE
remove assert() calls in the profiler

### DIFF
--- a/samples/Samples.SqlServer/Properties/launchSettings.json
+++ b/samples/Samples.SqlServer/Properties/launchSettings.json
@@ -12,7 +12,8 @@
         "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
-        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+        "DD_PROFILER_EXCLUDE_PROCESSES": "sqlservr.exe"
       },
       "nativeDebugging": true
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -541,6 +541,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   if (first_jit_compilation_app_domains.find(module_metadata->app_domain_id) ==
       first_jit_compilation_app_domains.end()) {
     first_jit_compilation_app_domains.insert(module_metadata->app_domain_id);
+
     hr = RunILStartupHook(module_metadata->metadata_emit, module_id,
                           function_token);
 
@@ -717,7 +718,6 @@ HRESULT CorProfiler::ProcessReplacementCalls(
           " name=", caller.type.name, ".", caller.name, "()");
         continue;
       }
-      
 
       auto method_def_md_token = target.id;
 
@@ -1084,7 +1084,7 @@ HRESULT CorProfiler::RunILStartupHook(
   hr = rewriter.Export();
 
   if (FAILED(hr)) {
-    Warn("RunILStartupHook: Call to ILRewriter.Export() failed for ModuleID=",module_id, " ", function_token);
+    Warn("RunILStartupHook: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ", function_token);
     return hr;
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -522,7 +522,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   }
 
   // get function info
-  auto caller =
+  const auto caller =
       GetFunctionInfo(module_metadata->metadata_import, function_token);
   if (!caller.IsValid()) {
     return S_OK;
@@ -558,7 +558,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   }
 
   // Get valid method replacements for this caller method
-  auto method_replacements =
+  const auto method_replacements =
       module_metadata->GetMethodReplacementsForCaller(caller);
   if (method_replacements.empty()) {
     return S_OK;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -900,7 +900,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
     hr = rewriter.Export();
 
     if (FAILED(hr)) {
-      Warn("ProcessReplacementCalls: Call to ILRewriter.Export() failed for ", module_id, " ", function_token);
+      Warn("ProcessReplacementCalls: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ", function_token);
       return hr;
     }
   }
@@ -978,7 +978,7 @@ HRESULT CorProfiler::ProcessInsertionCalls(
     hr = rewriter.Export();
 
     if (FAILED(hr)) {
-      Warn("ProcessInsertionCalls: Call to ILRewriter.Export() failed for ", module_id, " ", function_token);
+      Warn("ProcessInsertionCalls: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ", function_token);
       return hr;
     }
   }
@@ -1084,7 +1084,7 @@ HRESULT CorProfiler::RunILStartupHook(
   hr = rewriter.Export();
 
   if (FAILED(hr)) {
-    Warn("RunILStartupHook: Call to ILRewriter.Export() failed for ", module_id, " ", function_token);
+    Warn("RunILStartupHook: Call to ILRewriter.Export() failed for ModuleID=",module_id, " ", function_token);
     return hr;
   }
 
@@ -1657,7 +1657,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   hr = rewriter_void.Export();
   if (FAILED(hr)) {
-    Warn("GenerateVoidILStartupMethod: Unable to save the IL body. ModuleID=", module_id);
+    Warn("GenerateVoidILStartupMethod: Call to ILRewriter.Export() failed for ModuleID=", module_id);
     return hr;
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -518,7 +518,6 @@ again:
             break;
           default:
             return COR_E_INVALIDPROGRAM;
-            break;
         }
       }
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full
 // license information.
 
-#include <cassert>
 #include <corhlpr.cpp>
 
 #include "il_rewriter.h"

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -318,24 +318,26 @@ HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH) {
 
     EHClause* clause = &(m_pEH[iEH]);
     clause->m_Flags = ehInfo->GetFlags();
+    ILInstr* pInstr = nullptr;
 
-    IfFailRet(GetInstrFromOffset(ehInfo->GetTryOffset(), &clause->m_pTryBegin));
+    IfFailRet(GetInstrFromOffset(ehInfo->GetTryOffset(), &pInstr));
+    clause->m_pTryBegin = pInstr;
 
-    IfFailRet(GetInstrFromOffset(ehInfo->GetTryOffset() + ehInfo->GetTryLength(),
-                            &clause->m_pTryEnd));
+    IfFailRet(GetInstrFromOffset(ehInfo->GetTryOffset() + ehInfo->GetTryLength(), &pInstr));
+    clause->m_pTryEnd = pInstr;
 
-    IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset(),
-                            &clause->m_pHandlerBegin));
+    IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset(), &pInstr));
+    clause->m_pHandlerBegin = pInstr;
 
-    ILInstr* temp = nullptr;
-    IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset() +
-                            ehInfo->GetHandlerLength(), &temp));
-    clause->m_pHandlerEnd = temp->m_pPrev;
+    IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset() + ehInfo->GetHandlerLength(), &pInstr));
+    clause->m_pHandlerEnd = pInstr->m_pPrev;
+
 
     if ((clause->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0) {
       clause->m_ClassToken = ehInfo->GetClassToken();
     } else {
-      IfFailRet(GetInstrFromOffset(ehInfo->GetFilterOffset(), &clause->m_pFilter));
+      IfFailRet(GetInstrFromOffset(ehInfo->GetFilterOffset(), &pInstr));
+      clause->m_pFilter = pInstr;
     }
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -155,7 +155,7 @@ HRESULT ILRewriter::Import() {
   LPCBYTE pMethodBytes;
 
   IfFailRet(m_pICorProfilerInfo->GetILFunctionBody(m_moduleId, m_tkMethod,
-                                                   &pMethodBytes, NULL));
+                                                   &pMethodBytes, nullptr));
 
   COR_ILMETHOD_DECODER decoder((COR_ILMETHOD*)pMethodBytes);
 
@@ -275,7 +275,6 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
       }
       default:
         return COR_E_INVALIDPROGRAM;
-        break;
     }
     offset += size;
   }
@@ -300,7 +299,7 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
 HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH) {
   if(m_pEH != nullptr)
   {
-    return COR_E_ARGUMENT;
+    return COR_E_INVALIDOPERATION;
   }
 
   m_nEH = nEH;
@@ -328,7 +327,7 @@ HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH) {
     IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset(),
                             &clause->m_pHandlerBegin));
 
-    ILInstr* temp;
+    ILInstr* temp = nullptr;
     IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset() +
                             ehInfo->GetHandlerLength(), &temp));
     clause->m_pHandlerEnd = temp->m_pPrev;

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -347,14 +347,14 @@ ILInstr* ILRewriter::NewILInstr() {
   return new ILInstr();
 }
 
-HRESULT ILRewriter::GetInstrFromOffset(unsigned offset, ILInstr** pInstr) {
-  pInstr = nullptr;
+HRESULT ILRewriter::GetInstrFromOffset(unsigned offset, ILInstr** ppInstr) {
+  *ppInstr = nullptr;
 
   if (offset <= m_CodeSize) {
-    pInstr = &m_pOffsetToInstr[offset];
+    *ppInstr = m_pOffsetToInstr[offset];
   }
 
-  return (pInstr == nullptr) ? COR_E_INVALIDPROGRAM : S_OK;
+  return (*ppInstr == nullptr) ? COR_E_INVALIDPROGRAM : S_OK;
 }
 
 void ILRewriter::InsertBefore(ILInstr* pWhere, ILInstr* pWhat) {

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -289,8 +289,7 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
     for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL;
          pInstr = pInstr->m_pNext) {
       if (s_OpCodeFlags[pInstr->m_opcode] & OPCODEFLAGS_BranchTarget) {
-        HRESULT hr = GetInstrFromOffset(pInstr->m_Arg32, &pInstr->m_pTarget);
-        IfFailRet(hr);
+        IfFailRet(GetInstrFromOffset(pInstr->m_Arg32, &pInstr->m_pTarget));
       }
     }
   }
@@ -321,30 +320,23 @@ HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH) {
     EHClause* clause = &(m_pEH[iEH]);
     clause->m_Flags = ehInfo->GetFlags();
 
-    HRESULT hr;
+    IfFailRet(GetInstrFromOffset(ehInfo->GetTryOffset(), &clause->m_pTryBegin));
 
-    hr = GetInstrFromOffset(ehInfo->GetTryOffset(), &clause->m_pTryBegin);
-    IfFailRet(hr);
+    IfFailRet(GetInstrFromOffset(ehInfo->GetTryOffset() + ehInfo->GetTryLength(),
+                            &clause->m_pTryEnd));
 
-    hr = GetInstrFromOffset(ehInfo->GetTryOffset() + ehInfo->GetTryLength(),
-                            &clause->m_pTryEnd);
-    IfFailRet(hr);
-
-    hr = GetInstrFromOffset(ehInfo->GetHandlerOffset(),
-                            &clause->m_pHandlerBegin);
-    IfFailRet(hr);
+    IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset(),
+                            &clause->m_pHandlerBegin));
 
     ILInstr* temp;
-    hr = GetInstrFromOffset(ehInfo->GetHandlerOffset() +
-                            ehInfo->GetHandlerLength(), &temp);
-    IfFailRet(hr);
+    IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset() +
+                            ehInfo->GetHandlerLength(), &temp));
     clause->m_pHandlerEnd = temp->m_pPrev;
 
     if ((clause->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0) {
       clause->m_ClassToken = ehInfo->GetClassToken();
     } else {
-      hr = GetInstrFromOffset(ehInfo->GetFilterOffset(), &clause->m_pFilter);
-      IfFailRet(hr);
+      IfFailRet(GetInstrFromOffset(ehInfo->GetFilterOffset(), &clause->m_pFilter));
     }
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -332,7 +332,6 @@ HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH) {
     IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset() + ehInfo->GetHandlerLength(), &pInstr));
     clause->m_pHandlerEnd = pInstr->m_pPrev;
 
-
     if ((clause->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0) {
       clause->m_ClassToken = ehInfo->GetClassToken();
     } else {

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -192,7 +192,6 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
 
     if (opcode == CEE_PREFIX1) {
       if (offset >= m_CodeSize) {
-        assert(false);
         return COR_E_INVALIDPROGRAM;
       }
       opcode = 0x100 + pIL[offset++];
@@ -200,12 +199,10 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
 
     if ((CEE_PREFIX7 <= opcode) && (opcode <= CEE_PREFIX2)) {
       // NOTE: CEE_PREFIX2-7 are currently not supported
-      assert(false);
       return COR_E_INVALIDPROGRAM;
     }
 
     if (opcode >= CEE_COUNT) {
-      assert(false);
       return COR_E_INVALIDPROGRAM;
     }
 
@@ -213,7 +210,6 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
 
     int size = (flags & OPCODEFLAGS_SizeMask);
     if (offset + size > m_CodeSize) {
-      assert(false);
       return COR_E_INVALIDPROGRAM;
     }
 
@@ -251,7 +247,6 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
         break;
       case 0 | OPCODEFLAGS_Switch: {
         if (offset + sizeof(INT32) > m_CodeSize) {
-          assert(false);
           return COR_E_INVALIDPROGRAM;
         }
 
@@ -263,7 +258,6 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL) {
 
         for (unsigned iTarget = 0; iTarget < nTargets; iTarget++) {
           if (offset + sizeof(INT32) > m_CodeSize) {
-            assert(false);
             return COR_E_INVALIDPROGRAM;
           }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -349,13 +349,16 @@ ILInstr* ILRewriter::NewILInstr() {
 }
 
 HRESULT ILRewriter::GetInstrFromOffset(unsigned offset, ILInstr** ppInstr) {
-  *ppInstr = nullptr;
-
   if (offset <= m_CodeSize) {
-    *ppInstr = m_pOffsetToInstr[offset];
+    ILInstr* result = m_pOffsetToInstr[offset];
+
+    if(result != nullptr) {
+      *ppInstr = result;
+      return S_OK;
+    }
   }
 
-  return (*ppInstr == nullptr) ? COR_E_INVALIDPROGRAM : S_OK;
+  return COR_E_INVALIDPROGRAM;
 }
 
 void ILRewriter::InsertBefore(ILInstr* pWhere, ILInstr* pWhat) {

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
@@ -102,7 +102,7 @@ class ILRewriter {
 
   ILInstr* NewILInstr();
 
-  ILInstr* GetInstrFromOffset(unsigned offset);
+  HRESULT GetInstrFromOffset(unsigned offset, ILInstr** pInstr);
 
   void InsertBefore(ILInstr* pWhere, ILInstr* pWhat);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
@@ -102,7 +102,7 @@ class ILRewriter {
 
   ILInstr* NewILInstr();
 
-  HRESULT GetInstrFromOffset(unsigned offset, ILInstr** pInstr);
+  HRESULT GetInstrFromOffset(unsigned offset, ILInstr** ppInstr);
 
   void InsertBefore(ILInstr* pWhere, ILInstr* pWhat);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/macros.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/macros.h
@@ -11,12 +11,5 @@
       return (hr);             \
     }                          \
   } while (0)
-#define RETURN_OK_IF_FAILED(EXPR) \
-  do {                            \
-    hr = (EXPR);                  \
-    if (FAILED(hr)) {             \
-      return S_OK;                \
-    }                             \
-  } while (0)
 
 #endif  // DD_CLR_PROFILER_MACROS_H_


### PR DESCRIPTION
The goal of this PR is to disable instrumentation when invalid conditions are found when parsing IL opcodes instead of letting previous `assert()` calls stop the running process.

- return error `HRESULT` codes instead of calling `assert()` in `il_rewriter.cpp`
- add additional logging when instrumentation fails in `cor_profiler.cpp`

See #663