### PR TITLE
Cache tags from DbCommand

### DIFF
--- a/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+
+namespace Datadog.Trace.Util
+{
+    internal static class DbCommandCache
+    {
+        private static readonly ConcurrentDictionary<string, KeyValuePair<string, string>[]> Cache
+            = new ConcurrentDictionary<string, KeyValuePair<string, string>[]>();
+
+        public static KeyValuePair<string, string>[] GetTagsFromDbCommand(IDbCommand command)
+        {
+            return Cache.GetOrAdd(command.Connection.ConnectionString, connectionString =>
+            {
+                // Parse the connection string
+                var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+
+                return new[]
+                {
+                    new KeyValuePair<string, string>(
+                        Tags.DbName,
+                        GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog")),
+
+                    new KeyValuePair<string, string>(
+                        Tags.DbUser,
+                        GetConnectionStringValue(builder, "User ID", "UserID")),
+
+                    new KeyValuePair<string, string>(
+                        Tags.OutHost,
+                        GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"))
+                };
+            });
+        }
+
+        private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)
+        {
+            foreach (string name in names)
+            {
+                if (builder.TryGetValue(name, out object valueObj) &&
+                    valueObj is string value)
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Util
                 // Use atomic operation to log only once
                 if (Interlocked.Exchange(ref _cache, null) != null)
                 {
-                    Log.Information("More than 100 different connection strings were used, disabling cache");
+                    Log.Information($"More than {MaxConnectionStrings} different connection strings were used, disabling cache");
                 }
             }
 

--- a/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -2,36 +2,89 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Threading;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.Util
 {
     internal static class DbCommandCache
     {
-        private static readonly ConcurrentDictionary<string, KeyValuePair<string, string>[]> Cache
+        internal const int MaxConnectionStrings = 100;
+
+        private static readonly ILogger Log = DatadogLogging.GetLogger(typeof(DbCommandCache));
+
+        private static ConcurrentDictionary<string, KeyValuePair<string, string>[]> _cache
             = new ConcurrentDictionary<string, KeyValuePair<string, string>[]>();
+
+        /// <summary>
+        /// Gets or sets the underlying cache, to be used for unit tests
+        /// </summary>
+        internal static ConcurrentDictionary<string, KeyValuePair<string, string>[]> Cache
+        {
+            get
+            {
+                return _cache;
+            }
+
+            set
+            {
+                _cache = value;
+            }
+        }
 
         public static KeyValuePair<string, string>[] GetTagsFromDbCommand(IDbCommand command)
         {
-            return Cache.GetOrAdd(command.Connection.ConnectionString, connectionString =>
+            var connectionString = command.Connection.ConnectionString;
+            var cache = _cache;
+
+            if (cache != null)
             {
-                // Parse the connection string
-                var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
-
-                return new[]
+                if (cache.TryGetValue(connectionString, out var tags))
                 {
-                    new KeyValuePair<string, string>(
-                        Tags.DbName,
-                        GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog")),
+                    // Fast path: it's expected that most calls will end up in this branch
+                    return tags;
+                }
 
-                    new KeyValuePair<string, string>(
-                        Tags.DbUser,
-                        GetConnectionStringValue(builder, "User ID", "UserID")),
+                if (cache.Count <= MaxConnectionStrings)
+                {
+                    // Populating the cache. This path should be hit only during application warmup
+                    // ReSharper disable once ConvertClosureToMethodGroup -- Lambdas are cached by the compiler
+                    return cache.GetOrAdd(connectionString, cs => ExtractTagsFromConnectionString(cs));
+                }
 
-                    new KeyValuePair<string, string>(
-                        Tags.OutHost,
-                        GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"))
-                };
-            });
+                // The assumption "connection strings are a finite set" was wrong, disabling the cache
+                // Use atomic operation to log only once
+                if (Interlocked.Exchange(ref _cache, null) != null)
+                {
+                    Log.Information("More than 100 different connection strings were used, disabling cache");
+                }
+            }
+
+            // Fallback: too many different connection string, there might be a random part in them
+            // Stop using the cache to prevent memory leaks
+            return ExtractTagsFromConnectionString(connectionString);
+        }
+
+        private static KeyValuePair<string, string>[] ExtractTagsFromConnectionString(string connectionString)
+        {
+            // Parse the connection string
+            var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+
+            return new[]
+            {
+                new KeyValuePair<string, string>(
+                    Tags.DbName,
+                    GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog")),
+
+                new KeyValuePair<string, string>(
+                    Tags.DbUser,
+                    GetConnectionStringValue(builder, "User ID", "UserID")),
+
+                new KeyValuePair<string, string>(
+                    Tags.OutHost,
+                    GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"))
+            };
         }
 
         private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)

--- a/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -31,9 +31,9 @@ namespace Datadog.Trace.Tests.ExtensionMethods
 
             span.AddTagsFromDbCommand(CreateDbCommand(connectionString));
 
-            Assert.Equal(span.GetTag(Tags.DbName), expectedDbName);
-            Assert.Equal(span.GetTag(Tags.DbUser), expectedUserId);
-            Assert.Equal(span.GetTag(Tags.OutHost), expectedHost);
+            Assert.Equal(expectedDbName, span.GetTag(Tags.DbName));
+            Assert.Equal(expectedUserId, span.GetTag(Tags.DbUser));
+            Assert.Equal(expectedHost, span.GetTag(Tags.OutHost));
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -1,0 +1,58 @@
+using System.Data;
+using Datadog.Trace.ExtensionMethods;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.ExtensionMethods
+{
+    public class SpanExtensionsTests
+    {
+        [Theory]
+        [InlineData("Server=myServerName,myPortNumber;Database=myDataBase;User Id=myUsername;Password=myPassword;", "myDataBase", "myUsername", "myServerName,myPortNumber")]
+        [InlineData(@"Server=myServerName\myInstanceName;Database=myDataBase;User Id=myUsername;Password=myPassword;", "myDataBase", "myUsername", @"myServerName\myInstanceName")]
+        [InlineData(@"Server=.\SQLExpress;AttachDbFilename=|DataDirectory|mydbfile.mdf;Database=dbname;Trusted_Connection=Yes;", "dbname", null, @".\SQLExpress")]
+        public void ExtractProperTagsFromConnectionString(
+            string connectionString,
+            string expectedDbName,
+            string expectedUserId,
+            string expectedHost)
+        {
+            var spanContext = new SpanContext(Mock.Of<ISpanContext>(), Mock.Of<ITraceContext>(), "test");
+            var span = new Span(spanContext, null);
+
+            var dbConnection = new Mock<IDbConnection>();
+            dbConnection.SetupGet(c => c.ConnectionString).Returns(connectionString);
+
+            var dbCommand = new Mock<IDbCommand>();
+            dbCommand.SetupGet(c => c.Connection).Returns(dbConnection.Object);
+
+            span.AddTagsFromDbCommand(dbCommand.Object);
+
+            Assert.Equal(span.GetTag(Tags.DbName), expectedDbName);
+            Assert.Equal(span.GetTag(Tags.DbUser), expectedUserId);
+            Assert.Equal(span.GetTag(Tags.OutHost), expectedHost);
+        }
+
+        [Fact]
+        public void SetSpanTypeToSql()
+        {
+            const string connectionString = "Server=myServerName,myPortNumber;Database=myDataBase;User Id=myUsername;Password=myPassword;";
+            const string commandText = "SELECT * FROM Table ORDER BY id";
+
+            var spanContext = new SpanContext(Mock.Of<ISpanContext>(), Mock.Of<ITraceContext>(), "test");
+            var span = new Span(spanContext, null);
+
+            var dbConnection = new Mock<IDbConnection>();
+            dbConnection.SetupGet(c => c.ConnectionString).Returns(connectionString);
+
+            var dbCommand = new Mock<IDbCommand>();
+            dbCommand.SetupGet(c => c.Connection).Returns(dbConnection.Object);
+            dbCommand.SetupGet(c => c.CommandText).Returns(commandText);
+
+            span.AddTagsFromDbCommand(dbCommand.Object);
+
+            Assert.Equal(SpanTypes.Sql, span.Type);
+            Assert.Equal(commandText, span.ResourceName);
+        }
+    }
+}


### PR DESCRIPTION
Parsing the connection string is a costly operation that we do at every query, even though we can reasonably expect users to have a limited set of connection strings. 

Benchmark:

```csharp
// With connection string: Server=myServerName,myPortNumber;Database=myDataBase;User Id=myUsername;Password=myPassword;
SpanExtensions.AddTagsFromDbCommand(span, dbCommand);

```

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-VTGAFA : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-MNUBEA : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
| Method |       Runtime |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |-------------- |-----------:|---------:|---------:|------:|-------:|------:|------:|----------:|
|    Old |    .NET 4.7.2 | 4,336.9 ns | 49.97 ns | 44.30 ns |  1.00 | 0.3433 |     - |     - |    2182 B |
|    New |    .NET 4.7.2 |   242.4 ns |  1.54 ns |  1.45 ns |  0.06 |      - |     - |     - |         - |
|        |               |            |          |          |       |        |       |       |           |
|    Old | .NET Core 3.1 | 3,495.5 ns | 12.84 ns | 10.02 ns |  1.00 | 0.3510 |     - |     - |    2208 B |
|    New | .NET Core 3.1 |   236.4 ns |  3.97 ns |  3.52 ns |  0.07 |      - |     - |     - |         - |
