### PR TITLE
Remove unnecessary System.Collections.NonGeneric NuGet package

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -46,11 +46,6 @@
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_System.Collections.NonGeneric.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.NonGeneric.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Diagnostics.DiagnosticSource.dll"
               Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Datadog.Trace.ClrProfiler</RootNamespace>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- NuGet -->

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -46,9 +46,12 @@
     <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
   </PropertyGroup>
 
+  <!-- Remove System.Collections.NonGeneric. This was defined in Serilog 2.8.0 but it is unnecessary -->
+  <!--
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
   </ItemGroup>
+  -->
 
   <!--Serilog.Sinks.File-->
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
Remove unnecessary System.Collections.NonGeneric NuGet package that was originally added to vendor Serilog. This was defined in the original Serilog.csproj when compiling for netstandard2.0, but the final assembly only has one assembly reference, which is netstandard.dll, so this NuGet package is unnecessary and can be removed without affecting the compilation.

This saves space by not publishing the System.Collections.NonGeneric.dll for the netstandard2.0 framework in the Windows MSI and it saves potential confusion about the dependency tree of Datadog.Trace.dll

@DataDog/apm-dotnet