### PR TITLE
Adds support for 'x-datadog-origin' http header

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Helpers/SpanContextPropagatorHelpers.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Helpers/SpanContextPropagatorHelpers.cs
@@ -29,6 +29,13 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             headers.CallMethod<string, bool>("Remove", HttpHeaderNames.ParentId);
             headers.CallVoidMethod<string, string>("Add", HttpHeaderNames.ParentId, context.SpanId.ToString(InvariantCulture));
 
+            headers.CallMethod<string, bool>("Remove", HttpHeaderNames.Origin);
+            // avoid writing origin header if not set, keeping the previous behavior.
+            if (context.Origin != null)
+            {
+                headers.CallVoidMethod<string, string>("Add", HttpHeaderNames.Origin, context.Origin);
+            }
+
             var samplingPriority = (int?)(context.TraceContext?.SamplingPriority ?? context.SamplingPriority);
 
             headers.CallMethod<string, bool>("Remove", HttpHeaderNames.SamplingPriority);
@@ -55,8 +62,9 @@ namespace Datadog.Trace.ClrProfiler.Helpers
 
             var parentId = ParseUInt64(headers, HttpHeaderNames.ParentId);
             var samplingPriority = ParseEnum<SamplingPriority>(headers, HttpHeaderNames.SamplingPriority);
+            var origin = ParseString(headers, HttpHeaderNames.Origin);
 
-            return new SpanContext(traceId, parentId, samplingPriority);
+            return new SpanContext(traceId, parentId, samplingPriority, origin: origin);
         }
 
         private static ulong ParseUInt64(object headers, string headerName)
@@ -106,6 +114,26 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             }
 
             return default;
+        }
+
+        private static string ParseString(object headers, string headerName)
+        {
+            if (headers.CallMethod<string, bool>("Contains", headerName).Value)
+            {
+                var headerValues = headers.CallMethod<string, IEnumerable<string>>("GetValues", headerName).Value;
+                if (headerValues != null)
+                {
+                    foreach (string headerValue in headerValues)
+                    {
+                        if (!string.IsNullOrEmpty(headerValue))
+                        {
+                            return headerValue;
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Helpers/SpanContextPropagatorHelpers.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Helpers/SpanContextPropagatorHelpers.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             var samplingPriority = ParseEnum<SamplingPriority>(headers, HttpHeaderNames.SamplingPriority);
             var origin = ParseString(headers, HttpHeaderNames.Origin);
 
-            return new SpanContext(traceId, parentId, samplingPriority, origin: origin);
+            return new SpanContext(traceId, parentId, samplingPriority, null, origin);
         }
 
         private static ulong ParseUInt64(object headers, string headerName)

--- a/src/Datadog.Trace/HttpHeaderNames.cs
+++ b/src/Datadog.Trace/HttpHeaderNames.cs
@@ -25,5 +25,10 @@ namespace Datadog.Trace
         /// Tracing is enabled by default.
         /// </summary>
         public const string TracingEnabled = "x-datadog-tracing-enabled";
+
+        /// <summary>
+        /// Origin of the distributed trace.
+        /// </summary>
+        public const string Origin = "x-datadog-origin";
     }
 }

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the origin of the trace
         /// </summary>
-        public string Origin { get; }
+        internal string Origin { get; }
 
         /// <summary>
         /// Gets the trace context.

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -22,11 +22,13 @@ namespace Datadog.Trace
         /// <param name="spanId">The propagated span id.</param>
         /// <param name="samplingPriority">The propagated sampling priority.</param>
         /// <param name="serviceName">The service name to propagate to child spans.</param>
-        public SpanContext(ulong? traceId, ulong spanId, SamplingPriority? samplingPriority = null, string serviceName = null)
+        /// <param name="origin">The propagated origin of the trace.</param>
+        public SpanContext(ulong? traceId, ulong spanId, SamplingPriority? samplingPriority = null, string serviceName = null, string origin = null)
             : this(traceId, serviceName)
         {
             SpanId = spanId;
             SamplingPriority = samplingPriority;
+            Origin = origin;
         }
 
         /// <summary>
@@ -42,6 +44,10 @@ namespace Datadog.Trace
             SpanId = _random.Value.NextUInt63();
             Parent = parent;
             TraceContext = traceContext;
+            if (parent is SpanContext spanContext)
+            {
+                Origin = spanContext.Origin;
+            }
         }
 
         private SpanContext(ulong? traceId, string serviceName)
@@ -77,6 +83,11 @@ namespace Datadog.Trace
         /// Gets or sets the service name to propagate to child spans.
         /// </summary>
         public string ServiceName { get; set; }
+
+        /// <summary>
+        /// Gets the origin of the trace
+        /// </summary>
+        public string Origin { get; }
 
         /// <summary>
         /// Gets the trace context.

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -22,8 +22,24 @@ namespace Datadog.Trace
         /// <param name="spanId">The propagated span id.</param>
         /// <param name="samplingPriority">The propagated sampling priority.</param>
         /// <param name="serviceName">The service name to propagate to child spans.</param>
+        public SpanContext(ulong? traceId, ulong spanId, SamplingPriority? samplingPriority = null, string serviceName = null)
+            : this(traceId, serviceName)
+        {
+            SpanId = spanId;
+            SamplingPriority = samplingPriority;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpanContext"/> class
+        /// from a propagated context. <see cref="Parent"/> will be null
+        /// since this is a root context locally.
+        /// </summary>
+        /// <param name="traceId">The propagated trace id.</param>
+        /// <param name="spanId">The propagated span id.</param>
+        /// <param name="samplingPriority">The propagated sampling priority.</param>
+        /// <param name="serviceName">The service name to propagate to child spans.</param>
         /// <param name="origin">The propagated origin of the trace.</param>
-        public SpanContext(ulong? traceId, ulong spanId, SamplingPriority? samplingPriority = null, string serviceName = null, string origin = null)
+        internal SpanContext(ulong? traceId, ulong spanId, SamplingPriority? samplingPriority, string serviceName, string origin)
             : this(traceId, serviceName)
         {
             SpanId = spanId;

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -83,7 +83,7 @@ namespace Datadog.Trace
             var samplingPriority = ParseSamplingPriority(headers, HttpHeaderNames.SamplingPriority);
             var origin = ParseString(headers, HttpHeaderNames.Origin);
 
-            return new SpanContext(traceId, parentId, samplingPriority, origin: origin);
+            return new SpanContext(traceId, parentId, samplingPriority, null, origin);
         }
 
         private static ulong ParseUInt64<T>(T headers, string headerName)

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -147,22 +147,14 @@ namespace Datadog.Trace
 
         private static string ParseString(IHeadersCollection headers, string headerName)
         {
-            var headerValues = headers.GetValues(headerName).ToList();
+            var headerValues = headers.GetValues(headerName);
 
-            if (headerValues.Count > 0)
+            foreach (string headerValue in headerValues)
             {
-                foreach (string headerValue in headerValues)
+                if (!string.IsNullOrEmpty(headerValue))
                 {
-                    if (!string.IsNullOrEmpty(headerValue))
-                    {
-                        return headerValue;
-                    }
+                    return headerValue;
                 }
-
-                Log.Information(
-                    "Could not parse {0} headers: {1}",
-                    headerName,
-                    string.Join(",", headerValues));
             }
 
             return null;

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -205,5 +205,10 @@ namespace Datadog.Trace
         /// The subscription id of the site instance in azure app services where the traced application is running.
         /// </summary>
         public const string AzureAppServicesSubscriptionId = "aas.subscription.id";
+
+        /// <summary>
+        /// Configures the origin of the trace
+        /// </summary>
+        public const string Origin = "_dd.origin";
     }
 }

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -76,6 +76,12 @@ namespace Datadog.Trace
                                 Tracer.Sampler?.GetSamplingPriority(RootSpan);
                         }
                     }
+
+                    // set the origin tag to the root span of each trace/subtrace
+                    if (span.Context.Origin != null)
+                    {
+                        span.SetTag(Tags.Origin, span.Context.Origin);
+                    }
                 }
 
                 _spans.Add(span);

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -76,12 +76,6 @@ namespace Datadog.Trace
                                 Tracer.Sampler?.GetSamplingPriority(RootSpan);
                         }
                     }
-
-                    // set the origin tag to the root span of each trace/subtrace
-                    if (span.Context.Origin != null)
-                    {
-                        span.SetTag(Tags.Origin, span.Context.Origin);
-                    }
                 }
 
                 _spans.Add(span);
@@ -150,6 +144,12 @@ namespace Datadog.Trace
                 span.SetTag(Tags.AzureAppServicesResourceGroup, AzureAppServices.Metadata.ResourceGroup);
                 span.SetTag(Tags.AzureAppServicesSubscriptionId, AzureAppServices.Metadata.SubscriptionId);
                 span.SetTag(Tags.AzureAppServicesResourceId, AzureAppServices.Metadata.ResourceId);
+            }
+
+            // set the origin tag to the root span of each trace/subtrace
+            if (span.Context.Origin != null)
+            {
+                span.SetTag(Tags.Origin, span.Context.Origin);
             }
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/SpanContextPropagationHelpersTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/SpanContextPropagationHelpersTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             const string origin = "synthetics";
 
             var request = new HttpRequestMessage();
-            var context = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
+            var context = new SpanContext(traceId, spanId, samplingPriority, null, origin);
 
             SpanContextPropagatorHelpers.InjectHttpHeadersWithReflection(context, (object)request.Headers);
             var resultContext = SpanContextPropagatorHelpers.ExtractHttpHeadersWithReflection(request.Headers);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/SpanContextPropagationHelpersTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/SpanContextPropagationHelpersTests.cs
@@ -14,9 +14,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             const int traceId = 9;
             const int spanId = 7;
             const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
+            const string origin = "synthetics";
 
             var request = new HttpRequestMessage();
-            var context = new SpanContext(traceId, spanId, samplingPriority);
+            var context = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
 
             SpanContextPropagatorHelpers.InjectHttpHeadersWithReflection(context, (object)request.Headers);
             var resultContext = SpanContextPropagatorHelpers.ExtractHttpHeadersWithReflection(request.Headers);
@@ -25,6 +26,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(context.SpanId, resultContext.SpanId);
             Assert.Equal(context.TraceId, resultContext.TraceId);
             Assert.Equal(context.SamplingPriority, resultContext.SamplingPriority);
+            Assert.Equal(context.Origin, resultContext.Origin);
         }
 
         [Theory]
@@ -35,9 +37,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             const string spanId = "7";
             const string samplingPriority = "2";
+            const string origin = "synthetics";
 
             var request = new HttpRequestMessage();
-            InjectContext(request.Headers, traceId, spanId, samplingPriority);
+            InjectContext(request.Headers, traceId, spanId, samplingPriority, origin);
             var resultContext = SpanContextPropagatorHelpers.ExtractHttpHeadersWithReflection(request.Headers);
 
             // invalid traceId should return a null context even if other values are set
@@ -52,13 +55,15 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             const ulong traceId = 9;
             const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
+            const string origin = "synthetics";
 
             var request = new HttpRequestMessage();
             InjectContext(
                 request.Headers,
                 traceId.ToString(CultureInfo.InvariantCulture),
                 spanId,
-                ((int)samplingPriority).ToString(CultureInfo.InvariantCulture));
+                ((int)samplingPriority).ToString(CultureInfo.InvariantCulture),
+                origin);
 
             var resultContext = SpanContextPropagatorHelpers.ExtractHttpHeadersWithReflection(request.Headers);
 
@@ -66,6 +71,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(traceId, resultContext.TraceId);
             Assert.Equal(default(ulong), resultContext.SpanId);
             Assert.Equal(samplingPriority, resultContext.SamplingPriority);
+            Assert.Equal(origin, resultContext.Origin);
         }
 
         [Theory]
@@ -76,13 +82,15 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             const ulong traceId = 9;
             const ulong spanId = 7;
+            const string origin = "synthetics";
 
             var request = new HttpRequestMessage();
             InjectContext(
                 request.Headers,
                 traceId.ToString(CultureInfo.InvariantCulture),
                 spanId.ToString(CultureInfo.InvariantCulture),
-                samplingPriority);
+                samplingPriority,
+                origin);
 
             var resultContext = SpanContextPropagatorHelpers.ExtractHttpHeadersWithReflection(request.Headers);
 
@@ -90,13 +98,15 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(traceId, resultContext.TraceId);
             Assert.Equal(spanId, resultContext.SpanId);
             Assert.Null(resultContext.SamplingPriority);
+            Assert.Equal(origin, resultContext.Origin);
         }
 
-        private static void InjectContext(HttpRequestHeaders headers, string traceId, string spanId, string samplingPriority)
+        private static void InjectContext(HttpRequestHeaders headers, string traceId, string spanId, string samplingPriority, string origin)
         {
             headers.Add(HttpHeaderNames.TraceId, traceId);
             headers.Add(HttpHeaderNames.ParentId, spanId);
             headers.Add(HttpHeaderNames.SamplingPriority, samplingPriority);
+            headers.Add(HttpHeaderNames.Origin, origin);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
+++ b/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.Tests
             const string origin = "synthetics";
 
             IHeadersCollection headers = WebRequest.CreateHttp("http://localhost").Headers.Wrap();
-            var context = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
+            var context = new SpanContext(traceId, spanId, samplingPriority, null, origin);
 
             SpanContextPropagator.Instance.Inject(context, headers);
             var resultContext = SpanContextPropagator.Instance.Extract(headers);

--- a/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
+++ b/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
@@ -21,9 +21,10 @@ namespace Datadog.Trace.Tests
             const int traceId = 9;
             const int spanId = 7;
             const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
+            const string origin = "synthetics";
 
             IHeadersCollection headers = WebRequest.CreateHttp("http://localhost").Headers.Wrap();
-            var context = new SpanContext(traceId, spanId, samplingPriority);
+            var context = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
 
             SpanContextPropagator.Instance.Inject(context, headers);
             var resultContext = SpanContextPropagator.Instance.Extract(headers);
@@ -32,6 +33,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(context.SpanId, resultContext.SpanId);
             Assert.Equal(context.TraceId, resultContext.TraceId);
             Assert.Equal(context.SamplingPriority, resultContext.SamplingPriority);
+            Assert.Equal(context.Origin, resultContext.Origin);
         }
 
         [Theory]
@@ -42,8 +44,9 @@ namespace Datadog.Trace.Tests
         {
             const string spanId = "7";
             const string samplingPriority = "2";
+            const string origin = "synthetics";
 
-            var headers = InjectContext(traceId, spanId, samplingPriority);
+            var headers = InjectContext(traceId, spanId, samplingPriority, origin);
             var resultContext = SpanContextPropagator.Instance.Extract(headers);
 
             // invalid traceId should return a null context even if other values are set
@@ -58,11 +61,13 @@ namespace Datadog.Trace.Tests
         {
             const ulong traceId = 9;
             const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
+            const string origin = "synthetics";
 
             var headers = InjectContext(
                 traceId.ToString(CultureInfo.InvariantCulture),
                 spanId,
-                ((int)samplingPriority).ToString(CultureInfo.InvariantCulture));
+                ((int)samplingPriority).ToString(CultureInfo.InvariantCulture),
+                origin);
 
             var resultContext = SpanContextPropagator.Instance.Extract(headers);
 
@@ -70,6 +75,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(traceId, resultContext.TraceId);
             Assert.Equal(default(ulong), resultContext.SpanId);
             Assert.Equal(samplingPriority, resultContext.SamplingPriority);
+            Assert.Equal(origin, resultContext.Origin);
         }
 
         [Theory]
@@ -80,11 +86,13 @@ namespace Datadog.Trace.Tests
         {
             const ulong traceId = 9;
             const ulong spanId = 7;
+            const string origin = "synthetics";
 
             var headers = InjectContext(
                 traceId.ToString(CultureInfo.InvariantCulture),
                 spanId.ToString(CultureInfo.InvariantCulture),
-                samplingPriority);
+                samplingPriority,
+                origin);
 
             var resultContext = SpanContextPropagator.Instance.Extract(headers);
 
@@ -92,14 +100,16 @@ namespace Datadog.Trace.Tests
             Assert.Equal(traceId, resultContext.TraceId);
             Assert.Equal(spanId, resultContext.SpanId);
             Assert.Null(resultContext.SamplingPriority);
+            Assert.Equal(origin, resultContext.Origin);
         }
 
-        private static IHeadersCollection InjectContext(string traceId, string spanId, string samplingPriority)
+        private static IHeadersCollection InjectContext(string traceId, string spanId, string samplingPriority, string origin)
         {
             IHeadersCollection headers = new DictionaryHeadersCollection();
             headers.Add(HttpHeaderNames.TraceId, traceId);
             headers.Add(HttpHeaderNames.ParentId, spanId);
             headers.Add(HttpHeaderNames.SamplingPriority, samplingPriority);
+            headers.Add(HttpHeaderNames.Origin, origin);
             return headers;
         }
     }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -378,13 +378,12 @@ namespace Datadog.Trace.Tests
 
             IHeadersCollection headers = WebRequest.CreateHttp("http://localhost").Headers.Wrap();
 
-            SpanContextPropagator.Instance.Inject(firstSpan.Span.Context, headers);
+            SpanContextPropagator.Instance.Inject(secondSpan.Span.Context, headers);
             var resultContext = SpanContextPropagator.Instance.Extract(headers);
 
             Assert.NotNull(resultContext);
-            Assert.Equal(firstSpan.Span.Context.SpanId, resultContext.SpanId);
-            Assert.Equal(firstSpan.Span.Context.TraceId, resultContext.TraceId);
             Assert.Equal(firstSpan.Span.Context.Origin, resultContext.Origin);
+            Assert.Equal(secondSpan.Span.Context.Origin, resultContext.Origin);
             Assert.Equal(origin, resultContext.Origin);
         }
     }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using Moq;
@@ -336,6 +339,53 @@ namespace Datadog.Trace.Tests
 
             // reset the environment variable to its original values (if any) when done
             Environment.SetEnvironmentVariable(name, originalEnv);
+        }
+
+        [Fact]
+        public void OriginHeader_RootSpanTag()
+        {
+            const ulong traceId = 9;
+            const ulong spanId = 7;
+            const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
+            const string origin = "synthetics";
+
+            var propagatedContext = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
+            Assert.Equal(origin, propagatedContext.Origin);
+
+            using var firstSpan = _tracer.StartActive("First Span", propagatedContext);
+            Assert.True(firstSpan.Span.IsRootSpan);
+            Assert.Equal(origin, firstSpan.Span.Context.Origin);
+            Assert.Equal(origin, firstSpan.Span.GetTag(Tags.Origin));
+
+            using var secondSpan = _tracer.StartActive("Child", firstSpan.Span.Context);
+            Assert.False(secondSpan.Span.IsRootSpan);
+            Assert.Equal(origin, secondSpan.Span.Context.Origin);
+            Assert.Null(secondSpan.Span.GetTag(Tags.Origin));
+        }
+
+        [Fact]
+        public void OriginHeader_InjectFromChildSpan()
+        {
+            const ulong traceId = 9;
+            const ulong spanId = 7;
+            const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
+            const string origin = "synthetics";
+
+            var propagatedContext = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
+
+            using var firstSpan = _tracer.StartActive("First Span", propagatedContext);
+            using var secondSpan = _tracer.StartActive("Child", firstSpan.Span.Context);
+
+            IHeadersCollection headers = WebRequest.CreateHttp("http://localhost").Headers.Wrap();
+
+            SpanContextPropagator.Instance.Inject(firstSpan.Span.Context, headers);
+            var resultContext = SpanContextPropagator.Instance.Extract(headers);
+
+            Assert.NotNull(resultContext);
+            Assert.Equal(firstSpan.Span.Context.SpanId, resultContext.SpanId);
+            Assert.Equal(firstSpan.Span.Context.TraceId, resultContext.TraceId);
+            Assert.Equal(firstSpan.Span.Context.Origin, resultContext.Origin);
+            Assert.Equal(origin, resultContext.Origin);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -349,7 +349,7 @@ namespace Datadog.Trace.Tests
             const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
             const string origin = "synthetics";
 
-            var propagatedContext = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
+            var propagatedContext = new SpanContext(traceId, spanId, samplingPriority, null, origin);
             Assert.Equal(origin, propagatedContext.Origin);
 
             using var firstSpan = _tracer.StartActive("First Span", propagatedContext);
@@ -371,7 +371,7 @@ namespace Datadog.Trace.Tests
             const SamplingPriority samplingPriority = SamplingPriority.UserKeep;
             const string origin = "synthetics";
 
-            var propagatedContext = new SpanContext(traceId, spanId, samplingPriority, origin: origin);
+            var propagatedContext = new SpanContext(traceId, spanId, samplingPriority, null, origin);
 
             using var firstSpan = _tracer.StartActive("First Span", propagatedContext);
             using var secondSpan = _tracer.StartActive("Child", firstSpan.Span.Context);


### PR DESCRIPTION
- Enable Extractor to parse the header and store it in the span context.
- Enable Injector to inject the span context origin property to propagate the value.
- Sets the `_dd.origin` tag to a new span if the span context has the origin value and if is the root span of a trace.
- New constant values for the http header and the span tag.
- Unit tests for Extract, Inject and setting the tag in the root span.

@DataDog/apm-dotnet