### PR TITLE
Enable the HttpSocketsHandler behind opt-in flag

### DIFF
--- a/samples/Samples.HttpMessageHandler/Properties/launchSettings.json
+++ b/samples/Samples.HttpMessageHandler/Properties/launchSettings.json
@@ -12,7 +12,7 @@
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
-        "DD_HTTPSOCKETSHANDLER_ENABLED": "true",
+        "DD_HttpSocketsHandler_ENABLED": "true",
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },

--- a/samples/Samples.HttpMessageHandler/Properties/launchSettings.json
+++ b/samples/Samples.HttpMessageHandler/Properties/launchSettings.json
@@ -12,6 +12,7 @@
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 
+        "DD_HTTPSOCKETSHANDLER_ENABLED": "true",
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
       },

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            if (!(handler is HttpClientHandler || reportedType.FullName.Equals("System.Net.Http.SocketsHttpHandler", StringComparison.OrdinalIgnoreCase)) ||
+            if (!(handler is HttpClientHandler || IsSocketsHttpHandlerEnabled(reportedType)) ||
                 !IsTracingEnabled(request))
             {
                 // skip instrumentation
@@ -203,6 +203,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     throw;
                 }
             }
+        }
+
+        private static bool IsSocketsHttpHandlerEnabled(Type reportedType)
+        {
+            return Tracer.Instance.Settings.IsOptInIntegrationEnabled("HttpSocketsHandler") && reportedType.FullName.Equals("System.Net.Http.SocketsHttpHandler", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool IsTracingEnabled(HttpRequestMessage request)

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -248,6 +248,12 @@ namespace Datadog.Trace.Configuration
             return TraceEnabled && !disabled;
         }
 
+        internal bool IsOptInIntegrationEnabled(string name)
+        {
+            bool disabled = Integrations[name].Enabled != true || DisabledIntegrationNames.Contains(name);
+            return TraceEnabled && !disabled;
+        }
+
         internal double? GetIntegrationAnalyticsSampleRate(string name, bool enabledWithGlobalSetting)
         {
             var integrationSettings = Integrations[name];

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("HttpMessageHandler", output)
         {
             SetEnvironmentVariable("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION", "true");
-            SetEnvironmentVariable("DD_HTTPSOCKETSHANDLER_ENABLED", "true");
+            SetEnvironmentVariable("DD_HttpSocketsHandler_ENABLED", "true");
         }
 
         [Fact]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("HttpMessageHandler", output)
         {
             SetEnvironmentVariable("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION", "true");
+            SetEnvironmentVariable("DD_HTTPSOCKETSHANDLER_ENABLED", "true");
         }
 
         [Fact]


### PR DESCRIPTION
Enable the HttpSocketsHandler integration only when `DD_HttpSocketsHandler_ENABLED=true`. Enable this in the CI test as well.

@DataDog/apm-dotnet