### PR TITLE
Force msbuild to build sequentially

### DIFF
--- a/samples/Samples.MultiDomainHost.Runner/Samples.MultiDomainHost.Runner.csproj
+++ b/samples/Samples.MultiDomainHost.Runner/Samples.MultiDomainHost.Runner.csproj
@@ -25,7 +25,7 @@
     <ConvertToAbsolutePath Paths="$(OutputPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="AbsoluteOutputPath" />
     </ConvertToAbsolutePath>
-    <MSBuild Projects="@(SubApplications)" Targets="Restore;Build" Properties="OutputPath=$(AbsoluteOutputPath)\%(Name)\;TargetFramework=$(TargetFramework);ExcludeNativeProfiler=true;ExcludeManagedProfiler=true;LoadManagedProfilerFromProfilerDirectory=false" />
+    <MSBuild BuildInParallel="false" RunEachTargetSeparately="true" Projects="@(SubApplications)" Targets="Restore;Build" Properties="OutputPath=$(AbsoluteOutputPath)\%(Name)\;TargetFramework=$(TargetFramework);ExcludeNativeProfiler=true;ExcludeManagedProfiler=true;LoadManagedProfilerFromProfilerDirectory=false" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Transient build errors are caused by the project Samples.MultiDomainHost.Runner being restored by multiple tasks in parallel. I'm hoping that setting `RunEachTargetSeparately` will prevent that from happening.

I'm also setting `BuildInParallel` to false, but according to the documentation this is supposed to be the default value.