### PR TITLE
Improve span validation for automatic instrumentation of outbound HTTP calls

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -58,10 +58,7 @@ namespace Datadog.Trace.ClrProfiler
                 var span = scope.Span;
 
                 span.Type = SpanTypes.Http;
-                span.ResourceName = string.Join(
-                    " ",
-                    httpMethod,
-                    resourceUrl);
+                span.ResourceName = $"{httpMethod} {resourceUrl}";
 
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 span.SetTag(Tags.HttpMethod, httpMethod?.ToUpperInvariant());

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -41,8 +41,9 @@ namespace Datadog.Trace.ClrProfiler
 
                 if (parent != null &&
                     parent.Type == SpanTypes.Http &&
-                    parent.GetTag(Tags.HttpMethod).Equals(httpMethod, StringComparison.OrdinalIgnoreCase) &&
-                    parent.GetTag(Tags.HttpUrl).Equals(UriHelpers.CleanUri(requestUri, removeScheme: false, tryRemoveIds: false), StringComparison.OrdinalIgnoreCase))
+                    integrationName.Equals(parent.GetTag(Tags.InstrumentationName), StringComparison.OrdinalIgnoreCase) &&
+                    httpMethod.Equals(parent.GetTag(Tags.HttpMethod), StringComparison.OrdinalIgnoreCase) &&
+                    UriHelpers.CleanUri(requestUri, removeScheme: false, tryRemoveIds: false).Equals(parent.GetTag(Tags.HttpUrl), StringComparison.OrdinalIgnoreCase))
                 {
                     // we are already instrumenting this,
                     // don't instrument nested methods that belong to the same stacktrace

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 if (parent != null &&
                     parent.Type == SpanTypes.Http &&
-                    integrationName.Equals(parent.GetTag(Tags.InstrumentationName), StringComparison.OrdinalIgnoreCase) &&
+                    parent.GetTag(Tags.InstrumentationName) != null &&
                     httpMethod.Equals(parent.GetTag(Tags.HttpMethod), StringComparison.OrdinalIgnoreCase) &&
                     UriHelpers.CleanUri(requestUri, removeScheme: false, tryRemoveIds: false).Equals(parent.GetTag(Tags.HttpUrl), StringComparison.OrdinalIgnoreCase))
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -51,6 +51,7 @@ namespace Datadog.Trace.ClrProfiler
                     return null;
                 }
 
+                string resourceUrl = requestUri != null ? UriHelpers.CleanUri(requestUri, removeScheme: true, tryRemoveIds: true) : null;
                 string httpUrl = requestUri != null ? UriHelpers.CleanUri(requestUri, removeScheme: false, tryRemoveIds: false) : null;
 
                 scope = tracer.StartActive(OperationName, serviceName: $"{tracer.DefaultServiceName}-{ServiceName}");
@@ -60,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler
                 span.ResourceName = string.Join(
                     " ",
                     httpMethod,
-                    httpUrl);
+                    resourceUrl);
 
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
                 span.SetTag(Tags.HttpMethod, httpMethod?.ToUpperInvariant());

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler
                     UriHelpers.CleanUri(requestUri, removeScheme: true, tryRemoveIds: true));
 
                 span.SetTag(Tags.SpanKind, SpanKinds.Client);
-                span.SetTag(Tags.HttpMethod, httpMethod.ToUpperInvariant());
+                span.SetTag(Tags.HttpMethod, httpMethod?.ToUpperInvariant());
                 span.SetTag(Tags.HttpUrl, httpUrl);
                 span.SetTag(Tags.InstrumentationName, integrationName);
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -71,9 +71,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         [Theory]
-        [InlineData("HttpMessageHandler")]
-        [InlineData("WebRequest")]
-        public void CreateOutboundHttpScope_AlwaysCreatesOneAutomaticInstrumentationScope(string integrationName)
+        [InlineData("HttpMessageHandler", "HttpMessageHandler")] // This scenario may occur on any .NET runtime with nested HttpMessageHandler's and HttpSocketHandler's
+        [InlineData("WebRequest", "HttpMessageHandler")] // This scenario may occur on .NET Core where the underlying transport for WebRequest is HttpMessageHandler
+        public void CreateOutboundHttpScope_AlwaysCreatesOneAutomaticInstrumentationScope(string integrationName1, string integrationName2)
         {
             // Set up Tracer
             var settings = new TracerSettings();
@@ -91,9 +91,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 manualScope.Span.ResourceName = $"{method} {url}";
                 manualScope.Span.ServiceName = $"{tracer.DefaultServiceName}-http-client";
 
-                using (var automaticScope1 = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(url), integrationName))
+                using (var automaticScope1 = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(url), integrationName1))
                 {
-                    using (var automaticScope2 = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(url), integrationName))
+                    using (var automaticScope2 = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(url), integrationName2))
                     {
                         Assert.NotNull(manualScope);
                         Assert.NotNull(automaticScope1);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -32,20 +32,20 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         [Theory]
-        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "example.com/path/to/file.aspx")]
-        [InlineData("https://username@example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/to/file.aspx?query=1", "example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/to/file.aspx#fragment", "example.com/path/to/file.aspx")]
-        [InlineData("http://example.com/path/to/file.aspx", "example.com/path/to/file.aspx")]
-        [InlineData("https://example.com/path/123/file.aspx", "example.com/path/" + Id + "/file.aspx")]
-        [InlineData("https://example.com/path/123/", "example.com/path/" + Id + "/")]
-        [InlineData("https://example.com/path/123", "example.com/path/" + Id)]
-        [InlineData("https://example.com/path/4294967294/file.aspx", "example.com/path/" + Id + "/file.aspx")]
-        [InlineData("https://example.com/path/4294967294/", "example.com/path/" + Id + "/")]
-        [InlineData("https://example.com/path/4294967294", "example.com/path/" + Id)]
-        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "example.com/path/" + Id)]
-        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "example.com/path/" + Id)]
-        public void CleanUri_ResourceName(string uri, string expected)
+        [InlineData("https://username:password@example.com/path/to/file.aspx?query=1#fragment", "GET", "GET example.com/path/to/file.aspx")]
+        [InlineData("https://username@example.com/path/to/file.aspx", "GET", "GET example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx?query=1", "GET", "GET example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/to/file.aspx#fragment", "GET", "GET example.com/path/to/file.aspx")]
+        [InlineData("http://example.com/path/to/file.aspx", "GET", "GET example.com/path/to/file.aspx")]
+        [InlineData("https://example.com/path/123/file.aspx", "GET", "GET example.com/path/" + Id + "/file.aspx")]
+        [InlineData("https://example.com/path/123/", "GET", "GET example.com/path/" + Id + "/")]
+        [InlineData("https://example.com/path/123", "GET", "GET example.com/path/" + Id)]
+        [InlineData("https://example.com/path/4294967294/file.aspx", "GET", "GET example.com/path/" + Id + "/file.aspx")]
+        [InlineData("https://example.com/path/4294967294/", "GET", "GET example.com/path/" + Id + "/")]
+        [InlineData("https://example.com/path/4294967294", "GET", "GET example.com/path/" + Id)]
+        [InlineData("https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3", "GET", "GET example.com/path/" + Id)]
+        [InlineData("https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3", "GET", "GET example.com/path/" + Id)]
+        public void CleanUri_ResourceName(string uri, string method, string expected)
         {
             // Set up Tracer
             var settings = new TracerSettings();
@@ -53,13 +53,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
-            const string method = "GET";
             const string integrationName = "HttpMessageHandler";
 
-            // Manually create a span decorated with HTTP information
             using (var automaticScope = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(uri), integrationName))
             {
-                Assert.Equal(string.Join(" ", method, expected), automaticScope.Span.ResourceName);
+                Assert.Equal(expected, automaticScope.Span.ResourceName);
             }
         }
 
@@ -85,7 +83,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             const string method = "GET";
             const string integrationName = "HttpMessageHandler";
 
-            // Manually create a span decorated with HTTP information
             using (var automaticScope = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(uri), integrationName))
             {
                 Assert.Equal(expected, automaticScope.Span.GetTag(Tags.HttpUrl));


### PR DESCRIPTION
This PR improves the `Datadog.Trace.ClrProfiler.ScopeFactory.CreateOutboundHttpScope` helper method, used by both the `WebRequest` integration and the `HttpMessageHandler` integration, in the following ways:
1. Removes several possible locations for a `NullReferenceException` to occur in the method
2. Adds a more robust check on the parent span so that the HTTP span de-duplication logic (e.g. automatic instrumentation from nested `HttpMessageHandler` objects) will only consider spans created by automatic instrumentation, not custom spans

@DataDog/apm-dotnet