### PR TITLE
Revert domain-neutral override change

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -797,8 +797,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
       // At this point we know we've hit a match. Error out if
       //   1) The managed profiler has not been loaded yet
       //   2) The caller is domain-neutral AND we want to instrument domain-neutral assemblies AND the Profiler has already been loaded
-      if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id) &&
-          !(caller_assembly_is_domain_neutral && instrument_domain_neutral_assemblies && ProfilerAssemblyIsLoadedIntoAnyAppDomain())) {
+      if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id)) {
         Warn(
             "JITCompilationStarted skipping method: Method replacement "
             "found but the managed profiler has not yet been loaded "
@@ -1104,10 +1103,6 @@ bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_i
   return managed_profiler_loaded_domain_neutral ||
          managed_profiler_loaded_app_domains.find(app_domain_id) !=
              managed_profiler_loaded_app_domains.end();
-}
-
-bool CorProfiler::ProfilerAssemblyIsLoadedIntoAnyAppDomain() {
-  return !managed_profiler_loaded_app_domains.empty();
 }
 
 //

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -59,7 +59,6 @@ class CorProfiler : public CorProfilerBase {
                                          const FunctionInfo& caller,
                                          const std::vector<MethodReplacement> method_replacements);
   bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
-  bool ProfilerAssemblyIsLoadedIntoAnyAppDomain();
 
   //
   // Startup methods

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/DomainNeutralTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/DomainNeutralTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        [TargetFrameworkVersionsFact("net452;net461")]
+        [TargetFrameworkVersionsFact("net452;net461", Skip="Re-enable when domain-neutral instrumentation is truly tackled.")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         public void SubmitsTraces()


### PR DESCRIPTION
Revert change that instruments domain-neutral assemblies when the managed profiler is not domain-neutral because this change caused issues in Azure App Services.

@DataDog/apm-dotnet