### PR TITLE
[ClrProfiler] On IIS, force startup hook to run only once

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -568,8 +568,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   // is no longer provided in a NuGet package
   if (valid_startup_hook_callsite &&
       first_jit_compilation_app_domains.find(module_metadata->app_domain_id) ==
-      first_jit_compilation_app_domains.end() &&
-      !(module_metadata->assemblyName == "System"_W)) {
+      first_jit_compilation_app_domains.end()) {
     bool domain_neutral_assembly = runtime_information_.is_desktop() && corlib_module_loaded && module_metadata->app_domain_id == corlib_app_domain_id;
     Info("JITCompilationStarted: Startup hook registered in function_id=", function_id,
           " token=", function_token, " name=", caller.type.name, ".",


### PR DESCRIPTION
### Issue
We observed an issue that started in the .NET Tracer 1.16.2 where the `Datadog.Trace.ClrProfiler.Managed.Loader` assembly is loaded an extremely large number of times. This happened because the startup hook that loads the Datadog .NET assemblies is added to the method body of the first `JITCompilationStarted()` method that is considered for IL modification, and in an attempt to fix the `LoaderOptimization` registry key issue seen in #667, `System.Web` was completely ignored for all IL rewriting. This resulted in the startup hook being added to the constructor of `System.Collections.Specialized.HybridDictionary` when IIS starts an application. This method gets called plenty of times and causes the startup hook to run numerous times, which makes `Assembly.Load` calls and loads brand new copies of the same assembly over and over, leading to extremely high memory usage.


### Fix
The following changes ensure that, in an IIS application, the CLR profiler will add the startup hook to the well-known callsite `System.Web.Compilation.BuildManager.InvokePreStartInitMethods`, which is executed on the IIS application startup code path. This particular callsite was chosen because it is only called once per application and, since the method is called inside the `ApplicationImpersonationContext`, the `Datadog.Trace.ClrProfiler.Managed.Loader` assembly is loaded into each application's isolated AppDomain instead of the DefaultDomain.

Note: This was tested locally with and without the `LoaderOptimization` registry key being set to `1` and this shows correct behavior under both circumstances.

@DataDog/apm-dotnet