### PR TITLE
Ensure that we send statsd metrics on trace agent request failure

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -106,6 +106,7 @@ namespace Datadog.Trace.Agent
                     {
                         // stop retrying
                         Log.Error(exception, "An error occurred while sending traces to the agent at {0}", _tracesEndpoint);
+                        _statsd?.Send();
                         return false;
                     }
 


### PR DESCRIPTION
@DataDog/apm-dotnet