### PR TITLE
Dump stdout/stderr when smoketest fails

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
 using Datadog.Core.Tools;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -95,6 +98,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                         throw new NullException("We need a reference to the process for this test.");
                     }
 
+                    var cancellationTokenSource = new CancellationTokenSource();
+
+                    // Drain and store the output
+                    var stdoutReader = new OutputReader(process.StandardOutput, cancellationTokenSource.Token);
+                    var stderrReader = new OutputReader(process.StandardError, cancellationTokenSource.Token);
+
                     var ranToCompletion = process.WaitForExit(MaxTestRunMilliseconds);
 
                     if (AssumeSuccessOnTimeout && !ranToCompletion)
@@ -107,16 +116,30 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                     if (!ranToCompletion)
                     {
                         Output.WriteLine("The smoke test is running for too long or was lost.");
-                        DumpOutput(process, Output);
+                        Output.WriteLine($"StandardOutput:{Environment.NewLine}{stdoutReader.GetOutput()}");
+                        Output.WriteLine($"StandardError:{Environment.NewLine}{stderrReader.GetOutput()}");
+
+                        cancellationTokenSource.Cancel();
 
                         throw new TimeoutException("The smoke test is running for too long or was lost.");
                     }
 
-                    var output = DumpOutput(process, Output);
+                    var standardOutput = stdoutReader.GetOutput(waitForCompletion: true);
+                    var standardError = stderrReader.GetOutput(waitForCompletion: true);
+
+                    if (!string.IsNullOrWhiteSpace(standardOutput))
+                    {
+                        Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(standardError))
+                    {
+                        Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+                    }
 
                     int exitCode = process.ExitCode;
 
-                    result = new ProcessResult(process, output.Item1, output.Item2, exitCode);
+                    result = new ProcessResult(process, standardOutput, standardError, exitCode);
                 }
             }
 
@@ -125,22 +148,47 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
             Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");
         }
 
-        private static Tuple<string, string> DumpOutput(Process process, ITestOutputHelper output)
+        private class OutputReader
         {
-            var standardOutput = process.StandardOutput.ReadToEnd();
-            var standardError = process.StandardError.ReadToEnd();
+            private readonly StreamReader _reader;
+            private readonly StringBuilder _buffer = new StringBuilder();
+            private readonly CancellationToken _cancellationToken;
+            private readonly Thread _thread;
 
-            if (!string.IsNullOrWhiteSpace(standardOutput))
+            public OutputReader(StreamReader reader, CancellationToken token)
             {
-                output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+                _reader = reader;
+                _cancellationToken = token;
+
+                _thread = new Thread(Drain) { IsBackground = true };
+                _thread.Start();
             }
 
-            if (!string.IsNullOrWhiteSpace(standardError))
+            public string GetOutput(bool waitForCompletion = false)
             {
-                output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+                if (waitForCompletion)
+                {
+                    _thread.Join();
+                }
+
+                lock (_buffer)
+                {
+                    return _buffer.ToString();
+                }
             }
 
-            return Tuple.Create(standardOutput, standardError);
+            private void Drain()
+            {
+                while (!_reader.EndOfStream && !_cancellationToken.IsCancellationRequested)
+                {
+                    var line = _reader.ReadLine();
+
+                    lock (_buffer)
+                    {
+                        _buffer.Append(line);
+                    }
+                }
+            }
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -106,30 +106,41 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
                     if (!ranToCompletion)
                     {
+                        Output.WriteLine("The smoke test is running for too long or was lost.");
+                        DumpOutput(process, Output);
+
                         throw new TimeoutException("The smoke test is running for too long or was lost.");
                     }
 
-                    string standardOutput = process.StandardOutput.ReadToEnd();
-                    string standardError = process.StandardError.ReadToEnd();
+                    var output = DumpOutput(process, Output);
+
                     int exitCode = process.ExitCode;
 
-                    if (!string.IsNullOrWhiteSpace(standardOutput))
-                    {
-                        Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(standardError))
-                    {
-                        Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
-                    }
-
-                    result = new ProcessResult(process, standardOutput, standardError, exitCode);
+                    result = new ProcessResult(process, output.Item1, output.Item2, exitCode);
                 }
             }
 
             var successCode = 0;
             Assert.True(successCode == result.ExitCode, $"Non-success exit code {result.ExitCode}");
             Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");
+        }
+
+        private static Tuple<string, string> DumpOutput(Process process, ITestOutputHelper output)
+        {
+            var standardOutput = process.StandardOutput.ReadToEnd();
+            var standardError = process.StandardError.ReadToEnd();
+
+            if (!string.IsNullOrWhiteSpace(standardOutput))
+            {
+                output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(standardError))
+            {
+                output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
+            }
+
+            return Tuple.Create(standardOutput, standardError);
         }
     }
 }


### PR DESCRIPTION
It's hard to understand why a smoketest fails since we discard the output when it happens.