### PR TITLE
Improvement  in ToBoolean StringExtensions

### DIFF
--- a/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -50,14 +50,14 @@ namespace Datadog.Trace.ExtensionMethods
                 return null;
             }
 
-            if (string.Compare(value, "TRUE", StringComparison.OrdinalIgnoreCase) == 0 ||
-                string.Compare(value, "YES", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(value, "TRUE", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "YES", StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
-            if (string.Compare(value, "FALSE", StringComparison.OrdinalIgnoreCase) == 0 ||
-                string.Compare(value, "NO", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(value, "FALSE", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(value, "NO", StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }

--- a/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -22,31 +22,47 @@ namespace Datadog.Trace.ExtensionMethods
 
         /// <summary>
         /// Converts a <see cref="string"/> into a <see cref="bool"/> by comparing it to commonly used values
-        /// such as "True", "yes", or "1". Case-insensitive. Defaults to <c>false</c> if string is not recognized.
+        /// such as "True", "yes", "T", "Y", or "1" for <c>true</c> and "False", "no", "F", "N", or "0" for <c>false</c>. Case-insensitive.
+        /// Defaults to <c>null</c> if string is not recognized.
         /// </summary>
         /// <param name="value">The string to convert.</param>
-        /// <returns><c>true</c> if <paramref name="value"/> is one of the accepted values for <c>true</c>; <c>false</c> otherwise.</returns>
+        /// <returns><c>true</c> or <c>false</c> if <paramref name="value"/> is one of the accepted values; <c>null</c> otherwise.</returns>
         public static bool? ToBoolean(this string value)
         {
             if (value == null) { throw new ArgumentNullException(nameof(value)); }
 
-            switch (value.ToUpperInvariant())
+            if (value.Length == 1)
             {
-                case "TRUE":
-                case "YES":
-                case "T":
-                case "Y":
-                case "1":
+                if (value[0] == 'T' || value[0] == 't' ||
+                    value[0] == 'Y' || value[0] == 'y' ||
+                    value[0] == '1')
+                {
                     return true;
-                case "FALSE":
-                case "NO":
-                case "F":
-                case "N":
-                case "0":
+                }
+
+                if (value[0] == 'F' || value[0] == 'f' ||
+                    value[0] == 'N' || value[0] == 'n' ||
+                    value[0] == '0')
+                {
                     return false;
-                default:
-                    return null;
+                }
+
+                return null;
             }
+
+            if (string.Compare(value, "TRUE", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(value, "YES", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+
+            if (string.Compare(value, "FALSE", StringComparison.OrdinalIgnoreCase) == 0 ||
+                string.Compare(value, "NO", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return false;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
- Changes in the method documentation.
- Performance and allocations improvements.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-1068NG7 CPU 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.1.301
  [Host]        : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  .NET 4.7.2    : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT


```
|                Method |           Job |       Runtime |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |-------------- |-------------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
|    MatchOldSingleChar |    .NET 4.7.2 |    .NET 4.7.2 | 55.439 ns | 1.4445 ns | 4.1908 ns | 0.0076 |     - |     - |      32 B |
|    MatchNewSingleChar |    .NET 4.7.2 |    .NET 4.7.2 |  5.353 ns | 0.1361 ns | 0.1512 ns |      - |     - |     - |         - |
| NotMatchOldSingleChar |    .NET 4.7.2 |    .NET 4.7.2 | 47.954 ns | 0.7696 ns | 0.6427 ns | 0.0076 |     - |     - |      32 B |
| NotMatchNewSingleChar |    .NET 4.7.2 |    .NET 4.7.2 |  5.527 ns | 0.0837 ns | 0.0742 ns |      - |     - |     - |         - |
|        MatchOldString |    .NET 4.7.2 |    .NET 4.7.2 | 55.651 ns | 1.0918 ns | 1.2997 ns | 0.0076 |     - |     - |      32 B |
|        MatchNewString |    .NET 4.7.2 |    .NET 4.7.2 | 14.719 ns | 0.1993 ns | 0.1767 ns |      - |     - |     - |         - |
|     NotMatchOldString |    .NET 4.7.2 |    .NET 4.7.2 | 54.166 ns | 0.8966 ns | 0.8387 ns | 0.0095 |     - |     - |      40 B |
|     NotMatchNewString |    .NET 4.7.2 |    .NET 4.7.2 | 21.097 ns | 0.4389 ns | 0.4696 ns |      - |     - |     - |         - |
|    MatchOldSingleChar | .NET Core 3.1 | .NET Core 3.1 | 24.424 ns | 0.4487 ns | 0.4197 ns | 0.0057 |     - |     - |      24 B |
|    MatchNewSingleChar | .NET Core 3.1 | .NET Core 3.1 |  5.381 ns | 0.1208 ns | 0.2269 ns |      - |     - |     - |         - |
| NotMatchOldSingleChar | .NET Core 3.1 | .NET Core 3.1 | 19.606 ns | 0.4184 ns | 0.6875 ns | 0.0057 |     - |     - |      24 B |
| NotMatchNewSingleChar | .NET Core 3.1 | .NET Core 3.1 |  5.619 ns | 0.1320 ns | 0.1102 ns |      - |     - |     - |         - |
|        MatchOldString | .NET Core 3.1 | .NET Core 3.1 | 29.459 ns | 0.5760 ns | 0.5657 ns | 0.0076 |     - |     - |      32 B |
|        MatchNewString | .NET Core 3.1 | .NET Core 3.1 | 11.998 ns | 0.2627 ns | 0.4090 ns |      - |     - |     - |         - |
|     NotMatchOldString | .NET Core 3.1 | .NET Core 3.1 | 23.733 ns | 0.5007 ns | 0.6333 ns | 0.0076 |     - |     - |      32 B |
|     NotMatchNewString | .NET Core 3.1 | .NET Core 3.1 | 18.984 ns | 0.4084 ns | 0.4370 ns |      - |     - |     - |         - |
