### PR TITLE
RateLimiter improvements

### DIFF
--- a/src/Datadog.Trace/Sampling/RateLimiter.cs
+++ b/src/Datadog.Trace/Sampling/RateLimiter.cs
@@ -104,13 +104,13 @@ namespace Datadog.Trace.Sampling
 
         private void WaitForRefresh()
         {
-            int refreshing = 0;
+            int refreshInProgress = 0;
 
             try
             {
-                refreshing = Interlocked.CompareExchange(ref _refreshing, 1, 0);
+                refreshInProgress = Interlocked.CompareExchange(ref _refreshing, 1, 0);
 
-                if (refreshing != 0)
+                if (refreshInProgress != 0)
                 {
                     // A refresh is already in progress
                     return;
@@ -137,7 +137,7 @@ namespace Datadog.Trace.Sampling
             }
             finally
             {
-                if (refreshing == 0)
+                if (refreshInProgress == 0)
                 {
                     // If refreshing is 0, it means that this thread acquired the lock
                     // Releasing it before leaving

--- a/src/Datadog.Trace/Sampling/RateLimiter.cs
+++ b/src/Datadog.Trace/Sampling/RateLimiter.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Sampling
             _maxTracesPerInterval = maxTracesPerInterval ?? 100;
             _intervalMilliseconds = 1_000;
             _interval = TimeSpan.FromMilliseconds(_intervalMilliseconds);
-            _windowBegin = _lastRefresh = DateTime.Now;
+            _windowBegin = _lastRefresh = DateTime.UtcNow;
         }
 
         public bool Allowed(Span span)
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Sampling
                     return false;
                 }
 
-                _intervalQueue.Enqueue(DateTime.Now);
+                _intervalQueue.Enqueue(DateTime.UtcNow);
                 Interlocked.Increment(ref _windowAllowed);
 
                 return true;
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Sampling
                 // Block threads
                 _refreshEvent.Reset();
 
-                var now = DateTime.Now;
+                var now = DateTime.UtcNow;
                 _lastRefresh = now;
 
                 var timeSinceWindowStart = (now - _windowBegin).TotalMilliseconds;


### PR DESCRIPTION
- Uses UTC time to prevent issues during DST transitions
- Removes locking

@DataDog/apm-dotnet