### PR TITLE
fix artifact filename when uploading to s3, use stages

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -164,7 +164,7 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['push_to_s3'], 'true'))
+  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
 
   dependsOn:
     - windows_packages_and_nuget
@@ -199,6 +199,7 @@ jobs:
   - script: |
       MSI_NAME=$(ls s3_upload/*.msi)
       PACKAGE_NAME=${MSI_NAME::-7}
+      echo Renaming deb package to $PACKAGE_NAME-amd64.deb
       mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
     displayName: Rename deb package name to match MSI name
 
@@ -208,20 +209,25 @@ jobs:
       echo $(GitVersion.Sha) >> $INDEX_FILE
       pushd s3_upload && name=$(ls *.deb) && echo "${name::-7}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
+      cat $INDEX_FILE
     displayName: Write index.txt
 
   - script: sudo apt-get install -y awscli
     displayName: Install AWS CLI
+    condition: eq(variables['push_to_s3'], 'true')
 
   - script: aws configure set aws_access_key_id $SECRET
     displayName: Authenticate aws_access_key_id
+    condition: eq(variables['push_to_s3'], 'true')
     env:
       SECRET: $(AWS_ACCESS_KEY_ID)
 
   - script: aws configure set aws_secret_access_key $SECRET
     displayName: Authenticate aws_secret_access_key
+    condition: eq(variables['push_to_s3'], 'true')
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
   - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb, MSI, index.txt to s3
+    condition: eq(variables['push_to_s3'], 'true')

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -164,26 +164,6 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  # by default, run this job on master branch only, use "push_artifacts_to_s3" to override
-
-  # variable "push_artifacts_to_s3":
-  #   "true": run this job and push to s3 (run everything)
-  #   "false": do NOT run this job, do NOT push to s3 (skip everything)
-  #   "test": run this job, but do NOT push to s3 (skip last step)
-
-  # condition = succeeded &&
-  #             ((push_artifacts_to_s3 == "true") ||
-  #              (push_artifacts_to_s3 == "test") ||
-  #              (branch == "master" && push_artifacts_to_s3 != "false"))
-  condition: >
-    and(
-      succeeded(),
-      or(
-        eq(variables['push_artifacts_to_s3'], 'true'),
-        eq(variables['push_artifacts_to_s3'], 'test'),
-        and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['push_artifacts_to_s3'], 'false'))
-      )
-    )
 
   dependsOn:
     - windows_packages_and_nuget
@@ -245,6 +225,20 @@ jobs:
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
+  # by default, run this step on master branch only.
+  # use "push_artifacts_to_s3" to override:
+  #   "true": run this step
+  #   "false": do NOT run this step
+  #   else: run this stage if branch is master
+
   - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb, MSI, index.txt to s3
-    condition: and(succeeded(), ne(variables['push_artifacts_to_s3'], 'test'))
+    condition: >
+      and(
+        succeeded(),
+        ne(variables['push_artifacts_to_s3'], 'false'),
+        or(
+          eq(variables['push_artifacts_to_s3'], 'true'),
+          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        )
+      )

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -169,11 +169,12 @@ jobs:
   # variable "push_artifacts_to_s3":
   #   "true": run this job and push to s3 (run everything)
   #   "false": do NOT run this job, do NOT push to s3 (skip everything)
-  #   "test": run this job, do NOT push to s3 (skip last step)
+  #   "test": run this job, but do NOT push to s3 (skip last step)
 
   # condition = succeeded &&
   #             ((push_artifacts_to_s3 == "true") ||
-  #              (branch == master && push_artifacts_to_s3 != "false"))
+  #              (push_artifacts_to_s3 == "test") ||
+  #              (branch == "master" && push_artifacts_to_s3 != "false"))
   condition: >
     and(
       succeeded(),

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -194,8 +194,8 @@ jobs:
     displayName: Move deb package and MSI to s3_upload folder
 
   # for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
-  # to datadog-dotnet-apm-{version}-{tag}-amd64.deb
-  # by copying the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
+  # to datadog-dotnet-apm-{version}-{tag}-amd64.deb (i.e. add the prerelease tag)
+  # by copying most of the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
   - script: |
       MSI_NAME=$(ls s3_upload/*.msi)
       PACKAGE_NAME=${MSI_NAME::-8}
@@ -209,6 +209,7 @@ jobs:
       echo $(GitVersion.Sha) >> $INDEX_FILE
       pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
+      echo Generated index.txt file:
       cat $INDEX_FILE
     displayName: Write index.txt
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -193,10 +193,13 @@ jobs:
       mv $(Pipeline.Workspace)/linux-packages/*.deb s3_upload/
     displayName: Move deb package and MSI to s3_upload folder
 
+# for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
+# to datadog-dotnet-apm-{version}-{tag}-amd64.deb
+# by copying the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
   - script: |
       MSI_NAME=$(ls s3_upload/*.msi)
-      PACKAGE_NAME=${MSI_NAME::-4}
-      mv s3_upload/*.deb $PACKAGE_NAME.deb
+      PACKAGE_NAME=${MSI_NAME::-7}
+      mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
     displayName: Rename deb package name to match MSI name
 
   - script: |

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -164,7 +164,19 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  condition: and(succeeded(), not(startsWith(variables['Build.SourceBranch'], 'refs/tags/')))
+  # by default, run this job on master branch only,
+  # but allow overriding by setting the "push_artifacts_to_s3" variable.
+  # condition = succeeded &&
+  #             ((branch == master && push_artifacts_to_s3 != "false") ||
+  #              (branch != master && push_artifacts_to_s3 == "true"))
+  condition: >
+    and(
+      succeeded(),
+      or(
+        and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['push_artifacts_to_s3'], 'false')),
+        and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['push_artifacts_to_s3'], 'true')),
+      )
+    )
 
   dependsOn:
     - windows_packages_and_nuget
@@ -215,20 +227,17 @@ jobs:
 
   - script: sudo apt-get install -y awscli
     displayName: Install AWS CLI
-    condition: eq(variables['push_to_s3'], 'true')
 
   - script: aws configure set aws_access_key_id $SECRET
     displayName: Authenticate aws_access_key_id
-    condition: eq(variables['push_to_s3'], 'true')
     env:
       SECRET: $(AWS_ACCESS_KEY_ID)
 
   - script: aws configure set aws_secret_access_key $SECRET
     displayName: Authenticate aws_secret_access_key
-    condition: eq(variables['push_to_s3'], 'true')
     env:
       SECRET: $(AWS_SECRET_ACCESS_KEY)
 
   - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb, MSI, index.txt to s3
-    condition: eq(variables['push_to_s3'], 'true')
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')) # only upload in master branch

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -171,10 +171,6 @@ stages:
   jobs:
   - job: s3_upload
 
-    dependsOn:
-      - windows_packages_and_nuget
-      - linux_packages
-
     pool:
       vmImage: ubuntu-18.04
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -10,235 +10,241 @@ variables:
   dotnetCoreSdkVersion: 3.1.x
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
-jobs:
+stages:
+- stage: build
+  jobs:
 
-#### Windows and NuGet packages
+  #### Windows and NuGet packages
 
-- job: windows_packages_and_nuget
-  pool:
-    vmImage: windows-2019
-  variables:
-    tracerHomeName: windows-tracer-home
-    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/$(tracerHomeName)
-    msiHome: $(System.DefaultWorkingDirectory)/src/bin/msi
-    nuget_packages: $(Pipeline.Workspace)/.nuget/packages
+  - job: windows_packages_and_nuget
+    pool:
+      vmImage: windows-2019
+    variables:
+      tracerHomeName: windows-tracer-home
+      tracerHome: $(System.DefaultWorkingDirectory)/src/bin/$(tracerHomeName)
+      msiHome: $(System.DefaultWorkingDirectory)/src/bin/msi
+      nuget_packages: $(Pipeline.Workspace)/.nuget/packages
 
-  steps:
+    steps:
 
-  - task: UseDotNet@2
-    displayName: install dotnet core sdk
-    inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+    - task: UseDotNet@2
+      displayName: install dotnet core sdk
+      inputs:
+        packageType: sdk
+        version: $(dotnetCoreSdkVersion)
 
-  - task: NuGetToolInstaller@1
-    displayName: install nuget
+    - task: NuGetToolInstaller@1
+      displayName: install nuget
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet restore
-    inputs:
-      command: restore
-      projects: src/**/*.csproj
+    - task: DotNetCoreCLI@2
+      displayName: dotnet restore
+      inputs:
+        command: restore
+        projects: src/**/*.csproj
 
-  # native projects must be restored with nuget.exe
-  - task: NuGetCommand@2
-    displayName: nuget restore native
-    inputs:
-      restoreSolution: Datadog.Trace.Native.sln
-      verbosityRestore: Normal
+    # native projects must be restored with nuget.exe
+    - task: NuGetCommand@2
+      displayName: nuget restore native
+      inputs:
+        restoreSolution: Datadog.Trace.Native.sln
+        verbosityRestore: Normal
 
-  # this triggers a dependency chain that builds all the managed, x64, and x86 dlls, and the zip and msi files
-  - task: MSBuild@1
-    displayName: build both msi
-    inputs:
-      solution: Datadog.Trace.proj
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:msi /p:Platform=All;ZipHomeDirectory=true;TracerHomeDirectory=$(tracerHome);RunWixToolsOutOfProc=true;MsiOutputPath=$(msiHome)
-      maximumCpuCount: true
+    # this triggers a dependency chain that builds all the managed, x64, and x86 dlls, and the zip and msi files
+    - task: MSBuild@1
+      displayName: build both msi
+      inputs:
+        solution: Datadog.Trace.proj
+        configuration: $(buildConfiguration)
+        msbuildArguments: /t:msi /p:Platform=All;ZipHomeDirectory=true;TracerHomeDirectory=$(tracerHome);RunWixToolsOutOfProc=true;MsiOutputPath=$(msiHome)
+        maximumCpuCount: true
 
-  - publish: $(msiHome)/en-us
-    artifact: windows-msi
+    - publish: $(msiHome)/en-us
+      artifact: windows-msi
 
-  - publish: $(tracerHome).zip
-    artifact: $(tracerHomeName)
+    - publish: $(tracerHome).zip
+      artifact: $(tracerHomeName)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet pack
-    inputs:
-      command: pack
-      packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
-      packDirectory: $(System.DefaultWorkingDirectory)/nuget-output
-      configuration: $(buildConfiguration)
+    - task: DotNetCoreCLI@2
+      displayName: dotnet pack
+      inputs:
+        command: pack
+        packagesToPack: src/Datadog.Trace/Datadog.Trace.csproj;src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+        packDirectory: $(System.DefaultWorkingDirectory)/nuget-output
+        configuration: $(buildConfiguration)
 
-  - publish: $(System.DefaultWorkingDirectory)/nuget-output
-    artifact: nuget-packages
+    - publish: $(System.DefaultWorkingDirectory)/nuget-output
+      artifact: nuget-packages
 
-#### Linux packages
+  #### Linux packages
 
-- job: linux_packages
-  pool:
-    vmImage: ubuntu-18.04
-  variables:
-    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
+  - job: linux_packages
+    pool:
+      vmImage: ubuntu-18.04
+    variables:
+      tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
-  steps:
-  - task: UseDotNet@2
-    displayName: install dotnet core sdk
-    inputs:
-      version: $(dotnetCoreSdkVersion)
+    steps:
+    - task: UseDotNet@2
+      displayName: install dotnet core sdk
+      inputs:
+        version: $(dotnetCoreSdkVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
-    inputs:
-      command: build
-      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-      arguments: --configuration $(buildConfiguration)
+    - task: DotNetCoreCLI@2
+      displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+      inputs:
+        command: build
+        projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+        arguments: --configuration $(buildConfiguration)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
+    - task: DotNetCoreCLI@2
+      displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
+      inputs:
+        command: publish
+        publishWebProjects: false
+        modifyOutputPath: false
+        zipAfterPublish: false
+        projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+        arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
 
-  - task: DockerCompose@0
-    displayName: docker-compose run Profiler
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
+    - task: DockerCompose@0
+      displayName: docker-compose run Profiler
+      inputs:
+        containerregistrytype: Container Registry
+        dockerComposeCommand: run Profiler
 
-  - task: DockerCompose@0
-    displayName: docker-compose run package
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run package
+    - task: DockerCompose@0
+      displayName: docker-compose run package
+      inputs:
+        containerregistrytype: Container Registry
+        dockerComposeCommand: run package
 
-  - publish: deploy/linux
-    artifact: linux-packages
+    - publish: deploy/linux
+      artifact: linux-packages
 
-- job: linux_alpine_packages
-  pool:
-    vmImage: ubuntu-18.04
-  variables:
-    tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
+  - job: linux_alpine_packages
+    pool:
+      vmImage: ubuntu-18.04
+    variables:
+      tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
-  steps:
-  - task: UseDotNet@2
-    displayName: install dotnet core sdk
-    inputs:
-      version: $(dotnetCoreSdkVersion)
+    steps:
+    - task: UseDotNet@2
+      displayName: install dotnet core sdk
+      inputs:
+        version: $(dotnetCoreSdkVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
-    inputs:
-      command: build
-      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-      arguments: --configuration $(buildConfiguration)
+    - task: DotNetCoreCLI@2
+      displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+      inputs:
+        command: build
+        projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+        arguments: --configuration $(buildConfiguration)
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
-    inputs:
-      command: publish
-      publishWebProjects: false
-      modifyOutputPath: false
-      zipAfterPublish: false
-      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
-      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
+    - task: DotNetCoreCLI@2
+      displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed
+      inputs:
+        command: publish
+        publishWebProjects: false
+        modifyOutputPath: false
+        zipAfterPublish: false
+        projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+        arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(tracerHome)/netstandard2.0
 
-  - task: DockerCompose@0
-    displayName: docker-compose run Profiler.Alpine
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler.Alpine
+    - task: DockerCompose@0
+      displayName: docker-compose run Profiler.Alpine
+      inputs:
+        containerregistrytype: Container Registry
+        dockerComposeCommand: run Profiler.Alpine
 
-  - task: DockerCompose@0
-    displayName: docker-compose run package.alpine
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run package.alpine
+    - task: DockerCompose@0
+      displayName: docker-compose run package.alpine
+      inputs:
+        containerregistrytype: Container Registry
+        dockerComposeCommand: run package.alpine
 
-  - publish: deploy/linux
-    artifact: linux-alpine-packages
+    - publish: deploy/linux
+      artifact: linux-alpine-packages
 
-- job: s3_upload
+  #### Upload artifacts to S3
 
-  dependsOn:
-    - windows_packages_and_nuget
-    - linux_packages
+- stage: upload
+  jobs:
+  - job: s3_upload
 
-  pool:
-    vmImage: ubuntu-18.04
+    dependsOn:
+      - windows_packages_and_nuget
+      - linux_packages
 
-  steps:
-  - task: GitVersion@5
-    displayName: GitVersion
-    inputs:
-      preferBundledVersion: false
+    pool:
+      vmImage: ubuntu-18.04
 
-  - download: current
-    artifact: windows-msi
-    patterns: '**/*x64.msi'
+    steps:
+    - task: GitVersion@5
+      displayName: GitVersion
+      inputs:
+        preferBundledVersion: false
 
-  - download: current
-    artifact: linux-packages
-    patterns: '**/*amd64.deb'
+    - download: current
+      artifact: windows-msi
+      patterns: '**/*x64.msi'
 
-  - script: |
-      mkdir s3_upload
-      mv $(Pipeline.Workspace)/windows-msi/*.msi s3_upload/
-      mv $(Pipeline.Workspace)/linux-packages/*.deb s3_upload/
-    displayName: Move deb package and MSI to s3_upload folder
+    - download: current
+      artifact: linux-packages
+      patterns: '**/*amd64.deb'
 
-  # for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
-  # to datadog-dotnet-apm-{version}-{tag}-amd64.deb (i.e. add the prerelease tag)
-  # by copying most of the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
-  - script: |
-      MSI_NAME=$(ls s3_upload/*.msi)
-      PACKAGE_NAME=${MSI_NAME::-8}
-      echo Renaming deb package to $PACKAGE_NAME-amd64.deb
-      mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
-    displayName: Rename deb package name to match MSI name
+    - script: |
+        mkdir s3_upload
+        mv $(Pipeline.Workspace)/windows-msi/*.msi s3_upload/
+        mv $(Pipeline.Workspace)/linux-packages/*.deb s3_upload/
+      displayName: Move deb package and MSI to s3_upload folder
 
-  - script: |
-      INDEX_FILE=$(pwd)/s3_upload/index.txt
-      echo $(GitVersion.BranchName) >> $INDEX_FILE
-      echo $(GitVersion.Sha) >> $INDEX_FILE
-      pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
-      git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
-      echo Generated index.txt file:
-      cat $INDEX_FILE
-    displayName: Write index.txt
+    # for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
+    # to datadog-dotnet-apm-{version}-{tag}-amd64.deb (i.e. add the prerelease tag)
+    # by copying most of the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
+    - script: |
+        MSI_NAME=$(ls s3_upload/*.msi)
+        PACKAGE_NAME=${MSI_NAME::-8}
+        echo Renaming deb package to $PACKAGE_NAME-amd64.deb
+        mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
+      displayName: Rename deb package name to match MSI name
 
-  - script: sudo apt-get install -y awscli
-    displayName: Install AWS CLI
+    - script: |
+        INDEX_FILE=$(pwd)/s3_upload/index.txt
+        echo $(GitVersion.BranchName) >> $INDEX_FILE
+        echo $(GitVersion.Sha) >> $INDEX_FILE
+        pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
+        git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
+        echo Generated index.txt file:
+        cat $INDEX_FILE
+      displayName: Write index.txt
 
-  - script: aws configure set aws_access_key_id $SECRET
-    displayName: Authenticate aws_access_key_id
-    env:
-      SECRET: $(AWS_ACCESS_KEY_ID)
+    - script: sudo apt-get install -y awscli
+      displayName: Install AWS CLI
 
-  - script: aws configure set aws_secret_access_key $SECRET
-    displayName: Authenticate aws_secret_access_key
-    env:
-      SECRET: $(AWS_SECRET_ACCESS_KEY)
+    - script: aws configure set aws_access_key_id $SECRET
+      displayName: Authenticate aws_access_key_id
+      env:
+        SECRET: $(AWS_ACCESS_KEY_ID)
 
-  # by default, run this step on master branch only.
-  # use "push_artifacts_to_s3" to override:
-  #   "true": run this step
-  #   "false": do NOT run this step
-  #   else: run this stage if branch is master
+    - script: aws configure set aws_secret_access_key $SECRET
+      displayName: Authenticate aws_secret_access_key
+      env:
+        SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-  - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
-    displayName: Upload deb, MSI, index.txt to s3
-    condition: >
-      and(
-        succeeded(),
-        ne(variables['push_artifacts_to_s3'], 'false'),
-        or(
-          eq(variables['push_artifacts_to_s3'], 'true'),
-          eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    # by default, run this step on master branch only.
+    # use "push_artifacts_to_s3" to override:
+    #   "true": run this step
+    #   "false": do NOT run this step
+    #   else: run this stage if branch is master
+
+    - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
+      displayName: Upload deb, MSI, index.txt to s3
+      condition: >
+        and(
+          succeeded(),
+          ne(variables['push_artifacts_to_s3'], 'false'),
+          or(
+            eq(variables['push_artifacts_to_s3'], 'true'),
+            eq(variables['Build.SourceBranch'], 'refs/heads/master')
+          )
         )
-      )

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -171,7 +171,7 @@ jobs:
     - linux_packages
 
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-18.04
 
   steps:
   - task: GitVersion@5

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -164,17 +164,23 @@ jobs:
     artifact: linux-alpine-packages
 
 - job: s3_upload
-  # by default, run this job on master branch only,
-  # but allow overriding by setting the "push_artifacts_to_s3" variable.
+  # by default, run this job on master branch only, use "push_artifacts_to_s3" to override
+
+  # variable "push_artifacts_to_s3":
+  #   "true": run this job and push to s3 (run everything)
+  #   "false": do NOT run this job, do NOT push to s3 (skip everything)
+  #   "test": run this job, do NOT push to s3 (skip last step)
+
   # condition = succeeded &&
-  #             ((branch == master && push_artifacts_to_s3 != "false") ||
-  #              (branch != master && push_artifacts_to_s3 == "true"))
+  #             ((push_artifacts_to_s3 == "true") ||
+  #              (branch == master && push_artifacts_to_s3 != "false"))
   condition: >
     and(
       succeeded(),
       or(
-        and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['push_artifacts_to_s3'], 'false')),
-        and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['push_artifacts_to_s3'], 'true'))
+        eq(variables['push_artifacts_to_s3'], 'true'),
+        eq(variables['push_artifacts_to_s3'], 'test'),
+        and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['push_artifacts_to_s3'], 'false'))
       )
     )
 
@@ -240,4 +246,4 @@ jobs:
 
   - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
     displayName: Upload deb, MSI, index.txt to s3
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')) # only upload in master branch
+    condition: and(succeeded(), ne(variables['push_artifacts_to_s3'], 'test'))

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -198,7 +198,7 @@ jobs:
   # by copying the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
   - script: |
       MSI_NAME=$(ls s3_upload/*.msi)
-      PACKAGE_NAME=${MSI_NAME::-7}
+      PACKAGE_NAME=${MSI_NAME::-8}
       echo Renaming deb package to $PACKAGE_NAME-amd64.deb
       mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
     displayName: Rename deb package name to match MSI name
@@ -207,7 +207,7 @@ jobs:
       INDEX_FILE=$(pwd)/s3_upload/index.txt
       echo $(GitVersion.BranchName) >> $INDEX_FILE
       echo $(GitVersion.Sha) >> $INDEX_FILE
-      pushd s3_upload && name=$(ls *.deb) && echo "${name::-7}*" >> $INDEX_FILE && popd
+      pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
       git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
       cat $INDEX_FILE
     displayName: Write index.txt

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -174,7 +174,7 @@ jobs:
       succeeded(),
       or(
         and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), ne(variables['push_artifacts_to_s3'], 'false')),
-        and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['push_artifacts_to_s3'], 'true')),
+        and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['push_artifacts_to_s3'], 'true'))
       )
     )
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -193,9 +193,9 @@ jobs:
       mv $(Pipeline.Workspace)/linux-packages/*.deb s3_upload/
     displayName: Move deb package and MSI to s3_upload folder
 
-# for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
-# to datadog-dotnet-apm-{version}-{tag}-amd64.deb
-# by copying the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
+  # for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
+  # to datadog-dotnet-apm-{version}-{tag}-amd64.deb
+  # by copying the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
   - script: |
       MSI_NAME=$(ls s3_upload/*.msi)
       PACKAGE_NAME=${MSI_NAME::-7}


### PR DESCRIPTION
- fix platform name in debian package filename (should be `amd64`, not `x64`) when uploading artifacts to S3
- changed the condition to run the S3 upload to make it easier to force or skip, still default to running on `master`
  - this required replacing the pipeline variable `push_to_s3` with `push_artifacts_to_s3` because the default value changed from `true` to empty
- split pipeline into two stages because it's a cool feature 😅 

See [pipelines runs here](https://dev.azure.com/datadog-apm/dd-trace-dotnet/_build?definitionId=26&_a=summary&repositoryFilter=5&branchFilter=1602). Screenshots below.

(I recommend hiding whitespace changes when viewing the diff because most of the file has an additional level of indentation due to the addition of pipeline stages.)

![image](https://user-images.githubusercontent.com/1851278/81986515-ed645580-9605-11ea-9c20-5eead45b1241.png)

![image](https://user-images.githubusercontent.com/1851278/81986187-5eefd400-9605-11ea-90ee-646c622eb2a4.png)

Note: after merging this PR, we can remove the `push_to_s3` variable from the `packages` pipelines. It was replaced with `push_artifacts_to_s3` which has a different default value.