### PR TITLE
Suppress heap allocations in TracerSettings.IsIntegrationEnabled

### DIFF
--- a/src/Datadog.Trace/Configuration/IntegrationSettingsCollection.cs
+++ b/src/Datadog.Trace/Configuration/IntegrationSettingsCollection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Concurrent;
 
 namespace Datadog.Trace.Configuration
@@ -9,6 +10,7 @@ namespace Datadog.Trace.Configuration
     {
         private readonly IConfigurationSource _source;
         private readonly ConcurrentDictionary<string, IntegrationSettings> _settings;
+        private readonly Func<string, IntegrationSettings> _valueFactory;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegrationSettingsCollection"/> class.
@@ -18,6 +20,7 @@ namespace Datadog.Trace.Configuration
         {
             _source = source;
             _settings = new ConcurrentDictionary<string, IntegrationSettings>();
+            _valueFactory = name => new IntegrationSettings(name, _source);
         }
 
         /// <summary>
@@ -26,6 +29,6 @@ namespace Datadog.Trace.Configuration
         /// <param name="integrationName">The name of the integration.</param>
         /// <returns>The integration-specific settings for the specified integration.</returns>
         public IntegrationSettings this[string integrationName] =>
-            _settings.GetOrAdd(integrationName, name => new IntegrationSettings(name, _source));
+            _settings.GetOrAdd(integrationName, _valueFactory);
     }
 }

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -8,6 +8,7 @@ namespace Datadog.Trace.Util
     /// </summary>
     internal static class DomainMetadata
     {
+        private const string IsAppInsightKey = "DD_IsAppInsight";
         private const string UnknownName = "unknown";
         private static Process _currentProcess;
         private static bool _processDataPoisoned;
@@ -100,12 +101,15 @@ namespace Datadog.Trace.Util
 
         public static bool ShouldAvoidAppDomain()
         {
-            if (AppDomainName.IndexOf("ApplicationInsights", StringComparison.OrdinalIgnoreCase) >= 0)
+            var appDomain = AppDomain.CurrentDomain;
+
+            if (!(appDomain.GetData(IsAppInsightKey) is bool isAppInsight))
             {
-                return true;
+                isAppInsight = AppDomainName.IndexOf("ApplicationInsights", StringComparison.OrdinalIgnoreCase) >= 0;
+                appDomain.SetData(IsAppInsightKey, isAppInsight);
             }
 
-            return false;
+            return isAppInsight;
         }
 
         private static void TrySetProcess()

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -8,11 +8,11 @@ namespace Datadog.Trace.Util
     /// </summary>
     internal static class DomainMetadata
     {
-        private const string IsAppInsightKey = "DD_IsAppInsight";
         private const string UnknownName = "unknown";
         private static Process _currentProcess;
         private static bool _processDataPoisoned;
         private static bool _domainDataPoisoned;
+        private static bool? _isAppInsightsAppDomain;
 
         static DomainMetadata()
         {
@@ -101,15 +101,12 @@ namespace Datadog.Trace.Util
 
         public static bool ShouldAvoidAppDomain()
         {
-            var appDomain = AppDomain.CurrentDomain;
-
-            if (!(appDomain.GetData(IsAppInsightKey) is bool isAppInsight))
+            if (_isAppInsightsAppDomain == null)
             {
-                isAppInsight = AppDomainName.IndexOf("ApplicationInsights", StringComparison.OrdinalIgnoreCase) >= 0;
-                appDomain.SetData(IsAppInsightKey, isAppInsight);
+                _isAppInsightsAppDomain = AppDomainName.IndexOf("ApplicationInsights", StringComparison.OrdinalIgnoreCase) >= 0;
             }
 
-            return isAppInsight;
+            return _isAppInsightsAppDomain.Value;
         }
 
         private static void TrySetProcess()

--- a/test/Datadog.Trace.Tests/Util/DomainMetadataTests.cs
+++ b/test/Datadog.Trace.Tests/Util/DomainMetadataTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Datadog.Trace.Util;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util
+{
+    public class DomainMetadataTests
+    {
+#if !NETCOREAPP
+
+        private const string TestDataKey = "ShouldAvoidAppInsightsAppDomain";
+
+        [Fact]
+        public void ShouldAvoidAppInsightsAppDomain()
+        {
+            static void AppDomainCallback()
+            {
+                var result = DomainMetadata.ShouldAvoidAppDomain();
+                AppDomain.CurrentDomain.SetData(TestDataKey, result);
+            }
+
+            var domain1 = AppDomain.CreateDomain("ApplicationInsights", null, AppDomain.CurrentDomain.SetupInformation);
+
+            domain1.DoCallBack(AppDomainCallback);
+
+            var rawValue = domain1.GetData(TestDataKey);
+
+            Assert.IsType<bool>(rawValue);
+            Assert.True((bool)rawValue);
+
+            var domain2 = AppDomain.CreateDomain("Test", null, AppDomain.CurrentDomain.SetupInformation);
+
+            domain2.DoCallBack(AppDomainCallback);
+
+            rawValue = domain2.GetData(TestDataKey);
+
+            Assert.IsType<bool>(rawValue);
+            Assert.False((bool)rawValue);
+        }
+#endif
+    }
+}


### PR DESCRIPTION
- Remove closure allocation in IntegrationSettingsCollection
- Getting the AppDomain friendly name seems to internally call Assembly.GetName, which seems to allocate quite a bit (especially on .net core). Used AppDomain.SetData to cache the result and prevent further allocations

Benchmark:
```csharp
TracerSettings.IsIntegrationEnabled("Test")
```

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-VTGAFA : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-MNUBEA : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
| Method |       Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |-------------- |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|    Old |    .NET 4.7.2 | 254.26 ns |  5.100 ns |  7.149 ns |  1.00 |    0.00 | 0.0191 |     - |     - |     120 B |
|    New |    .NET 4.7.2 | 108.29 ns |  2.160 ns |  2.731 ns |  0.43 |    0.02 |      - |     - |     - |         - |
|        |               |           |           |           |       |         |        |       |       |           |
|    Old | .NET Core 3.1 | 894.16 ns | 17.648 ns | 28.499 ns |  1.00 |    0.00 | 0.0744 |     - |     - |     472 B |
|    New | .NET Core 3.1 |  59.63 ns |  1.178 ns |  1.102 ns |  0.07 |    0.00 |      - |     - |     - |         - |

