### PR TITLE
Fix flaky OrleansCrash smoke test

### DIFF
--- a/reproductions/OrleansCrash/Clients/HelloWorldClientHostedService.cs
+++ b/reproductions/OrleansCrash/Clients/HelloWorldClientHostedService.cs
@@ -30,6 +30,11 @@ namespace OrleansCrash.Clients
 
         public Grains.IHello GimmeTheGrain()
         {
+            while (!_client.IsInitialized)
+            {
+                Thread.Sleep(500);
+            }
+
             return _client.GetGrain<Grains.IHello>(0);
         }
     }

--- a/reproductions/OrleansCrash/Program.cs
+++ b/reproductions/OrleansCrash/Program.cs
@@ -37,10 +37,6 @@ namespace OrleansCrash
                 var clientTask = clientHost.RunAsync(tokenSource.Token);
                 orleansTasks.Add(clientTask);
 
-                Console.WriteLine("Waiting a little before grabbing a service.");
-                // TODO: Make this based on a ping or something
-                Task.Delay(4_000, tokenSource.Token).Wait(); // Give the cluster time to start
-
                 Console.WriteLine("Grabbing an orleans singleton service.");
                 var helloWorldClient = clientHost.Services.GetService<IHelloWorldHostedService>();
                 var helloGrain = helloWorldClient.GimmeTheGrain();


### PR DESCRIPTION
Wait for the Orleans client to be initialized before calling GetGrain.

@DataDog/apm-dotnet