### PR TITLE
Fix "System.Runtime.Remoting.RemotingException: Object /<identifier1>/<identifier2>.rem has been disconnected or does not exist at the server."

### DIFF
--- a/src/Datadog.Trace/AsyncLocalCompat.cs
+++ b/src/Datadog.Trace/AsyncLocalCompat.cs
@@ -20,7 +20,12 @@ namespace Datadog.Trace
 
         public void Set(T value)
         {
-            CallContext.LogicalSetData(_name, new ObjectHandle(value));
+            if (CallContext.LogicalGetData(_name) is IDisposable oldHandle)
+            {
+                oldHandle.Dispose();
+            }
+
+            CallContext.LogicalSetData(_name, new DisposableObjectHandle(value));
         }
     }
 

--- a/src/Datadog.Trace/DisposableObjectHandle.cs
+++ b/src/Datadog.Trace/DisposableObjectHandle.cs
@@ -14,6 +14,8 @@ namespace Datadog.Trace
     {
         private static readonly ISponsor LifeTimeSponsor = new ClientSponsor();
 
+        private bool _disposed;
+
         public DisposableObjectHandle(object o)
             : base(o)
         {
@@ -26,12 +28,24 @@ namespace Datadog.Trace
             return lease;
         }
 
-        public void Dispose()
+        public void Dispose() => Dispose(true);
+
+        private void Dispose(bool disposing)
         {
-            if (GetLifetimeService() is ILease lease)
+            if (_disposed)
             {
-                lease.Unregister(LifeTimeSponsor);
+                return;
             }
+
+            if (disposing)
+            {
+                if (GetLifetimeService() is ILease lease)
+                {
+                    lease.Unregister(LifeTimeSponsor);
+                }
+            }
+
+            _disposed = true;
         }
     }
 }

--- a/src/Datadog.Trace/DisposableObjectHandle.cs
+++ b/src/Datadog.Trace/DisposableObjectHandle.cs
@@ -1,0 +1,38 @@
+#if NET45
+using System;
+using System.Runtime.Remoting;
+using System.Runtime.Remoting.Lifetime;
+
+namespace Datadog.Trace
+{
+    // Create a wrapper around ObjectHandle to enable a Sponsor for
+    // objects stored in the CallContext until the host AppDomain
+    // no longer needs them.
+    // This issue was raised in the Serilog library here: https://github.com/serilog/serilog/issues/987
+    // This solution was borrowed from the corresponding fix in the following PR: https://github.com/serilog/serilog/pull/992
+    internal sealed class DisposableObjectHandle : ObjectHandle, IDisposable
+    {
+        private static readonly ISponsor LifeTimeSponsor = new ClientSponsor();
+
+        public DisposableObjectHandle(object o)
+            : base(o)
+        {
+        }
+
+        public override object InitializeLifetimeService()
+        {
+            var lease = (ILease)base.InitializeLifetimeService();
+            lease?.Register(LifeTimeSponsor);
+            return lease;
+        }
+
+        public void Dispose()
+        {
+            if (GetLifetimeService() is ILease lease)
+            {
+                lease.Unregister(LifeTimeSponsor);
+            }
+        }
+    }
+}
+#endif

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -1,7 +1,12 @@
 using System;
-using System.Collections.Specialized;
 using System.Linq;
 using System.Net;
+#if NET452
+using System.Runtime.Remoting;
+using System.Runtime.Remoting.Lifetime;
+using System.Runtime.Remoting.Services;
+#endif
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
@@ -17,6 +22,14 @@ namespace Datadog.Trace.Tests
     public class TracerTests
     {
         private readonly Tracer _tracer;
+
+        static TracerTests()
+        {
+#if NET452
+            LifetimeServices.LeaseTime = TimeSpan.FromMilliseconds(100);
+            LifetimeServices.LeaseManagerPollTime = TimeSpan.FromMilliseconds(10);
+#endif
+        }
 
         public TracerTests()
         {
@@ -357,5 +370,90 @@ namespace Datadog.Trace.Tests
             Assert.Equal(secondSpan.Span.Context.Origin, resultContext.Origin);
             Assert.Equal(origin, resultContext.Origin);
         }
+#if NET452
+
+        // Test that storage in the Logical Call Context does not expire
+        // See GitHub issue https://github.com/serilog/serilog/issues/987
+        // and the associated PR https://github.com/serilog/serilog/pull/992
+        [Fact]
+        public void DoesNotThrowOnCrossDomainCallsWhenLeaseExpired()
+        {
+            // Arrange
+            RemotingException remotingException = null;
+
+            AppDomain.CurrentDomain.FirstChanceException +=
+                (_, e) => remotingException = e.Exception is RemotingException re ? re : remotingException;
+
+            var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation);
+
+            // Act
+            try
+            {
+                using (_tracer.StartActive("test-span"))
+                {
+                    remote.DoCallBack(CallFromRemote);
+                }
+            }
+            finally
+            {
+                AppDomain.Unload(remote);
+            }
+
+            // Assert
+            Assert.Null(remotingException);
+
+            void CallFromRemote() => Thread.Sleep(200);
+        }
+
+        [Fact]
+        public async Task DisconnectRemoteObjectsAfterCrossDomainCallsOnDispose()
+        {
+            // Arrange
+            var tracker = new InMemoryRemoteObjectTracker();
+            TrackingServices.RegisterTrackingHandler(tracker);
+
+            var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation);
+
+            // Act
+            try
+            {
+                using (_tracer.StartActive("test-span"))
+                {
+                    remote.DoCallBack(CallFromRemote);
+
+                    using (_tracer.StartActive("test-span-inner"))
+                    {
+                        remote.DoCallBack(CallFromRemote);
+                    }
+                }
+            }
+            finally
+            {
+                AppDomain.Unload(remote);
+            }
+
+            await Task.Delay(200);
+
+            // Assert
+            Assert.Equal(2, tracker.DisconnectCount);
+
+            void CallFromRemote() { }
+        }
+
+        private class InMemoryRemoteObjectTracker : ITrackingHandler
+        {
+            public int DisconnectCount { get; set; }
+
+            public void DisconnectedObject(object obj) => DisconnectCount++;
+
+            public void MarshaledObject(object obj, ObjRef or)
+            {
+            }
+
+            public void UnmarshaledObject(object obj, ObjRef or)
+            {
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
When building Datadog.Trace for net45, we simulate AsyncLocal storage (needed for correct scope management) by storing the current Scope in the Logical Call Context. This uses the remoting infrastructure which sets default leases on objects stored in the Logical Call Context. If execution happens in another AppDomain and the lease expires, we get the above exception.

This PR follows the solution laid out by Serilog when they previously encountered this error. See issue https://github.com/serilog/serilog/issues/987 and the corresponding fix https://github.com/serilog/serilog/pull/992. When adding objects to the Logical Call Context, add logic so they always have an object claiming a lease on them from the host AppDomain so they never get removed from the "remote client" (Logical Call Context).

@DataDog/apm-dotnet