### PR TITLE
Make benchmark results more stable

### DIFF
--- a/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -21,6 +21,8 @@ namespace Benchmarks.Trace
 
         static AgentWriterBenchmark()
         {
+            TracerSettings.DisableSharedInstance = true;
+
             var settings = TracerSettings.FromDefaultSources();
 
             settings.StartupDiagnosticLogEnabled = false;

--- a/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -133,7 +133,7 @@ namespace Benchmarks.Trace
     public class AspNetCoreBenchmark
     {
         [Benchmark]
-        public Task<string> SendRequest()
+        public string SendRequest()
         {
             return null;
         }

--- a/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -25,8 +25,7 @@ namespace Benchmarks.Trace
 
         static AspNetCoreBenchmark()
         {
-            Environment.SetEnvironmentVariable(ConfigurationKeys.TraceEnabled, "0");
-            Environment.SetEnvironmentVariable(ConfigurationKeys.StartupDiagnosticLogEnabled, "0");
+            TracerSettings.DisableSharedInstance = true;
 
             var settings = new TracerSettings
             {
@@ -45,12 +44,14 @@ namespace Benchmarks.Trace
             Datadog.Trace.ClrProfiler.Instrumentation.Initialize();
 
             HomeController.Initialize();
+
+            new AspNetCoreBenchmark().SendRequest();
         }
 
         [Benchmark]
-        public Task<string> SendRequest()
+        public string SendRequest()
         {
-            return Client.GetStringAsync("/Home");
+            return Client.GetStringAsync("/Home").GetAwaiter().GetResult();
         }
 
         private class Startup

--- a/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -17,6 +17,8 @@ namespace Benchmarks.Trace
 
         static SpanBenchmark()
         {
+            TracerSettings.DisableSharedInstance = true;
+
             var settings = new TracerSettings
             {
                 TraceEnabled = false,

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -270,6 +270,10 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether the shared Tracer instance is disabled.
+        /// To be used to prevent the automatic instantiation of Tracer.Instance when running tests/benchmarks
+        /// </summary>
         internal static bool DisableSharedInstance { get; set; }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -270,6 +270,8 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
 
+        internal static bool DisableSharedInstance { get; set; }
+
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources
         /// returned by <see cref="CreateDefaultConfigurationSource"/>.

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -44,8 +44,12 @@ namespace Datadog.Trace
         static Tracer()
         {
             TracingProcessManager.Initialize();
-            // create the default global Tracer
-            Instance = new Tracer();
+
+            if (!TracerSettings.DisableSharedInstance)
+            {
+                // create the default global Tracer
+                Instance = new Tracer();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR solves 2 issues:

 - A default instance of the Tracer is automatically created when the static constructor runs. That instance runs things in the background, adding noise to benchmarks
 - Because the first invocation is much longer than the others, BenchmarkDotNet overestimates the time it takes to run the aspnetcore benchmark and ends up doing only one invocation. Running the benchmark once in the static constructor hides the warmup time from BenchmarkDotNet (I shouldn't have to do that, but I couldn't find a better solution)