### PR TITLE
Unit test improvements

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -106,6 +106,7 @@ namespace Datadog.Trace.Agent
                     {
                         // stop retrying
                         Log.Error(exception, "An error occurred while sending traces to the agent at {0}", _tracesEndpoint);
+                        _statsd?.Send();
                         return false;
                     }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -106,7 +106,6 @@ namespace Datadog.Trace.Agent
                     {
                         // stop retrying
                         Log.Error(exception, "An error occurred while sending traces to the agent at {0}", _tracesEndpoint);
-                        _statsd?.Send();
                         return false;
                     }
 

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -40,9 +40,9 @@ namespace Datadog.Trace.Tests
 
             // Setup mock to set a bool when receiving a successful response from the agent, so we know to verify success or error.
             var requestSuccessful = false;
-            var requestHadErrors = false;
+            var requestEncounteredErrors = false;
             statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, It.IsAny<string[]>())).Callback(() => requestSuccessful = true);
-            statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, It.IsAny<string[]>())).Callback(() => requestHadErrors = true);
+            statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, It.IsAny<string[]>())).Callback(() => requestEncounteredErrors = true);
 
             var spans = SendSpan(tracerMetricsEnabled: true, statsd);
 
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Tests
                     Times.Once());
             }
 
-            if (requestHadErrors)
+            if (requestEncounteredErrors)
             {
                 statsd.Verify(
                     s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, null),

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -39,10 +39,10 @@ namespace Datadog.Trace.Tests
             var statsd = new Mock<IStatsd>();
 
             // Setup mock to set a bool when receiving a successful response from the agent, so we know to verify success or error.
-            var markOneSuccess = false;
-            var markOneError = false;
-            statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, "status:200")).Callback(() => markOneSuccess = true);
-            statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, null)).Callback(() => markOneError = true);
+            var requestSuccessful = false;
+            var requestHadErrors = false;
+            statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, It.IsAny<string[]>())).Callback(() => requestSuccessful = true);
+            statsd.Setup(s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, It.IsAny<string[]>())).Callback(() => requestHadErrors = true);
 
             var spans = SendSpan(tracerMetricsEnabled: true, statsd);
 
@@ -69,32 +69,18 @@ namespace Datadog.Trace.Tests
                 s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Requests, 1, 1, null),
                 Times.Once());
 
-            if (markOneSuccess)
+            if (requestSuccessful)
             {
                 statsd.Verify(
                     s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, "status:200"),
                     Times.Once());
-                statsd.Verify(
-                    s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, null),
-                    Times.Never());
             }
-            else if (markOneError)
+
+            if (requestHadErrors)
             {
                 statsd.Verify(
                     s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, null),
-                    Times.Once());
-                statsd.Verify(
-                    s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, "status:200"),
-                    Times.Never());
-            }
-            else
-            {
-                statsd.Verify(
-                    s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Responses, 1, 1, "status:200"),
-                    Times.Never());
-                statsd.Verify(
-                    s => s.Add<Statsd.Counting, int>(TracerMetricNames.Api.Errors, 1, 1, null),
-                    Times.Never());
+                    Times.AtLeastOnce());
             }
 
             // these methods can be called multiple times with a "0" value (no more traces left)


### PR DESCRIPTION
Affected tests:
- `Datadog.Trace.Tests.DogStatsDTests.Send_metrics_when_enabled`: Improve the logic that validates 1+ errors when sending traces to the agent

@DataDog/apm-dotnet