### PR TITLE
Fix CLR Profiler IIS calculation to use correct iisexpress.exe process name.

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -48,7 +48,7 @@ SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Don't attach the profiler to these processes
-SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe
+SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;ServiceHub.TestWindowStoreHost.exe;ServiceHub.DataWarehouseHost.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe
 
 rem Set dotnet tracer home path
 SET DD_DOTNET_TRACER_HOME=%~dp0

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -189,7 +189,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
 
   runtime_information_ = GetRuntimeInformation(this->info_);
   if (process_name == "w3wp.exe"_W  ||
-      process_name == "iisexpresstray.exe"_W) {
+      process_name == "iisexpress.exe"_W) {
     is_desktop_iis = runtime_information_.is_desktop();
   }
 


### PR DESCRIPTION
Additionally, add another process name to the process exclusion list in our developer script.

@DataDog/apm-dotnet 