### PR TITLE
Use command-line args to configure benchmarks

### DIFF
--- a/benchmarks/Benchmarks.Trace/Program.cs
+++ b/benchmarks/Benchmarks.Trace/Program.cs
@@ -6,7 +6,7 @@ namespace Benchmarks.Trace
     {
         private static void Main(string[] args)
         {
-            BenchmarkRunner.Run<SpanBenchmark>();
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
         }
     }
 }

--- a/benchmarks/Benchmarks.Trace/Program.cs
+++ b/benchmarks/Benchmarks.Trace/Program.cs
@@ -1,4 +1,6 @@
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
+using Datadog.Trace.BenchmarkDotNet;
 
 namespace Benchmarks.Trace
 {
@@ -6,7 +8,9 @@ namespace Benchmarks.Trace
     {
         private static void Main(string[] args)
         {
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+            var config = DefaultConfig.Instance.AddExporter(DatadogExporter.Default);
+
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
         }
     }
 }

--- a/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -11,8 +11,6 @@ namespace Benchmarks.Trace
     /// </summary>
     [DatadogExporter]
     [MemoryDiagnoser]
-    [SimpleJob(RuntimeMoniker.Net472)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     public class SpanBenchmark
     {
         private static Tracer _tracer;

--- a/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -1,7 +1,5 @@
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 using Datadog.Trace;
-using Datadog.Trace.BenchmarkDotNet;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Benchmarks.Trace
@@ -9,7 +7,6 @@ namespace Benchmarks.Trace
     /// <summary>
     /// Span benchmarks
     /// </summary>
-    [DatadogExporter]
     [MemoryDiagnoser]
     public class SpanBenchmark
     {


### PR DESCRIPTION
Since those benchmarks will be launched automatically in different environments, we need to be able to give the parameters through the command-line instead of hardcoding them with attributes.