### PR TITLE
Settings: add ALL_CAPS fallback for environment variables

### DIFF
--- a/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Configuration
         public IDictionary<string, string> GetDictionary(string key)
         {
             return _sources.Select(source => source.GetDictionary(key))
-                        .FirstOrDefault(value => value != null);
+                           .FirstOrDefault(value => value != null);
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -93,6 +93,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Configuration key for a list of tags to be applied globally to spans.
+        /// Comma-separated "key:value" pairs, e.g. <c>"k1:v1,k2:v2"</c>.
         /// </summary>
         /// <seealso cref="TracerSettings.GlobalTags"/>
         public const string GlobalTags = "DD_TAGS";
@@ -100,6 +101,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for a map of header keys to tag names.
         /// Automatically apply header values as tags on traces.
+        /// Comma-separated "key:value" pairs, e.g. <c>"k1:v1,k2:v2"</c>.
         /// </summary>
         /// <seealso cref="TracerSettings.HeaderTags"/>
         public const string HeaderTags = "DD_TRACE_HEADER_TAGS";

--- a/src/Datadog.Trace/Configuration/EnvironmentConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/EnvironmentConfigurationSource.cs
@@ -1,3 +1,4 @@
+using System;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -11,7 +12,19 @@ namespace Datadog.Trace.Configuration
         /// <inheritdoc />
         public override string GetString(string key)
         {
-            return EnvironmentHelpers.GetEnvironmentVariable(key);
+            var value = EnvironmentHelpers.GetEnvironmentVariable(key);
+
+            // note: avoid RuntimeInformation.IsOSPlatform(), it is was added in net471
+            if (value == null && Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                // Env var names are case-sensitive on non-Windows platforms.
+                // This fallback fixes an issue where users set an
+                // env var name like "DD_TRACE_ADONET_ENABLED"
+                // but key is "DD_TRACE_AdoNet_ENABLED".
+                return EnvironmentHelpers.GetEnvironmentVariable(key.ToUpperInvariant());
+            }
+
+            return value;
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
@@ -14,12 +14,13 @@ namespace Datadog.Trace.Configuration
         /// Returns a <see cref="IDictionary{TKey, TValue}"/> from parsing
         /// <paramref name="data"/>.
         /// </summary>
-        /// <param name="data">A string containing key-value pairs which are comma-separated, and for which the key and value are colon-separated.</param>
+        /// <param name="data">
+        /// A string containing key-value pairs which are comma-separated,
+        /// and for which the key and value are colon-separated, e.g. <c>"k1:v1,k2:v2"</c>
+        /// </param>
         /// <returns><see cref="IDictionary{TKey, TValue}"/> of key value pairs.</returns>
         public static IDictionary<string, string> ParseCustomKeyValues(string data)
         {
-            var dictionary = new ConcurrentDictionary<string, string>();
-
             // A null return value means the key was not present,
             // and CompositeConfigurationSource depends on this behavior
             // (it returns the first non-null value it finds).
@@ -27,6 +28,8 @@ namespace Datadog.Trace.Configuration
             {
                 return null;
             }
+
+            var dictionary = new ConcurrentDictionary<string, string>();
 
             if (string.IsNullOrWhiteSpace(data))
             {

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -228,11 +228,14 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets or sets the global tags, which are applied to all <see cref="Span"/>s.
+        /// Comma-separated "key:value" pairs, e.g. <c>"k1:v1,k2:v2"</c>.
         /// </summary>
         public IDictionary<string, string> GlobalTags { get; set; }
 
         /// <summary>
-        /// Gets or sets the map of header keys to tag names, which are applied to the root <see cref="Span"/> of incoming requests.
+        /// Gets or sets the map of header keys to tag names,
+        /// which are applied to the root <see cref="Span"/> of incoming requests.
+        /// Comma-separated "key:value" pairs, e.g. <c>"k1:v1,k2:v2"</c>.
         /// </summary>
         public IDictionary<string, string> HeaderTags { get; set; }
 

--- a/test/Datadog.Trace.Tests/Configuration/EnvironmentConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/EnvironmentConfigurationSourceTests.cs
@@ -1,0 +1,24 @@
+using System;
+using Datadog.Trace.Configuration;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class EnvironmentConfigurationSourceTests
+    {
+        [Theory]
+        [InlineData("DD_EnvironmentConfigurationSourceTests", "1", "1")]
+        [InlineData("DD_ENVIRONMENTCONFIGURATIONSOURCETESTS", "2", "2")]
+        [InlineData("dd_environmentconfigurationsourcetests", "3", "3")]
+        public void CaseInsensitiveKey(string settingName, string settingValue, string expected)
+        {
+            Environment.SetEnvironmentVariable(settingName, settingValue);
+
+            var source = new EnvironmentConfigurationSource();
+            var actual = source.GetString(settingName);
+            Assert.Equal(expected, actual);
+
+            Environment.SetEnvironmentVariable(settingName, null);
+        }
+    }
+}


### PR DESCRIPTION
Environment variable names are case-sensitive on some platform, so a setting like `DD_TRACE_AdoNet_ENABLED` will not match `DD_TRACE_ADONET_ENABLED`. This has caused user confusion in the past, and going forwards we expect all our settings to use ALL CAPS for env var names. For these reasons, this PR adds a `ToUpper()` fallback when a requested env var is not found.

Unrelated: expanded some comments with examples for dictionary valued settings