### PR TITLE
Remove remaining usages of LibLog

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         private const string NpgsqlCommandTypeName = "Npgsql.NpgsqlCommand";
         private const string NpgsqlDataReaderTypeName = "Npgsql.NpgsqlDataReader";
 
-        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(NpgsqlCommandIntegration));
 
         /// <summary>
         /// Instrumentation wrapper for NpgsqlCommand />
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)");
                 throw;
             }
 
@@ -116,7 +116,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)");
                 throw;
             }
 
@@ -189,7 +189,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)");
                 throw;
             }
 
@@ -267,7 +267,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)");
                 throw;
             }
 
@@ -320,7 +320,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)");
                 throw;
             }
 
@@ -395,7 +395,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQueryAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQueryAsync}(...)");
                 throw;
             }
 
@@ -448,7 +448,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)");
                 throw;
             }
 
@@ -523,7 +523,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalarAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {NpgsqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalarAsync}(...)");
                 throw;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         private const string SqlCommandTypeName = "System.Data.SqlClient.SqlCommand";
         private const string SqlDataReaderTypeName = "System.Data.SqlClient.SqlDataReader";
 
-        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(SqlCommandIntegration));
 
         /// <summary>
         /// Instrumentation wrapper for SqlCommand.ExecuteReader().
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)");
                 throw;
             }
 
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReader}(...)");
                 throw;
             }
 
@@ -192,7 +192,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteReaderAsync}(...)");
                 throw;
             }
 
@@ -245,7 +245,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQuery}(...)");
                 throw;
             }
 
@@ -320,7 +320,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQueryAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteNonQueryAsync}(...)");
                 throw;
             }
 
@@ -373,7 +373,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalar}(...)");
                 throw;
             }
 
@@ -448,7 +448,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             }
             catch (Exception ex)
             {
-                Log.ErrorException($"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalarAsync}(...)", ex);
+                Log.Error(ex, $"Error resolving {SqlCommandTypeName}.{AdoNetConstants.MethodNames.ExecuteScalarAsync}(...)");
                 throw;
             }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.Agent
 
                 if (frameworkDescription != null)
                 {
+                    Log.Information(frameworkDescription.ToString());
                     _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageInterpreter, frameworkDescription.Name);
                     _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.LanguageVersion, frameworkDescription.ProductVersion);
                 }

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace
 {
     internal class FrameworkDescription
     {
-        private static readonly ILog Log = LogProvider.GetCurrentClassLogger();
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(FrameworkDescription));
 
         private static readonly Assembly RootAssembly = typeof(object).Assembly;
 
@@ -98,7 +98,7 @@ namespace Datadog.Trace
             }
             catch (Exception e)
             {
-                Log.ErrorException("Error getting framework name from RuntimeInformation", e);
+                Log.Error(e, "Error getting framework name from RuntimeInformation");
             }
 
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
@@ -145,7 +145,7 @@ namespace Datadog.Trace
             }
             catch (Exception e)
             {
-                Log.ErrorException("Error getting .NET Framework version from Windows Registry", e);
+                Log.Error(e, "Error getting .NET Framework version from Windows Registry");
             }
 
             if (productVersion == null)
@@ -186,7 +186,7 @@ namespace Datadog.Trace
                 }
                 catch (Exception e)
                 {
-                    Log.ErrorException("Error getting .NET Core version from assembly path", e);
+                    Log.Error(e, "Error getting .NET Core version from assembly path");
                 }
             }
 
@@ -220,7 +220,7 @@ namespace Datadog.Trace
             }
             catch (Exception e)
             {
-                Log.ErrorException("Error getting framework version from [AssemblyInformationalVersion]", e);
+                Log.Error(e, "Error getting framework version from [AssemblyInformationalVersion]");
             }
 
             if (productVersion == null)
@@ -233,7 +233,7 @@ namespace Datadog.Trace
                 }
                 catch (Exception e)
                 {
-                    Log.ErrorException("Error getting framework version from [AssemblyFileVersion]", e);
+                    Log.Error(e, "Error getting framework version from [AssemblyFileVersion]");
                 }
             }
 

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -81,11 +81,6 @@ namespace Datadog.Trace.Logging
             {
                 // Don't let this exception bubble up as this logger is for debugging and is non-critical
             }
-            finally
-            {
-                // Log some information to correspond with the app domain
-                SharedLogger.Information(FrameworkDescription.Create().ToString());
-            }
         }
 
         public static ILogger GetLogger(Type classType)


### PR DESCRIPTION
Migrate last remaining usages of `LibLog.LogProvider` so it is only used for Logs Injection by the `LibLogScopeEventSubscriber` class. Also, add a try/catch in the `LibLogScopeEventSubscriber` constructor in case the application logger cannot be resolved.

@DataDog/apm-dotnet