### PR TITLE
Fix Linux integration-tests build for projects referencing Samples.DatabaseHelper.netstandard

### DIFF
--- a/sample-libs/Samples.DatabaseHelper.netstandard/Samples.DatabaseHelper.netstandard.csproj
+++ b/sample-libs/Samples.DatabaseHelper.netstandard/Samples.DatabaseHelper.netstandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Samples.DatabaseHelper</RootNamespace>
 
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
Change Samples.DatabaseHelper.netstandard to use TargetFrameworks

@DataDog/apm-dotnet