### PR TITLE
Increase timeout for Windows integration tests

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -196,6 +196,7 @@ jobs:
     condition: succeededOrFailed()
 
 - job: Windows
+  timeoutInMinutes: 80
   strategy:
     matrix:
       x64:


### PR DESCRIPTION
Increase timeout from default value (60 minutes) to 80 minutes