### PR TITLE
[ClrProfiler] Guarantee that startup hook only runs at one callsite in IIS applications

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -71,6 +71,11 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     return E_FAIL;
   }
 
+  if (process_name == "w3wp.exe"_W  ||
+      process_name == "iisexpresstray.exe"_W) {
+    is_iis = true;
+  }
+
   // get Profiler interface
   HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo3>(
       &this->info_);
@@ -525,11 +530,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   // own AppDomain because at this point in the code path, the ApplicationImpersonationContext
   // has been started.
   auto valid_startup_hook_callsite = true;
-  if (module_metadata->assemblyName == "System"_W ||
-      module_metadata->assemblyName == "System.Net.Http"_W ||
-      module_metadata->assemblyName == "Microsoft.WindowsAzure.WebSites.Diagnostics"_W ||
-     (module_metadata->assemblyName == "System.Web"_W && !(caller.type.name == "System.Web.Compilation.BuildManager"_W && caller.name == "InvokePreStartInitMethods"_W))) {
-    valid_startup_hook_callsite = false;
+  if (is_iis) {
+      valid_startup_hook_callsite =
+            module_metadata->assemblyName == "System.Web"_W &&
+            caller.type.name == "System.Web.Compilation.BuildManager"_W &&
+            caller.name == "InvokePreStartInitMethods"_W;
   }
 
   // The first time a method is JIT compiled in an AppDomain, insert our startup

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -537,6 +537,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
             module_metadata->assemblyName == "System.Web"_W &&
             caller.type.name == "System.Web.Compilation.BuildManager"_W &&
             caller.name == "InvokePreStartInitMethods"_W;
+  } else if (module_metadata->assemblyName == "System"_W ||
+             module_metadata->assemblyName == "System.Net.Http"_W) {
+    valid_startup_hook_callsite = false;
   }
 
   // The first time a method is JIT compiled in an AppDomain, insert our startup

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -71,11 +71,6 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     return E_FAIL;
   }
 
-  if (process_name == "w3wp.exe"_W  ||
-      process_name == "iisexpresstray.exe"_W) {
-    is_iis = true;
-  }
-
   // get Profiler interface
   HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo3>(
       &this->info_);
@@ -193,6 +188,10 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   }
 
   runtime_information_ = GetRuntimeInformation(this->info_);
+  if (process_name == "w3wp.exe"_W  ||
+      process_name == "iisexpresstray.exe"_W) {
+    is_desktop_iis = runtime_information_.is_desktop();
+  }
 
   // we're in!
   Info("Profiler attached.");
@@ -529,8 +528,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   // which correctly loads Datadog.Trace.ClrProfiler.Managed.Loader into the application's
   // own AppDomain because at this point in the code path, the ApplicationImpersonationContext
   // has been started.
+  //
+  // Note: This check must only run on desktop because it is possible (and the default) to host
+  // ASP.NET Core in-process, so a new .NET Core runtime is instantiated and run in the same w3wp.exe process
   auto valid_startup_hook_callsite = true;
-  if (is_iis) {
+  if (is_desktop_iis) {
       valid_startup_hook_callsite =
             module_metadata->assemblyName == "System.Web"_W &&
             caller.type.name == "System.Web.Compilation.BuildManager"_W &&

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -32,7 +32,7 @@ class CorProfiler : public CorProfilerBase {
   std::unordered_set<AppDomainID> managed_profiler_loaded_app_domains;
   std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
   bool in_azure_app_services = false;
-  bool is_iis = false;
+  bool is_desktop_iis = false;
 
   //
   // Module helper variables

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -32,6 +32,7 @@ class CorProfiler : public CorProfilerBase {
   std::unordered_set<AppDomainID> managed_profiler_loaded_app_domains;
   std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
   bool in_azure_app_services = false;
+  bool is_iis = false;
 
   //
   // Module helper variables


### PR DESCRIPTION
Modify the profiler so that, when running IIS or IIS Express on .NET Framework, the startup hook is only inserted in the `System.Web.Compilation.BuildManager.InvokePreStartInitMethods`. This has the following effects:

1. This removes the guess-and-check nature of valid callsites for the startup logic when running IIS. Before, `System.Web.Compilation.BuildManager.InvokePreStartInitMethods` was called out as a valid callsite, but it was possible for other modules to be loaded and methods to be called before this, causing the startup logic to run in the incorrect place.
2. This leaves ASP.NET Core apps hosted on IIS and IIS Express unchanged as they will still load at the earliest possible time in the setup of the ASP.NET Core application.
3. For ASP.NET (.NET Framework) applications, additional AppDomains that are not the main AppDomain won't be automatically instrumented. This trade-off should be acceptable as any automatic tracing there would be disconnected from the original request anyways since it is separated by the AppDomain boundary.

@DataDog/apm-dotnet