### PR TITLE
Skip DNS resolution when agent is bound to localhost

### DIFF
--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -74,6 +74,16 @@ namespace Datadog.Trace.Configuration
 
             AgentUri = new Uri(agentUri);
 
+            if (string.Equals(AgentUri.Host, "localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                // Replace localhost with 127.0.0.1 to avoid DNS resolution.
+                // When ipv6 is enabled, localhost is first resolved to ::1, which fails
+                // because the trace agent is only bound to ipv4.
+                // This causes delays when sending traces.
+                var builder = new UriBuilder(agentUri) { Host = "127.0.0.1" };
+                AgentUri = builder.Uri;
+            }
+
             AnalyticsEnabled = source?.GetBool(ConfigurationKeys.GlobalAnalyticsEnabled) ??
                                // default value
                                false;

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -180,11 +180,11 @@ namespace Datadog.Trace.TestHelpers
 
             string integrations = string.Join(";", GetIntegrationsFilePaths());
             environmentVariables["DD_INTEGRATIONS"] = integrations;
-            environmentVariables["DD_TRACE_AGENT_HOSTNAME"] = "localhost";
+            environmentVariables["DD_TRACE_AGENT_HOSTNAME"] = "127.0.0.1";
             environmentVariables["DD_TRACE_AGENT_PORT"] = agentPort.ToString();
 
             // for ASP.NET Core sample apps, set the server's port
-            environmentVariables["ASPNETCORE_URLS"] = $"http://localhost:{aspNetCorePort}/";
+            environmentVariables["ASPNETCORE_URLS"] = $"http://127.0.0.1:{aspNetCorePort}/";
 
             foreach (var name in new[] { "SERVICESTACK_REDIS_HOST", "STACKEXCHANGE_REDIS_HOST" })
             {

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.TestHelpers
                 // seems like we can't reuse a listener if it fails to start,
                 // so create a new listener each time we retry
                 var listener = new HttpListener();
-                listener.Prefixes.Add($"http://localhost:{port}/");
+                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
 
                 try
                 {

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.TestHelpers
                 // so create a new listener each time we retry
                 var listener = new HttpListener();
                 listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+                listener.Prefixes.Add($"http://localhost:{port}/");
 
                 try
                 {

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tests
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
 
-            var api = new Api(new Uri("http://localhost:1234"), apiRequestFactory: factoryMock.Object, statsd: null);
+            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: factoryMock.Object, statsd: null);
 
             var span = _tracer.StartSpan("Operation");
             var traces = new[] { new[] { span } };
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tests
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
 
-            var api = new Api(new Uri("http://localhost:1234"), apiRequestFactory: factoryMock.Object, statsd: null);
+            var api = new Api(new Uri("http://127.0.0.1:1234"), apiRequestFactory: factoryMock.Object, statsd: null);
 
             var sw = new Stopwatch();
             sw.Start();

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests.Configuration
         public static IEnumerable<object[]> GetDefaultTestData()
         {
             yield return new object[] { CreateFunc(s => s.TraceEnabled), true };
-            yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://localhost:8126/") };
+            yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://127.0.0.1:8126/") };
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.TraceEnabled, "false", CreateFunc(s => s.TraceEnabled), false };
 
             yield return new object[] { ConfigurationKeys.AgentHost, "test-host", CreateFunc(s => s.AgentUri), new Uri("http://test-host:8126/") };
-            yield return new object[] { ConfigurationKeys.AgentPort, "9000", CreateFunc(s => s.AgentUri), new Uri("http://localhost:9000/") };
+            yield return new object[] { ConfigurationKeys.AgentPort, "9000", CreateFunc(s => s.AgentUri), new Uri("http://127.0.0.1:9000/") };
 
             yield return new object[] { ConfigurationKeys.Environment, "staging", CreateFunc(s => s.Environment), "staging" };
 

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.Tests
             {
                 var settings = new TracerSettings
                                {
-                                   AgentUri = new Uri($"http://localhost:{agent.Port}"),
+                                   AgentUri = new Uri($"http://127.0.0.1:{agent.Port}"),
                                    TracerMetricsEnabled = tracerMetricsEnabled
                                };
 

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -81,5 +81,20 @@ namespace Datadog.Trace.Tests
 
             _writerMock.Verify(w => w.WriteTrace(It.IsAny<Span[]>()), assertion);
         }
+
+        [Theory]
+        [InlineData("http://localhost:7777/agent?querystring", "http://127.0.0.1:7777/agent?querystring")]
+        [InlineData("http://datadog:7777/agent?querystring", "http://datadog:7777/agent?querystring")]
+        public void ReplaceLocalhost(string original, string expected)
+        {
+            var settings = new NameValueCollection
+            {
+                { ConfigurationKeys.AgentUri, original }
+            };
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings));
+
+            Assert.Equal(expected, tracerSettings.AgentUri.ToString());
+        }
     }
 }


### PR DESCRIPTION
Attempting to re-merge https://github.com/DataDog/dd-trace-dotnet/pull/841 with fixes for failing tests