### PR TITLE
MSBuild logger try/catch blocks

### DIFF
--- a/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -23,8 +23,15 @@ namespace Datadog.Trace.MSBuild
 
         static DatadogLogger()
         {
-            // Preload environment variables.
-            CIEnvironmentValues.DecorateSpan(null);
+            try
+            {
+                // Preload environment variables.
+                CIEnvironmentValues.DecorateSpan(null);
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error initializing DatadogLogger type.");
+            }
         }
 
         /// <summary>
@@ -57,14 +64,22 @@ namespace Datadog.Trace.MSBuild
                 return;
             }
 
-            _tracer = Tracer.Instance;
+            try
+            {
+                _tracer = Tracer.Instance;
 
-            eventSource.BuildStarted += EventSource_BuildStarted;
-            eventSource.BuildFinished += EventSource_BuildFinished;
-            eventSource.ProjectStarted += EventSource_ProjectStarted;
-            eventSource.ProjectFinished += EventSource_ProjectFinished;
-            eventSource.ErrorRaised += EventSource_ErrorRaised;
-            eventSource.WarningRaised += EventSource_WarningRaised;
+                // Attach to the eventSource events only if we successfully get the tracer instance.
+                eventSource.BuildStarted += EventSource_BuildStarted;
+                eventSource.BuildFinished += EventSource_BuildFinished;
+                eventSource.ProjectStarted += EventSource_ProjectStarted;
+                eventSource.ProjectFinished += EventSource_ProjectFinished;
+                eventSource.ErrorRaised += EventSource_ErrorRaised;
+                eventSource.WarningRaised += EventSource_WarningRaised;
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error initializing the logger.");
+            }
         }
 
         /// <inheritdoc />
@@ -74,202 +89,248 @@ namespace Datadog.Trace.MSBuild
 
         private void EventSource_BuildStarted(object sender, BuildStartedEventArgs e)
         {
-            Log.Debug("Build Started");
-
-            _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
-            _buildSpan.SetMetric(Tags.Analytics, 1.0d);
-            _buildSpan.SetTraceSamplingPriority(SamplingPriority.UserKeep);
-
-            _buildSpan.Type = SpanTypes.Build;
-            _buildSpan.SetTag(BuildTags.BuildName, e.SenderName);
-            foreach (KeyValuePair<string, string> envValue in e.BuildEnvironment)
+            try
             {
-                _buildSpan.SetTag($"{BuildTags.BuildEnvironment}.{envValue.Key}", envValue.Value);
+                Log.Debug("Build Started");
+
+                _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
+                _buildSpan.SetMetric(Tags.Analytics, 1.0d);
+                _buildSpan.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+
+                _buildSpan.Type = SpanTypes.Build;
+                _buildSpan.SetTag(BuildTags.BuildName, e.SenderName);
+                foreach (KeyValuePair<string, string> envValue in e.BuildEnvironment)
+                {
+                    _buildSpan.SetTag($"{BuildTags.BuildEnvironment}.{envValue.Key}", envValue.Value);
+                }
+
+                _buildSpan.SetTag(BuildTags.BuildCommand, Environment.CommandLine);
+                _buildSpan.SetTag(BuildTags.BuildWorkingFolder, Environment.CurrentDirectory);
+                _buildSpan.SetTag(BuildTags.BuildStartMessage, e.Message);
+
+                _buildSpan.SetTag(CommonTags.RuntimeOSArchitecture, Environment.Is64BitOperatingSystem ? "x64" : "x86");
+                _buildSpan.SetTag(CommonTags.RuntimeProcessArchitecture, Environment.Is64BitProcess ? "x64" : "x86");
+
+                CIEnvironmentValues.DecorateSpan(_buildSpan);
             }
-
-            _buildSpan.SetTag(BuildTags.BuildCommand, Environment.CommandLine);
-            _buildSpan.SetTag(BuildTags.BuildWorkingFolder, Environment.CurrentDirectory);
-            _buildSpan.SetTag(BuildTags.BuildStartMessage, e.Message);
-
-            _buildSpan.SetTag(CommonTags.RuntimeOSArchitecture, Environment.Is64BitOperatingSystem ? "x64" : "x86");
-            _buildSpan.SetTag(CommonTags.RuntimeProcessArchitecture, Environment.Is64BitProcess ? "x64" : "x86");
-
-            CIEnvironmentValues.DecorateSpan(_buildSpan);
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error in BuildStarted event");
+            }
         }
 
         private void EventSource_BuildFinished(object sender, BuildFinishedEventArgs e)
         {
-            Log.Debug("Build Finished");
-
-            _buildSpan.SetTag(BuildTags.BuildStatus, e.Succeeded ? BuildTags.BuildSucceededStatus : BuildTags.BuildFailedStatus);
-            if (!e.Succeeded)
+            try
             {
-                _buildSpan.Error = true;
-            }
+                Log.Debug("Build Finished");
+                if (_buildSpan is null)
+                {
+                    return;
+                }
 
-            _buildSpan.SetTag(BuildTags.BuildEndMessage, e.Message);
-            _buildSpan.Finish(e.Timestamp);
+                _buildSpan.SetTag(BuildTags.BuildStatus, e.Succeeded ? BuildTags.BuildSucceededStatus : BuildTags.BuildFailedStatus);
+                if (!e.Succeeded)
+                {
+                    _buildSpan.Error = true;
+                }
+
+                _buildSpan.SetTag(BuildTags.BuildEndMessage, e.Message);
+                _buildSpan.Finish(e.Timestamp);
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error in BuildFinished event");
+            }
         }
 
         private void EventSource_ProjectStarted(object sender, ProjectStartedEventArgs e)
         {
-            if (e.TargetNames.StartsWith("_"))
+            try
             {
-                // Ignoring internal targetNames
-                return;
+                if (e.TargetNames.StartsWith("_"))
+                {
+                    // Ignoring internal targetNames
+                    return;
+                }
+
+                Log.Debug("Project Started");
+
+                int parentContext = e.ParentProjectBuildEventContext.ProjectContextId;
+                int context = e.BuildEventContext.ProjectContextId;
+                if (!_projects.TryGetValue(parentContext, out Span parentSpan))
+                {
+                    parentSpan = _buildSpan;
+                }
+
+                string projectName = Path.GetFileName(e.ProjectFile);
+
+                Span projectSpan = _tracer.StartSpan(BuildTags.BuildOperationName, parent: parentSpan.Context, serviceName: projectName);
+                projectSpan.ResourceName = projectName;
+                projectSpan.SetMetric(Tags.Analytics, 1.0d);
+                projectSpan.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+                projectSpan.Type = SpanTypes.Build;
+
+                foreach (KeyValuePair<string, string> prop in e.GlobalProperties)
+                {
+                    projectSpan.SetTag($"{BuildTags.ProjectProperties}.{prop.Key}", prop.Value);
+                }
+
+                projectSpan.SetTag(BuildTags.ProjectFile, e.ProjectFile);
+                projectSpan.SetTag(BuildTags.ProjectSenderName, e.SenderName);
+                projectSpan.SetTag(BuildTags.ProjectTargetNames, e.TargetNames);
+                projectSpan.SetTag(BuildTags.ProjectToolsVersion, e.ToolsVersion);
+                projectSpan.SetTag(BuildTags.BuildName, projectName);
+                projectSpan.SetTag(BuildTags.BuildStartMessage, e.Message);
+                _projects.TryAdd(context, projectSpan);
             }
-
-            Log.Debug("Project Started");
-
-            int parentContext = e.ParentProjectBuildEventContext.ProjectContextId;
-            int context = e.BuildEventContext.ProjectContextId;
-            if (!_projects.TryGetValue(parentContext, out Span parentSpan))
+            catch (Exception ex)
             {
-                parentSpan = _buildSpan;
+                Log.SafeLogError(ex, "Error in ProjectStarted event");
             }
-
-            string projectName = Path.GetFileName(e.ProjectFile);
-
-            Span projectSpan = _tracer.StartSpan(BuildTags.BuildOperationName, parent: parentSpan.Context, serviceName: projectName);
-            projectSpan.ResourceName = projectName;
-            projectSpan.SetMetric(Tags.Analytics, 1.0d);
-            projectSpan.SetTraceSamplingPriority(SamplingPriority.UserKeep);
-            projectSpan.Type = SpanTypes.Build;
-
-            foreach (KeyValuePair<string, string> prop in e.GlobalProperties)
-            {
-                projectSpan.SetTag($"{BuildTags.ProjectProperties}.{prop.Key}", prop.Value);
-            }
-
-            projectSpan.SetTag(BuildTags.ProjectFile, e.ProjectFile);
-            projectSpan.SetTag(BuildTags.ProjectSenderName, e.SenderName);
-            projectSpan.SetTag(BuildTags.ProjectTargetNames, e.TargetNames);
-            projectSpan.SetTag(BuildTags.ProjectToolsVersion, e.ToolsVersion);
-            projectSpan.SetTag(BuildTags.BuildName, projectName);
-            projectSpan.SetTag(BuildTags.BuildStartMessage, e.Message);
-            _projects.TryAdd(context, projectSpan);
         }
 
         private void EventSource_ProjectFinished(object sender, ProjectFinishedEventArgs e)
         {
-            int context = e.BuildEventContext.ProjectContextId;
-            if (_projects.TryRemove(context, out Span projectSpan))
+            try
             {
-                Log.Debug("Project Finished");
-
-                projectSpan.SetTag(BuildTags.BuildStatus, e.Succeeded ? BuildTags.BuildSucceededStatus : BuildTags.BuildFailedStatus);
-                if (!e.Succeeded)
+                int context = e.BuildEventContext.ProjectContextId;
+                if (_projects.TryRemove(context, out Span projectSpan))
                 {
-                    projectSpan.Error = true;
-                }
+                    Log.Debug("Project Finished");
 
-                projectSpan.SetTag(BuildTags.BuildEndMessage, e.Message);
-                projectSpan.Finish(e.Timestamp);
+                    projectSpan.SetTag(BuildTags.BuildStatus, e.Succeeded ? BuildTags.BuildSucceededStatus : BuildTags.BuildFailedStatus);
+                    if (!e.Succeeded)
+                    {
+                        projectSpan.Error = true;
+                    }
+
+                    projectSpan.SetTag(BuildTags.BuildEndMessage, e.Message);
+                    projectSpan.Finish(e.Timestamp);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error in ProjectFinished event");
             }
         }
 
         private void EventSource_ErrorRaised(object sender, BuildErrorEventArgs e)
         {
-            if (e.BuildEventContext == null)
+            try
             {
-                return;
-            }
-
-            Log.Debug("Error Raised");
-
-            int context = e.BuildEventContext.ProjectContextId;
-            if (_projects.TryGetValue(context, out Span projectSpan))
-            {
-                string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
-                string message = e.Message;
-                string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Error";
-                string code = e.Code;
-                int? lineNumber = e.LineNumber > 0 ? (int?)e.LineNumber : null;
-                int? columnNumber = e.ColumnNumber > 0 ? (int?)e.ColumnNumber : null;
-                int? endLineNumber = e.EndLineNumber > 0 ? (int?)e.EndLineNumber : null;
-                int? endColumnNumber = e.EndColumnNumber > 0 ? (int?)e.EndColumnNumber : null;
-                string projectFile = e.ProjectFile;
-                string filePath = null;
-                string stack = null;
-                string subCategory = e.Subcategory;
-
-                projectSpan.Error = true;
-                projectSpan.SetTag(BuildTags.ErrorMessage, message);
-                projectSpan.SetTag(BuildTags.ErrorType, type);
-                projectSpan.SetTag(BuildTags.ErrorCode, code);
-                projectSpan.SetTag(BuildTags.ErrorStartLine, lineNumber.ToString());
-                projectSpan.SetTag(BuildTags.ErrorStartColumn, columnNumber.ToString());
-                projectSpan.SetTag(BuildTags.ErrorProjectFile, projectFile);
-
-                if (!string.IsNullOrEmpty(e.File))
+                if (e.BuildEventContext == null)
                 {
-                    filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
-                    projectSpan.SetTag(BuildTags.ErrorFile, filePath);
-                    if (lineNumber.HasValue && lineNumber != 0)
+                    return;
+                }
+
+                Log.Debug("Error Raised");
+
+                int context = e.BuildEventContext.ProjectContextId;
+                if (_projects.TryGetValue(context, out Span projectSpan))
+                {
+                    string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
+                    string message = e.Message;
+                    string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Error";
+                    string code = e.Code;
+                    int? lineNumber = e.LineNumber > 0 ? (int?)e.LineNumber : null;
+                    int? columnNumber = e.ColumnNumber > 0 ? (int?)e.ColumnNumber : null;
+                    int? endLineNumber = e.EndLineNumber > 0 ? (int?)e.EndLineNumber : null;
+                    int? endColumnNumber = e.EndColumnNumber > 0 ? (int?)e.EndColumnNumber : null;
+                    string projectFile = e.ProjectFile;
+                    string filePath = null;
+                    string stack = null;
+                    string subCategory = e.Subcategory;
+
+                    projectSpan.Error = true;
+                    projectSpan.SetTag(BuildTags.ErrorMessage, message);
+                    projectSpan.SetTag(BuildTags.ErrorType, type);
+                    projectSpan.SetTag(BuildTags.ErrorCode, code);
+                    projectSpan.SetTag(BuildTags.ErrorStartLine, lineNumber.ToString());
+                    projectSpan.SetTag(BuildTags.ErrorStartColumn, columnNumber.ToString());
+                    projectSpan.SetTag(BuildTags.ErrorProjectFile, projectFile);
+
+                    if (!string.IsNullOrEmpty(e.File))
                     {
-                        stack = $" at Source code in {filePath}:line {e.LineNumber}";
-                        projectSpan.SetTag(BuildTags.ErrorStack, stack);
+                        filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
+                        projectSpan.SetTag(BuildTags.ErrorFile, filePath);
+                        if (lineNumber.HasValue && lineNumber != 0)
+                        {
+                            stack = $" at Source code in {filePath}:line {e.LineNumber}";
+                            projectSpan.SetTag(BuildTags.ErrorStack, stack);
+                        }
                     }
-                }
 
-                if (!string.IsNullOrEmpty(subCategory))
-                {
-                    projectSpan.SetTag(BuildTags.ErrorSubCategory, subCategory);
-                }
+                    if (!string.IsNullOrEmpty(subCategory))
+                    {
+                        projectSpan.SetTag(BuildTags.ErrorSubCategory, subCategory);
+                    }
 
-                if (endLineNumber.HasValue && endLineNumber != 0)
-                {
-                    projectSpan.SetTag(BuildTags.ErrorEndLine, endLineNumber.ToString());
-                }
+                    if (endLineNumber.HasValue && endLineNumber != 0)
+                    {
+                        projectSpan.SetTag(BuildTags.ErrorEndLine, endLineNumber.ToString());
+                    }
 
-                if (endColumnNumber.HasValue && endColumnNumber != 0)
-                {
-                    projectSpan.SetTag(BuildTags.ErrorEndColumn, endColumnNumber.ToString());
-                }
+                    if (endColumnNumber.HasValue && endColumnNumber != 0)
+                    {
+                        projectSpan.SetTag(BuildTags.ErrorEndColumn, endColumnNumber.ToString());
+                    }
 
-                LogItem logItem = new LogItem("error", message, type, code, lineNumber, columnNumber, endLineNumber, endColumnNumber, projectFile, filePath, stack, subCategory);
-                string logMessage = correlation + JsonConvert.SerializeObject(logItem);
-                Console.WriteLine(logMessage);
+                    LogItem logItem = new LogItem("error", message, type, code, lineNumber, columnNumber, endLineNumber, endColumnNumber, projectFile, filePath, stack, subCategory);
+                    string logMessage = correlation + JsonConvert.SerializeObject(logItem);
+                    Console.WriteLine(logMessage);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error in ErrorRaised event");
             }
         }
 
         private void EventSource_WarningRaised(object sender, BuildWarningEventArgs e)
         {
-            if (e.BuildEventContext == null)
+            try
             {
-                return;
-            }
-
-            Log.Debug("Warning Raised");
-
-            int context = e.BuildEventContext.ProjectContextId;
-            if (_projects.TryGetValue(context, out Span projectSpan))
-            {
-                string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
-                string message = e.Message;
-                string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Warning";
-                string code = e.Code;
-                int? lineNumber = e.LineNumber > 0 ? (int?)e.LineNumber : null;
-                int? columnNumber = e.ColumnNumber > 0 ? (int?)e.ColumnNumber : null;
-                int? endLineNumber = e.EndLineNumber > 0 ? (int?)e.EndLineNumber : null;
-                int? endColumnNumber = e.EndColumnNumber > 0 ? (int?)e.EndColumnNumber : null;
-                string projectFile = e.ProjectFile;
-                string filePath = null;
-                string stack = null;
-                string subCategory = e.Subcategory;
-
-                if (!string.IsNullOrEmpty(e.File))
+                if (e.BuildEventContext == null)
                 {
-                    filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
-                    if (lineNumber.HasValue && lineNumber != 0)
-                    {
-                        stack = $" at Source code in {filePath}:line {e.LineNumber}";
-                    }
+                    return;
                 }
 
-                LogItem logItem = new LogItem("warn", message, type, code, lineNumber, columnNumber, endLineNumber, endColumnNumber, projectFile, filePath, stack, subCategory);
-                string logMessage = correlation + JsonConvert.SerializeObject(logItem);
-                Console.WriteLine(logMessage);
+                Log.Debug("Warning Raised");
+
+                int context = e.BuildEventContext.ProjectContextId;
+                if (_projects.TryGetValue(context, out Span projectSpan))
+                {
+                    string correlation = $"[{CorrelationIdentifier.TraceIdKey}={projectSpan.TraceId},{CorrelationIdentifier.SpanIdKey}={projectSpan.SpanId}]";
+                    string message = e.Message;
+                    string type = $"{e.SenderName?.ToUpperInvariant()} ({e.Code}) Warning";
+                    string code = e.Code;
+                    int? lineNumber = e.LineNumber > 0 ? (int?)e.LineNumber : null;
+                    int? columnNumber = e.ColumnNumber > 0 ? (int?)e.ColumnNumber : null;
+                    int? endLineNumber = e.EndLineNumber > 0 ? (int?)e.EndLineNumber : null;
+                    int? endColumnNumber = e.EndColumnNumber > 0 ? (int?)e.EndColumnNumber : null;
+                    string projectFile = e.ProjectFile;
+                    string filePath = null;
+                    string stack = null;
+                    string subCategory = e.Subcategory;
+
+                    if (!string.IsNullOrEmpty(e.File))
+                    {
+                        filePath = Path.Combine(Path.GetDirectoryName(projectFile), e.File);
+                        if (lineNumber.HasValue && lineNumber != 0)
+                        {
+                            stack = $" at Source code in {filePath}:line {e.LineNumber}";
+                        }
+                    }
+
+                    LogItem logItem = new LogItem("warn", message, type, code, lineNumber, columnNumber, endLineNumber, endColumnNumber, projectFile, filePath, stack, subCategory);
+                    string logMessage = correlation + JsonConvert.SerializeObject(logItem);
+                    Console.WriteLine(logMessage);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.SafeLogError(ex, "Error in WarningRaised event");
             }
         }
     }

--- a/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -94,8 +94,7 @@ namespace Datadog.Trace.MSBuild
                 Log.Debug("Build Started");
 
                 _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
-                _buildSpan.SetMetric(Tags.Analytics, 1.0d);
-                _buildSpan.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+                _buildSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
                 _buildSpan.Type = SpanTypes.Build;
                 _buildSpan.SetTag(BuildTags.BuildName, e.SenderName);
@@ -167,8 +166,7 @@ namespace Datadog.Trace.MSBuild
 
                 Span projectSpan = _tracer.StartSpan(BuildTags.BuildOperationName, parent: parentSpan.Context, serviceName: projectName);
                 projectSpan.ResourceName = projectName;
-                projectSpan.SetMetric(Tags.Analytics, 1.0d);
-                projectSpan.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+                projectSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                 projectSpan.Type = SpanTypes.Build;
 
                 foreach (KeyValuePair<string, string> prop in e.GlobalProperties)


### PR DESCRIPTION
This PR adds some try/catch blocks to avoid breaking builds in case of exceptions.

Currently if we have problem initialising the tracer all the build command fails, this PR tries to avoid that.

Also ensures the created spans has the AutoKeep sampling priority as required by the ciapp.

@DataDog/apm-dotnet