### PR TITLE
Remove NuGet package dependencies from Datadog.Trace and Datadog.Trace.ClrProfiler.Managed

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
@@ -45,11 +45,6 @@
               Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net45_GAC_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
-              KeyPath="yes" Checksum="yes" Assembly=".net"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
@@ -45,11 +45,6 @@
               Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net45_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.TracerHomeDirectory)\net45\System.Runtime.InteropServices.RuntimeInformation.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
@@ -45,11 +45,6 @@
               Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net461_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.TracerHomeDirectory)\net461\System.Runtime.InteropServices.RuntimeInformation.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -26,11 +26,6 @@
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_Microsoft.CSharp.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\Microsoft.CSharp.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
         <File Id="netstandard20_Newtonsoft.Json.dll"
               Source="$(var.TracerHomeDirectory)\netstandard2.0\Newtonsoft.Json.dll"
               KeyPath="yes" Checksum="yes"/>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -81,11 +81,6 @@
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_System.Runtime.InteropServices.RuntimeInformation.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Runtime.InteropServices.RuntimeInformation.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Threading.dll"
               Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Threading.dll"
               KeyPath="yes" Checksum="yes"/>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -99,28 +99,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
         }
 
-        private static string GetHost(dynamic redisNativeClient)
+        private static string GetHost(object redisNativeClient)
         {
-            try
-            {
-                return redisNativeClient?.Host;
-            }
-            catch
-            {
-                return string.Empty;
-            }
+            return redisNativeClient.GetProperty<string>("Host").GetValueOrDefault() ?? string.Empty;
         }
 
-        private static string GetPort(dynamic redisNativeClient)
+        private static string GetPort(object redisNativeClient)
         {
-            try
-            {
-                return ((object)redisNativeClient?.Port)?.ToString();
-            }
-            catch
-            {
-                return string.Empty;
-            }
+            return redisNativeClient.GetProperty<int>("Port").GetValueOrDefault().ToString();
         }
 
         private static string GetRawCommand(byte[][] cmdWithBinaryArgs)

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -13,12 +13,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <!--
-    This reference allows us to build the code without precompiler directives,
-    but the logic at runtime will never try to use the Registry if it's not available
-    -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" PrivateAssets="all" />
-
     <!-- Instrumented libraries -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" PrivateAssets="All" />
@@ -29,7 +23,6 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
-    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
   <!-- Below this point is reserved for vendor items -->

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
   </ItemGroup>

--- a/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -1,0 +1,104 @@
+#if !NETFRAMEWORK
+using System;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace
+{
+    internal partial class FrameworkDescription
+    {
+        public static FrameworkDescription Create()
+        {
+            return CreateFromRuntimeInformation();
+        }
+
+        private static FrameworkDescription CreateFromRuntimeInformation()
+        {
+            string frameworkName = null;
+            string osPlatform = null;
+
+            try
+            {
+                // RuntimeInformation.FrameworkDescription returns a string like ".NET Framework 4.7.2" or ".NET Core 2.1",
+                // we want to return everything before the last space
+                string frameworkDescription = RuntimeInformation.FrameworkDescription;
+                int index = frameworkDescription.LastIndexOf(' ');
+                frameworkName = frameworkDescription.Substring(0, index).Trim();
+            }
+            catch (Exception e)
+            {
+                Log.SafeLogError(e, "Error getting framework name from RuntimeInformation");
+            }
+
+            if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                osPlatform = "Windows";
+            }
+            else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
+            {
+                osPlatform = "Linux";
+            }
+            else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
+            {
+                osPlatform = "MacOS";
+            }
+
+            return new FrameworkDescription(
+                frameworkName ?? "unknown",
+                GetNetCoreVersion() ?? "unknown",
+                osPlatform ?? "unknown",
+                RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
+                RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant());
+        }
+
+        private static string GetNetCoreVersion()
+        {
+            string productVersion = null;
+
+            if (Environment.Version.Major == 3 || Environment.Version.Major >= 5)
+            {
+                // Environment.Version returns "4.x" in .NET Core 2.x,
+                // but it is correct since .NET Core 3.0.0
+                productVersion = Environment.Version.ToString();
+            }
+
+            if (productVersion == null)
+            {
+                try
+                {
+                    // try to get product version from assembly path
+                    Match match = Regex.Match(
+                        RootAssembly.CodeBase,
+                        @"/[^/]*microsoft\.netcore\.app/(\d+\.\d+\.\d+[^/]*)/",
+                        RegexOptions.IgnoreCase);
+
+                    if (match.Success && match.Groups.Count > 0 && match.Groups[1].Success)
+                    {
+                        productVersion = match.Groups[1].Value;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Log.SafeLogError(e, "Error getting .NET Core version from assembly path");
+                }
+            }
+
+            if (productVersion == null)
+            {
+                // if we fail to extract version from assembly path,
+                // fall back to the [AssemblyInformationalVersion] or [AssemblyFileVersion]
+                productVersion = GetVersionFromAssemblyAttributes();
+            }
+
+            if (productVersion == null)
+            {
+                // at this point, everything else has failed (this is probably the same as [AssemblyFileVersion] above)
+                productVersion = Environment.Version.ToString();
+            }
+
+            return productVersion;
+        }
+    }
+}
+#endif

--- a/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -10,11 +10,6 @@ namespace Datadog.Trace
     {
         public static FrameworkDescription Create()
         {
-            return CreateFromRuntimeInformation();
-        }
-
-        private static FrameworkDescription CreateFromRuntimeInformation()
-        {
             string frameworkName = null;
             string osPlatform = null;
 
@@ -46,13 +41,13 @@ namespace Datadog.Trace
 
             return new FrameworkDescription(
                 frameworkName ?? "unknown",
-                GetNetCoreVersion() ?? "unknown",
+                GetNetCoreOrNetFrameworkVersion() ?? "unknown",
                 osPlatform ?? "unknown",
                 RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
                 RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant());
         }
 
-        private static string GetNetCoreVersion()
+        private static string GetNetCoreOrNetFrameworkVersion()
         {
             string productVersion = null;
 

--- a/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -1,0 +1,61 @@
+#if NETFRAMEWORK
+using System;
+using System.Linq;
+using Datadog.Trace.Logging;
+using Microsoft.Win32;
+
+namespace Datadog.Trace
+{
+    internal partial class FrameworkDescription
+    {
+        public static FrameworkDescription Create()
+        {
+            var assemblyName = RootAssembly.GetName();
+
+            // .NET Framework
+            return new FrameworkDescription(
+                ".NET Framework",
+                GetNetFrameworkVersion() ?? "unknown",
+                "Windows",
+                Environment.Is64BitOperatingSystem ? "x64" : "x86",
+                Environment.Is64BitProcess ? "x64" : "x86");
+        }
+
+        private static string GetNetFrameworkVersion()
+        {
+            string productVersion = null;
+
+            try
+            {
+                object registryValue;
+
+                using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default))
+                using (var subKey = baseKey.OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
+                {
+                    registryValue = subKey?.GetValue("Release");
+                }
+
+                if (registryValue is int release)
+                {
+                    // find the known version on the list with the largest release number
+                    // that is lower than or equal to the release number in the Windows Registry
+                    productVersion = DotNetFrameworkVersionMapping.FirstOrDefault(t => release >= t.Item1)?.Item2;
+                }
+            }
+            catch (Exception e)
+            {
+                Log.SafeLogError(e, "Error getting .NET Framework version from Windows Registry");
+            }
+
+            if (productVersion == null)
+            {
+                // if we fail to extract version from assembly path,
+                // fall back to the [AssemblyInformationalVersion] or [AssemblyFileVersion]
+                productVersion = GetVersionFromAssemblyAttributes();
+            }
+
+            return productVersion;
+        }
+    }
+}
+#endif

--- a/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -10,8 +10,6 @@ namespace Datadog.Trace
     {
         public static FrameworkDescription Create()
         {
-            var assemblyName = RootAssembly.GetName();
-
             // .NET Framework
             return new FrameworkDescription(
                 ".NET Framework",

--- a/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -52,6 +52,12 @@ namespace Datadog.Trace
                 productVersion = GetVersionFromAssemblyAttributes();
             }
 
+            if (productVersion == null)
+            {
+                // at this point, everything else has failed (this is probably the same as [AssemblyFileVersion] above)
+                productVersion = Environment.Version.ToString();
+            }
+
             return productVersion;
         }
     }

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -8,7 +8,7 @@ using Microsoft.Win32;
 
 namespace Datadog.Trace
 {
-    internal class FrameworkDescription
+    internal partial class FrameworkDescription
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(FrameworkDescription));
 
@@ -56,154 +56,12 @@ namespace Datadog.Trace
 
         public string ProcessArchitecture { get; }
 
-        public static FrameworkDescription Create()
-        {
-            var assemblyName = RootAssembly.GetName();
-
-            if (string.Equals(assemblyName.Name, "mscorlib", StringComparison.OrdinalIgnoreCase))
-            {
-                // .NET Framework
-                return new FrameworkDescription(
-                    ".NET Framework",
-                    GetNetFrameworkVersion() ?? "unknown",
-                    "Windows",
-                    Environment.Is64BitOperatingSystem ? "x64" : "x86",
-                    Environment.Is64BitProcess ? "x64" : "x86");
-            }
-
-            // .NET Core
-            return CreateFromRuntimeInformation();
-        }
-
         public override string ToString()
         {
             // examples:
             // .NET Framework 4.8 x86 on Windows x64
             // .NET Core 3.0.0 x64 on Linux x64
             return $"{Name} {ProductVersion} {ProcessArchitecture} on {OSPlatform} {OSArchitecture}";
-        }
-
-        private static FrameworkDescription CreateFromRuntimeInformation()
-        {
-            string frameworkName = null;
-            string osPlatform = null;
-
-            try
-            {
-                // RuntimeInformation.FrameworkDescription returns a string like ".NET Framework 4.7.2" or ".NET Core 2.1",
-                // we want to return everything before the last space
-                string frameworkDescription = RuntimeInformation.FrameworkDescription;
-                int index = frameworkDescription.LastIndexOf(' ');
-                frameworkName = frameworkDescription.Substring(0, index).Trim();
-            }
-            catch (Exception e)
-            {
-                Log.SafeLogError(e, "Error getting framework name from RuntimeInformation");
-            }
-
-            if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
-            {
-                osPlatform = "Windows";
-            }
-            else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
-            {
-                osPlatform = "Linux";
-            }
-            else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
-            {
-                osPlatform = "MacOS";
-            }
-
-            return new FrameworkDescription(
-                frameworkName ?? "unknown",
-                GetNetCoreVersion() ?? "unknown",
-                osPlatform ?? "unknown",
-                RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant(),
-                RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant());
-        }
-
-        private static string GetNetFrameworkVersion()
-        {
-            string productVersion = null;
-
-            try
-            {
-                object registryValue;
-
-                using (var baseKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default))
-                using (var subKey = baseKey.OpenSubKey(@"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\"))
-                {
-                    registryValue = subKey?.GetValue("Release");
-                }
-
-                if (registryValue is int release)
-                {
-                    // find the known version on the list with the largest release number
-                    // that is lower than or equal to the release number in the Windows Registry
-                    productVersion = DotNetFrameworkVersionMapping.FirstOrDefault(t => release >= t.Item1)?.Item2;
-                }
-            }
-            catch (Exception e)
-            {
-                Log.SafeLogError(e, "Error getting .NET Framework version from Windows Registry");
-            }
-
-            if (productVersion == null)
-            {
-                // if we fail to extract version from assembly path,
-                // fall back to the [AssemblyInformationalVersion] or [AssemblyFileVersion]
-                productVersion = GetVersionFromAssemblyAttributes();
-            }
-
-            return productVersion;
-        }
-
-        private static string GetNetCoreVersion()
-        {
-            string productVersion = null;
-
-            if (Environment.Version.Major == 3 || Environment.Version.Major >= 5)
-            {
-                // Environment.Version returns "4.x" in .NET Core 2.x,
-                // but it is correct since .NET Core 3.0.0
-                productVersion = Environment.Version.ToString();
-            }
-
-            if (productVersion == null)
-            {
-                try
-                {
-                    // try to get product version from assembly path
-                    Match match = Regex.Match(
-                        RootAssembly.CodeBase,
-                        @"/[^/]*microsoft\.netcore\.app/(\d+\.\d+\.\d+[^/]*)/",
-                        RegexOptions.IgnoreCase);
-
-                    if (match.Success && match.Groups.Count > 0 && match.Groups[1].Success)
-                    {
-                        productVersion = match.Groups[1].Value;
-                    }
-                }
-                catch (Exception e)
-                {
-                    Log.SafeLogError(e, "Error getting .NET Core version from assembly path");
-                }
-            }
-
-            if (productVersion == null)
-            {
-                // if we fail to extract version from assembly path,
-                // fall back to the [AssemblyInformationalVersion] or [AssemblyFileVersion]
-                productVersion = GetVersionFromAssemblyAttributes();
-            }
-
-            if (productVersion == null)
-            {
-                // at this point, everything else has failed (this is probably the same as [AssemblyFileVersion] above)
-                productVersion = Environment.Version.ToString();
-            }
-
-            return productVersion;
         }
 
         private static string GetVersionFromAssemblyAttributes()

--- a/src/Datadog.Trace/FrameworkDescription.cs
+++ b/src/Datadog.Trace/FrameworkDescription.cs
@@ -16,9 +16,6 @@ namespace Datadog.Trace
 
         private static readonly Tuple<int, string>[] DotNetFrameworkVersionMapping =
         {
-            // highest known value is 528049
-            Tuple.Create(528050, "4.8+"),
-
             // known min value for each framework version
             Tuple.Create(528040, "4.8"),
             Tuple.Create(461808, "4.7.2"),

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -141,6 +141,13 @@ namespace Datadog.Trace.Logging
             //   - Path.GetTempPath
             if (logDirectory == null)
             {
+#if NETFRAMEWORK
+                var windowsDefaultDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
+                if (Directory.Exists(windowsDefaultDirectory))
+                {
+                    logDirectory = windowsDefaultDirectory;
+                }
+#else
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     var windowsDefaultDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
@@ -170,6 +177,7 @@ namespace Datadog.Trace.Logging
                         }
                     }
                 }
+#endif
             }
 
             if (logDirectory == null)

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -13,8 +13,6 @@ namespace Datadog.Trace.Logging
 {
     internal static class DatadogLogging
     {
-        private const string NixDefaultDirectory = "/var/log/datadog/dotnet";
-
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly LoggingLevelSwitch LoggingLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
         private static readonly ILogger SharedLogger = null;
@@ -159,7 +157,7 @@ namespace Datadog.Trace.Logging
                 else
                 {
                     // Linux
-                    logDirectory = NixDefaultDirectory;
+                    logDirectory = "/var/log/datadog/dotnet";
                 }
 #endif
             }


### PR DESCRIPTION
Changes proposed in this pull request
- Remove `Microsoft.CSharp` NuGet package reference. This was only necessary for using the `dynamic` keyword, so those have been refactored to objects that use our existing `ObjectExtensions` methods
- Remove `System.Runtime.InteropServices.RuntimeInformation` NuGet package reference. This is responsible for the additional `System.Runtime.InteropServices.RuntimeInformation.dll` on all platforms. It is built-in for `netstandard2.0` so the logic that uses the new API's was ifdef'd out of the .NET Framework build targets.
- Remove `Microsoft.Win32.Registry` NuGet package reference. This was no longer needed after refactoring of `FrameworkDescription` code.



@DataDog/apm-dotnet