### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Datadog.Trace;
 using Datadog.Trace.Agent;
@@ -11,6 +12,10 @@ namespace Benchmarks.Trace
         public Task FlushAndCloseAsync()
         {
             return Task.CompletedTask;
+        }
+
+        public void SetApiBaseEndpoint(Uri uri)
+        {
         }
 
         public Task FlushTracesAsync()


### PR DESCRIPTION
Looks like benchmarks are not automatically built, otherwise this kind of stuff couldn't happen.

Gonna update the CI in a separate PR. 