### PR TITLE
[ClrProfiler] Fix missing instrumentation when DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION is enabled

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -329,7 +329,7 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter"(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True" -p:Platform=$(buildPlatform)
+      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True" -p:Platform=$(buildPlatform)
 
   - task: DockerCompose@0
     displayName: docker-compose stop services

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -260,12 +260,6 @@ jobs:
       msbuildArguments: /t:BuildFrameworkReproductions
       maximumCpuCount: true
 
-  - powershell: |
-      [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
-      $publish = New-Object System.EnterpriseServices.Internal.Publish
-      Get-ChildItem $(publishOutput)/net45 -Filter *.dll | Foreach-Object { $publish.GacInstall($_.FullName) }
-    displayName: Add net45 Datadog.Trace.ClrProfiler.Managed assets to the GAC
-
   - task: DotNetCoreCLI@2
     displayName: dotnet build integration tests
     inputs:
@@ -321,7 +315,21 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "RunOnWindows=True|Category=Smoke" -p:Platform=$(buildPlatform)
+      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True" -p:Platform=$(buildPlatform)
+
+  - powershell: |
+      [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
+      $publish = New-Object System.EnterpriseServices.Internal.Publish
+      Get-ChildItem $(publishOutput)/net45 -Filter *.dll | Foreach-Object { $publish.GacInstall($_.FullName) }
+    displayName: Add net45 Datadog.Trace.ClrProfiler.Managed assets to the GAC
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test --filter LoadFromGAC=True
+    inputs:
+      command: test
+      configuration: $(buildConfiguration)
+      projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+      arguments: --filter"(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True" -p:Platform=$(buildPlatform)
 
   - task: DockerCompose@0
     displayName: docker-compose stop services

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -322,6 +322,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DomainNeutralAssemblies.App
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DomainNeutralAssemblies.FileLoadException", "reproductions\DomainNeutralAssemblies.FileLoadException\DomainNeutralAssemblies.FileLoadException.csproj", "{38EF60FF-9127-4C6B-93F7-8E62C3DF5C68}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.NetFramework.DomainNeutralInstrumentationWithoutGac", "samples\Samples.NetFramework.DomainNeutralInstrumentationWithoutGac\Samples.NetFramework.DomainNeutralInstrumentationWithoutGac.csproj", "{CB9789C7-9FC4-41AE-9943-D647954CA326}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1172,6 +1174,16 @@ Global
 		{38EF60FF-9127-4C6B-93F7-8E62C3DF5C68}.Release|x64.Build.0 = Release|x64
 		{38EF60FF-9127-4C6B-93F7-8E62C3DF5C68}.Release|x86.ActiveCfg = Release|x86
 		{38EF60FF-9127-4C6B-93F7-8E62C3DF5C68}.Release|x86.Build.0 = Release|x86
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Debug|x64.ActiveCfg = Debug|x64
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Debug|x64.Build.0 = Debug|x64
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Debug|x86.ActiveCfg = Debug|x86
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Debug|x86.Build.0 = Debug|x86
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Release|Any CPU.ActiveCfg = Release|x86
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Release|x64.ActiveCfg = Release|x64
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Release|x64.Build.0 = Release|x64
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Release|x86.ActiveCfg = Release|x86
+		{CB9789C7-9FC4-41AE-9943-D647954CA326}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1257,6 +1269,7 @@ Global
 		{4BB17962-8146-462F-8657-0DD4C2FFFFB7} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{5717623C-56D3-4B15-BF59-1594A44C4BE6} = {641C9C61-53FD-4504-B8D9-84008BDB89D1}
 		{38EF60FF-9127-4C6B-93F7-8E62C3DF5C68} = {550AE553-2BBB-4021-B55A-137EF31A6B1F}
+		{CB9789C7-9FC4-41AE-9943-D647954CA326} = {AA6F5582-3B71-49AC-AA39-8F7815AC46BE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/samples/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac/Program.cs
+++ b/samples/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac/Program.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.NetFramework.DomainNeutralInstrumentationWithoutGac
+{
+    public static class Program
+    {
+        /// <summary>
+        /// Instruct the runtime to load assemblies as domain-neutral, if possible.
+        /// Although there are async methods throughout the application, setting the top-level
+        /// Main method as 'async Task' instead of 'void' messes with the domain-neutral loading,
+        /// so leave as 'void'.
+        /// </summary>
+        /// <param name="args"></param>
+        [LoaderOptimization(LoaderOptimization.MultiDomainHost)]
+        static void Main(string[] args)
+        {
+            InnerMethodToAllowProfilerInjection().GetAwaiter().GetResult();
+        }
+
+        static async Task InnerMethodToAllowProfilerInjection()
+        {
+            var url = "http://www.contoso.com/";
+            var additionalDelay = 2000;
+
+            // Add dependency on System.Net.WebClient which lives in the System assembly
+            // System will always be loaded domain-neutral
+            Console.WriteLine($"[WebClient] sending request to {url}");
+            using (var webClient = new WebClient())
+            {
+                webClient.Encoding = Encoding.UTF8;
+                webClient.DownloadString(url);
+            }
+
+            // Add dependency on System.Net.HttpMessageHandler which lives in the System.Net.Http assembly
+            // System.Net.Http will always be loaded domain-neutral since we're not adding it as a NuGet package reference
+            Console.WriteLine($"[HttpClient] sending request to {url}");
+            var client = new HttpClient();
+            await client.GetAsync(url);
+
+            Console.WriteLine($"Waiting {additionalDelay} ms to allow Tracer to flush");
+            await Task.Delay(additionalDelay);
+            Console.WriteLine("All done!");
+        }
+    }
+}

--- a/samples/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac/Properties/launchSettings.json
+++ b/samples/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "Samples.NetFramework.DomainNeutralInstrumentationWithoutGac": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+        "DD_VERSION": "1.0.0",
+        "DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION": "1"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/samples/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac.csproj
+++ b/samples/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac/Samples.NetFramework.DomainNeutralInstrumentationWithoutGac.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;net461</TargetFrameworks>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+</Project>

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -790,9 +790,15 @@ HRESULT CorProfiler::ProcessReplacementCalls(
         continue;
       }
 
+      bool caller_assembly_is_domain_neutral =
+          runtime_information_.is_desktop() && corlib_module_loaded &&
+          module_metadata->app_domain_id == corlib_app_domain_id;
+
       // At this point we know we've hit a match. Error out if
       //   1) The managed profiler has not been loaded yet
-      if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id)) {
+      //   2) The caller is domain-neutral AND we want to instrument domain-neutral assemblies AND the Profiler has already been loaded
+      if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id) &&
+          !(caller_assembly_is_domain_neutral && instrument_domain_neutral_assemblies && ProfilerAssemblyIsLoadedIntoAnyAppDomain())) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement "
             "found but the managed profiler has not yet been loaded "
@@ -806,9 +812,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
       // At this point we know we've hit a match. Error out if
       //   1) The calling assembly is domain-neutral
       //   2) The profiler is not configured to instrument domain-neutral assemblies
-      if (runtime_information_.is_desktop() && corlib_module_loaded &&
-          module_metadata->app_domain_id == corlib_app_domain_id &&
-          !instrument_domain_neutral_assemblies) {
+      if (caller_assembly_is_domain_neutral && !instrument_domain_neutral_assemblies) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement",
             " found but the calling assembly ", module_metadata->assemblyName,
@@ -1100,6 +1104,10 @@ bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_i
   return managed_profiler_loaded_domain_neutral ||
          managed_profiler_loaded_app_domains.find(app_domain_id) !=
              managed_profiler_loaded_app_domains.end();
+}
+
+bool CorProfiler::ProfilerAssemblyIsLoadedIntoAnyAppDomain() {
+  return !managed_profiler_loaded_app_domains.empty();
 }
 
 //

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -791,10 +791,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(
       }
 
       // At this point we know we've hit a match. Error out if
-      //   1) The target assembly is Datadog.Trace.ClrProfiler.Managed
-      //   2) The managed profiler has not been loaded yet
-      if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id) &&
-          method_replacement.wrapper_method.assembly.name == "Datadog.Trace.ClrProfiler.Managed"_W) {
+      //   1) The managed profiler has not been loaded yet
+      if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id)) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement "
             "found but the managed profiler has not yet been loaded "
@@ -808,11 +806,9 @@ HRESULT CorProfiler::ProcessReplacementCalls(
       // At this point we know we've hit a match. Error out if
       //   1) The calling assembly is domain-neutral
       //   2) The profiler is not configured to instrument domain-neutral assemblies
-      //   3) The target assembly is Datadog.Trace.ClrProfiler.Managed
       if (runtime_information_.is_desktop() && corlib_module_loaded &&
           module_metadata->app_domain_id == corlib_app_domain_id &&
-          !instrument_domain_neutral_assemblies &&
-          method_replacement.wrapper_method.assembly.name == "Datadog.Trace.ClrProfiler.Managed"_W) {
+          !instrument_domain_neutral_assemblies) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement",
             " found but the calling assembly ", module_metadata->assemblyName,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -59,6 +59,7 @@ class CorProfiler : public CorProfilerBase {
                                          const FunctionInfo& caller,
                                          const std::vector<MethodReplacement> method_replacements);
   bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
+  bool ProfilerAssemblyIsLoadedIntoAnyAppDomain();
 
   //
   // Startup methods

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/DomainNeutralTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/DomainNeutralTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Core.Tools;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class DomainNeutralTests : TestHelper
+    {
+        public DomainNeutralTests(ITestOutputHelper output)
+            : base("NetFramework.DomainNeutralInstrumentationWithoutGac", output)
+        {
+            SetEnvironmentVariable("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION", "true");
+            SetServiceVersion("1.0.0");
+        }
+
+        [TargetFrameworkVersionsFact("net452;net461")]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTraces()
+        {
+            const int expectedSpanCount = 2;
+            const string expectedOperationName = "http.request";
+            const string expectedServiceName = "Samples.NetFramework.DomainNeutralInstrumentationWithoutGac-http-client";
+
+            Assert.False(typeof(Instrumentation).Assembly.GlobalAssemblyCache, "Datadog.Trace.ClrProfiler.Managed was loaded from the GAC. Ensure that the assembly and its dependencies are not installed in the GAC when running this test.");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            int httpPort = TcpPortProvider.GetOpenPort();
+
+            Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"HttpClient Port={httpPort}"))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
+
+                var spans = agent.WaitForSpans(expectedSpanCount);
+                Assert.True(spans.Count >= expectedSpanCount, $"Expected at least {expectedSpanCount} span, only received {spans.Count}");
+
+                foreach (var span in spans)
+                {
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(SpanTypes.Http, span.Type);
+                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/DomainNeutralTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/DomainNeutralTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Datadog.Core.Tools;
@@ -52,6 +54,29 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Assert.Equal(SpanTypes.Http, span.Type);
                     Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
                 }
+            }
+        }
+
+        [TargetFrameworkVersionsFact("net452;net461")]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void DoesNotCrashInBadConfiguration()
+        {
+            // Set bad configuration
+            SetEnvironmentVariable("DD_DOTNET_TRACER_HOME", Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location));
+
+            Assert.False(typeof(Instrumentation).Assembly.GlobalAssemblyCache, "Datadog.Trace.ClrProfiler.Managed was loaded from the GAC. Ensure that the assembly and its dependencies are not installed in the GAC when running this test.");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            int httpPort = TcpPortProvider.GetOpenPort();
+
+            Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"HttpClient Port={httpPort}"))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
             }
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpClientTests.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Fact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         public void HttpClient()
         {
             int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 2 : 1;
@@ -64,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Fact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         public void HttpClient_TracingDisabled()
         {
             int agentPort = TcpPortProvider.GetOpenPort();
@@ -90,6 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Fact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         public void WebClient()
         {
             int agentPort = TcpPortProvider.GetOpenPort();
@@ -124,6 +127,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Fact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         public void WebClient_TracingDisabled()
         {
             int agentPort = TcpPortProvider.GetOpenPort();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DomainNeutralAssembliesFileLoadExceptionSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DomainNeutralAssembliesFileLoadExceptionSmokeTest.cs
@@ -13,6 +13,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [TargetFrameworkVersionsFact("net461")]
         [Trait("Category", "Smoke")]
+        [Trait("LoadFromGAC", "True")]
         public void NoExceptions()
         {
             CheckForSmoke(shouldDeserializeTraces: false);


### PR DESCRIPTION
### Issue
The environment variable `DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` has been issued as a workaround when an application running in IIS and Azure App Services is missing .NET framework spans because the framework is loaded in a shared context. This override is only safe when the user can guarantee that only one application is being loaded in the Application Pool.

The issue today is that even when the environment variable `DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` is set, we still do not perform instrumentation when our instrumentation assembly `Datadog.Trace.ClrProfiler.Managed` is loaded app-local. Since the user knows that there will only be one application in the Application Pool (meaning only one AppDomain will be instrumented), this is safe to do and we should enable that functionality.

### Changes proposed in this pull request:
- Add a code path in the profiler to instrument domain-neutral assemblies when the environment variable `DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION` is set and the `Datadog.Trace.ClrProfiler.Managed` assembly is loaded app-local
- Add a new .NET Framework sample to test this scenario that creates outbound HTTP requests using the framework-provided `System` and `System.Net.Http`
- Add integration test to run this sample and to run the sample under a bad configuration to make sure we don't crash with the new functionality

@DataDog/apm-dotnet