### PR TITLE
NUnit framework integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1487,6 +1487,61 @@
     ]
   },
   {
+    "name": "NUnit",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "nunit.framework",
+          "type": "NUnit.Framework.Internal.Commands.TestMethodCommand",
+          "method": "Execute",
+          "signature_types": [
+            "NUnit.Framework.Internal.TestResult",
+            "NUnit.Framework.Internal.TestExecutionContext"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 3,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.19.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.Testing.NUnitIntegration",
+          "method": "TestMethodCommand_Execute",
+          "signature": "00 05 1C 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "nunit.framework",
+          "type": "NUnit.Framework.Internal.Commands.SkipCommand",
+          "method": "Execute",
+          "signature_types": [
+            "NUnit.Framework.Internal.TestResult",
+            "NUnit.Framework.Internal.TestExecutionContext"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 3,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.19.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.Testing.NUnitIntegration",
+          "method": "SkipCommand_Execute",
+          "signature": "00 05 1C 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
+      }
+    ]
+  },
+  {
     "name": "ServiceStackRedis",
     "method_replacements": [
       {

--- a/integrations.json
+++ b/integrations.json
@@ -1493,7 +1493,7 @@
         "caller": {},
         "target": {
           "assembly": "nunit.framework",
-          "type": "NUnit.Framework.Internal.Commands.TestMethodCommand",
+          "type": "NUnit.Framework.Internal.Commands.TestCommand",
           "method": "Execute",
           "signature_types": [
             "NUnit.Framework.Internal.TestResult",
@@ -1509,7 +1509,7 @@
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.19.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Testing.NUnitIntegration",
-          "method": "TestMethodCommand_Execute",
+          "method": "TestCommand_Execute",
           "signature": "00 05 1C 1C 1C 08 08 0A",
           "action": "ReplaceTargetMethod"
         }
@@ -1518,11 +1518,10 @@
         "caller": {},
         "target": {
           "assembly": "nunit.framework",
-          "type": "NUnit.Framework.Internal.Commands.SkipCommand",
-          "method": "Execute",
+          "type": "NUnit.Framework.Internal.Execution.WorkShift",
+          "method": "ShutDown",
           "signature_types": [
-            "NUnit.Framework.Internal.TestResult",
-            "NUnit.Framework.Internal.TestExecutionContext"
+            "System.Void"
           ],
           "minimum_major": 3,
           "minimum_minor": 0,
@@ -1534,8 +1533,8 @@
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.19.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.Testing.NUnitIntegration",
-          "method": "SkipCommand_Execute",
-          "signature": "00 05 1C 1C 1C 08 08 0A",
+          "method": "WorkShift_ShutDown",
+          "signature": "00 04 01 1C 08 08 0A",
           "action": "ReplaceTargetMethod"
         }
       }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci;
+using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Integrations.Testing
+{
+    /// <summary>
+    /// Tracing integration for NUnit teting framework
+    /// </summary>
+    public static class NUnitIntegration
+    {
+        private const string IntegrationName = "NUnit";
+        private const string Major3 = "3";
+        private const string Major3Minor0 = "3.0";
+
+        private const string NUnitAssembly = "nunit.framework";
+
+        private const string NUnitTestMethodCommandType = "NUnit.Framework.Internal.Commands.TestMethodCommand";
+        private const string NUnitSkipCommandType = "NUnit.Framework.Internal.Commands.SkipCommand";
+
+        private const string NUnitExecuteMethod = "Execute";
+
+        private const string NUnitTestResultType = "NUnit.Framework.Internal.TestResult";
+        private const string NUnitTestExecutionContextType = "NUnit.Framework.Internal.TestExecutionContext";
+
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(NUnitIntegration));
+        private static readonly FrameworkDescription _runtimeDescription;
+
+        static NUnitIntegration()
+        {
+            // Preload environment variables.
+            CIEnvironmentValues.DecorateSpan(null);
+
+            _runtimeDescription = FrameworkDescription.Create();
+        }
+
+        /// <summary>
+        /// Wrap the original NUnit.Framework.Internal.Commands.TestMethodCommand.Execute method by adding instrumentation code around it
+        /// </summary>
+        /// <param name="testMethodCommand">The test method command instance</param>
+        /// <param name="testExecutionContext">Test execution context</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The original method's return value.</returns>
+        [InterceptMethod(
+            TargetAssembly = NUnitAssembly,
+            TargetType = NUnitTestMethodCommandType,
+            TargetMethod = NUnitExecuteMethod,
+            TargetMinimumVersion = Major3Minor0,
+            TargetMaximumVersion = Major3,
+            TargetSignatureTypes = new[] { NUnitTestResultType, NUnitTestExecutionContextType })]
+        public static object TestMethodCommand_Execute(
+            object testMethodCommand,
+            object testExecutionContext,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            if (testMethodCommand == null) { throw new ArgumentNullException(nameof(testMethodCommand)); }
+
+            Type testMethodCommandType = testMethodCommand.GetType();
+            Func<object, object, object> execute;
+
+            try
+            {
+                execute = MethodBuilder<Func<object, object, object>>
+                    .Start(moduleVersionPtr, mdToken, opCode, NUnitExecuteMethod)
+                    .WithConcreteType(testMethodCommandType)
+                    .WithParameters(testExecutionContext)
+                    .WithNamespaceAndNameFilters(NUnitTestResultType, NUnitTestExecutionContextType)
+                    .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorRetrievingMethod(
+                    exception: ex,
+                    moduleVersionPointer: moduleVersionPtr,
+                    mdToken: mdToken,
+                    opCode: opCode,
+                    instrumentedType: NUnitTestMethodCommandType,
+                    methodName: NUnitExecuteMethod,
+                    instanceType: testMethodCommandType.AssemblyQualifiedName);
+                throw;
+            }
+
+            Log.Information("Executing: " + NUnitTestMethodCommandType);
+            return execute(testMethodCommand, testExecutionContext);
+        }
+
+        /// <summary>
+        /// Wrap the original NUnit.Framework.Internal.Commands.SkipCommand.Execute method by adding instrumentation code around it
+        /// </summary>
+        /// <param name="skipCommand">The skip command instance</param>
+        /// <param name="testExecutionContext">Test execution context</param>
+        /// <param name="opCode">The OpCode used in the original method call.</param>
+        /// <param name="mdToken">The mdToken of the original method call.</param>
+        /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
+        /// <returns>The original method's return value.</returns>
+        [InterceptMethod(
+            TargetAssembly = NUnitAssembly,
+            TargetType = NUnitSkipCommandType,
+            TargetMethod = NUnitExecuteMethod,
+            TargetMinimumVersion = Major3Minor0,
+            TargetMaximumVersion = Major3,
+            TargetSignatureTypes = new[] { NUnitTestResultType, NUnitTestExecutionContextType })]
+        public static object SkipCommand_Execute(
+            object skipCommand,
+            object testExecutionContext,
+            int opCode,
+            int mdToken,
+            long moduleVersionPtr)
+        {
+            if (skipCommand == null) { throw new ArgumentNullException(nameof(skipCommand)); }
+
+            Type skipCommandType = skipCommand.GetType();
+            Func<object, object, object> execute;
+
+            try
+            {
+                execute = MethodBuilder<Func<object, object, object>>
+                    .Start(moduleVersionPtr, mdToken, opCode, NUnitExecuteMethod)
+                    .WithConcreteType(skipCommandType)
+                    .WithParameters(testExecutionContext)
+                    .WithNamespaceAndNameFilters(NUnitTestResultType, NUnitTestExecutionContextType)
+                    .Build();
+            }
+            catch (Exception ex)
+            {
+                Log.ErrorRetrievingMethod(
+                    exception: ex,
+                    moduleVersionPointer: moduleVersionPtr,
+                    mdToken: mdToken,
+                    opCode: opCode,
+                    instrumentedType: NUnitSkipCommandType,
+                    methodName: NUnitExecuteMethod,
+                    instanceType: skipCommandType.AssemblyQualifiedName);
+                throw;
+            }
+
+            Log.Information("Executing: " + NUnitSkipCommandType);
+            return execute(skipCommand, testExecutionContext);
+        }
+    }
+}


### PR DESCRIPTION
Adds the `NUnit` test framework integration to report test traces using the profiler.

Works similar to the `xUnit` integration.


#### Usage:
Run the test command with the profiler env-vars.

@DataDog/apm-dotnet