### PR TITLE
Service Unification: Add new properties to the CorrelationIdentifer API for simplified, manual trace-log correlation

### DIFF
--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace
         internal static readonly string SpanIdKey = "dd.span_id";
 
         /// <summary>
-        /// Gets the service of the application
+        /// Gets the name of the service
         /// </summary>
         public static string Service
         {
@@ -25,7 +25,7 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Gets the version of the application
+        /// Gets the version of the service
         /// </summary>
         public static string Version
         {
@@ -36,7 +36,7 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Gets the env of the application
+        /// Gets the environment name of the service
         /// </summary>
         public static string Env
         {
@@ -47,8 +47,9 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Gets the trace id of the active span
+        /// Gets the id of the active trace.
         /// </summary>
+        /// <returns>The id of the active trace. If there is no active trace, returns zero.</returns>
         public static ulong TraceId
         {
             get
@@ -58,8 +59,9 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Gets the span id of the active span
+        /// Gets the id of the active span.
         /// </summary>
+        /// <returns>The id of the active span. If there is no active span, returns zero.</returns>
         public static ulong SpanId
         {
             get

--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace
         {
             get
             {
-                return Tracer.Instance.Settings.ServiceName ?? string.Empty;
+                return Tracer.Instance.DefaultServiceName ?? string.Empty;
             }
         }
 

--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -3,18 +3,51 @@ using System;
 namespace Datadog.Trace
 {
     /// <summary>
-    /// An API to access the active trace and span ids.
+    /// An API to access identifying values of the service and the active span
     /// </summary>
     public static class CorrelationIdentifier
     {
-        internal static readonly string ServiceNameKey = "dd.service";
-        internal static readonly string ServiceVersionKey = "dd.version";
+        internal static readonly string ServiceKey = "dd.service";
+        internal static readonly string VersionKey = "dd.version";
         internal static readonly string EnvKey = "dd.env";
         internal static readonly string TraceIdKey = "dd.trace_id";
         internal static readonly string SpanIdKey = "dd.span_id";
 
         /// <summary>
-        /// Gets the trace id
+        /// Gets the service of the application
+        /// </summary>
+        public static string Service
+        {
+            get
+            {
+                return Tracer.Instance.Settings.ServiceName ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the version of the application
+        /// </summary>
+        public static string Version
+        {
+            get
+            {
+                return Tracer.Instance.Settings.ServiceVersion ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the env of the application
+        /// </summary>
+        public static string Env
+        {
+            get
+            {
+                return Tracer.Instance.Settings.Environment ?? string.Empty;
+            }
+        }
+
+        /// <summary>
+        /// Gets the trace id of the active span
         /// </summary>
         public static ulong TraceId
         {
@@ -25,7 +58,7 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Gets the span id
+        /// Gets the span id of the active span
         /// </summary>
         public static ulong SpanId
         {

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -156,10 +156,10 @@ namespace Datadog.Trace.Logging
                 // TODO: Debug logs
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.ServiceNameKey, service, destructure: false));
+                        CorrelationIdentifier.ServiceKey, service, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.ServiceVersionKey, version, destructure: false));
+                        CorrelationIdentifier.VersionKey, version, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
                         CorrelationIdentifier.EnvKey, env, destructure: false));

--- a/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -2,6 +2,7 @@ using System;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers;
 using Moq;
 using Xunit;
 
@@ -65,7 +66,7 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void ServiceIdentifiers_EmptyStringIfUnset()
+        public void VersionAndEnv_EmptyStringIfUnset()
         {
             var settings = new TracerSettings();
             var tracer = new Tracer(settings);
@@ -74,14 +75,28 @@ namespace Datadog.Trace.Tests
             using (var parentScope = Tracer.Instance.StartActive("parent"))
             using (var childScope = Tracer.Instance.StartActive("child"))
             {
-                Assert.Equal(string.Empty, CorrelationIdentifier.Service);
                 Assert.Equal(string.Empty, CorrelationIdentifier.Version);
                 Assert.Equal(string.Empty, CorrelationIdentifier.Env);
             }
 
-            Assert.Equal(string.Empty, CorrelationIdentifier.Service);
             Assert.Equal(string.Empty, CorrelationIdentifier.Version);
             Assert.Equal(string.Empty, CorrelationIdentifier.Env);
+        }
+
+        [Fact]
+        public void Service_DefaultServiceNameIfUnset()
+        {
+            var settings = new TracerSettings();
+            var tracer = new Tracer(settings);
+            Tracer.Instance = tracer;
+
+            using (var parentScope = Tracer.Instance.StartActive("parent"))
+            using (var childScope = Tracer.Instance.StartActive("child"))
+            {
+                Assert.Contains(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
+            }
+
+            Assert.Contains(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
@@ -9,24 +10,78 @@ namespace Datadog.Trace.Tests
     public class CorrelationIdentifierTests
     {
         [Fact]
-        public void Ids_MatchWithActiveSpan_ZeroWithoutActiveSpan()
+        public void TraceIdSpanId_MatchActiveSpan()
         {
-            var parentScope = Tracer.Instance.StartActive("parent");
-            var parentSpan = parentScope.Span;
+            using (var parentScope = Tracer.Instance.StartActive("parent"))
+            {
+                using (var childScope = Tracer.Instance.StartActive("child"))
+                {
+                    Assert.Equal<ulong>(childScope.Span.SpanId, CorrelationIdentifier.SpanId);
+                    Assert.Equal<ulong>(childScope.Span.TraceId, CorrelationIdentifier.TraceId);
+                }
+            }
+        }
 
-            var childScope = Tracer.Instance.StartActive("child");
-            var childSpan = childScope.Span;
-
-            Assert.Equal<ulong>(childSpan.SpanId, CorrelationIdentifier.SpanId);
-            Assert.Equal<ulong>(childSpan.TraceId, CorrelationIdentifier.TraceId);
-            childScope.Close();
-
-            Assert.Equal<ulong>(parentSpan.SpanId, CorrelationIdentifier.SpanId);
-            Assert.Equal<ulong>(parentSpan.TraceId, CorrelationIdentifier.TraceId);
-            parentScope.Close();
+        [Fact]
+        public void TraceIdSpanId_ZeroOutsideActiveSpan()
+        {
+            using (var parentScope = Tracer.Instance.StartActive("parent"))
+            using (var childScope = Tracer.Instance.StartActive("child"))
+            {
+                // Do nothing
+            }
 
             Assert.Equal<ulong>(0, CorrelationIdentifier.SpanId);
             Assert.Equal<ulong>(0, CorrelationIdentifier.TraceId);
+        }
+
+        [Fact]
+        public void ServiceIdentifiers_MatchTracerInstanceSettings()
+        {
+            const string service = "unit-test";
+            const string version = "1.0.0";
+            const string env = "staging";
+
+            var settings = new TracerSettings()
+            {
+                ServiceName = service,
+                ServiceVersion = version,
+                Environment = env
+            };
+            var tracer = new Tracer(settings);
+            Tracer.Instance = tracer;
+
+            using (var parentScope = Tracer.Instance.StartActive("parent"))
+            using (var childScope = Tracer.Instance.StartActive("child"))
+            {
+                Assert.Equal(service, CorrelationIdentifier.Service);
+                Assert.Equal(version, CorrelationIdentifier.Version);
+                Assert.Equal(env, CorrelationIdentifier.Env);
+            }
+
+            Assert.Equal(service, CorrelationIdentifier.Service);
+            Assert.Equal(version, CorrelationIdentifier.Version);
+            Assert.Equal(env, CorrelationIdentifier.Env);
+        }
+
+        [Fact]
+        public void ServiceIdentifiers_EmptyStringIfUnset()
+        {
+            var settings = new TracerSettings();
+            var tracer = new Tracer(settings);
+            Tracer.Instance = tracer;
+
+            using (var parentScope = Tracer.Instance.StartActive("parent"))
+            using (var childScope = Tracer.Instance.StartActive("child"))
+            {
+                Assert.Equal(string.Empty, CorrelationIdentifier.Service);
+                Assert.Equal(string.Empty, CorrelationIdentifier.Version);
+                Assert.Equal(string.Empty, CorrelationIdentifier.Env);
+            }
+
+            Assert.Equal(string.Empty, CorrelationIdentifier.Service);
+            Assert.Equal(string.Empty, CorrelationIdentifier.Version);
+            Assert.Equal(string.Empty, CorrelationIdentifier.Env);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -93,10 +93,10 @@ namespace Datadog.Trace.Tests
             using (var parentScope = Tracer.Instance.StartActive("parent"))
             using (var childScope = Tracer.Instance.StartActive("child"))
             {
-                Assert.Contains(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
+                Assert.Equal(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
             }
 
-            Assert.Contains(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
+            Assert.Equal(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/Log4NetLogProviderTests.cs
@@ -118,11 +118,11 @@ namespace Datadog.Trace.Tests.Logging
 
         internal static void LogEventContains(log4net.Core.LoggingEvent logEvent, string service, string version, string env, ulong traceId, ulong spanId)
         {
-            Assert.Contains(CorrelationIdentifier.ServiceNameKey, logEvent.Properties.GetKeys());
-            Assert.Equal(service, logEvent.Properties[CorrelationIdentifier.ServiceNameKey].ToString());
+            Assert.Contains(CorrelationIdentifier.ServiceKey, logEvent.Properties.GetKeys());
+            Assert.Equal(service, logEvent.Properties[CorrelationIdentifier.ServiceKey].ToString());
 
-            Assert.Contains(CorrelationIdentifier.ServiceVersionKey, logEvent.Properties.GetKeys());
-            Assert.Equal(version, logEvent.Properties[CorrelationIdentifier.ServiceVersionKey].ToString());
+            Assert.Contains(CorrelationIdentifier.VersionKey, logEvent.Properties.GetKeys());
+            Assert.Equal(version, logEvent.Properties[CorrelationIdentifier.VersionKey].ToString());
 
             Assert.Contains(CorrelationIdentifier.EnvKey, logEvent.Properties.GetKeys());
             Assert.Equal(env, logEvent.Properties[CorrelationIdentifier.EnvKey].ToString());

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -124,9 +124,9 @@ namespace Datadog.Trace.Tests.Logging
 
         internal static void LogEventContains(string nLogString, string service, string version, string env, Scope scope)
         {
-            Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.ServiceNameKey, service), nLogString);
+            Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.ServiceKey, service), nLogString);
             Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.EnvKey, env), nLogString);
-            Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.ServiceVersionKey, version), nLogString);
+            Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.VersionKey, version), nLogString);
             Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.SpanIdKey, scope.Span.SpanId), nLogString);
             Assert.Contains(string.Format(NLogExpectedStringFormat, CorrelationIdentifier.TraceIdKey, scope.Span.TraceId), nLogString);
         }

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -110,11 +110,11 @@ namespace Datadog.Trace.Tests.Logging
 
         internal static void Contains(Serilog.Events.LogEvent logEvent, string service, string version, string env, ulong traceId, ulong spanId)
         {
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.ServiceNameKey));
-            Assert.Equal(service, logEvent.Properties[CorrelationIdentifier.ServiceNameKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.ServiceKey));
+            Assert.Equal(service, logEvent.Properties[CorrelationIdentifier.ServiceKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
 
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.ServiceVersionKey));
-            Assert.Equal(version, logEvent.Properties[CorrelationIdentifier.ServiceVersionKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.VersionKey));
+            Assert.Equal(version, logEvent.Properties[CorrelationIdentifier.VersionKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
 
             Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.EnvKey));
             Assert.Equal(env, logEvent.Properties[CorrelationIdentifier.EnvKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);


### PR DESCRIPTION
Changes proposed in this pull request:
* Add the following API's to Datadog.Trace:
  - `CorrelationIdentifier.Service`
  - `CorrelationIdentifier.Version`
  - `CorrelationIdentifier.Env`
* Add unit tests for the new APIs.
* Rename internal constants `CorrelationIdentifier.ServiceVersionKey`=>`CorrelationIdentifier.VersionKey` and `CorrelationIdentifier.ServiceNameKey`=>`CorrelationIdentifier.ServiceKey` to align with public-facing strings

@DataDog/apm-dotnet