### PR TITLE
Add status code in ASP.NET integration

### DIFF
--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1309:FieldNamesMustNotBeginWithUnderscore", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Reviewed.")]
-[assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1131:Use readable conditions", Justification = "Suppressing this rule allows for intuitive integer range comparisons.")]
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:UsingDirectivesMustBePlacedWithinNamespace", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1512:Single-line comments must not be followed by blank line", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:Single-line comment must be preceded by blank line", Justification = "Reviewed.")]

--- a/GlobalSuppressions.cs
+++ b/GlobalSuppressions.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1309:FieldNamesMustNotBeginWithUnderscore", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Reviewed.")]
+[assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1131:Use readable conditions", Justification = "Suppressing this rule allows for intuitive integer range comparisons.")]
 [assembly: SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1200:UsingDirectivesMustBePlacedWithinNamespace", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1512:Single-line comments must not be followed by blank line", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:Single-line comment must be preceded by blank line", Justification = "Reviewed.")]

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -197,8 +197,9 @@ namespace Datadog.Trace.AspNet
                 {
                     scope.Span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
 
-                    if (500 <= statusCode && statusCode <= 599)
+                    if (statusCode / 100 == 5)
                     {
+                        // 5xx codes are server-side errors
                         scope.Span.Error = true;
                     }
                 }

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -201,6 +201,11 @@ namespace Datadog.Trace.AspNet
                     {
                         // 5xx codes are server-side errors
                         scope.Span.Error = true;
+
+                        if (scope.Span.GetTag(Tags.ErrorMsg) == null)
+                        {
+                            scope.Span.SetTag(Tags.ErrorMsg, $"Datadog detected StatusCode={statusCode} that is within the range of server errors: 500-599");
+                        }
                     }
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -363,8 +363,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 scope.Span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
 
-                if (500 <= statusCode && statusCode <= 599)
+                if (statusCode / 100 == 5)
                 {
+                    // 5xx codes are server-side errors
                     scope.Span.Error = true;
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -361,7 +361,12 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             try
             {
-                scope?.Span?.SetTag(Tags.HttpStatusCode, statusCode.ToString());
+                scope.Span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
+
+                if (500 <= statusCode && statusCode <= 599)
+                {
+                    scope.Span.Error = true;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -367,6 +367,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                     // 5xx codes are server-side errors
                     scope.Span.Error = true;
+
+                    if (scope.Span.GetTag(Tags.ErrorMsg) == null)
+                    {
+                        scope.Span.SetTag(Tags.ErrorMsg, $"Datadog detected StatusCode={statusCode} that is within the range of server errors: 500-599");
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -329,8 +329,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 scope.Span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
 
-                if (500 <= statusCode && statusCode <= 599)
+                if (statusCode / 100 == 5)
                 {
+                    // 5xx codes are server-side errors
                     scope.Span.Error = true;
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -328,6 +328,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             try
             {
                 scope.Span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
+
+                if (500 <= statusCode && statusCode <= 599)
+                {
+                    scope.Span.Error = true;
+                }
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -333,6 +333,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                     // 5xx codes are server-side errors
                     scope.Span.Error = true;
+
+                    if (scope.Span.GetTag(Tags.ErrorMsg) == null)
+                    {
+                        scope.Span.SetTag(Tags.ErrorMsg, $"Datadog detected StatusCode={statusCode} that is within the range of server errors: 500-599");
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -164,7 +164,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     UpdateSpan(controllerContext, scope.Span, Enumerable.Empty<KeyValuePair<string, string>>());
 
                     var statusCode = responseMessage.GetProperty("StatusCode");
-                    scope.Span.SetTag(Tags.HttpStatusCode, ((int)statusCode.Value).ToString());
+                    scope.Span.SetServerStatusCode((int)statusCode.Value);
                     scope.Dispose();
                 }
 
@@ -318,32 +318,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(System.Web.HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            SetStatusCode(scope, httpContext.Response.StatusCode);
+            scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
             scope.Span.Finish(finishTime);
             scope.Dispose();
-        }
-
-        private static void SetStatusCode(Scope scope, int statusCode)
-        {
-            try
-            {
-                scope.Span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
-
-                if (statusCode / 100 == 5)
-                {
-                    // 5xx codes are server-side errors
-                    scope.Span.Error = true;
-
-                    if (scope.Span.GetTag(Tags.ErrorMsg) == null)
-                    {
-                        scope.Span.SetTag(Tags.ErrorMsg, $"Datadog detected StatusCode={statusCode} that is within the range of server errors: 500-599");
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error while setting span tag with status code");
-            }
         }
     }
 }

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -65,5 +65,16 @@ namespace Datadog.Trace.ExtensionMethods
                 span.SetTag(kvp.Key, kvp.Value);
             }
         }
+
+        internal static void SetServerStatusCode(this Span span, int statusCode)
+        {
+            span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
+
+            // 5xx codes are server-side errors
+            if (statusCode / 100 == 5)
+            {
+                span.Error = true;
+            }
+        }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -23,19 +23,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET /home/index", HttpStatusCode.OK)]
-        [InlineData("/Home/BadRequest", "GET /home/badrequest", HttpStatusCode.InternalServerError)]
-        [InlineData("/Home/StatusCode?value=201", "GET /home/statuscode", HttpStatusCode.Created)]
+        [InlineData("/Home/Index", "GET /home/index", HttpStatusCode.OK, false)]
+        [InlineData("/Home/BadRequest", "GET /home/badrequest", HttpStatusCode.InternalServerError, true)]
+        [InlineData("/Home/StatusCode?value=201", "GET /home/statuscode", HttpStatusCode.Created, false)]
+        [InlineData("/Home/StatusCode?value=503", "GET /home/statuscode", HttpStatusCode.ServiceUnavailable, true)]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,
-            HttpStatusCode expectedStatusCode)
+            HttpStatusCode expectedStatusCode,
+            bool isError)
         {
             await AssertWebServerSpan(
                 path,
                 _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 expectedStatusCode,
+                isError,
                 "web",
                 "aspnet-mvc.request",
                 expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -24,22 +24,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET", "/home/index", HttpStatusCode.OK)]
-        [InlineData("/delay/0", "GET", "/delay/{seconds}", HttpStatusCode.OK)]
-        [InlineData("/delay-async/0", "GET", "/delay-async/{seconds}", HttpStatusCode.OK)]
-        [InlineData("/badrequest", "GET", "/badrequest", HttpStatusCode.InternalServerError)]
-        [InlineData("/statuscode/201", "GET", "/statuscode/{value}", HttpStatusCode.Created)]
+        [InlineData("/Home/Index", "GET", "/home/index", HttpStatusCode.OK, false)]
+        [InlineData("/delay/0", "GET", "/delay/{seconds}", HttpStatusCode.OK, false)]
+        [InlineData("/delay-async/0", "GET", "/delay-async/{seconds}", HttpStatusCode.OK, false)]
+        [InlineData("/badrequest", "GET", "/badrequest", HttpStatusCode.InternalServerError, true)]
+        [InlineData("/statuscode/201", "GET", "/statuscode/{value}", HttpStatusCode.Created, false)]
+        [InlineData("/statuscode/503", "GET", "/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true)]
         public async Task SubmitsTraces(
             string path,
             string expectedVerb,
             string expectedResourceSuffix,
-            HttpStatusCode expectedStatusCode)
+            HttpStatusCode expectedStatusCode,
+            bool isError)
         {
             await AssertWebServerSpan(
                 path,
                 _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 expectedStatusCode,
+                isError,
                 "web",
                 "aspnet-mvc.request",
                 $"{expectedVerb} {expectedResourceSuffix}",

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -24,22 +24,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
-        [InlineData("/api/environment", "GET api/environment", HttpStatusCode.OK)]
-        [InlineData("/api/delay/0", "GET api/delay/{seconds}", HttpStatusCode.OK)]
-        [InlineData("/api/delay-async/0", "GET api/delay-async/{seconds}", HttpStatusCode.OK)]
-        [InlineData("/api/transient-failure/true", "GET api/transient-failure/{value}", HttpStatusCode.OK)]
-        [InlineData("/api/transient-failure/false", "GET api/transient-failure/{value}", HttpStatusCode.InternalServerError)]
-        [InlineData("/api/statuscode/201", "GET api/statuscode/{value}", HttpStatusCode.Created)]
+        [InlineData("/api/environment", "GET api/environment", HttpStatusCode.OK, false)]
+        [InlineData("/api/delay/0", "GET api/delay/{seconds}", HttpStatusCode.OK, false)]
+        [InlineData("/api/delay-async/0", "GET api/delay-async/{seconds}", HttpStatusCode.OK, false)]
+        [InlineData("/api/transient-failure/true", "GET api/transient-failure/{value}", HttpStatusCode.OK, false)]
+        [InlineData("/api/transient-failure/false", "GET api/transient-failure/{value}", HttpStatusCode.InternalServerError, true)]
+        [InlineData("/api/statuscode/201", "GET api/statuscode/{value}", HttpStatusCode.Created, false)]
+        [InlineData("/api/statuscode/503", "GET api/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true)]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,
-            HttpStatusCode expectedStatusCode)
+            HttpStatusCode expectedStatusCode,
+            bool isError)
         {
             await AssertWebServerSpan(
                 path,
                 _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 expectedStatusCode,
+                isError,
                 "web",
                 "aspnet-webapi.request",
                 expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -28,16 +28,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(AspNetWebFormsTests))]
-        [InlineData("/Account/Login", "GET /account/login")]
+        [InlineData("/Account/Login", "GET /account/login", false)]
         public async Task SubmitsTraces(
             string path,
-            string expectedResourceName)
+            string expectedResourceName,
+            bool isError)
         {
             await AssertWebServerSpan(
                 path,
                 _iisFixture.Agent,
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
+                isError,
                 SpanTypes.Web,
                 "aspnet.request",
                 expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -234,6 +234,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             MockTracerAgent agent,
             int httpPort,
             HttpStatusCode expectedHttpStatusCode,
+            bool isError,
             string expectedSpanType,
             string expectedOperationName,
             string expectedResourceName,
@@ -260,6 +261,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             MockTracerAgent.Span span = spans[0];
+            Assert.Equal(isError, span.Error == 1);
             Assert.Equal(expectedSpanType, span.Type);
             Assert.Equal(expectedOperationName, span.Name);
             Assert.Equal(expectedResourceName, span.Resource);


### PR DESCRIPTION
Changes proposed in this pull request:
- Add status code in ASP.NET integration both on error and on success
- Modify all ASP.NET integrations to automatically set `span.Error = true` when the response status code is 5xx. This is the default behavior across server spans in Datadog tracers
- Add `span.Error` check in integration tests

@DataDog/apm-dotnet