### PR TITLE
Fixes the MongoDB integration on Execute with Void return type.

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1174,7 +1174,7 @@
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.18.4.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.MongoDbIntegration",
           "method": "Execute",
-          "signature": "00 06 1C 1C 1C 1C 08 08 0A",
+          "signature": "00 06 01 1C 1C 1C 08 08 0A",
           "action": "ReplaceTargetMethod"
         }
       },

--- a/samples/Samples.MongoDB/Program.cs
+++ b/samples/Samples.MongoDB/Program.cs
@@ -49,7 +49,9 @@ namespace Samples.MongoDB
                 Run(collection, newDocument);
                 RunAsync(collection, newDocument).Wait();
 
+#if MONGODB_2_2
                 WireProtocolExecuteIntegrationTest(client);
+#endif
             }
         }
 
@@ -115,6 +117,7 @@ namespace Samples.MongoDB
                 Console.WriteLine(allDocuments.FirstOrDefault());
             }
         }
+#if MONGODB_2_2
 
         public static void WireProtocolExecuteIntegrationTest(MongoClient client)
         {
@@ -133,5 +136,6 @@ namespace Samples.MongoDB
                 return servers;
             }
         }
+#endif
     }
 }

--- a/samples/Samples.MongoDB/Program.cs
+++ b/samples/Samples.MongoDB/Program.cs
@@ -16,7 +16,7 @@ namespace Samples.MongoDB
     {
         private static string Host()
         {
-            return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "10.37.129.2";
+            return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
         }
 
         public static void Main(string[] args)

--- a/samples/Samples.MongoDB/Program.cs
+++ b/samples/Samples.MongoDB/Program.cs
@@ -1,11 +1,14 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
 using Datadog.Trace.ClrProfiler;
 using MongoDB.Bson;
 using MongoDB.Driver;
-using MongoDB.Driver.Core.Operations;
+using MongoDB.Driver.Core.Clusters;
+using MongoDB.Driver.Core.Servers;
 
 namespace Samples.MongoDB
 {
@@ -13,7 +16,7 @@ namespace Samples.MongoDB
     {
         private static string Host()
         {
-            return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
+            return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "10.37.129.2";
         }
 
         public static void Main(string[] args)
@@ -45,8 +48,11 @@ namespace Samples.MongoDB
 
                 Run(collection, newDocument);
                 RunAsync(collection, newDocument).Wait();
+
+                WireProtocolExecuteIntegrationTest(client);
             }
         }
+
 
         public static void Run(IMongoCollection<BsonDocument> collection, BsonDocument newDocument)
         {
@@ -107,6 +113,24 @@ namespace Samples.MongoDB
                 var find = await collection.FindAsync(allFilter);
                 var allDocuments = await find.ToListAsync();
                 Console.WriteLine(allDocuments.FirstOrDefault());
+            }
+        }
+
+        public static void WireProtocolExecuteIntegrationTest(MongoClient client)
+        {
+            using (var syncScope = Tracer.Instance.StartActive("sync-calls-execute", serviceName: "Samples.MongoDB"))
+            {
+                var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
+                var channel = server.GetChannel(CancellationToken.None);
+                channel.KillCursors(new long[] { 0, 1, 2 }, new global::MongoDB.Driver.Core.WireProtocol.Messages.Encoders.MessageEncoderSettings(), CancellationToken.None);
+            }
+        }
+
+        internal class ServerSelector : global::MongoDB.Driver.Core.Clusters.ServerSelectors.IServerSelector
+        {
+            public IEnumerable<ServerDescription> SelectServers(ClusterDescription cluster, IEnumerable<ServerDescription> servers)
+            {
+                return servers;
             }
         }
     }


### PR DESCRIPTION
Without the fix the integration of Execute with void return type throws an IL error.

This scenario is pretty difficult to test, due the method is not being used in normal MongoDB operations (hence the problem has not being reported)

![image](https://user-images.githubusercontent.com/69803/87933823-3a452c00-ca8e-11ea-95ca-b4c6514d9bcf.png)

`MongoDB.Driver.Core.WireProtocol.IWireProtocol` it's being implemented by `KillCursorsWireProtocol` only being used in `KillCursors`.

@DataDog/apm-dotnet