### PR TITLE
Optimizations for ObjectExtensions

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MemberResult.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MemberResult.cs
@@ -2,12 +2,14 @@ using System;
 
 namespace Datadog.Trace.ClrProfiler.Emit
 {
-    internal sealed class MemberResult<T>
+    internal readonly struct MemberResult<T>
     {
         /// <summary>
         /// A static value used to represent a member that was not found.
         /// </summary>
-        public static readonly MemberResult<T> NotFound = new MemberResult<T>();
+        public static readonly MemberResult<T> NotFound = default;
+
+        public readonly bool HasValue;
 
         private readonly T _value;
 
@@ -17,16 +19,10 @@ namespace Datadog.Trace.ClrProfiler.Emit
             HasValue = true;
         }
 
-        private MemberResult()
-        {
-        }
-
         public T Value =>
             HasValue
                 ? _value
                 : throw new InvalidOperationException("Reflected member not found.");
-
-        public bool HasValue { get; }
 
         public T GetValueOrDefault()
         {
@@ -35,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         public MemberResult<TResult> GetProperty<TResult>(string propertyName)
         {
-            if (ReferenceEquals(this, NotFound) || Value == null || !Value.TryGetPropertyValue(propertyName, out TResult result))
+            if (!HasValue || Value == null || !Value.TryGetPropertyValue(propertyName, out TResult result))
             {
                 return MemberResult<TResult>.NotFound;
             }
@@ -50,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         public MemberResult<TResult> GetField<TResult>(string fieldName)
         {
-            if (ReferenceEquals(this, NotFound) || Value == null || !Value.TryGetFieldValue(fieldName, out TResult result))
+            if (!HasValue || Value == null || !Value.TryGetFieldValue(fieldName, out TResult result))
             {
                 return MemberResult<TResult>.NotFound;
             }
@@ -65,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         public MemberResult<TResult> CallMethod<TArg1, TResult>(string methodName, TArg1 arg1)
         {
-            if (ReferenceEquals(this, NotFound) || Value == null || !Value.TryCallMethod(methodName, arg1, out TResult result))
+            if (!HasValue || Value == null || !Value.TryCallMethod(methodName, arg1, out TResult result))
             {
                 return MemberResult<TResult>.NotFound;
             }
@@ -80,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         public override string ToString()
         {
-            if (ReferenceEquals(this, NotFound) || Value == null)
+            if (!HasValue || Value == null)
             {
                 return string.Empty;
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -227,7 +227,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
         private static PropertyFetcherCacheKey GetKey<TResult>(string name, Type type)
         {
-            return new PropertyFetcherCacheKey(typeof(TResult), type, name);
+            return new PropertyFetcherCacheKey(type, typeof(TResult), name);
         }
 
         private static Func<object, TResult> CreatePropertyDelegate<TResult>(Type containerType, string propertyName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -11,8 +11,8 @@ namespace Datadog.Trace.ClrProfiler.Emit
     /// </summary>
     internal static class ObjectExtensions
     {
-        private static readonly ConcurrentDictionary<string, object> Cache = new ConcurrentDictionary<string, object>();
-        private static readonly ConcurrentDictionary<string, PropertyFetcher> PropertyFetcherCache = new ConcurrentDictionary<string, PropertyFetcher>();
+        private static readonly ConcurrentDictionary<PropertyFetcherCacheKey, object> Cache = new ConcurrentDictionary<PropertyFetcherCacheKey, object>();
+        private static readonly ConcurrentDictionary<PropertyFetcherCacheKey, PropertyFetcher> PropertyFetcherCache = new ConcurrentDictionary<PropertyFetcherCacheKey, PropertyFetcher>();
 
         /// <summary>
         /// Tries to call an instance method with the specified name, a single parameter, and a return value.
@@ -30,14 +30,14 @@ namespace Datadog.Trace.ClrProfiler.Emit
             var paramType1 = typeof(TArg1);
 
             object cachedItem = Cache.GetOrAdd(
-                $"{type.AssemblyQualifiedName}.{methodName}.{paramType1.AssemblyQualifiedName}",
+                new PropertyFetcherCacheKey(type, paramType1, methodName),
                 key =>
                     DynamicMethodBuilder<Func<object, TArg1, TResult>>
                        .CreateMethodCallDelegate(
-                            type,
-                            methodName,
+                            key.Type1,
+                            key.Name,
                             OpCodeValue.Callvirt,
-                            methodParameterTypes: new[] { paramType1 }));
+                            methodParameterTypes: new[] { key.Type2 }));
 
             if (cachedItem is Func<object, TArg1, TResult> func)
             {
@@ -97,12 +97,12 @@ namespace Datadog.Trace.ClrProfiler.Emit
             var type = source.GetType();
 
             object cachedItem = Cache.GetOrAdd(
-                $"{type.AssemblyQualifiedName}.{methodName}",
+                new PropertyFetcherCacheKey(type, null, methodName),
                 key =>
                     DynamicMethodBuilder<Func<object, TResult>>
                        .CreateMethodCallDelegate(
-                            type,
-                            methodName,
+                            key.Type1,
+                            key.Name,
                             OpCodeValue.Callvirt));
 
             if (cachedItem is Func<object, TResult> func)
@@ -157,11 +157,11 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
                 PropertyFetcher fetcher = PropertyFetcherCache.GetOrAdd(
                     GetKey<TResult>(propertyName, type),
-                    key => new PropertyFetcher(propertyName));
+                    key => new PropertyFetcher(key.Name));
 
                 if (fetcher != null)
                 {
-                    value = (TResult)fetcher.Fetch(source);
+                    value = fetcher.Fetch<TResult>(source, type);
                     return true;
                 }
             }
@@ -201,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             object cachedItem = Cache.GetOrAdd(
                 GetKey<TResult>(fieldName, type),
-                key => CreateFieldDelegate<TResult>(type, fieldName));
+                key => CreateFieldDelegate<TResult>(key.Type1, key.Name));
 
             if (cachedItem is Func<object, TResult> func)
             {
@@ -225,9 +225,9 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return GetField<object>(source, fieldName);
         }
 
-        private static string GetKey<TResult>(string name, Type type)
+        private static PropertyFetcherCacheKey GetKey<TResult>(string name, Type type)
         {
-            return $"{typeof(TResult).AssemblyQualifiedName}:{type.AssemblyQualifiedName}:{name}";
+            return new PropertyFetcherCacheKey(typeof(TResult), type, name);
         }
 
         private static Func<object, TResult> CreatePropertyDelegate<TResult>(Type containerType, string propertyName)
@@ -312,6 +312,41 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             dynamicMethod.Return();
             return dynamicMethod.CreateDelegate();
+        }
+
+        private readonly struct PropertyFetcherCacheKey : IEquatable<PropertyFetcherCacheKey>
+        {
+            public readonly Type Type1;
+            public readonly Type Type2;
+            public readonly string Name;
+
+            public PropertyFetcherCacheKey(Type type1, Type type2, string name)
+            {
+                Type1 = type1;
+                Type2 = type2;
+                Name = name;
+            }
+
+            public bool Equals(PropertyFetcherCacheKey other)
+            {
+                return Equals(Type1, other.Type1) && Equals(Type2, other.Type2) && Name == other.Name;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is PropertyFetcherCacheKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (Type1 != null ? Type1.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Type2 != null ? Type2.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -322,9 +322,9 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             public PropertyFetcherCacheKey(Type type1, Type type2, string name)
             {
-                Type1 = type1;
+                Type1 = type1 ?? throw new ArgumentNullException(nameof(type1));
                 Type2 = type2;
-                Name = name;
+                Name = name ?? throw new ArgumentNullException(nameof(name));
             }
 
             public bool Equals(PropertyFetcherCacheKey other)
@@ -341,9 +341,9 @@ namespace Datadog.Trace.ClrProfiler.Emit
             {
                 unchecked
                 {
-                    var hashCode = (Type1 != null ? Type1.GetHashCode() : 0);
+                    var hashCode = Type1.GetHashCode();
                     hashCode = (hashCode * 397) ^ (Type2 != null ? Type2.GetHashCode() : 0);
-                    hashCode = (hashCode * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ Name.GetHashCode();
                     return hashCode;
                 }
             }

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnHostingHttpRequestInStart(object arg)
         {
-            var httpContext = (HttpContext)HttpRequestInStartHttpContextFetcher.Fetch(arg);
+            var httpContext = HttpRequestInStartHttpContextFetcher.Fetch<HttpContext>(arg);
 
             if (ShouldIgnore(httpContext))
             {
@@ -176,7 +176,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnMvcBeforeAction(object arg)
         {
-            var httpContext = (HttpContext)BeforeActionHttpContextFetcher.Fetch(arg);
+            var httpContext = BeforeActionHttpContextFetcher.Fetch<HttpContext>(arg);
 
             if (ShouldIgnore(httpContext))
             {
@@ -193,7 +193,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 {
                     // NOTE: This event is the start of the action pipeline. The action has been selected, the route
                     //       has been selected but no filters have run and model binding hasn't occured.
-                    var actionDescriptor = (ActionDescriptor)BeforeActionActionDescriptorFetcher.Fetch(arg);
+                    var actionDescriptor = BeforeActionActionDescriptorFetcher.Fetch<ActionDescriptor>(arg);
                     HttpRequest request = httpContext.Request;
 
                     string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
@@ -214,7 +214,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (scope != null)
             {
-                var httpContext = (HttpContext)HttpRequestInStopHttpContextFetcher.Fetch(arg);
+                var httpContext = HttpRequestInStopHttpContextFetcher.Fetch<HttpContext>(arg);
                 scope.Span.SetTag(Tags.HttpStatusCode, httpContext.Response.StatusCode.ToString());
 
                 if (httpContext.Response.StatusCode / 100 == 5)
@@ -233,8 +233,8 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (span != null)
             {
-                var exception = (Exception)UnhandledExceptionExceptionFetcher.Fetch(arg);
-                var httpContext = (HttpContext)UnhandledExceptionHttpContextFetcher.Fetch(arg);
+                var exception = UnhandledExceptionExceptionFetcher.Fetch<Exception>(arg);
+                var httpContext = UnhandledExceptionHttpContextFetcher.Fetch<HttpContext>(arg);
 
                 span.SetException(exception);
                 _options.OnError?.Invoke(span, exception, httpContext);

--- a/src/Datadog.Trace/Util/PropertyFetcher.cs
+++ b/src/Datadog.Trace/Util/PropertyFetcher.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace.Util
 
                 Type typedPropertyFetcher = typeof(TypedFetchProperty<,>);
                 Type instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(
-                    propertyInfo.PropertyType, propertyInfo.DeclaringType, propertyInfo.PropertyType);
+                    typeof(T), propertyInfo.DeclaringType, propertyInfo.PropertyType);
 
                 return (PropertyFetch<T>)Activator.CreateInstance(instantiatedTypedPropertyFetcher, propertyInfo);
             }
@@ -89,7 +89,8 @@ namespace Datadog.Trace.Util
                 return default;
             }
 
-            private class TypedFetchProperty<TObject, TProperty> : PropertyFetch<TProperty>
+            private class TypedFetchProperty<TObject, TProperty> : PropertyFetch<T>
+                where TProperty : T
             {
                 private readonly Func<TObject, TProperty> _propertyFetch;
 
@@ -98,7 +99,7 @@ namespace Datadog.Trace.Util
                     _propertyFetch = (Func<TObject, TProperty>)property.GetMethod.CreateDelegate(typeof(Func<TObject, TProperty>));
                 }
 
-                public override TProperty Fetch(object obj)
+                public override T Fetch(object obj)
                 {
                     return _propertyFetch((TObject)obj);
                 }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
@@ -5,6 +5,13 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 {
     public class ObjectExtensionTests
     {
+        private enum SomeEnum
+        {
+            Zero = 0,
+            One = 1,
+            Two = 2
+        }
+
         [Fact]
         public void GetProperty_WithDifferentType_ShouldNotAffectResult()
         {
@@ -17,6 +24,21 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var actualResult = someCast.GetProperty<int>("SomeIntProperty");
 
             Assert.Equal(expected, (int)objectResult.GetValueOrDefault());
+            Assert.Equal(expected, actualResult.GetValueOrDefault());
+        }
+
+        [Fact]
+        public void GetProperty_WithNoDirectInheritance_ShouldNotAffectResult()
+        {
+            var someInstance = new SomeClass();
+            var expected = someInstance.SomeEnumProperty;
+
+            var someCast = (object)someInstance;
+
+            var intResult = someCast.GetProperty<int>("SomeEnumProperty");
+            var actualResult = someCast.GetProperty<SomeEnum>("SomeEnumProperty");
+
+            Assert.Equal((int)expected, intResult.GetValueOrDefault());
             Assert.Equal(expected, actualResult.GetValueOrDefault());
         }
 
@@ -40,6 +62,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             private readonly int someIntField = 305;
 
             public override int SomeIntProperty { get; } = 205;
+
+            public SomeEnum SomeEnumProperty { get; } = SomeEnum.Two;
 
             public int GetSomeIntField()
             {


### PR DESCRIPTION
- Make MemberResult a struct
- Add a custom key type for the cache to avoid building a string every time
- Use the custom key to prevent closure allocation in the ConcurrentDictionary.GetOrAdd callbacks
- Make the PropertyFetcher generic to prevent boxing when fetching a value type
- Add a Fetch overload to provide the type when it's already known


**Benchmark:**
```csharp
return ObjectsExtensions.Emit.ObjectExtensions.GetProperty<int>("source", "Length").Value;
```

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT


```
|          Method |      Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |----------:|---------:|---------:|------:|-------:|------:|------:|----------:|
| OldGetProperty | 445.22 ns | 3.179 ns | 2.818 ns |  1.00 | 0.1721 |     - |     - |    1083 B |
| NewGetProperty |  84.56 ns | 0.821 ns | 0.768 ns |  0.19 |      - |     - |     - |         - |
