### PR TITLE
Fixes InvalidProgramException when reading push values outside the boundaries of the array

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -100,6 +100,8 @@ static int k_rgnStackPushes[] = {
 #undef PushRef
 #undef VarPush
 #undef OPDEF
+    0,  // CEE_COUNT
+    0   // CEE_SWITCH_ARG
 };
 
 ILRewriter::ILRewriter(


### PR DESCRIPTION
This PR fixes a possible InvalidProgramException when the IL method body contains switch statements due to invalid maxstack header value by reading outside the boundaries of the push values array. To mitigate this we add the missing values to the array.

#### Changes:
- Adds the push value for both `CEE_COUNT` and `CEE_SWITCH_ARG`




@DataDog/apm-dotnet