### PR TITLE
Skip DNS resolution when agent is bound to localhost

### DIFF
--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -74,6 +74,16 @@ namespace Datadog.Trace.Configuration
 
             AgentUri = new Uri(agentUri);
 
+            if (string.Equals(AgentUri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                // Replace localhost with 127.0.0.1 to avoid DNS resolution.
+                // When ipv6 is enabled, localhost is first resolved to ::1, which fails
+                // because the trace agent is only bound to ipv4.
+                // This causes delays when sending traces.
+                var builder = new UriBuilder(agentUri) { Host = "127.0.0.1" };
+                AgentUri = builder.Uri;
+            }
+
             AnalyticsEnabled = source?.GetBool(ConfigurationKeys.GlobalAnalyticsEnabled) ??
                                // default value
                                false;

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests.Configuration
         public static IEnumerable<object[]> GetDefaultTestData()
         {
             yield return new object[] { CreateFunc(s => s.TraceEnabled), true };
-            yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://localhost:8126/") };
+            yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://127.0.0.1:8126/") };
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.TraceEnabled, "false", CreateFunc(s => s.TraceEnabled), false };
 
             yield return new object[] { ConfigurationKeys.AgentHost, "test-host", CreateFunc(s => s.AgentUri), new Uri("http://test-host:8126/") };
-            yield return new object[] { ConfigurationKeys.AgentPort, "9000", CreateFunc(s => s.AgentUri), new Uri("http://localhost:9000/") };
+            yield return new object[] { ConfigurationKeys.AgentPort, "9000", CreateFunc(s => s.AgentUri), new Uri("http://127.0.0.1:9000/") };
 
             yield return new object[] { ConfigurationKeys.Environment, "staging", CreateFunc(s => s.Environment), "staging" };
 

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -81,5 +81,20 @@ namespace Datadog.Trace.Tests
 
             _writerMock.Verify(w => w.WriteTrace(It.IsAny<Span[]>()), assertion);
         }
+
+        [Theory]
+        [InlineData("http://localhost:7777/agent?querystring", "http://127.0.0.1:7777/agent?querystring")]
+        [InlineData("http://datadog:7777/agent?querystring", "http://datadog:7777/agent?querystring")]
+        public void ReplaceLocalhost(string original, string expected)
+        {
+            var settings = new NameValueCollection
+            {
+                { ConfigurationKeys.AgentUri, original }
+            };
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings));
+
+            Assert.Equal(expected, tracerSettings.AgentUri.ToString());
+        }
     }
 }


### PR DESCRIPTION
On .net core, when resolving localhost on a machine with ipv6 enabled, ::1 is considered first. Unfortunately, the agent is bound only to ipv4, so the initial connection timeouts and adds a 2 seconds delay.

Changing localhost to 127.0.0.1 should fix this in the most common case.