### PR TITLE
Add delay to all smoke tests to prevent SIGSEGV

### DIFF
--- a/reproductions/AssemblyLoad.FileNotFoundException/Program.cs
+++ b/reproductions/AssemblyLoad.FileNotFoundException/Program.cs
@@ -8,6 +8,12 @@ namespace AssemblyLoad.FileNotFoundException
     {
         private static async Task<int> Main()
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 var baseAddress = new Uri("https://www.example.com/");

--- a/reproductions/DataDogThreadTest/Program.cs
+++ b/reproductions/DataDogThreadTest/Program.cs
@@ -17,6 +17,12 @@ namespace DataDogThreadTest
 
         static int Main(string[] args)
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 InMemoryLog4NetLogger.Setup();

--- a/reproductions/EntityFramework6x.MdTokenLookupFailure/Program.cs
+++ b/reproductions/EntityFramework6x.MdTokenLookupFailure/Program.cs
@@ -12,6 +12,12 @@ namespace EntityFramework6x.MdTokenLookupFailure
     {
         static int Main(string[] args)
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 using (var ctx = new SchoolDbContextEntities())

--- a/reproductions/HttpMessageHandler.StackOverflowException/Program.cs
+++ b/reproductions/HttpMessageHandler.StackOverflowException/Program.cs
@@ -11,6 +11,12 @@ namespace HttpMessageHandler.StackOverflowException
     {
         private static async Task<int> Main()
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");

--- a/reproductions/Log4Net.SerializationException/Program.cs
+++ b/reproductions/Log4Net.SerializationException/Program.cs
@@ -10,6 +10,12 @@ namespace Log4Net.SerializationException
     {
         public static int Main(string[] args)
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             // The library we want to run was built and copied to the ApplicationFiles subdirectory
             // Create an AppDomain with that directory as the appBasePath
             var entryDirectory = Directory.GetParent(Assembly.GetEntryAssembly().Location);

--- a/reproductions/NLog10LogsInjection.NullReferenceException/Program.cs
+++ b/reproductions/NLog10LogsInjection.NullReferenceException/Program.cs
@@ -11,6 +11,12 @@ namespace NLog10LogsInjection.NullReferenceException
 
         static int Main(string[] args)
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             using (var scope = Tracer.Instance.StartActive("Main"))
             {
                 Logger.Info("Message during a trace.");

--- a/reproductions/OrleansCrash/Program.cs
+++ b/reproductions/OrleansCrash/Program.cs
@@ -20,6 +20,12 @@ namespace OrleansCrash
     {
         public static int Main(string[] args)
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 var orleansTasks = new List<Task>();

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
@@ -11,6 +11,12 @@ namespace StackExchange.Redis.AssemblyConflict.LegacyProject
     {
         public static async Task Main()
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 await RunTest();

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -11,6 +11,12 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
     {
         public static async Task Main()
         {
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             try
             {
                 await RunTest();


### PR DESCRIPTION
This is a follow-up of https://github.com/DataDog/dd-trace-dotnet/pull/878

I originally thought only 2 projects were impacted, but I've seen failure on other projects as well, so I prefer to update them all.