### PR TITLE
Optimize UriHelper.GetRelativeUrl

### DIFF
--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Text;
 
 namespace Datadog.Trace.Util
 {
@@ -27,36 +27,57 @@ namespace Datadog.Trace.Util
         {
             // try to remove segments that look like ids
             string path = tryRemoveIds
-                              ? string.Concat(uri.Segments.Select(CleanUriSegment))
+                              ? CleanUriSegment(uri.AbsolutePath)
                               : uri.AbsolutePath;
             return path;
         }
 
-        public static string CleanUriSegment(string segment)
+        public static string CleanUriSegment(string absolutePath)
         {
-            if (string.IsNullOrWhiteSpace(segment))
+            if (string.IsNullOrWhiteSpace(absolutePath))
             {
-                return string.Empty;
+                return absolutePath;
             }
 
-            bool hasTrailingSlash = segment.EndsWith("/", StringComparison.Ordinal);
+            // Sanitized url will be at worse as long as the original
+            var sb = new StringBuilder(absolutePath.Length);
 
-            // remove trailing slash
-            if (hasTrailingSlash)
+            int previousIndex = 0;
+            int index = 0;
+
+            while (index != -1)
             {
-                segment = segment.Substring(0, segment.Length - 1);
+                index = absolutePath.IndexOf('/', previousIndex);
+
+                string segment;
+
+                if (index == -1)
+                {
+                    // Last segment
+                    segment = absolutePath.Substring(previousIndex);
+                }
+                else
+                {
+                    segment = absolutePath.Substring(previousIndex, index - previousIndex);
+                }
+
+                segment = long.TryParse(segment, out _) ||
+                    Guid.TryParseExact(segment, "N", out _) ||
+                    Guid.TryParseExact(segment, "D", out _)
+                        ? UrlIdPlaceholder
+                        : segment;
+
+                sb.Append(segment);
+
+                if (index != -1)
+                {
+                    sb.Append("/");
+                }
+
+                previousIndex = index + 1;
             }
 
-            // remove path segments that look like int or guid (with or without dashes)
-            segment = long.TryParse(segment, out _) ||
-                      Guid.TryParseExact(segment, "N", out _) ||
-                      Guid.TryParseExact(segment, "D", out _)
-                          ? UrlIdPlaceholder
-                          : segment;
-
-            return hasTrailingSlash
-                       ? segment + "/"
-                       : segment;
+            return sb.ToString();
         }
     }
 }

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -61,6 +61,7 @@ namespace Datadog.Trace.Util
                     segment = absolutePath.Substring(previousIndex, index - previousIndex);
                 }
 
+                // replace path segments that look like numbers or guid
                 segment = long.TryParse(segment, out _) ||
                     Guid.TryParseExact(segment, "N", out _) ||
                     Guid.TryParseExact(segment, "D", out _)


### PR DESCRIPTION
Rewrote the method to get rid of some intermediate string allocations.

We could probably do much better if we had a netcoreapp target, it's worth considering.

**Benchmark:**

```csharp
UriHelper.GetRelativeUrl(new Uri("https://localhost:5101/mvc/queries/raw"))
```

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-VTGAFA : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-MNUBEA : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
| Method |       Runtime |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |-------------- |-----------:|---------:|---------:|------:|-------:|------:|------:|----------:|
|    Old |    .NET 4.7.2 | 1,239.0 ns | 19.69 ns | 17.46 ns |  1.00 | 0.1030 |     - |     - |     658 B |
|    New |    .NET 4.7.2 |   660.6 ns |  4.33 ns |  3.61 ns |  0.53 | 0.0429 |     - |     - |     273 B |
|        |               |            |          |          |       |        |       |       |           |
|    Old | .NET Core 3.1 |   579.6 ns | 11.57 ns | 11.88 ns |  1.00 | 0.0782 |     - |     - |     496 B |
|    New | .NET Core 3.1 |   303.4 ns |  2.92 ns |  2.58 ns |  0.52 | 0.0420 |     - |     - |     264 B |
