### PR TITLE
rename settings

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.Configuration
         /// Can only be set with an environment variable
         /// or in the <c>app.config</c>/<c>web.config</c> file.
         /// </summary>
-        public const string ConfigurationFileName = "DD_DOTNET_TRACER_CONFIG_FILE";
+        public const string ConfigurationFileName = "DD_TRACE_CONFIG_FILE";
 
         /// <summary>
         /// Configuration key for the application's environment. Sets the "env" tag on every <see cref="Span"/>.
@@ -219,17 +219,17 @@ namespace Datadog.Trace.Configuration
             /// <summary>
             /// Configuration key pattern for enabling or disabling an integration.
             /// </summary>
-            public const string Enabled = "DD_{0}_ENABLED";
+            public const string Enabled = "DD_TRACE_{0}_ENABLED";
 
             /// <summary>
             /// Configuration key pattern for enabling or disabling Analytics in an integration.
             /// </summary>
-            public const string AnalyticsEnabled = "DD_{0}_ANALYTICS_ENABLED";
+            public const string AnalyticsEnabled = "DD_TRACE_{0}_ANALYTICS_ENABLED";
 
             /// <summary>
             /// Configuration key pattern for setting Analytics sampling rate in an integration.
             /// </summary>
-            public const string AnalyticsSampleRate = "DD_{0}_ANALYTICS_SAMPLE_RATE";
+            public const string AnalyticsSampleRate = "DD_TRACE_{0}_ANALYTICS_SAMPLE_RATE";
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -112,6 +112,7 @@ namespace Datadog.Trace.Configuration
 
             // if environment variable is not set, look for default file name in the current directory
             var configurationFileName = configurationSource.GetString(ConfigurationKeys.ConfigurationFileName) ??
+                                        configurationSource.GetString("DD_DOTNET_TRACER_CONFIG_FILE") ??
                                         Path.Combine(currentDirectory, "datadog.json");
 
             if (Path.GetExtension(configurationFileName).ToUpperInvariant() == ".JSON" &&

--- a/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -21,11 +21,15 @@ namespace Datadog.Trace.Configuration
                 return;
             }
 
-            Enabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.Enabled, integrationName));
+            Enabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.Enabled, integrationName)) ??
+                      source.GetBool(string.Format("DD_{0}_ENABLED", integrationName));
 
-            AnalyticsEnabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName));
+            AnalyticsEnabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName)) ??
+                               source.GetBool(string.Format("DD_{0}_ANALYTICS_ENABLED", integrationName));
 
             AnalyticsSampleRate = source.GetDouble(string.Format(ConfigurationKeys.Integrations.AnalyticsSampleRate, integrationName)) ??
+                                  source.GetDouble(string.Format("DD_{0}_ANALYTICS_SAMPLE_RATE", integrationName)) ??
+                                  // default value
                                   1.0;
         }
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Linq;
 using Datadog.Trace.Configuration;
 using Newtonsoft.Json;
 using Xunit;
@@ -10,10 +9,10 @@ namespace Datadog.Trace.Tests.Configuration
 {
     public class ConfigurationSourceTests
     {
-        private static readonly Dictionary<string, string> TagsK1V1K2V2 = new Dictionary<string, string>() { { "k1", "v1" }, { "k2", "v2" } };
-        private static readonly Dictionary<string, string> TagsK2V2 = new Dictionary<string, string>() { { "k2", "v2" } };
-        private static readonly Dictionary<string, string> HeaderTags = new Dictionary<string, string>() { { "header1", "tag1" } };
-        private static readonly Dictionary<string, string> HeaderTagsSameTag = new Dictionary<string, string>() { { "header1", "tag1" }, { "header2", "tag1" } };
+        private static readonly Dictionary<string, string> TagsK1V1K2V2 = new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" } };
+        private static readonly Dictionary<string, string> TagsK2V2 = new Dictionary<string, string> { { "k2", "v2" } };
+        private static readonly Dictionary<string, string> HeaderTags = new Dictionary<string, string> { { "header1", "tag1" } };
+        private static readonly Dictionary<string, string> HeaderTagsSameTag = new Dictionary<string, string> { { "header1", "tag1" }, { "header2", "tag1" } };
 
         public static IEnumerable<object[]> GetGlobalDefaultTestData()
         {

--- a/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/IntegrationSettingsTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Specialized;
+using Datadog.Trace.Configuration;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class IntegrationSettingsTests
+    {
+        [Theory]
+        [InlineData("DD_TRACE_FOO_ENABLED", "true", true)]
+        [InlineData("DD_TRACE_FOO_ENABLED", "false", false)]
+        [InlineData("DD_FOO_ENABLED", "true", true)]
+        [InlineData("DD_FOO_ENABLED", "false", false)]
+        public void IntegrationEnabled(string settingName, string settingValue, bool expected)
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection
+                                                          {
+                                                              { settingName, settingValue }
+                                                          });
+
+            var settings = new IntegrationSettings("FOO", source);
+            Assert.Equal(expected, settings.Enabled);
+        }
+
+        [Theory]
+        [InlineData("DD_TRACE_FOO_ANALYTICS_ENABLED", "true", true)]
+        [InlineData("DD_TRACE_FOO_ANALYTICS_ENABLED", "false", false)]
+        [InlineData("DD_FOO_ANALYTICS_ENABLED", "true", true)]
+        [InlineData("DD_FOO_ANALYTICS_ENABLED", "false", false)]
+        public void IntegrationAnalyticsEnabled(string settingName, string settingValue, bool expected)
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection
+                                                          {
+                                                              { settingName, settingValue }
+                                                          });
+
+            var settings = new IntegrationSettings("FOO", source);
+            Assert.Equal(expected, settings.AnalyticsEnabled);
+        }
+
+        [Theory]
+        [InlineData("DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE", "0.2", 0.2)]
+        [InlineData("DD_FOO_ANALYTICS_SAMPLE_RATE", "0.6", 0.6)]
+        public void IntegrationAnalyticsSampleRate(string settingName, string settingValue, double expected)
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection
+                                                          {
+                                                              { settingName, settingValue }
+                                                          });
+
+            var settings = new IntegrationSettings("FOO", source);
+            Assert.Equal(expected, settings.AnalyticsSampleRate);
+        }
+    }
+}


### PR DESCRIPTION
Rename the following settings for consistency across language tracers. As usual, the old names are still supported via fallbacks for backwards compatibility.
Before | After
-|-
`DD_DOTNET_TRACER_CONFIG_FILE` | `DD_TRACE_CONFIG_FILE`
`DD_<INTEGRATION>_ENABLED` | `DD_TRACE_<INTEGRATION>_ENABLED`
`DD_<INTEGRATION>_ANALYTICS_ENABLED` | `DD_TRACE_<INTEGRATION>_ANALYTICS_ENABLED`
`DD_<INTEGRATION>_ANALYTICS_SAMPLE_RATE` | `DD_TRACE_<INTEGRATION>_ANALYTICS_SAMPLE_RATE`