### PR TITLE
use fixed SDK version

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk
+    displayName: install dotnet core sdk 3.1
     inputs:
       version: $(dotnetCoreSdkVersion)
 
@@ -107,7 +107,7 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk
+    displayName: install dotnet core sdk 3.1
     inputs:
       version: $(dotnetCoreSdkVersion)
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -211,15 +211,15 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 2.1
+    displayName: install dotnet core runtime 2.1
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 2.1.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.0
+    displayName: install dotnet core runtime 3.0
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 3.0.x
 
   - task: UseDotNet@2

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -22,7 +22,7 @@ pool:
 variables:
   buildConfiguration: Debug
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
-  dotnetCoreSdkVersion: 3.1.x
+  dotnetCoreSdkVersion: 3.1.107
 
 jobs:
 
@@ -226,7 +226,7 @@ jobs:
     displayName: install dotnet core sdk 3.1
     inputs:
       packageType: sdk
-      version: 3.1.x
+      version: $(dotnetCoreSdkVersion)
 
   - task: NuGetToolInstaller@1
     displayName: install nuget

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -18,6 +18,7 @@ pr:
 
 pool:
   vmImage: ubuntu-18.04
+
 variables:
   buildConfiguration: Debug
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
@@ -73,7 +74,7 @@ jobs:
       netcoreapp3_1:
         dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
- 
+
   variables:
     TestAllPackageVersions: true
 
@@ -153,7 +154,7 @@ jobs:
       netcoreapp3_1:
         dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
-  
+
   variables:
     TestAllPackageVersions: true
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -66,13 +66,10 @@ jobs:
   strategy:
     matrix:
       netcoreapp2_1:
-        dotnetCoreSdkVersion: 2.1.x
         publishTargetFramework: netcoreapp2.1
       netcoreapp3_0:
-        dotnetCoreSdkVersion: 3.0.x
         publishTargetFramework: netcoreapp3.0
       netcoreapp3_1:
-        dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
 
   variables:
@@ -146,13 +143,10 @@ jobs:
   strategy:
     matrix:
       netcoreapp2_1:
-        dotnetCoreSdkVersion: 2.1.x
         publishTargetFramework: netcoreapp2.1
       netcoreapp3_0:
-        dotnetCoreSdkVersion: 3.0.x
         publishTargetFramework: netcoreapp3.0
       netcoreapp3_1:
-        dotnetCoreSdkVersion: 3.1.x
         publishTargetFramework: netcoreapp3.1
 
   variables:

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -14,7 +14,7 @@ schedules:
 
 variables:
   buildConfiguration: release
-  dotnetCoreSdkVersion: 3.1.x
+  dotnetCoreSdkVersion: 3.1.107
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
 stages:

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -35,7 +35,7 @@ stages:
     steps:
 
     - task: UseDotNet@2
-      displayName: install dotnet core sdk
+      displayName: install dotnet core sdk 3.1
       inputs:
         packageType: sdk
         version: $(dotnetCoreSdkVersion)

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -11,6 +11,7 @@ trigger:
 
 variables:
   buildConfiguration: Debug
+  dotnetCoreSdkVersion: 3.1.107
 
 jobs:
 
@@ -41,7 +42,7 @@ jobs:
     displayName: install dotnet core sdk 3.1
     inputs:
       packageType: sdk
-      version: 3.1.x
+      version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build
@@ -75,7 +76,7 @@ jobs:
     displayName: install dotnet core sdk 3.1
     inputs:
       packageType: sdk
-      version: 3.1.x
+      version: $(dotnetCoreSdkVersion)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build


### PR DESCRIPTION
SDK 3.1.401 was released 2020-08-11, but fails in Azure Pipelines because Visual Studio has not been updated to 16.7+.

```
Version 3.1.401 of the .NET Core SDK requires at least version 16.7.0 of MSBuild.
The current available version of MSBuild is 16.6.0.22303.
Change the .NET Core SDK specified in global.json to an older version that requires the MSBuild version currently available.
```
([link to build error](https://dev.azure.com/datadog-apm/dd-trace-dotnet/_build/results?buildId=19951&view=logs&j=a1d15400-7ceb-56b8-c6cc-fab367557c4f&t=7d3fcb13-0f45-598d-6544-804598cb4f5b&l=12))

related:
- https://github.com/actions/virtual-environments/issues/1407
- https://github.com/actions/virtual-environments/pull/1402