### PR TITLE
Fix "FileNotFoundException (Could not load file or assembly ‘System.Net.Http, Version=4.0.0.0’ . . .)"

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -35,7 +35,6 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
-    <Reference Include="System.ServiceModel" />
 
     <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" PrivateAssets="all" />
   </ItemGroup>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -1,0 +1,71 @@
+#if NET461
+
+using System.Collections.Generic;
+using Datadog.Core.Tools;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class WcfTests : TestHelper
+    {
+        private const string ServiceVersion = "1.0.0";
+
+        public WcfTests(ITestOutputHelper output)
+            : base("Wcf", output)
+        {
+            SetServiceVersion(ServiceVersion);
+        }
+
+        [Fact(Skip = "Skipped until we determine a strategy for testing two executables in conjunction.")]
+        [Trait("Category", "EndToEnd")]
+        public void SubmitsTraces()
+        {
+            Output.WriteLine("Starting WcfTests.SubmitsTraces. Starting the Samples.Wcf requires ADMIN privileges");
+
+            const string expectedOperationName = "wcf.request";
+            const string expectedServiceName = "Samples.Wcf";
+            HashSet<string> expectedResourceNames = new HashSet<string>()
+            {
+                "http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue",
+                "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue",
+                "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/SCT",
+                "WcfSample/ICalculator/Add"
+            };
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            int wcfPort = 8585;
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (var processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"WSHttpBinding Port={wcfPort} Timeout=20000"))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+
+                var spans = agent.WaitForSpans(4, 20000);
+                Assert.True(spans.Count >= 4, $"Expecting at least 3 spans, only received {spans.Count}");
+
+                foreach (var span in spans)
+                {
+                    // Validate server fields
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(ServiceVersion, span.Tags[Tags.Version]);
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(SpanTypes.Web, span.Type);
+                    Assert.Equal(SpanKinds.Server, span.Tags[Tags.SpanKind]);
+
+                    // Validate resource name
+                    Assert.Contains(span.Resource, expectedResourceNames);
+
+                    // Test HTTP tags
+                    Assert.Equal("POST", span.Tags[Tags.HttpMethod]);
+                    Assert.Equal("http://localhost:8585/WcfSample/CalculatorService", span.Tags[Tags.HttpUrl]);
+                    Assert.Equal($"localhost:{wcfPort}", span.Tags[Tags.HttpRequestHeadersHost]);
+                }
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
### Issue
Beginning with .NET Tracer v1.18.0, the following error message begins occurring: `Could not load file or assembly 'System.Net.Http, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.` This occurs in the following conditions:
- The application targets .NET Framework 4.6 or higher
  - .NET Core is unaffected
- The application references the System.Net.Http NuGet package
- The application has a binding redirect on System.Net.Http to load a version higher than 4.0.0.0

This occurs because the .NET Tracer still has  a transitive dependency on `System.Net.Http, Version=4.0.0.0` by having an assembly reference to `System.ServiceModel, Version=4.0.0.0`. This transitive dependency on System.Net.Http was not an issue until version 1.18.0 of the .NET Tracer when the .NET Tracer began implementing a new CLR Profiler callback called `ICorProfilerCallback6::GetAssemblyReferences` (see #876 for further background). This new behavior results in the .NET runtime eagerly loading the entire assembly closure for a given assembly to ensure that the domain-neutral decision made at the time of loading is correct. In our case, the assembly closure walk of `Datadog.Trace.ClrProfiler.Managed` triggers an eager load of System.Net.Http v4.0.0.0. However, this load fails, and all subsequent loads of System.Net.Http v4.0.0.0 return with the cached load failure, even though they should be redirected to the version specified in the web.config.

### Changes
- Remove assembly reference to `System.ServiceModel.dll` in `Datadog.Trace.ClrProfiler.Managed.dll`
- Modify WCF automatic instrumentation to dynamically access fields / properties on WCF objects
- Add a test for the WCF automatic instrumentation

@DataDog/apm-dotnet