### PR TITLE
Increase LocalDB connection timeout in tests

### DIFF
--- a/reproduction-dependencies/AppDomain.Instance/SqlServerNestedProgram.cs
+++ b/reproduction-dependencies/AppDomain.Instance/SqlServerNestedProgram.cs
@@ -14,7 +14,7 @@ namespace AppDomain.Instance
         public int CurrentCallCount { get; set; }
         public bool DenyAllCalls { get; set; }
 
-        private readonly string _connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=30";
+        private readonly string _connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60";
         private readonly string _jokeTable = "GreatJoke";
 
         public SqlServerNestedProgram()

--- a/reproductions/EntityFramework6x.MdTokenLookupFailure/App.config
+++ b/reproductions/EntityFramework6x.MdTokenLookupFailure/App.config
@@ -8,7 +8,7 @@
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
   </startup>
   <connectionStrings>
-    <add name="SchoolDbContextEntities" connectionString="metadata=res://*/SchoolModel.csdl|res://*/SchoolModel.ssdl|res://*/SchoolModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=(localdb)\MSSQLLocalDB;initial catalog=SchoolDbContext;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient"/>
+    <add name="SchoolDbContextEntities" connectionString="metadata=res://*/SchoolModel.csdl|res://*/SchoolModel.ssdl|res://*/SchoolModel.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=(localdb)\MSSQLLocalDB;initial catalog=SchoolDbContext;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework;Connection Timeout=60&quot;" providerName="System.Data.EntityClient"/>
   </connectionStrings>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">

--- a/samples-aspnet/Samples.WebForms.Empty/SqlServer.aspx.cs
+++ b/samples-aspnet/Samples.WebForms.Empty/SqlServer.aspx.cs
@@ -17,7 +17,7 @@ namespace Samples.WebForms.Empty
     {
         public object GetValue()
         {
-            var connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true";
+            var connectionString = @"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60";
 
             using (var connection = (DbConnection)new SqlConnection(connectionString))
             using (var command = connection.CreateCommand())

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -27,7 +27,7 @@ namespace Samples.SqlServer
         {
             int numAttempts = 3;
             var connectionString = Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING") ??
-@"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=30";
+@"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60";
 
             for (int i = 0; i < numAttempts; i++)
             {


### PR DESCRIPTION
Failure seen in integration tests:
```The duration spent while attempting to connect to this server was - [Pre-Login] initialization=28486; handshake=1043;```

The connection is not stuck since it managed to move to handshake 1 second before timeout. Giving a few extra seconds may fix those errors.