### PR TITLE
Cache agent response and discard default sampling rates

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -6,7 +6,6 @@ using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
-using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -208,7 +207,7 @@ namespace Datadog.Trace.Agent
                     {
                         var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
 
-                        if (!DefaultSamplingRule.OptimEnabled || responseContent != _cachedResponse)
+                        if (responseContent != _cachedResponse)
                         {
                             var apiResponse = JsonConvert.DeserializeObject<ApiResponse>(responseContent);
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;

--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Sampling
@@ -18,8 +17,6 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         public int Priority => int.MinValue;
 
-        internal static bool OptimEnabled { get; set; }
-
         public bool IsMatch(Span span)
         {
             return true;
@@ -29,12 +26,9 @@ namespace Datadog.Trace.Sampling
         {
             Log.Debug("Using the default sampling logic");
 
-            if (OptimEnabled)
+            if (_sampleRates.Count == 0)
             {
-                if (_sampleRates.Count == 0)
-                {
-                    return 1;
-                }
+                return 1;
             }
 
             var env = span.GetTag(Tags.Env);

--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -17,8 +17,6 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         public int Priority => int.MinValue;
 
-        internal static bool UseOptim { get; set; }
-
         public bool IsMatch(Span span)
         {
             return true;

--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace.Sampling
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<DefaultSamplingRule>();
 
-        private static Dictionary<string, float> _sampleRates = new Dictionary<string, float>();
+        private static Dictionary<SampleRateKey, float> _sampleRates = new Dictionary<SampleRateKey, float>();
 
         public string RuleName => "default-rule";
 
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Sampling
         /// Gets the lowest possible priority
         /// </summary>
         public int Priority => int.MinValue;
+
+        internal static bool UseOptim { get; set; }
 
         public bool IsMatch(Span span)
         {
@@ -34,7 +36,7 @@ namespace Datadog.Trace.Sampling
             var env = span.GetTag(Tags.Env);
             var service = span.ServiceName;
 
-            var key = $"service:{service},env:{env}";
+            var key = new SampleRateKey(service, env);
 
             if (_sampleRates.TryGetValue(key, out var sampleRate))
             {
@@ -51,21 +53,92 @@ namespace Datadog.Trace.Sampling
         {
             // to avoid locking if writers and readers can access the dictionary at the same time,
             // build the new dictionary first, then replace the old one
-            var rates = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+            var rates = new Dictionary<SampleRateKey, float>();
 
             if (sampleRates != null)
             {
                 foreach (var pair in sampleRates)
                 {
                     // No point in adding default rates
-                    if (pair.Value != 1)
+                    if (pair.Value == 1.0f)
                     {
-                        rates.Add(pair.Key, pair.Value);
+                        continue;
                     }
+
+                    var key = SampleRateKey.Parse(pair.Key);
+
+                    if (key == null)
+                    {
+                        Log.Warning("Could not parse sample rate key {0}", pair.Key);
+                        continue;
+                    }
+
+                    rates.Add(key.Value, pair.Value);
                 }
             }
 
             _sampleRates = rates;
+        }
+
+        private readonly struct SampleRateKey : IEquatable<SampleRateKey>
+        {
+            private static readonly char[] PartSeparator = new[] { ',' };
+            private static readonly char[] ValueSeparator = new[] { ':' };
+
+            private readonly string _service;
+            private readonly string _env;
+
+            public SampleRateKey(string service, string env)
+            {
+                _service = service;
+                _env = env;
+            }
+
+            public static SampleRateKey? Parse(string key)
+            {
+                // Expected format:
+                // service:{service},env:{env}
+                var parts = key.Split(PartSeparator);
+
+                if (parts.Length != 2)
+                {
+                    return null;
+                }
+
+                var serviceParts = parts[0].Split(ValueSeparator, 2);
+
+                if (serviceParts.Length != 2)
+                {
+                    return null;
+                }
+
+                var envParts = parts[1].Split(ValueSeparator, 2);
+
+                if (envParts.Length != 2)
+                {
+                    return null;
+                }
+
+                return new SampleRateKey(serviceParts[1], envParts[1]);
+            }
+
+            public bool Equals(SampleRateKey other)
+            {
+                return _service == other._service && _env == other._env;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is SampleRateKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((_service != null ? _service.GetHashCode() : 0) * 397) ^ (_env != null ? _env.GetHashCode() : 0);
+                }
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Sampling;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Sampling
+{
+    public class DefaultSamplingRuleTests
+    {
+        [Theory]
+        // Value returned by the agent per default
+        [InlineData("service:,env:", "hello", "world", 1f)]
+        // Does not match
+        [InlineData("service:nope,env:nope", "hello", "world", 1f)]
+        // Nominal case
+        [InlineData("service:hello,env:world", "hello", "world", .5f)]
+        // Too many values
+        [InlineData("service:hello,env:world,xxxx", "hello", "world", 1f)]
+        // ':' in service name
+        [InlineData("service:hello:1,env:world", "hello:1", "world", .5f)]
+        // ':' in env name
+        [InlineData("service:hello,env:world:1", "hello", "world:1", .5f)]
+        public void KeyParsing(string key, string expectedService, string expectedEnv, float expectedRate)
+        {
+            var rule = new DefaultSamplingRule();
+
+            rule.SetDefaultSampleRates(new[] { new KeyValuePair<string, float>(key, .5f) });
+
+            var span = new Span(new SpanContext(1, 1, null, serviceName: expectedService), DateTimeOffset.Now);
+            span.SetTag(Tags.Env, expectedEnv);
+
+            var samplingRate = rule.GetSamplingRate(span);
+
+            Assert.Equal(expectedRate, samplingRate);
+        }
+    }
+}


### PR DESCRIPTION
This optimization takes advantage of two things:
 - The agent will most of the time send the same response
 - Sampling rates are usually 1

Benchmarks:

AspNetCore SendRequest:

```
|           Method |     Mean |   Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|--------:|--------:|------:|--------:|-------:|------:|------:|----------:|
| SendRequest      | 126.6 μs | 1.58 μs | 1.40 μs |  1.00 |    0.00 | 2.9297 |     - |     - |  17.79 KB |
| SendRequest_New  | 122.1 μs | 0.89 μs | 0.69 μs |  0.96 |    0.01 | 2.9297 |     - |     - |  17.67 KB |
```

Spans:

```
|               Method |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|      StartFinishSpan |   965.6 ns | 19.29 ns | 26.41 ns | 0.1259 |     - |     - |     792 B |
|  StartFinishSpan_New |   903.2 ns | 10.20 ns |  8.52 ns | 0.1068 |     - |     - |     672 B |
|     StartFinishScope | 1,095.6 ns | 20.39 ns | 17.03 ns | 0.1488 |     - |     - |     936 B |
| StartFinishScope_New |   994.4 ns | 18.76 ns | 19.26 ns | 0.1297 |     - |     - |     816 B |
```