### PR TITLE
Adds a catch for ObjectDisposedException in MockTracerAgent

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -211,6 +211,10 @@ namespace Datadog.Trace.TestHelpers
                     // listener was stopped,
                     // ignore to let the loop end and the method return
                 }
+                catch (ObjectDisposedException)
+                {
+                    // the response has been disposed already.
+                }
             }
         }
 

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.TestHelpers
                 }
                 catch (ObjectDisposedException)
                 {
-                    // the response has been disposed already.
+                    // the response has been already disposed.
                 }
             }
         }


### PR DESCRIPTION
From time to time the tests crashes with the following exception:

```csharp
The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.ObjectDisposedException: Safe handle has been closed.
Object name: 'SafeHandle'.
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success)
   at Interop.HttpApi.HttpSendResponseEntityBody(SafeHandle requestQueueHandle, UInt64 requestId, UInt32 flags, UInt16 entityChunkCount, HTTP_DATA_CHUNK* pEntityChunks, UInt32* pBytesSent, SafeLocalAllocHandle pRequestBuffer, UInt32 requestBufferLength, NativeOverlapped* pOverlapped, Void* pLogData)
   at System.Net.HttpResponseStream.DisposeCore()
   at System.Net.HttpResponseStream.Dispose(Boolean disposing)
   at System.IO.Stream.Close()
   at System.Net.HttpListenerResponse.Dispose()
   at System.Net.HttpListenerResponse.System.IDisposable.Dispose()
   at System.Net.HttpListenerResponse.Close()
   at Datadog.Trace.TestHelpers.MockTracerAgent.HandleHttpRequests() in C:\github\dd-trace-dotnet\test\Datadog.Trace.TestHelpers\MockTracerAgent.cs:line 207
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
```

In this PR we ignore the exception to avoid crashing the test host.


@DataDog/apm-dotnet