### PR TITLE
Fix trace agent connection issues that emerge in Azure App Service environment

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -27,9 +27,9 @@ namespace Datadog.Trace.Agent
             _flushTask = Task.Run(FlushTracesTaskLoopAsync);
         }
 
-        public void OverrideApi(IApi api)
+        public void OverrideApiBaseEndpoint(Uri uri)
         {
-            _api = api;
+            _api.OverrideBaseEndpoint(uri);
         }
 
         public Task<bool> Ping()

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -27,9 +27,9 @@ namespace Datadog.Trace.Agent
             _flushTask = Task.Run(FlushTracesTaskLoopAsync);
         }
 
-        public void OverrideApiBaseEndpoint(Uri uri)
+        public void SetApiBaseEndpoint(Uri uri)
         {
-            _api.OverrideBaseEndpoint(uri);
+            _api.SetBaseEndpoint(uri);
         }
 
         public Task<bool> Ping()

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Agent
                     if (innermostException is SocketException se)
                     {
                         isSocketException = true;
-                        Log.Error(se, "Unable to communicate with the trace agent at {0}", _tracesEndpoint);
+                        Log.Error(exception, "Unable to communicate with the trace agent at {0}", _tracesEndpoint);
                         TracingProcessManager.TryForceTraceAgentRefresh();
                     }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        public void OverrideBaseEndpoint(Uri baseEndpoint)
+        public void SetBaseEndpoint(Uri baseEndpoint)
         {
             _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
         }

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -49,9 +49,9 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        public void OverrideBaseEndpoint(Uri uri)
+        public void OverrideBaseEndpoint(Uri baseEndpoint)
         {
-            _tracesEndpoint = new Uri(uri, TracesPath);
+            _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
         }
 
         public async Task<bool> SendTracesAsync(Span[][] traces)

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -19,10 +19,10 @@ namespace Datadog.Trace.Agent
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly IStatsd _statsd;
-        private readonly Uri _tracesEndpoint;
         private readonly FormatterResolverWrapper _formatterResolver = new FormatterResolverWrapper(SpanFormatterResolver.Instance);
         private readonly string _containerId;
         private readonly FrameworkDescription _frameworkDescription;
+        private Uri _tracesEndpoint; // The Uri may be reassigned dynamically so that retry attempts may attempt updated Agent ports
 
         public Api(Uri baseEndpoint, IApiRequestFactory apiRequestFactory, IStatsd statsd)
         {
@@ -47,6 +47,11 @@ namespace Datadog.Trace.Agent
             {
                 Log.SafeLogError(e, "Error getting framework description");
             }
+        }
+
+        public void OverrideBaseEndpoint(Uri uri)
+        {
+            _tracesEndpoint = new Uri(uri, TracesPath);
         }
 
         public async Task<bool> SendTracesAsync(Span[][] traces)

--- a/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
@@ -12,6 +13,6 @@ namespace Datadog.Trace.Agent
 
         Task FlushAndCloseAsync();
 
-        void OverrideApi(IApi api);
+        void OverrideApiBaseEndpoint(Uri uri);
     }
 }

--- a/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -13,6 +13,6 @@ namespace Datadog.Trace.Agent
 
         Task FlushAndCloseAsync();
 
-        void OverrideApiBaseEndpoint(Uri uri);
+        void SetApiBaseEndpoint(Uri uri);
     }
 }

--- a/src/Datadog.Trace/Agent/IApi.cs
+++ b/src/Datadog.Trace/Agent/IApi.cs
@@ -5,7 +5,7 @@ namespace Datadog.Trace.Agent
 {
     internal interface IApi
     {
-        public void OverrideBaseEndpoint(Uri baseEndpoint);
+        public void SetBaseEndpoint(Uri baseEndpoint);
 
         Task<bool> SendTracesAsync(Span[][] traces);
     }

--- a/src/Datadog.Trace/Agent/IApi.cs
+++ b/src/Datadog.Trace/Agent/IApi.cs
@@ -5,7 +5,7 @@ namespace Datadog.Trace.Agent
 {
     internal interface IApi
     {
-        public void OverrideBaseEndpoint(Uri uri);
+        public void OverrideBaseEndpoint(Uri baseEndpoint);
 
         Task<bool> SendTracesAsync(Span[][] traces);
     }

--- a/src/Datadog.Trace/Agent/IApi.cs
+++ b/src/Datadog.Trace/Agent/IApi.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
     internal interface IApi
     {
+        public void OverrideBaseEndpoint(Uri uri);
+
         Task<bool> SendTracesAsync(Span[][] traces);
     }
 }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace
                     }
                     else
                     {
-                        _agentWriter.OverrideApiBaseEndpoint(baseEndpoint);
+                        _agentWriter.SetApiBaseEndpoint(baseEndpoint);
                     }
                 });
 

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -102,14 +102,15 @@ namespace Datadog.Trace
                     Log.Debug("Attempting to override trace agent port with {0}", port);
                     var builder = new UriBuilder(Settings.AgentUri) { Port = port };
                     var baseEndpoint = builder.Uri;
-                    IApi overridingApiClient = new Api(baseEndpoint, apiRequestFactory: null, Statsd);
+
                     if (_agentWriter == null)
                     {
+                        IApi overridingApiClient = new Api(baseEndpoint, apiRequestFactory: null, Statsd);
                         _agentWriter = _agentWriter ?? new AgentWriter(overridingApiClient, Statsd);
                     }
                     else
                     {
-                        _agentWriter.OverrideApi(overridingApiClient);
+                        _agentWriter.OverrideApiBaseEndpoint(baseEndpoint);
                     }
                 });
 

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -266,6 +266,7 @@ namespace Datadog.Trace
                 {
                     if (!metadata.IsBeingManaged)
                     {
+                        metadata.HasAttemptedStartup = false;
                         metadata.KeepAliveTask = StartProcessWithKeepAlive(metadata);
                     }
                 }
@@ -664,7 +665,7 @@ namespace Datadog.Trace
                     catch (Exception ex)
                     {
                         Log.Error(ex, "Error when alerting subscribers for {0}", Name);
-                        Thread.Sleep(5); // Wait just a tiny bit just to let the file come unlocked
+                        Thread.Sleep(20); // Wait just a tiny bit just to let the file come unlocked
                     }
                 }
             }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -229,6 +229,12 @@ namespace Datadog.Trace
                                 }
                             }
                         }
+                        catch (ArgumentException)
+                        {
+                            // It is expected for Process.GetProcessById to throw an ArgumentException
+                            // if there is no process matching the identifier argument.
+                            // This is fine, do not bubble up the exception any further.
+                        }
                         finally
                         {
                             if (!isActive)

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -71,7 +71,6 @@ namespace Datadog.Trace
                     return;
                 }
 
-                Log.Warning("Attempting to force a child process refresh.");
                 InitializePortManagerClaimFiles(TraceAgentMetadata.DirectoryPath);
 
                 if (!_isProcessManager)
@@ -82,7 +81,9 @@ namespace Datadog.Trace
 
                 if (Processes.All(p => p.HasAttemptedStartup))
                 {
-                    Log.Debug("Forcing a full refresh on agent processes.");
+                    Log.Warning("Attempting to force a child process refresh.");
+
+                    Log.Debug("Stopping child processes.");
                     StopProcesses();
 
                     _cancellationTokenSource = new CancellationTokenSource();
@@ -92,7 +93,7 @@ namespace Datadog.Trace
                 }
                 else
                 {
-                    Log.Debug("This process has not had a chance to initialize agent processes.");
+                    Log.Warning("This process has not had a chance to initialize agent processes.");
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
- Fix regression from v1.18.0 when the Tracer began using WebRequest instead of HttpClient. This change caused us to miss SocketExceptions that indicated we needed to restart the trace agent, since the SocketException was nested in two exceptions instead of one. Now, we unwrap the exceptions until reaching the innermost exception to determine if we encountered the SocketException.
- Make Api._tracesEndpoint mutable so retries can receive an updated port number, if needed.
- Reset the ProcessMetadata.HasAttemptedStartup field when forcing a restart so consecutive failed Trace agent responses don't trigger resets that are already in-progress.
- Immediately catch ArgumentExceptions when invoking Process.GetProcessById because we fully expect this to occur.



@DataDog/apm-dotnet