### PR TITLE
Remove instance of DateTimeOffset in Span.Finish

### DIFF
--- a/src/Datadog.Trace/ITraceContext.cs
+++ b/src/Datadog.Trace/ITraceContext.cs
@@ -15,5 +15,7 @@ namespace Datadog.Trace
         void CloseSpan(Span span);
 
         void LockSamplingPriority();
+
+        TimeSpan ElapsedSince(DateTimeOffset date);
     }
 }

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace
 
         public Span RootSpan { get; private set; }
 
-        public DateTimeOffset UtcNow => _utcStart.Add(StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp));
+        public DateTimeOffset UtcNow => _utcStart.Add(Elapsed);
 
         public IDatadogTracer Tracer { get; }
 
@@ -46,6 +46,8 @@ namespace Datadog.Trace
                 }
             }
         }
+
+        private TimeSpan Elapsed => StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp);
 
         public void AddSpan(Span span)
         {
@@ -127,6 +129,11 @@ namespace Datadog.Trace
             {
                 _samplingPriorityLocked = true;
             }
+        }
+
+        public TimeSpan ElapsedSince(DateTimeOffset date)
+        {
+            return Elapsed + (_utcStart - date);
         }
 
         private void DecorateRootSpan(Span span)


### PR DESCRIPTION
It looks like creating a DateTimeOffset because of the number of internal checks. We only need the Timespan in that codepath.

Benchmark:
```csharp
_scope.Span.Finish();
```

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  DefaultJob : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT


```
| Method |     Mean |   Error |  StdDev | Ratio | RatioSD |
|------- |---------:|--------:|--------:|------:|--------:|
|    Old | 143.7 ns | 2.40 ns | 3.67 ns |  1.00 |    0.00 |
|    New | 119.5 ns | 2.33 ns | 2.29 ns |  0.82 |    0.03 |
