### PR TITLE
Remove the heap allocation from Stopwatch

### DIFF
--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace
 {
@@ -11,7 +12,7 @@ namespace Datadog.Trace
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<TraceContext>();
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
-        private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+        private readonly long _timestamp = Stopwatch.GetTimestamp();
         private readonly List<Span> _spans = new List<Span>();
 
         private int _openSpans;
@@ -25,7 +26,7 @@ namespace Datadog.Trace
 
         public Span RootSpan { get; private set; }
 
-        public DateTimeOffset UtcNow => _utcStart.Add(_stopwatch.Elapsed);
+        public DateTimeOffset UtcNow => _utcStart.Add(StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp));
 
         public IDatadogTracer Tracer { get; }
 

--- a/src/Datadog.Trace/Util/StopwatchHelpers.cs
+++ b/src/Datadog.Trace/Util/StopwatchHelpers.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Util
+{
+    internal class StopwatchHelpers
+    {
+        private static readonly double DateTimeTickFrequency = 10000000.0 / Stopwatch.Frequency;
+
+        public static TimeSpan GetElapsed(long stopwatchTicks)
+        {
+            var ticks = (long)(stopwatchTicks * DateTimeTickFrequency);
+
+            return new TimeSpan(ticks);
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/StopwatchTests.cs
+++ b/test/Datadog.Trace.Tests/StopwatchTests.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using Datadog.Trace.Util;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class StopwatchTests
+    {
+        [Fact]
+        public void ComputesCorrectTimespan()
+        {
+            var sw = Stopwatch.StartNew();
+
+            Thread.Sleep(50);
+
+            sw.Stop();
+
+            // Extract the internal ticks
+            var stopwatchTicks = (long)typeof(Stopwatch)
+                .GetMethod("GetRawElapsedTicks", BindingFlags.Instance | BindingFlags.NonPublic)
+                .Invoke(sw, null);
+
+            var elapsed = StopwatchHelpers.GetElapsed(stopwatchTicks);
+
+            Assert.Equal(sw.Elapsed, elapsed);
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Util/StopwatchTests.cs
+++ b/test/Datadog.Trace.Tests/Util/StopwatchTests.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using Datadog.Trace.Util;
 using Xunit;
 
-namespace Datadog.Trace.Tests
+namespace Datadog.Trace.Tests.Util
 {
     public class StopwatchTests
     {


### PR DESCRIPTION
Remove the heap allocation from `Stopwatch` (one per trace).
See comments below for benchmarks.