### PR TITLE
Optimize HttpMessageHandlerIntegration

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed.Core/TypeExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Core/TypeExtensions.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler
 
             while (currentType != null)
             {
-                if (currentType.Namespace == instrumentedNamespace && currentType.Name == instrumentedTypeName)
+                if (currentType.Name == instrumentedTypeName && currentType.Namespace == instrumentedNamespace)
                 {
                     return currentType;
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed.Core/TypeExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Core/TypeExtensions.cs
@@ -26,6 +26,31 @@ namespace Datadog.Trace.ClrProfiler
             return null;
         }
 
+        public static System.Type GetInstrumentedType(
+            this object runtimeObject,
+            string instrumentedNamespace,
+            string instrumentedTypeName)
+        {
+            if (runtimeObject == null)
+            {
+                return null;
+            }
+
+            var currentType = runtimeObject.GetType();
+
+            while (currentType != null)
+            {
+                if (currentType.Namespace == instrumentedNamespace && currentType.Name == instrumentedTypeName)
+                {
+                    return currentType;
+                }
+
+                currentType = currentType.BaseType;
+            }
+
+            return null;
+        }
+
         public static System.Type GetInstrumentedInterface(
             this object runtimeObject,
             string instrumentedInterfaceName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Helpers/AsyncHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Helpers/AsyncHelper.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.ClrProfiler.Helpers
 {
     internal static class AsyncHelper
     {
-        private static readonly ConcurrentDictionary<string, MethodInfo> MethodCache = new ConcurrentDictionary<string, MethodInfo>();
+        private static readonly ConcurrentDictionary<Key, MethodInfo> MethodCache = new ConcurrentDictionary<Key, MethodInfo>();
 
         internal static object InvokeGenericTaskDelegate(
             Type owningType,
@@ -16,15 +16,16 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             Type integrationType,
             params object[] parametersToPass)
         {
-            var methodKey =
-                Interception.MethodKey(
-                    owningType: owningType,
-                    returnType: taskResultType,
-                    genericTypes: Interception.NullTypeArray,
-                    parameterTypes: Interception.ParamsToTypes(parametersToPass));
+            var methodKey = new Key(
+                owningType,
+                taskResultType,
+                Interception.NullTypeArray,
+                Interception.ParamsToTypes(parametersToPass),
+                nameOfIntegrationMethod,
+                integrationType);
 
             var asyncDelegate =
-                MethodCache.GetOrAdd(methodKey, _ => GetGenericAsyncMethodInfo(taskResultType, nameOfIntegrationMethod, integrationType));
+                MethodCache.GetOrAdd(methodKey, key => GetGenericAsyncMethodInfo(key.ReturnType, key.IntegrationName, key.IntegrationType));
 
             return asyncDelegate.Invoke(null, parametersToPass);
         }
@@ -49,6 +50,98 @@ namespace Datadog.Trace.ClrProfiler.Helpers
             }
 
             return method.MakeGenericMethod(taskResultType);
+        }
+
+        private readonly struct Key : IEquatable<Key>
+        {
+            public readonly Type OwningType;
+            public readonly Type ReturnType;
+
+            public readonly Type[] GenericTypes;
+            public readonly Type[] ParameterTypes;
+
+            public readonly string IntegrationName;
+            public readonly Type IntegrationType;
+
+            public Key(Type owningType, Type returnType, Type[] genericTypes, Type[] parameterTypes, string integrationName, Type integrationType)
+            {
+                OwningType = owningType;
+                ReturnType = returnType;
+                GenericTypes = genericTypes;
+                ParameterTypes = parameterTypes;
+                IntegrationName = integrationName;
+                IntegrationType = integrationType;
+            }
+
+            public bool Equals(Key other)
+            {
+                return Equals(OwningType, other.OwningType)
+                    && Equals(ReturnType, other.ReturnType)
+                    && ArrayEquals(GenericTypes, other.GenericTypes)
+                    && ArrayEquals(ParameterTypes, other.ParameterTypes);
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is Key other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (OwningType != null ? OwningType.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (ReturnType != null ? ReturnType.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ GetHashCode(GenericTypes);
+                    hashCode = (hashCode * 397) ^ GetHashCode(ParameterTypes);
+                    return hashCode;
+                }
+            }
+
+            private static int GetHashCode(Type[] array)
+            {
+                if (array == null)
+                {
+                    return 0;
+                }
+
+                int value = array.Length;
+
+                for (int i = 0; i < array.Length; i++)
+                {
+                    value = unchecked((value * 31) + array[i]?.GetHashCode() ?? 0);
+                }
+
+                return value;
+            }
+
+            private static bool ArrayEquals(Type[] array1, Type[] array2)
+            {
+                if (array1 == null)
+                {
+                    return array2 == null;
+                }
+
+                if (array2 == null)
+                {
+                    return false;
+                }
+
+                if (array1.Length != array2.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < array1.Length; i++)
+                {
+                    if (array1[i] != array2[i])
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Helpers/TaskExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Helpers/TaskExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.ClrProfiler.Helpers
+{
+    internal static class TaskExtensions
+    {
+        private static readonly ConcurrentDictionary<Type, Func<Task<object>, object>> Converters = new ConcurrentDictionary<Type, Func<Task<object>, object>>();
+
+        public static object Cast(this Task<object> parent, Type taskResultType)
+        {
+            var converter = Converters.GetOrAdd(
+                taskResultType,
+                type =>
+                {
+                    var methodInfo = typeof(TaskExtensions)
+                        .GetMethod(nameof(ConvertTaskImpl), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                        .MakeGenericMethod(type);
+
+                    return (Func<Task<object>, object>)methodInfo.CreateDelegate(typeof(Func<Task<object>, object>));
+                });
+
+            return converter(parent);
+        }
+
+        private static async Task<T> ConvertTaskImpl<T>(Task<object> parent)
+        {
+            return (T)await parent.ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -33,7 +33,9 @@ namespace Datadog.Trace
         /// </summary>
         /// <param name="context">A <see cref="SpanContext"/> value that will be propagated into <paramref name="headers"/>.</param>
         /// <param name="headers">A <see cref="IHeadersCollection"/> to add new headers to.</param>
-        public void Inject(SpanContext context, IHeadersCollection headers)
+        /// <typeparam name="T">Type of header collection</typeparam>
+        public void Inject<T>(SpanContext context, T headers)
+            where T : IHeadersCollection
         {
             if (context == null) { throw new ArgumentNullException(nameof(context)); }
 


### PR DESCRIPTION
- Make SpanContextPropagator.Inject generic to prevent the boxing of the headers collection
- Add an overload in TypeExtensions to avoid building the full type name
- Stop using String keys in AsyncHelper
- Reuse the boxed cancellationtoken when needed
- Split SendAsyncInternal to avoid allocating the async state machine on the fast path
- Cache the "namespace and name filters" array
- Cache the return task type

**Benchmark:**

```csharp
public class CustomMessageHandler : HttpMessageHandler
{
	private static Task<HttpResponseMessage> _cachedResult = Task.FromResult(new HttpResponseMessage());
	private static HttpResponseMessage _cachedResponse = new HttpResponseMessage();

	protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
	{
		return _cachedResult;
	}
}

(Task)HttpMessageHandlerIntegration.HttpMessageHandler_SendAsync(...).Wait();
```

FastPath: Takes the "skip instrumentation" path in `SendAsyncInternal`
Full: Goes through the instrumentation code

``` ini

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
  [Host]     : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-VTGAFA : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  Job-MNUBEA : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT


```

**.NET 4.7.2:**

|                    Method |          Mean |         Error |         StdDev |        Median |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|-------------------------- |--------------:|--------------:|---------------:|--------------:|-------:|-------:|-------:|----------:|
| SendRequest_NoIntegration |      3.781 ns |     0.1032 ns |      0.1447 ns |      3.706 ns |      - |      - |      - |         - |
|      SendRequest_Full_Old | 18,710.139 ns |   399.8844 ns |    460.5075 ns | 18,551.764 ns | 3.2043 | 0.4578 | 0.1526 |   20201 B |
|      SendRequest_Full_New | 11,077.879 ns |   121.0923 ns |    107.3451 ns | 11,080.820 ns | 0.4120 | 0.1984 |      - |    2624 B |
|  SendRequest_Fastpath_Old |  6,020.003 ns |    94.4310 ns |     88.3308 ns |  5,999.944 ns | 2.8534 | 0.0153 |      - |   17991 B |
|  SendRequest_Fastpath_New |  2,177.383 ns |    42.6974 ns |     37.8501 ns |  2,162.498 ns | 0.0725 | 0.0076 |      - |     457 B |


**.NET Core 3.1:**

|                    Method |          Mean |         Error |         StdDev |        Median |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|-------------------------- |--------------:|--------------:|---------------:|--------------:|-------:|-------:|-------:|----------:|
| SendRequest_NoIntegration |      4.122 ns |     0.0380 ns |      0.0337 ns |      4.116 ns |      - |      - |      - |         - |
|      SendRequest_Full_Old | 15,527.897 ns |   304.9692 ns |    501.0731 ns | 15,470.544 ns | 3.4485 | 0.5798 | 0.1526 |   21319 B |
|      SendRequest_Full_New |  7,810.876 ns |   151.9542 ns |    134.7034 ns |  7,782.911 ns | 0.3815 | 0.1831 |      - |    2416 B |
|  SendRequest_Fastpath_Old |  5,331.927 ns |   105.6334 ns |    187.7632 ns |  5,289.986 ns | 3.0823 | 0.0153 |      - |   19359 B |
|  SendRequest_Fastpath_New |  1,132.209 ns |     6.6264 ns |      5.5334 ns |  1,131.997 ns | 0.0725 |      - |      - |     456 B |

