### PR TITLE
More precise agent process management

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Agent
                     if (ex.InnerException is SocketException se)
                     {
                         isSocketException = true;
-                        Log.Error(se, "Unable to communicate with the trace agent.", _tracesEndpoint);
+                        Log.Error(se, "Unable to communicate with the trace agent at {Endpoint}", _tracesEndpoint);
                         TracingProcessManager.TryForceTraceAgentRefresh();
                     }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
@@ -117,6 +118,14 @@ namespace Datadog.Trace.Agent
                         return;
                     }
 #endif
+                    var isSocketException = false;
+                    if (ex.InnerException is SocketException se)
+                    {
+                        isSocketException = true;
+                        Log.Error(se, "Unable to communicate with the trace agent.", _tracesEndpoint);
+                        TracingProcessManager.TryForceTraceAgentRefresh();
+                    }
+
                     if (retryCount >= retryLimit)
                     {
                         // stop retrying
@@ -128,7 +137,13 @@ namespace Datadog.Trace.Agent
                     await Task.Delay(sleepDuration).ConfigureAwait(false);
                     retryCount++;
                     sleepDuration *= 2;
-                    TracingProcessManager.TraceAgentMetadata.ForcePortFileRead();
+
+                    if (isSocketException)
+                    {
+                        // Ensure we have the most recent port before trying again
+                        TracingProcessManager.TraceAgentMetadata.ForcePortFileRead();
+                    }
+
                     continue;
                 }
 

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
 {
@@ -244,14 +245,23 @@ namespace Datadog.Trace.Configuration
 
         internal bool IsIntegrationEnabled(string name)
         {
-            bool disabled = Integrations[name].Enabled == false || DisabledIntegrationNames.Contains(name);
-            return TraceEnabled && !disabled;
+            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
+            {
+                return Integrations[name].Enabled == false || DisabledIntegrationNames.Contains(name);
+            }
+
+            return false;
         }
 
         internal bool IsOptInIntegrationEnabled(string name)
         {
-            bool disabled = Integrations[name].Enabled != true || DisabledIntegrationNames.Contains(name);
-            return TraceEnabled && !disabled;
+            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
+            {
+                var disabled = Integrations[name].Enabled != true || DisabledIntegrationNames.Contains(name);
+                return !disabled;
+            }
+
+            return false;
         }
 
         internal double? GetIntegrationAnalyticsSampleRate(string name, bool enabledWithGlobalSetting)

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -47,9 +48,8 @@ namespace Datadog.Trace.Logging
                     return;
                 }
 
-                var currentProcess = Process.GetCurrentProcess();
                 // Ends in a dash because of the date postfix
-                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-{currentProcess.ProcessName}-.log");
+                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-{DomainMetadata.ProcessName}-.log");
 
                 var loggerConfiguration =
                     new LoggerConfiguration()
@@ -64,10 +64,9 @@ namespace Datadog.Trace.Logging
 
                 try
                 {
-                    var currentAppDomain = AppDomain.CurrentDomain;
-                    loggerConfiguration.Enrich.WithProperty("MachineName", currentProcess.MachineName);
-                    loggerConfiguration.Enrich.WithProperty("Process", $"[{currentProcess.Id} {currentProcess.ProcessName}]");
-                    loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{currentAppDomain.Id} {currentAppDomain.FriendlyName}]");
+                    loggerConfiguration.Enrich.WithProperty("MachineName", DomainMetadata.MachineName);
+                    loggerConfiguration.Enrich.WithProperty("Process", $"[{DomainMetadata.ProcessId} {DomainMetadata.ProcessName}]");
+                    loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{DomainMetadata.AppDomainId} {DomainMetadata.AppDomainName}]");
                     loggerConfiguration.Enrich.WithProperty("TracerVersion", TracerConstants.AssemblyVersion);
                 }
                 catch

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -186,7 +186,7 @@ namespace Datadog.Trace
             var fileClaim =
                 Path.Combine(
                     portManagerDirectory,
-                    string.Format(CultureInfo.InvariantCulture, "{0}_{1}", DomainMetadata.ProcessId, DomainMetadata.AppDomainId);
+                    string.Format(CultureInfo.InvariantCulture, "{0}_{1}", DomainMetadata.ProcessId, DomainMetadata.AppDomainId));
 
             var portManagerFiles = Directory.GetFiles(portManagerDirectory);
             if (portManagerFiles.Length > 0)
@@ -194,7 +194,7 @@ namespace Datadog.Trace
                 int? GetProcessIdFromFileName(string fullPath)
                 {
                     var fileName = Path.GetFileNameWithoutExtension(fullPath);
-                    if (int.TryParse(NumberStyles.Integer, CultureInfo.InvariantCulture, fileName?.Split('_')[0], out var pid))
+                    if (int.TryParse(fileName?.Split('_')[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var pid))
                     {
                         return pid;
                     }
@@ -213,7 +213,7 @@ namespace Datadog.Trace
                         {
                             if (claimPid != null)
                             {
-                                using (var process = Process.GetProcessById(claimPid.Value))
+                                using (Process.GetProcessById(claimPid.Value))
                                 {
                                     isActive = true;
                                 }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -194,7 +194,7 @@ namespace Datadog.Trace
                 int? GetProcessIdFromFileName(string fullPath)
                 {
                     var fileName = Path.GetFileNameWithoutExtension(fullPath);
-                    if (int.TryParse(fileName?.Split('_')[0], out var pid))
+                    if (int.TryParse(NumberStyles.Integer, CultureInfo.InvariantCulture, fileName?.Split('_')[0], out var pid))
                     {
                         return pid;
                     }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -215,10 +215,7 @@ namespace Datadog.Trace
                             {
                                 using (var process = Process.GetProcessById(claimPid.Value))
                                 {
-                                    if (!process.HasExited)
-                                    {
-                                        isActive = true;
-                                    }
+                                    isActive = true;
                                 }
                             }
                         }
@@ -563,9 +560,16 @@ namespace Datadog.Trace
                         }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // ignore
+                    try
+                    {
+                        Log.Error(ex, "Error when force killing process {0}.", ProcessPath);
+                    }
+                    catch
+                    {
+                        // ignore, to be safe
+                    }
                 }
             }
 
@@ -592,8 +596,17 @@ namespace Datadog.Trace
 
                     return false;
                 }
-                catch
+                catch (Exception ex)
                 {
+                    try
+                    {
+                        Log.Error(ex, "Error when checking for running program {0}.", ProcessPath);
+                    }
+                    catch
+                    {
+                        // ignore, to be safe
+                    }
+
                     return false;
                 }
             }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -150,7 +150,10 @@ namespace Datadog.Trace
                 Directory.CreateDirectory(portManagerDirectory);
             }
 
-            var fileClaim = Path.Combine(portManagerDirectory, ClaimFileName());
+            var fileClaim =
+                Path.Combine(
+                    portManagerDirectory,
+                    $"{DomainMetadata.ProcessId}_{DomainMetadata.AppDomainId}");
 
             var portManagerFiles = Directory.GetFiles(portManagerDirectory);
             if (portManagerFiles.Length > 0)
@@ -179,12 +182,6 @@ namespace Datadog.Trace
                 File.WriteAllText(fileClaim, DateTime.Now.ToString(CultureInfo.InvariantCulture));
                 _isProcessManager = true;
             }
-        }
-
-        private static string ClaimFileName()
-        {
-            var fileClaimName = $"{DomainMetadata.ProcessId}_{DomainMetadata.AppDomainId}";
-            return fileClaimName;
         }
 
         private static void StartProcesses()

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -65,11 +65,11 @@ namespace Datadog.Trace
         {
             if (string.IsNullOrEmpty(TraceAgentMetadata.DirectoryPath))
             {
-                Log.Debug("This is not a context where we manage sub processes.");
+                Log.Debug("This is not a context where we manage agent processes.");
                 return;
             }
 
-            Log.Warning("We are attempting to force a child process refresh.");
+            Log.Warning("Attempting to force a child process refresh.");
             InitializePortManagerClaimFiles(TraceAgentMetadata.DirectoryPath);
 
             if (!_isProcessManager)

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -221,8 +221,9 @@ namespace Datadog.Trace
                 return false;
             }
 
-            var processId = GetProcessIdFromFileName(fullPath);
-            var processesByName = Process.GetProcessesByName(processId);
+            // fileName will match either TraceAgentMetadata.Name or DogStatsDMetadata.Name
+            var fileName = Path.GetFileNameWithoutExtension(fullPath);
+            var processesByName = Process.GetProcessesByName(fileName);
 
             if (processesByName?.Length > 0)
             {
@@ -230,6 +231,7 @@ namespace Datadog.Trace
                 return true;
             }
 
+            Log.Debug("Program [{0}] managing child processes is no longer running", fullPath);
             return false;
         }
 

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -186,7 +186,7 @@ namespace Datadog.Trace
             var fileClaim =
                 Path.Combine(
                     portManagerDirectory,
-                    $"{DomainMetadata.ProcessId}_{DomainMetadata.AppDomainId}");
+                    string.Format(CultureInfo.InvariantCulture, "{0}_{1}", DomainMetadata.ProcessId, DomainMetadata.AppDomainId);
 
             var portManagerFiles = Directory.GetFiles(portManagerDirectory);
             if (portManagerFiles.Length > 0)

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -434,9 +434,16 @@ namespace Datadog.Trace
                         File.Delete(PortFilePath);
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // ignore for dispose, to be safe
+                    try
+                    {
+                        Log.Error(ex, "Error when disposing of process manager resources.");
+                    }
+                    catch
+                    {
+                        // ignore for dispose, to be safe
+                    }
                 }
             }
 

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -81,16 +81,12 @@ namespace Datadog.Trace
             if (Processes.All(p => p.HasAttemptedStartup))
             {
                 Log.Debug("Forcing a full refresh on agent processes.");
-
                 StopProcesses();
 
                 _cancellationTokenSource = new CancellationTokenSource();
 
-                if (_isProcessManager)
-                {
-                    Log.Debug("Starting child processes from process {0}, AppDomain {1}.", DomainMetadata.ProcessName, DomainMetadata.AppDomainName);
-                    StartProcesses();
-                }
+                Log.Debug("Starting child processes.");
+                StartProcesses();
             }
             else
             {

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -161,7 +161,7 @@ namespace Datadog.Trace
                     try
                     {
                         var claimPid = GetProcessIdFromFileName(portManagerFileName);
-                        if (!activePids.Contains(claimPid))
+                        if (claimPid == null || !activePids.Contains(claimPid))
                         {
                             File.Delete(portManagerFileName);
                         }
@@ -239,15 +239,7 @@ namespace Datadog.Trace
         private static string GetProcessIdFromFileName(string fullPath)
         {
             var fileName = Path.GetFileNameWithoutExtension(fullPath);
-
-            if (fileName == null)
-            {
-                return "-1";
-            }
-
-            var parts = fileName.Split('_');
-
-            return parts[0];
+            return fileName?.Split('_')[0];
         }
 
         private static Task StartProcessWithKeepAlive(ProcessMetadata metadata)

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -13,14 +13,18 @@ namespace Datadog.Trace.Util
         private static bool _processDataPoisoned;
         private static bool _domainDataPoisoned;
 
+        static DomainMetadata()
+        {
+            TrySetProcess();
+        }
+
         public static string ProcessName
         {
             get
             {
                 try
                 {
-                    TrySetProcess();
-                    return _currentProcess?.ProcessName ?? UnknownName;
+                    return !_processDataPoisoned ? _currentProcess.ProcessName : UnknownName;
                 }
                 catch
                 {
@@ -36,8 +40,7 @@ namespace Datadog.Trace.Util
             {
                 try
                 {
-                    TrySetProcess();
-                    return _currentProcess?.MachineName ?? UnknownName;
+                    return !_processDataPoisoned ? _currentProcess.MachineName : UnknownName;
                 }
                 catch
                 {
@@ -53,8 +56,7 @@ namespace Datadog.Trace.Util
             {
                 try
                 {
-                    TrySetProcess();
-                    return _currentProcess?.Id ?? -1;
+                    return !_processDataPoisoned ? _currentProcess.Id : -1;
                 }
                 catch
                 {

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -3,6 +3,9 @@ using System.Diagnostics;
 
 namespace Datadog.Trace.Util
 {
+    /// <summary>
+    /// Dedicated helper class for consistently referencing Process and AppDomain information.
+    /// </summary>
     internal static class DomainMetadata
     {
         private static Process _currentProcess = null;

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -100,9 +100,8 @@ namespace Datadog.Trace.Util
 
         public static bool ShouldAvoidAppDomain()
         {
-            if (AppDomainName.ToLowerInvariant().Contains("applicationinsights"))
+            if (AppDomainName.Contains("applicationinsights", StringComparison.OrdinalIgnoreCase))
             {
-                // unsafe context to operate in
                 return true;
             }
 

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -9,14 +9,9 @@ namespace Datadog.Trace.Util
     internal static class DomainMetadata
     {
         private const string UnknownName = "unknown";
-        private static Process _currentProcess = null;
-        private static bool _processDataPoisoned = false;
-        private static bool _domainDataPoisoned = false;
-
-        static DomainMetadata()
-        {
-            TrySetProcess();
-        }
+        private static Process _currentProcess;
+        private static bool _processDataPoisoned;
+        private static bool _domainDataPoisoned;
 
         public static string ProcessName
         {
@@ -24,7 +19,8 @@ namespace Datadog.Trace.Util
             {
                 try
                 {
-                    return !_processDataPoisoned ? _currentProcess.ProcessName : UnknownName;
+                    TrySetProcess();
+                    return _currentProcess?.ProcessName ?? UnknownName;
                 }
                 catch
                 {
@@ -40,7 +36,8 @@ namespace Datadog.Trace.Util
             {
                 try
                 {
-                    return !_processDataPoisoned ? _currentProcess.MachineName : UnknownName;
+                    TrySetProcess();
+                    return _currentProcess?.MachineName ?? UnknownName;
                 }
                 catch
                 {
@@ -56,7 +53,8 @@ namespace Datadog.Trace.Util
             {
                 try
                 {
-                    return !_processDataPoisoned ? _currentProcess.Id : -1;
+                    TrySetProcess();
+                    return _currentProcess?.Id ?? -1;
                 }
                 catch
                 {

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -100,8 +100,7 @@ namespace Datadog.Trace.Util
 
         public static bool ShouldAvoidAppDomain()
         {
-            var domainUpper = AppDomainName.ToUpperInvariant();
-            if (domainUpper.Contains("APPLICATIONINSIGHTS"))
+            if (AppDomainName.IndexOf("ApplicationInsights", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 return true;
             }

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Diagnostics;
+
+namespace Datadog.Trace.Util
+{
+    internal static class DomainMetadata
+    {
+        private static Process _currentProcess = null;
+        private static bool _poisoned = false;
+
+        static DomainMetadata()
+        {
+            TrySetProcess();
+        }
+
+        public static string ProcessName
+        {
+            get
+            {
+                return !_poisoned ? _currentProcess.ProcessName : "unknown";
+            }
+        }
+
+        public static string MachineName
+        {
+            get
+            {
+                return !_poisoned ? _currentProcess.MachineName : "unknown";
+            }
+        }
+
+        public static int ProcessId
+        {
+            get
+            {
+                return _poisoned ? _currentProcess.Id : -1;
+            }
+        }
+
+        public static string AppDomainName
+        {
+            get
+            {
+                try
+                {
+                    return AppDomain.CurrentDomain.FriendlyName;
+                }
+                catch
+                {
+                    return "unknown";
+                }
+            }
+        }
+
+        public static int AppDomainId
+        {
+            get
+            {
+                try
+                {
+                    return AppDomain.CurrentDomain.Id;
+                }
+                catch
+                {
+                    return -1;
+                }
+            }
+        }
+
+        public static bool ShouldAvoidAppDomain()
+        {
+            if (AppDomainName.ToLowerInvariant().Contains("applicationinsights"))
+            {
+                // unsafe context to operate in
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void TrySetProcess()
+        {
+            try
+            {
+                if (!_poisoned && _currentProcess == null)
+                {
+                    _currentProcess = Process.GetCurrentProcess();
+                }
+            }
+            catch
+            {
+                _poisoned = true;
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -100,7 +100,8 @@ namespace Datadog.Trace.Util
 
         public static bool ShouldAvoidAppDomain()
         {
-            if (AppDomainName.Contains("applicationinsights", StringComparison.OrdinalIgnoreCase))
+            var domainUpper = AppDomainName.ToUpperInvariant();
+            if (domainUpper.Contains("APPLICATIONINSIGHTS"))
             {
                 return true;
             }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -82,8 +82,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             Process process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000);
 
-            string standardOutput = process.StandardOutput.ReadToEnd();
-            string standardError = process.StandardError.ReadToEnd();
+            string standardOutput = string.Empty; // process.StandardOutput.ReadToEnd();
+            string standardError = string.Empty; // process.StandardError.ReadToEnd();
             process.WaitForExit();
             int exitCode = process.ExitCode;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -80,12 +80,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public ProcessResult RunSampleAndWaitForExit(int traceAgentPort, string arguments = null, string packageVersion = "")
         {
-            Process process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000);
+            var process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000);
 
-            string standardOutput = process.StandardOutput.ReadToEnd();
-            string standardError = process.StandardError.ReadToEnd();
+            var standardOutput = process.StandardOutput.ReadToEnd();
+            var standardError = process.StandardError.ReadToEnd();
             process.WaitForExit();
-            int exitCode = process.ExitCode;
+            var exitCode = process.ExitCode;
 
             if (!string.IsNullOrWhiteSpace(standardOutput))
             {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -82,8 +82,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             Process process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000);
 
-            string standardOutput = string.Empty; // process.StandardOutput.ReadToEnd();
-            string standardError = string.Empty; // process.StandardError.ReadToEnd();
+            string standardOutput = process.StandardOutput.ReadToEnd();
+            string standardError = process.StandardError.ReadToEnd();
             process.WaitForExit();
             int exitCode = process.ExitCode;
 

--- a/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -47,8 +47,8 @@ namespace Datadog.Trace.TestHelpers
 
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
-            // startInfo.RedirectStandardOutput = true;
-            // startInfo.RedirectStandardError = true;
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
             startInfo.RedirectStandardInput = redirectStandardInput;
 
             return Process.Start(startInfo);

--- a/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -47,8 +47,8 @@ namespace Datadog.Trace.TestHelpers
 
             startInfo.UseShellExecute = false;
             startInfo.CreateNoWindow = true;
-            startInfo.RedirectStandardOutput = true;
-            startInfo.RedirectStandardError = true;
+            // startInfo.RedirectStandardOutput = true;
+            // startInfo.RedirectStandardError = true;
             startInfo.RedirectStandardInput = redirectStandardInput;
 
             return Process.Start(startInfo);


### PR DESCRIPTION
Changes proposed in this pull request:
Use app domain to determine port manager lock.
Add code to skip tracing in unsafe contexts such as ApplicationInsights.
More robust process checking and aggressive file deletion.

@DataDog/apm-dotnet