### PR TITLE
Fix DisconnectRemoteObjectsAfterCrossDomainCallsOnDispose unit test

### DIFF
--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -434,9 +434,10 @@ namespace Datadog.Trace.Tests
             // Ensure that we wait long enough for the lease manager poll to occur.
             // Even though we reset LifetimeServices.LeaseManagerPollTime to a shorter duration,
             // the default value is 10 seconds so the first poll may not be affected by our modification
-            cde.Wait(TimeSpan.FromSeconds(30));
+            bool eventSet = cde.Wait(TimeSpan.FromSeconds(30));
 
             // Assert
+            Assert.True(eventSet);
             Assert.Equal(2, tracker.DisconnectCount);
         }
 

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -451,10 +451,6 @@ namespace Datadog.Trace.Tests
         {
             private CountdownEvent _cde;
 
-            public InMemoryRemoteObjectTracker()
-            {
-            }
-
             public InMemoryRemoteObjectTracker(CountdownEvent cde)
             {
                 _cde = cde;

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -461,7 +461,7 @@ namespace Datadog.Trace.Tests
             public void DisconnectedObject(object obj)
             {
                 DisconnectCount++;
-                _cde?.Signal();
+                _cde.Signal();
             }
 
             public void MarshaledObject(object obj, ObjRef or)


### PR DESCRIPTION
Fix DisconnectRemoteObjectsAfterCrossDomainCallsOnDispose unit test by introducing a CountdownEvent with a timeout. This ensures that the lease manager polling will occur at least once and we will exit as soon as we receive the DisconnectedObject events we are awaiting.

@DataDog/apm-dotnet