### PR TITLE
MethodBuilder optimizations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -158,6 +158,13 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return WithParameters(types);
         }
 
+        public MethodBuilder<TDelegate> WithParameters<TParam1, TParam2, TParam3, TParam4>(TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4)
+        {
+            var types = new[] { param1?.GetType(), param2?.GetType(), param3?.GetType(), param4?.GetType() };
+
+            return WithParameters(types);
+        }
+
         public MethodBuilder<TDelegate> WithExplicitParameterTypes(params Type[] types)
         {
             _explicitParameterTypes = types;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -743,17 +743,17 @@ namespace Datadog.Trace.ClrProfiler.Emit
         {
             public bool Equals(Key x, Key y)
             {
-                if (!int.Equals(x.CallingModuleMetadataToken, y.CallingModuleMetadataToken))
+                if (x.CallingModuleMetadataToken != y.CallingModuleMetadataToken)
                 {
                     return false;
                 }
 
-                if (!int.Equals(x.MethodMetadataToken, y.MethodMetadataToken))
+                if (x.MethodMetadataToken != y.MethodMetadataToken)
                 {
                     return false;
                 }
 
-                if (!short.Equals(x.CallOpCode, y.CallOpCode))
+                if (x.CallOpCode != y.CallOpCode)
                 {
                     return false;
                 }
@@ -783,7 +783,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
                     int hash = 17;
                     hash = (hash * 23) + obj.CallingModuleMetadataToken.GetHashCode();
                     hash = (hash * 23) + obj.MethodMetadataToken.GetHashCode();
-                    hash = (hash * 23) + obj.CallOpCode.GetHashCode();
+                    hash = (hash * 23) + ((short)obj.CallOpCode).GetHashCode();
                     hash = (hash * 23) + obj.ConcreteTypeName.GetHashCode();
                     hash = (hash * 23) + obj.GenericSpec.GetHashCode();
                     hash = (hash * 23) + obj.ExplicitParams.GetHashCode();


### PR DESCRIPTION
Bunch of optimizations for MethodBuilder (used in most integrations as far as I can tell)

- Add generic overloads to `WithParameters` and eagerly resolve the type, to avoid boxing when possible
- Remove all the boxing in the KeyComparer
- Directly use the types in the key instead of concatenating them into strings
- Embed the builder in the key (removes the closure allocation from GetOrAdd, and gives a nice speed boost by making the key object much lighter)

The review is quite big so I split it into multiple commits, to make the changes easier to understand.

The remaining heap allocations come from the MethodBuilder itself. I tried changing it into a struct, but the object is so big that it degraded performance quite a bit. Maybe it's possible to avoid that by using the in/ref keywords, but this would require a big refactoring for a small gain so I'd rather take care of other optimizations first.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT


```
|                Method |       Mean |    Error |  StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |-----------:|---------:|--------:|------:|-------:|------:|------:|----------:|
|     MethodBuilder_Old | 1,027.4 ns | 11.68 ns | 9.75 ns |  1.00 | 0.2003 |     - |     - |    1268 B |
|     MethodBuilder_New |   158.5 ns |  1.51 ns | 1.41 ns |  0.15 | 0.0279 |     - |     - |     177 B |
