### PR TITLE
Update CI job for benchmarks

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -71,4 +71,6 @@ stages:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
         arguments: '-c Release -f netcoreapp3.1 -- -i -m -f * '
-  
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '5'

--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -70,7 +70,7 @@ stages:
       inputs:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
-        arguments: '-c Release -f netcoreapp3.1 -- -i -m -f * '
+        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * '
     - task: PowerShell@2
       inputs:
         targetType: 'inline'

--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -71,6 +71,7 @@ stages:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
         arguments: '-c Release -f netcoreapp3.1 -- -i -m -f * '
-    - task: Delay@1
+    - task: PowerShell@2
       inputs:
-        delayForMinutes: '5'
+        targetType: 'inline'
+        script: 'Start-Sleep -s 120'


### PR DESCRIPTION
- Add a 2 minutes pause at the end to give the agent enough time to push the traces
- Changed the command-line to run benchmarks for both .NET Framework and .NET Core