### PR TITLE
Use a cached buffer for serialization

### DIFF
--- a/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -81,7 +81,7 @@ namespace Benchmarks.Trace
 
             public async Task<IApiResponse> PostAsync(Span[][] traces, FormatterResolverWrapper formatterResolver)
             {
-                using (var requestStream = new NullStream())
+                using (var requestStream = Stream.Null)
                 {
                     await CachedSerializer.Instance.SerializeAsync(requestStream, traces, formatterResolver).ConfigureAwait(false);
                 }
@@ -102,38 +102,6 @@ namespace Benchmarks.Trace
             }
 
             public void Dispose()
-            {
-            }
-        }
-
-        private class NullStream : Stream
-        {
-            public override bool CanRead => false;
-            public override bool CanSeek => false;
-            public override bool CanWrite => true;
-            public override long Length => throw new NotImplementedException();
-            public override long Position { get; set; }
-
-            public override void Flush()
-            {
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void SetLength(long value)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                throw new NotImplementedException();
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
             {
             }
         }

--- a/src/Datadog.Trace/Agent/ApiWebRequest.cs
+++ b/src/Datadog.Trace/Agent/ApiWebRequest.cs
@@ -1,7 +1,6 @@
 using System.Net;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
-using Datadog.Trace.Vendors.MessagePack;
 
 namespace Datadog.Trace.Agent
 {
@@ -33,7 +32,7 @@ namespace Datadog.Trace.Agent
             _request.ContentType = "application/msgpack";
             using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
             {
-                await MessagePackSerializer.SerializeAsync(requestStream, traces, formatterResolver).ConfigureAwait(false);
+                await CachedSerializer.Instance.SerializeAsync(requestStream, traces, formatterResolver).ConfigureAwait(false);
             }
 
             try

--- a/src/Datadog.Trace/Agent/MessagePack/CachedSerializer.cs
+++ b/src/Datadog.Trace/Agent/MessagePack/CachedSerializer.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Datadog.Trace.Agent.MessagePack
+{
+    internal class CachedSerializer
+    {
+        internal static readonly CachedSerializer Instance = new CachedSerializer();
+
+        private const int InitialBufferSize = 64 * 1024;
+        private byte[] _buffer;
+
+        public CachedSerializer()
+        {
+            _buffer = new byte[InitialBufferSize];
+        }
+
+        public async Task SerializeAsync<T>(Stream stream, T obj, IFormatterResolver resolver)
+        {
+            byte[] buffer = null;
+            bool usingCachedBuffer = true;
+
+            try
+            {
+                // Sanity check, in case the serializer is incorrectly used concurrently
+                buffer = Interlocked.Exchange(ref _buffer, null);
+
+                if (buffer == null)
+                {
+                    usingCachedBuffer = false;
+                    buffer = new byte[InitialBufferSize];
+                }
+
+                int length = MessagePackSerializer.Serialize(ref buffer, 0, obj, resolver);
+
+                await stream.WriteAsync(buffer, 0, length).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (usingCachedBuffer)
+                {
+                    _buffer = buffer;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
MessagePack has an internal pool of buffers, [but they are thread-static](https://github.com/DataDog/dd-trace-dotnet/blob/ec5f59eaab49b19cd900421f2530174ea324a088/src/Datadog.Trace/Vendors/MessagePack/MessagePackSerializer.cs#L317). It's bad because:
- Given that we flush traces only every second, there's little chance that we end up using the same thread
- Every new buffer will stay alive in the thread TLS, probably long enough to end up in gen 2

We almost never send traces to the agent concurrently (I believe the call to `IAgentWriter.Ping()` at startup is the only exception so far). Therefore it makes sense to use a single cached buffer, and fallback to allocating a new one in the unlikely case we need it from two different threads at the same time.

I also updated the `WriteAndFlushTraces` benchmark to use a fake stream, because the MemoryStream was the source of a lot of extra allocations. In the real world we would be writing to a network stream and we have (AFAIK) no control over how much it'll allocate. It's better to focus on measuring what's actionable.

Benchmark: `AgentWriterBenchmark.WriteAndFlushTraces`

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.302
  [Host]        : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
  .NET 4.7.2    : .NET Framework 4.8 (4.8.4180.0), X64 RyuJIT
  .NET Core 3.1 : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT


```
|                  Method |           Job |       Runtime |     Mean |   Error |   StdDev |   Median | Ratio | RatioSD |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|------------------------ |-------------- |-------------- |---------:|--------:|---------:|---------:|------:|--------:|--------:|--------:|--------:|----------:|
| WriteAndFlushTraces_New |    .NET 4.7.2 |    .NET 4.7.2 | 403.3 μs | 8.01 μs | 22.61 μs | 394.6 μs |  0.85 |    0.08 | 12.2070 |  1.4648 |       - |  76.83 KB |
| WriteAndFlushTraces_Old |    .NET 4.7.2 |    .NET 4.7.2 | 484.1 μs | 9.62 μs | 18.08 μs | 490.7 μs |  1.00 |    0.00 | 41.0156 | 41.0156 | 41.0156 | 205.65 KB |
|                         |               |               |          |         |          |          |       |         |         |         |         |           |
| WriteAndFlushTraces_New | .NET Core 3.1 | .NET Core 3.1 | 296.3 μs | 5.63 μs |  6.70 μs | 295.9 μs |  0.80 |    0.03 | 11.7188 |  1.4648 |       - |  74.82 KB |
| WriteAndFlushTraces_Old | .NET Core 3.1 | .NET Core 3.1 | 370.6 μs | 7.28 μs |  7.79 μs | 368.6 μs |  1.00 |    0.00 | 41.5039 | 41.5039 | 41.5039 | 202.85 KB |


The main source of allocations remaining on this codepath is `GetUniqueTraceIds`. I tried replacing the hashset by a Linq Distinct() operation. It reduces heap allocations by about 40% (down to ~45KB) but also increase processing time by about 10% on .NET Framework (up to 440µs, no significant increase on .NET Core), so I don't know if it's worth it.

