### PR TITLE
Dump IL rewrite code from profiler to the log

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1281,7 +1281,13 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
     
     orig_sstream << cInstr;
     orig_sstream << ": ";
-    if (cInstr->m_opcode < opcodes_names.size()) {
+    if (cInstr->m_opcode == CEE_COUNT) {
+      orig_sstream << std::setw(10) << "(count)";
+    }
+    else if (cInstr->m_opcode == CEE_SWITCH_ARG) {
+      orig_sstream << std::setw(10) << "->";
+    }
+    else if (cInstr->m_opcode < opcodes_names.size()) {
       orig_sstream << std::setw(10) << opcodes_names[cInstr->m_opcode];
     } else {
        orig_sstream << "0x";

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -221,6 +221,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   opcodes_names.push_back(s);
 #include "opcode.def"
 #undef OPDEF
+  opcodes_names.push_back("(count)");
+  opcodes_names.push_back("->");
 
   // we're in!
   Info("Profiler attached.");
@@ -1281,11 +1283,7 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
     
     orig_sstream << cInstr;
     orig_sstream << ": ";
-    if (cInstr->m_opcode == CEE_COUNT) {
-      orig_sstream << std::setw(10) << "(count)";
-    } else if (cInstr->m_opcode == CEE_SWITCH_ARG) {
-      orig_sstream << std::setw(10) << "->";
-    } else if (cInstr->m_opcode < opcodes_names.size()) {
+    if (cInstr->m_opcode < opcodes_names.size()) {
       orig_sstream << std::setw(10) << opcodes_names[cInstr->m_opcode];
     } else {
        orig_sstream << "0x";

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1283,11 +1283,9 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
     orig_sstream << ": ";
     if (cInstr->m_opcode == CEE_COUNT) {
       orig_sstream << std::setw(10) << "(count)";
-    }
-    else if (cInstr->m_opcode == CEE_SWITCH_ARG) {
+    } else if (cInstr->m_opcode == CEE_SWITCH_ARG) {
       orig_sstream << std::setw(10) << "->";
-    }
-    else if (cInstr->m_opcode < opcodes_names.size()) {
+    } else if (cInstr->m_opcode < opcodes_names.size()) {
       orig_sstream << std::setw(10) << opcodes_names[cInstr->m_opcode];
     } else {
        orig_sstream << "0x";

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -221,8 +221,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   opcodes_names.push_back(s);
 #include "opcode.def"
 #undef OPDEF
-  opcodes_names.push_back("(count)");
-  opcodes_names.push_back("->");
+  opcodes_names.push_back("(count)"); // CEE_COUNT
+  opcodes_names.push_back("->"); // CEE_SWITCH_ARG
 
   // we're in!
   Info("Profiler attached.");

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -216,7 +216,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     is_desktop_iis = runtime_information_.is_desktop();
   }
 
-  // writing opcodes vector
+  // writing opcodes vector for the IL dumper
 #define OPDEF(c, s, pop, push, args, type, l, s1, s2, flow) \
   opcodes_names.push_back(s);
 #include "opcode.def"
@@ -1277,7 +1277,7 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
   orig_sstream << ToString(caller.type.name);
   orig_sstream << ".";
   orig_sstream << ToString(caller.name.c_str());
-  orig_sstream << " : \n";
+  orig_sstream << " =>" << std::endl;
   for (ILInstr* cInstr = rewriter->GetILList()->m_pNext;
        cInstr != rewriter->GetILList(); cInstr = cInstr->m_pNext) {
     
@@ -1297,7 +1297,7 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
       orig_sstream << " ";
       orig_sstream << cInstr->m_Arg64;
     }
-    orig_sstream << "\n";
+    orig_sstream << std::endl;
   }
   return orig_sstream.str();
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1277,7 +1277,9 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
   orig_sstream << ToString(caller.type.name);
   orig_sstream << ".";
   orig_sstream << ToString(caller.name.c_str());
-  orig_sstream << " =>" << std::endl;
+  orig_sstream << " => (max_stack: ";
+  orig_sstream << rewriter->GetMaxStackValue();
+  orig_sstream << ")" << std::endl;
   for (ILInstr* cInstr = rewriter->GetILList()->m_pNext;
        cInstr != rewriter->GetILList(); cInstr = cInstr->m_pNext) {
     

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <vector>
 #include <string>
 #include <unordered_map>
 #include "cor.h"
@@ -34,6 +35,11 @@ class CorProfiler : public CorProfilerBase {
   std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
   bool in_azure_app_services = false;
   bool is_desktop_iis = false;
+
+  //
+  // OpCodes helper
+  //
+  std::vector<std::string> opcodes_names;
 
   //
   // Module helper variables

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -13,6 +13,7 @@
 #include "integration.h"
 #include "module_metadata.h"
 #include "pal.h"
+#include "il_rewriter.h"
 
 namespace trace {
 
@@ -60,7 +61,8 @@ class CorProfiler : public CorProfilerBase {
                                          const FunctionInfo& caller,
                                          const std::vector<MethodReplacement> method_replacements);
   bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
-
+  std::string GetILCodes(std::string title, ILRewriter* rewriter,
+                         const FunctionInfo& caller);
   //
   // Startup methods
   //

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -9,6 +9,7 @@ namespace trace {
   WSTRING env_vars_to_display[]{
     environment::tracing_enabled,
     environment::debug_enabled,
+    environment::dump_il_rewrite_enabled,
     environment::profiler_home_path,
     environment::integrations_path,
     environment::include_process_names,

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -95,6 +95,9 @@ const WSTRING azure_app_services_cli_telemetry_profile_value =
 // Default to false for now to avoid the unexpected overhead of additional spans.
 const WSTRING netstandard_enabled = "DD_TRACE_NETSTANDARD_ENABLED"_W;
 
+// Enable the profiler to dump the IL original code and modification to the log.
+const WSTRING dump_il_rewrite_enabled = "DD_DUMP_ILREWRITE_ENABLED"_W;
+
 }  // namespace environment
 }  // namespace trace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -5,6 +5,7 @@
 #include <corhlpr.cpp>
 
 #include "il_rewriter.h"
+#include <string>
 
 #undef IfFailRet
 #define IfFailRet(EXPR)  \

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -5,7 +5,6 @@
 #include <corhlpr.cpp>
 
 #include "il_rewriter.h"
-#include <string>
 
 #undef IfFailRet
 #define IfFailRet(EXPR)  \

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -654,3 +654,5 @@ void ILRewriter::DeallocateILMemory(LPBYTE pBody) {
 
   delete[] pBody;
 }
+
+unsigned ILRewriter::GetMaxStackValue() { return m_maxStack; }

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -100,8 +100,8 @@ static int k_rgnStackPushes[] = {
 #undef PushRef
 #undef VarPush
 #undef OPDEF
-    0,  // CEE_COUNT
-    0   // CEE_SWITCH_ARG
+    0, // CEE_COUNT
+    0  // CEE_SWITCH_ARG
 };
 
 ILRewriter::ILRewriter(

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
@@ -125,6 +125,8 @@ class ILRewriter {
   LPBYTE AllocateILMemory(unsigned size);
 
   void DeallocateILMemory(LPBYTE pBody);
+
+  unsigned GetMaxStackValue();
 };
 
 #endif  // DD_CLR_PROFILER_IL_REWRITER_H_

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
@@ -7,7 +7,6 @@
 
 #include <corhlpr.h>
 #include <corprof.h>
-#include <vector>
 
 typedef enum {
 #define OPDEF(c, s, pop, push, args, type, l, s1, s2, ctrl) c,

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
@@ -7,6 +7,7 @@
 
 #include <corhlpr.h>
 #include <corprof.h>
+#include <vector>
 
 typedef enum {
 #define OPDEF(c, s, pop, push, args, type, l, s1, s2, ctrl) c,

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -9,6 +9,7 @@
 namespace trace {
 
 bool debug_logging_enabled = false;
+bool dump_il_rewrite_enabled = false;
 
 void Log(const std::string& str) {
   static auto current_process_name = ToString(GetCurrentProcessName());

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -6,6 +6,7 @@
 namespace trace {
 
 extern bool debug_logging_enabled;
+extern bool dump_il_rewrite_enabled;
 
 void Log(const std::string &str);
 


### PR DESCRIPTION
This `PR` adds a new environment variable to the profiler to dump the il code being modified.

#### Example:
```
[dotnet.exe] 2300: [info] *** JITCompilationStarted() replaced calls from System.Net.Http.HttpMessageInvoker.SendAsync() to System.Net.Http.HttpMessageHandler.SendAsync() 100663996 with calls to Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration.HttpMessageHandler_SendAsync() 167773584
[dotnet.exe] 2300: [info] ***   IL original code for caller: System.Net.Http.HttpMessageInvoker.SendAsync => (max_stack: 24)
000002507BB97F80:    ldarg.1
000002507BB97BC0:   brtrue.s 000002507BB985B0
000002507BB98160:      ldstr 0000000070003DD1
000002507BB97E60:     newobj 000000000A00007A
000002507BB97BF0:      throw
000002507BB985B0:    ldarg.0
000002507BB98670:       call 00000000060002C4
000002507BB98580:       call 000000000600011D
000002507BB98700:  brfalse.s 000002507BB97FB0
000002507BB98640:    ldarg.0
000002507BB98040:    ldarg.1
000002507BB98370:      ldstr 0000000070004059
000002507BB98190:       call 000000000600010B
000002507BB97FB0:    ldarg.0
000002507BB98280:      ldfld 00000000040001A6
000002507BB986A0:    ldarg.1
000002507BB981C0:    ldarg.2
000002507BB97FE0:   callvirt 00000000060002BC
000002507BB98490:    stloc.0
000002507BB983A0:       call 000000000600011D
000002507BB981F0:  brfalse.s 000002507BB98730
000002507BB984F0:    ldarg.0
000002507BB97E00:    ldloc.0
000002507BB98010:      ldstr 0000000070004059
000002507BB97CB0:       call 0000000006000110
000002507BB98730:    ldloc.0
000002507BB982B0:        ret

[dotnet.exe] 2300: [info] ***   IL modification  for caller: System.Net.Http.HttpMessageInvoker.SendAsync => (max_stack: 29)
000002507BB97F80:    ldarg.1
000002507BB97BC0:   brtrue.s 000002507BB985B0
000002507BB98160:      ldstr 0000000070003DD1
000002507BB97E60:     newobj 000000000A00007A
000002507BB97BF0:      throw
000002507BB985B0:    ldarg.0
000002507BB98670:       call 00000000060002C4
000002507BB98580:       call 000000000600011D
000002507BB98700:  brfalse.s 000002507BB97FB0
000002507BB98640:    ldarg.0
000002507BB98040:    ldarg.1
000002507BB98370:      ldstr 0000000070004059
000002507BB98190:       call 000000000600010B
000002507BB97FB0:    ldarg.0
000002507BB98280:      ldfld 00000000040001A6
000002507BB986A0:    ldarg.1
000002507BB981C0:    ldarg.2
000002507BB97FE0:        nop 00000000060002BC
000002507BB97C50:        box 0000000001000024
000002507BB983D0:   ldc.i4.s 000000000000006F
000002507BB980A0:     ldc.i4 00000000060002BC
000002507BB97CE0:     ldc.i8 000002507B44B838
000002507BB97C80:       call 000000000A000590
000002507BB98490:    stloc.0
000002507BB983A0:       call 000000000600011D
000002507BB981F0:  brfalse.s 000002507BB98730
000002507BB984F0:    ldarg.0
000002507BB97E00:    ldloc.0
000002507BB98010:      ldstr 0000000070004059
000002507BB97CB0:       call 0000000006000110
000002507BB98730:    ldloc.0
000002507BB982B0:        ret

```
@DataDog/apm-dotnet