### PR TITLE
Remove System.Diagnostics.DiagnosticSource from the .NET Framework build

### DIFF
--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.GAC.wxs
@@ -35,11 +35,6 @@
               Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net45_GAC_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
-              KeyPath="yes" Checksum="yes" Assembly=".net"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net45.wxs
@@ -35,11 +35,6 @@
               Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net45_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.TracerHomeDirectory)\net45\System.Diagnostics.DiagnosticSource.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
+++ b/deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/Files.Managed.Net461.wxs
@@ -35,11 +35,6 @@
               Source="$(var.TracerHomeDirectory)\net461\Sigil.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net461_System.Diagnostics.DiagnosticSource.dll"
-              Source="$(var.TracerHomeDirectory)\net461\System.Diagnostics.DiagnosticSource.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
@@ -47,10 +47,12 @@ namespace Datadog.Trace.ClrProfiler
             {
                 var tracer = Tracer.Instance;
 
+#if NETSTANDARD
                 if (tracer.Settings.DiagnosticSourceEnabled)
                 {
                     tracer.StartDiagnosticObservers();
                 }
+#endif
             }
             catch
             {

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -206,7 +206,7 @@ namespace Datadog.Trace.Configuration
         public const string DogStatsDArgs = "DD_DOGSTATSD_ARGS";
 
         /// <summary>
-        /// Configuration key for enabling or disabling the use of <see cref="System.Diagnostics.DiagnosticSource"/>.
+        /// Configuration key for enabling or disabling the use of System.Diagnostics.DiagnosticSource.
         /// Default value is <c>true</c> (enabled).
         /// </summary>
         public const string DiagnosticSourceEnabled = "DD_DIAGNOSTIC_SOURCE_ENABLED";

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -251,7 +251,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets or sets a value indicating whether the use
-        /// of <see cref="System.Diagnostics.DiagnosticSource"/> is enabled.
+        /// of System.Diagnostics.DiagnosticSource is enabled.
         /// </summary>
         public bool DiagnosticSourceEnabled { get; set; }
 

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -16,11 +16,12 @@
     <!-- Instrumented libraries -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" PrivateAssets="All" />
+
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="LibLog" Version="5.0.6" PrivateAssets="All" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.4.1" />
   </ItemGroup>
 
   <!-- Below this point is reserved for vendor items -->

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
@@ -1,3 +1,4 @@
+#if NETSTANDARD
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -92,3 +93,4 @@ namespace Datadog.Trace.DiagnosticListeners
         }
     }
 }
+#endif

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
@@ -1,3 +1,4 @@
+#if NETSTANDARD
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -65,3 +66,4 @@ namespace Datadog.Trace.DiagnosticListeners
         protected abstract void OnNext(string eventName, object arg);
     }
 }
+#endif

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -383,6 +383,7 @@ namespace Datadog.Trace
             return _agentWriter.FlushTracesAsync();
         }
 
+#if NETSTANDARD
         internal void StartDiagnosticObservers()
         {
             // instead of adding a hard dependency on DiagnosticSource,
@@ -406,7 +407,6 @@ namespace Datadog.Trace
 
             var observers = new List<DiagnosticObserver>();
 
-#if NETSTANDARD
             if (Settings.IsIntegrationEnabled(AspNetCoreDiagnosticObserver.IntegrationName))
             {
                 Log.Debug("Adding AspNetCoreDiagnosticObserver");
@@ -414,7 +414,6 @@ namespace Datadog.Trace
                 var aspNetCoreDiagnosticOptions = new AspNetCoreDiagnosticOptions();
                 observers.Add(new AspNetCoreDiagnosticObserver(this, aspNetCoreDiagnosticOptions));
             }
-#endif
 
             if (observers.Count == 0)
             {
@@ -429,6 +428,7 @@ namespace Datadog.Trace
                 DiagnosticManager = diagnosticManager;
             }
         }
+#endif
 
         internal async Task WriteDiagnosticLog()
         {


### PR DESCRIPTION
After working on #880 (which focuses on System.Net.Http), it seems especially dangerous to even have an assembly reference on an assembly that can be provided by NuGet instead of the GAC. Since we do not use System.Diagnostics.DiagnosticSource right now on .NET Framework, this change removes it from the build to get rid of the possibility of assembly loading issues. Properly loading this on .NET Framework will be addressed when we begin moving towards using the Activity class to propagate events.

@DataDog/apm-dotnet