### PR TITLE
Always use the default WebRequest for the http:// prefix

### DIFF
--- a/src/Datadog.Trace/Agent/ApiWebRequestFactory.cs
+++ b/src/Datadog.Trace/Agent/ApiWebRequestFactory.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
@@ -11,7 +7,7 @@ namespace Datadog.Trace.Agent
     {
         public IApiRequest Create(Uri endpoint)
         {
-            return new ApiWebRequest((HttpWebRequest)WebRequest.Create(endpoint));
+            return new ApiWebRequest(WebRequest.CreateHttp(endpoint));
         }
     }
 }

--- a/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
+++ b/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net;
+using System.Reflection;
+using Datadog.Trace.Agent;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class ApiWebRequestFactoryTests
+    {
+        /// <summary>
+        /// This test ensures that the ApiWebRequestFactory behaves correctly when
+        /// a different type of WebRequest is assigned to the http:// prefix
+        /// </summary>
+        [Fact]
+        public void OverrideHttpPrefix()
+        {
+            // Couldn't find a way to "officially" unregister a prefix but that shouldn't stop us
+            var prefixListProperty = typeof(WebRequest).GetProperty("PrefixList", BindingFlags.Static | BindingFlags.NonPublic);
+            var oldPrefixList = prefixListProperty.GetValue(null);
+
+            WebRequest.RegisterPrefix("http://", new CustomWebRequestCreator());
+
+            // Make sure we properly hooked the WebRequest factory
+            Assert.IsType<FakeWebRequest>(WebRequest.Create("http://localhost/"));
+
+            try
+            {
+                var factory = new ApiWebRequestFactory();
+
+                var request = factory.Create(new Uri("http://localhost"));
+
+                Assert.NotNull(request);
+            }
+            finally
+            {
+                // Unregister the prefix
+                prefixListProperty.SetValue(null, oldPrefixList);
+            }
+
+            // Make sure we properly restored the old WebRequest factory
+            Assert.IsType<HttpWebRequest>(WebRequest.Create("http://localhost/"));
+        }
+
+        private class CustomWebRequestCreator : IWebRequestCreate
+        {
+            public WebRequest Create(Uri uri)
+            {
+                return new FakeWebRequest();
+            }
+        }
+
+        private class FakeWebRequest : WebRequest
+        {
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-dotnet/issues/858

