### PR TITLE
Small improvements to ObjectExtensions class

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -221,11 +221,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
                        : MemberResult<TResult>.NotFound;
         }
 
-        public static MemberResult<object> GetField(this object source, string fieldName)
-        {
-            return GetField<object>(source, fieldName);
-        }
-
         private static PropertyFetcherCacheKey GetKey<TResult>(string name, Type type)
         {
             return new PropertyFetcherCacheKey(type, typeof(TResult), name);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -96,9 +96,10 @@ namespace Datadog.Trace.ClrProfiler.Emit
         public static bool TryCallMethod<TResult>(this object source, string methodName, out TResult value)
         {
             var type = source.GetType();
+            var returnType = typeof(TResult);
 
             object cachedItem = Cache.GetOrAdd(
-                new PropertyFetcherCacheKey(type, null, methodName),
+                new PropertyFetcherCacheKey(type, returnType, methodName),
                 key =>
                     DynamicMethodBuilder<Func<object, TResult>>
                        .CreateMethodCallDelegate(
@@ -121,11 +122,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
             return source.TryCallMethod(methodName, arg1, out TResult result)
                        ? new MemberResult<TResult>(result)
                        : MemberResult<TResult>.NotFound;
-        }
-
-        public static MemberResult<object> CallMethod<TArg1>(this object source, string methodName, TArg1 arg1)
-        {
-            return CallMethod<TArg1, object>(source, methodName, arg1);
         }
 
         public static MemberResult<TResult> CallMethod<TResult>(this object source, string methodName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -28,9 +28,10 @@ namespace Datadog.Trace.ClrProfiler.Emit
         {
             var type = source.GetType();
             var paramType1 = typeof(TArg1);
+            var returnType = typeof(TResult);
 
             object cachedItem = Cache.GetOrAdd(
-                new PropertyFetcherCacheKey(type, paramType1, methodName),
+                new PropertyFetcherCacheKey(type, paramType1, returnType, methodName),
                 key =>
                     DynamicMethodBuilder<Func<object, TArg1, TResult>>
                        .CreateMethodCallDelegate(

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /// <returns>The multiplexer</returns>
         public static object GetMultiplexer(object obj)
         {
-            return obj.GetField("multiplexer").GetValueOrDefault();
+            return obj.GetField<object>("multiplexer").GetValueOrDefault();
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
@@ -57,6 +57,19 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(expected, actualResult.GetValueOrDefault());
         }
 
+        [Fact]
+        public void CallMethod_TwoOverloads_WithDifferentType_ShouldNotAffectResult()
+        {
+            var someInstance = new SomeClass();
+            var expected = 1;
+
+            var objectResult = someInstance.CallMethod<int, object>("AddOne", 0);
+            var actualResult = someInstance.CallMethod<int, int>("AddOne", 0);
+
+            Assert.Equal(expected, (int)objectResult.GetValueOrDefault());
+            Assert.Equal(expected, actualResult.GetValueOrDefault());
+        }
+
         private class SomeClass : SomeBaseClass
         {
             private readonly int someIntField = 305;
@@ -68,6 +81,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             public int GetSomeIntField()
             {
                 return someIntField;
+            }
+
+            public int AddOne(int value)
+            {
+                return value + 1;
             }
         }
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
@@ -83,6 +83,23 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(expected, actualResult.GetValueOrDefault());
         }
 
+        [Fact]
+        public void CallVoidMethod_TwoTypeArgs_CallsCorrectOverload()
+        {
+            var someInstance = new SomeClass();
+            var expectedObjectResult = "12";
+            var expectedActualResult = "3";
+
+            someInstance.CallVoidMethod<object, object>("Add", 1, 2);
+            var objectResult = someInstance.LastAddResult;
+
+            someInstance.CallVoidMethod<int, int>("Add", 1, 2);
+            var actualResult = someInstance.LastAddResult;
+
+            Assert.Equal(expectedObjectResult, objectResult);
+            Assert.Equal(expectedActualResult, actualResult);
+        }
+
         private class SomeClass : SomeBaseClass
         {
             private readonly int someIntField = 305;
@@ -90,6 +107,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             public override int SomeIntProperty { get; } = 205;
 
             public SomeEnum SomeEnumProperty { get; } = SomeEnum.Two;
+
+            public string LastAddResult { get; internal set; } = string.Empty;
 
             public int GetSomeIntField()
             {
@@ -104,6 +123,16 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             public int AddOne(int value)
             {
                 return value + 1;
+            }
+
+            public void Add(object arg1, object arg2)
+            {
+                LastAddResult = arg1.ToString() + arg2.ToString();
+            }
+
+            public void Add(int arg1, int arg2)
+            {
+                LastAddResult = (arg1 + arg2).ToString();
             }
         }
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ObjectExtensionTests.cs
@@ -58,7 +58,20 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         [Fact]
-        public void CallMethod_TwoOverloads_WithDifferentType_ShouldNotAffectResult()
+        public void CallMethod_OneTypeArg_WithDifferentReturnType_ShouldNotAffectResult()
+        {
+            var someInstance = new SomeClass();
+            var expected = 42;
+
+            var objectResult = someInstance.CallMethod<object>("GetTheAnswerToTheUniverse");
+            var actualResult = someInstance.CallMethod<int>("GetTheAnswerToTheUniverse");
+
+            Assert.Equal(expected, (int)objectResult.GetValueOrDefault());
+            Assert.Equal(expected, actualResult.GetValueOrDefault());
+        }
+
+        [Fact]
+        public void CallMethod_TwoTypeArgs_WithDifferentReturnType_ShouldNotAffectResult()
         {
             var someInstance = new SomeClass();
             var expected = 1;
@@ -81,6 +94,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             public int GetSomeIntField()
             {
                 return someIntField;
+            }
+
+            public int GetTheAnswerToTheUniverse()
+            {
+                return 42;
             }
 
             public int AddOne(int value)


### PR DESCRIPTION
- Add unit tests to make sure the `CallMethod` overloads work with different specified return types
- Add fix to include the return type in `CallMethod` cache keys
- Remove unused `CreatePropertyDelegate`

@DataDog/apm-dotnet