### PR TITLE
Add app domain id and tracer version to log context

### DIFF
--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -66,9 +66,9 @@ namespace Datadog.Trace.Logging
                 {
                     var currentAppDomain = AppDomain.CurrentDomain;
                     loggerConfiguration.Enrich.WithProperty("MachineName", currentProcess.MachineName);
-                    loggerConfiguration.Enrich.WithProperty("ProcessName", currentProcess.ProcessName);
-                    loggerConfiguration.Enrich.WithProperty("PID", currentProcess.Id);
-                    loggerConfiguration.Enrich.WithProperty("AppDomainName", currentAppDomain.FriendlyName);
+                    loggerConfiguration.Enrich.WithProperty("Process", $"[{currentProcess.Id} {currentProcess.ProcessName}]");
+                    loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{currentAppDomain.Id} {currentAppDomain.FriendlyName}]");
+                    loggerConfiguration.Enrich.WithProperty("TracerVersion", TracerConstants.AssemblyVersion);
                 }
                 catch
                 {


### PR DESCRIPTION
Add some more valuable detail into the log context so we can examine disparate versions and app domains.

@DataDog/apm-dotnet