### PR TITLE
[CI] Allow a trace count of zero in MockTracerAgent

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.TestHelpers
                     {
                         if (int.TryParse(header, out int traceCount))
                         {
-                            return traceCount > 0;
+                            return traceCount >= 0;
                         }
 
                         return false;


### PR DESCRIPTION
@DataDog/apm-dotnet