### PR TITLE
Reduce heap allocations in AspNetCoreDiagnosticObserver

### DIFF
--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -75,6 +75,21 @@ namespace Datadog.Trace.DiagnosticListeners
             }
         }
 
+        private static string GetUrl(HttpRequest request)
+        {
+            if (request.Host.HasValue)
+            {
+                return $"{request.Scheme}://{request.Host.Value}{request.PathBase.Value}{request.Path.Value}";
+            }
+
+            // HTTP 1.0 requests are not required to provide a Host to be valid
+            // Since this is just for display, we can provide a string that is
+            // not an actual Uri with only the fields that are specified.
+            // request.GetDisplayUrl(), used above, will throw an exception
+            // if request.Host is null.
+            return $"{request.Scheme}://{NoHostSpecified}{request.PathBase.Value}{request.Path.Value}";
+        }
+
         private static SpanContext ExtractPropagatedContext(HttpRequest request)
         {
             try
@@ -93,21 +108,6 @@ namespace Datadog.Trace.DiagnosticListeners
             }
 
             return null;
-        }
-
-        private static string GetUrl(HttpRequest request)
-        {
-            if (request.Host.HasValue)
-            {
-                return $"{request.Scheme}://{request.Host.Value}{request.PathBase.Value}{request.Path.Value}";
-            }
-
-            // HTTP 1.0 requests are not required to provide a Host to be valid
-            // Since this is just for display, we can provide a string that is
-            // not an actual Uri with only the fields that are specified.
-            // request.GetDisplayUrl(), used above, will throw an exception
-            // if request.Host is null.
-            return $"{request.Scheme}://{NoHostSpecified}{request.PathBase.Value}{request.Path.Value}";
         }
 
         private bool ShouldIgnore(HttpContext httpContext)

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -52,26 +52,6 @@ namespace Datadog.Trace.DiagnosticListeners
 
         protected override string ListenerName => DiagnosticListenerName;
 
-        public static SpanContext ExtractPropagatedContext(HttpRequest request)
-        {
-            try
-            {
-                // extract propagation details from http headers
-                var requestHeaders = request.Headers;
-
-                if (requestHeaders != null)
-                {
-                    return SpanContextPropagator.Instance.Extract(new HeadersCollectionAdapter(requestHeaders));
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.SafeLogError(ex, "Error extracting propagated HTTP headers.");
-            }
-
-            return null;
-        }
-
         protected override void OnNext(string eventName, object arg)
         {
             switch (eventName)
@@ -93,6 +73,26 @@ namespace Datadog.Trace.DiagnosticListeners
                     OnHostingUnhandledException(arg);
                     break;
             }
+        }
+
+        private static SpanContext ExtractPropagatedContext(HttpRequest request)
+        {
+            try
+            {
+                // extract propagation details from http headers
+                var requestHeaders = request.Headers;
+
+                if (requestHeaders != null)
+                {
+                    return SpanContextPropagator.Instance.Extract(new HeadersCollectionAdapter(requestHeaders));
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error extracting propagated HTTP headers.");
+            }
+
+            return null;
         }
 
         private static string GetUrl(HttpRequest request)

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 
@@ -12,6 +12,18 @@ namespace Datadog.Trace
 
         private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<SpanContextPropagator>();
+
+        private static readonly Dictionary<string, SamplingPriority> SamplingPriorities;
+
+        static SpanContextPropagator()
+        {
+            SamplingPriorities = new Dictionary<string, SamplingPriority>();
+
+            foreach (SamplingPriority value in Enum.GetValues(typeof(SamplingPriority)))
+            {
+                SamplingPriorities.Add(value.ToString(), value);
+            }
+        }
 
         private SpanContextPropagator()
         {
@@ -48,8 +60,10 @@ namespace Datadog.Trace
         /// Extracts a <see cref="SpanContext"/> from the values found in the specified headers.
         /// </summary>
         /// <param name="headers">The headers that contain the values to be extracted.</param>
+        /// <typeparam name="T">Type of header collection</typeparam>
         /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
-        public SpanContext Extract(IHeadersCollection headers)
+        public SpanContext Extract<T>(T headers)
+            where T : IHeadersCollection
         {
             if (headers == null)
             {
@@ -65,47 +79,55 @@ namespace Datadog.Trace
             }
 
             var parentId = ParseUInt64(headers, HttpHeaderNames.ParentId);
-            var samplingPriority = ParseEnum<SamplingPriority>(headers, HttpHeaderNames.SamplingPriority);
+            var samplingPriority = ParseSamplingPriority(headers, HttpHeaderNames.SamplingPriority);
 
             return new SpanContext(traceId, parentId, samplingPriority);
         }
 
-        private static ulong ParseUInt64(IHeadersCollection headers, string headerName)
+        private static ulong ParseUInt64<T>(T headers, string headerName)
+            where T : IHeadersCollection
         {
-            var headerValues = headers.GetValues(headerName).ToList();
+            var headerValues = headers.GetValues(headerName);
 
-            if (headerValues.Count > 0)
+            bool hasValue = false;
+
+            foreach (string headerValue in headerValues)
             {
-                foreach (string headerValue in headerValues)
+                if (ulong.TryParse(headerValue, NumberStyles, InvariantCulture, out var result))
                 {
-                    if (ulong.TryParse(headerValue, NumberStyles, InvariantCulture, out var result))
-                    {
-                        return result;
-                    }
+                    return result;
                 }
 
+                hasValue = true;
+            }
+
+            if (hasValue)
+            {
                 Log.Information("Could not parse {0} headers: {1}", headerName, string.Join(",", headerValues));
             }
 
             return 0;
         }
 
-        private static T? ParseEnum<T>(IHeadersCollection headers, string headerName)
-            where T : struct, Enum
+        private static SamplingPriority? ParseSamplingPriority<T>(T headers, string headerName)
+            where T : IHeadersCollection
         {
-            var headerValues = headers.GetValues(headerName).ToList();
+            var headerValues = headers.GetValues(headerName);
 
-            if (headerValues.Count > 0)
+            bool hasValue = false;
+
+            foreach (string headerValue in headerValues)
             {
-                foreach (string headerValue in headerValues)
+                if (SamplingPriorities.TryGetValue(headerValue, out var result))
                 {
-                    if (Enum.TryParse<T>(headerValue, out var result) &&
-                        Enum.IsDefined(typeof(T), result))
-                    {
-                        return result;
-                    }
+                    return result;
                 }
 
+                hasValue = true;
+            }
+
+            if (hasValue)
+            {
                 Log.Information(
                     "Could not parse {0} headers: {1}",
                     headerName,


### PR DESCRIPTION
- Use a wrapper on top of IHeaderDictionary instead of duplicating the headers
- Make all methods that expect a IHeadersCollection generic, to avoid boxing the wrapper
- Cache the SamplingPriority values in a dictionary to avoid the costly enum conversion
- Remove the ToList when accessing the header values

**Benchmark:**

```csharp
AspNetCoreDiagnosticObserver.ExtractPropagatedContext(request)
```
- No headers: request with empty headers
- All headers: request with headers TraceId / ParentId / SamplingPriority


``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.301
  [Host]     : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
|         Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
|  NoHeaders_Old |  95.84 ns |  1.299 ns |  1.215 ns | 0.0305 |     - |     - |     192 B |
|  NoHeaders_New |  32.65 ns |  0.177 ns |  0.147 ns | 0.0038 |     - |     - |      24 B |
| AllHeaders_Old | 998.29 ns | 21.315 ns | 19.938 ns | 0.1640 |     - |     - |    1032 B |
| AllHeaders_New | 226.51 ns |  5.037 ns |  6.186 ns | 0.0443 |     - |     - |     280 B |
