### PR TITLE
Switch back to installing the sdk in the build image

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -211,15 +211,15 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core runtime 2.1
+    displayName: install dotnet core sdk 2.1
     inputs:
-      packageType: runtime
+      packageType: sdk
       version: 2.1.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core runtime 3.0
+    displayName: install dotnet core sdk 3.0
     inputs:
-      packageType: runtime
+      packageType: sdk
       version: 3.0.x
 
   - task: UseDotNet@2


### PR DESCRIPTION
The base runtime does not contain the required aspnetcore runtime
