### PR TITLE
Add benchmark for the AgentWriter

### DIFF
--- a/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -1,0 +1,109 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Datadog.Trace;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.MessagePack;
+using Datadog.Trace.BenchmarkDotNet;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Benchmarks.Trace
+{
+    [DatadogExporter]
+    [MemoryDiagnoser]
+    [SimpleJob(RuntimeMoniker.Net472)]
+    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
+    public class AgentWriterBenchmark
+    {
+        private const int SpanCount = 1000;
+
+        private static readonly IAgentWriter _agentWriter;
+        private static readonly Span[] _spans;
+
+        static AgentWriterBenchmark()
+        {
+            var settings = TracerSettings.FromDefaultSources();
+
+            settings.StartupDiagnosticLogEnabled = false;
+            settings.TraceEnabled = false;
+
+            var api = new Api(settings.AgentUri, new FakeApiRequestFactory(), statsd: null);
+
+            _agentWriter = new AgentWriter(api, statsd: null, automaticFlush: false);
+
+            _spans = new Span[SpanCount];
+            var now = DateTimeOffset.UtcNow;
+
+            for (int i = 0; i < SpanCount; i++)
+            {
+                _spans[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
+            }
+        }
+
+        /// <summary>
+        /// Write traces to the agent and flushes them
+        /// </summary>
+        [Benchmark]
+        public Task WriteAndFlushTraces()
+        {
+            _agentWriter.WriteTrace(_spans);
+            return _agentWriter.FlushTracesAsync();
+        }
+
+        /// <summary>
+        /// Try to mimick as much as possible the overhead of the ApiWebRequestFactory,
+        /// without actually sending the requests
+        /// </summary>
+        private class FakeApiRequestFactory : IApiRequestFactory
+        {
+            private readonly IApiRequestFactory _realFactory = new ApiWebRequestFactory();
+
+            public IApiRequest Create(Uri endpoint)
+            {
+                var request = _realFactory.Create(endpoint);
+
+                return new FakeApiRequest(request);
+            }
+        }
+
+        private class FakeApiRequest : IApiRequest
+        {
+            private readonly IApiRequest _realRequest;
+
+            public FakeApiRequest(IApiRequest request)
+            {
+                _realRequest = request;
+            }
+
+            public void AddHeader(string name, string value)
+            {
+                _realRequest.AddHeader(name, value);
+            }
+
+            public async Task<IApiResponse> PostAsync(Span[][] traces, FormatterResolverWrapper formatterResolver)
+            {
+                using (var requestStream = new MemoryStream())
+                {
+                    await MessagePackSerializer.SerializeAsync(requestStream, traces, formatterResolver).ConfigureAwait(false);
+                }
+
+                return new FakeApiResponse();
+            }
+        }
+
+        private class FakeApiResponse : IApiResponse
+        {
+            public int StatusCode => 200;
+
+            public long ContentLength => 0;
+
+            public Task<string> ReadAsStringAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Benchmarks.Trace
@@ -10,11 +11,17 @@ namespace Benchmarks.Trace
     [MemoryDiagnoser]
     public class SpanBenchmark
     {
-        private static Tracer _tracer;
+        private static readonly Tracer Tracer;
 
         static SpanBenchmark()
         {
-            _tracer = new Tracer(null, new DummyAgentWriter(), null, null, null);
+            var settings = new TracerSettings
+            {
+                TraceEnabled = false,
+                StartupDiagnosticLogEnabled = false
+            };
+
+            Tracer = new Tracer(settings, new DummyAgentWriter(), null, null, null);
         }
 
         /// <summary>
@@ -23,7 +30,7 @@ namespace Benchmarks.Trace
         [Benchmark]
         public void StartFinishSpan()
         {
-            Span span = _tracer.StartSpan("operation");
+            Span span = Tracer.StartSpan("operation");
             span.SetTraceSamplingPriority(SamplingPriority.UserReject);
             span.Finish();
         }
@@ -34,7 +41,7 @@ namespace Benchmarks.Trace
         [Benchmark]
         public void StartFinishScope()
         {
-            using (Scope scope = _tracer.StartActive("operation"))
+            using (Scope scope = Tracer.StartActive("operation"))
             {
                 scope.Span.SetTraceSamplingPriority(SamplingPriority.UserReject);
             }

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -21,10 +21,16 @@ namespace Datadog.Trace.Agent
         private IApi _api;
 
         public AgentWriter(IApi api, IStatsd statsd)
+            : this(api, statsd, automaticFlush: true)
+        {
+        }
+
+        internal AgentWriter(IApi api, IStatsd statsd, bool automaticFlush)
         {
             _api = api;
             _statsd = statsd;
-            _flushTask = Task.Run(FlushTracesTaskLoopAsync);
+
+            _flushTask = automaticFlush ? Task.Run(FlushTracesTaskLoopAsync) : Task.FromResult(true);
         }
 
         public void OverrideApi(IApi api)


### PR DESCRIPTION
Added a benchmark for flushing traces for the agent, and disabled some background stuff for the span benchmarks.

Also added a way to disable the background task from the AgentWriter, to have more predictable results.

I had to mock the API requests and not actually send them, because I was getting throttled by the trace agent.