### PR TITLE
Optimize AspNetCoreDiagnosticObserver path

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -6,7 +6,6 @@ using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
-using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -208,7 +207,7 @@ namespace Datadog.Trace.Agent
                     {
                         var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
 
-                        if (!DefaultSamplingRule.OptimEnabled || responseContent != _cachedResponse)
+                        if (responseContent != _cachedResponse)
                         {
                             var apiResponse = JsonConvert.DeserializeObject<ApiResponse>(responseContent);
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -166,7 +166,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
                 string url = GetUrl(request);
 
-                string resourceUrl = UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true)
+                string resourceUrl = UriHelpers.GetRelativeUrl(url, tryRemoveIds: true)
                                                .ToLowerInvariant();
 
                 string resourceName = $"{httpMethod} {resourceUrl}";
@@ -230,7 +230,17 @@ namespace Datadog.Trace.DiagnosticListeners
             if (scope != null)
             {
                 var httpContext = HttpRequestInStopHttpContextFetcher.Fetch<HttpContext>(arg);
-                scope.Span.SetTag(Tags.HttpStatusCode, httpContext.Response.StatusCode.ToString());
+
+                var statusCode = httpContext.Response.StatusCode;
+
+                if (statusCode == 200)
+                {
+                    scope.Span.SetTag(Tags.HttpStatusCode, "200");
+                }
+                else
+                {
+                    scope.Span.SetTag(Tags.HttpStatusCode, httpContext.Response.StatusCode.ToString());
+                }
 
                 if (httpContext.Response.StatusCode / 100 == 5)
                 {

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -112,19 +112,24 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private static IEnumerable<KeyValuePair<string, string>> ExtractHeaderTags(HttpRequest request, IDatadogTracer tracer)
         {
-            try
-            {
-                // extract propagation details from http headers
-                var requestHeaders = request.Headers;
+            var settings = tracer.Settings;
 
-                if (requestHeaders != null)
-                {
-                    return SpanContextPropagator.Instance.ExtractHeaderTags(new HeadersCollectionAdapter(requestHeaders), tracer.Settings.HeaderTags);
-                }
-            }
-            catch (Exception ex)
+            if (!settings.HeaderTagsEmpty)
             {
-                Log.SafeLogError(ex, "Error extracting propagated HTTP headers.");
+                try
+                {
+                    // extract propagation details from http headers
+                    var requestHeaders = request.Headers;
+
+                    if (requestHeaders != null)
+                    {
+                        return SpanContextPropagator.Instance.ExtractHeaderTags(new HeadersCollectionAdapter(requestHeaders), settings.HeaderTags);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.SafeLogError(ex, "Error extracting propagated HTTP headers.");
+                }
             }
 
             return Enumerable.Empty<KeyValuePair<string, string>>();

--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Sampling
@@ -18,8 +17,6 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         public int Priority => int.MinValue;
 
-        internal static bool OptimEnabled { get; set; }
-
         public bool IsMatch(Span span)
         {
             return true;
@@ -29,12 +26,9 @@ namespace Datadog.Trace.Sampling
         {
             Log.Debug("Using the default sampling logic");
 
-            if (OptimEnabled)
+            if (_sampleRates.Count == 0)
             {
-                if (_sampleRates.Count == 0)
-                {
-                    return 1;
-                }
+                return 1;
             }
 
             var env = span.GetTag(Tags.Env);

--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace.Sampling
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<DefaultSamplingRule>();
 
-        private static Dictionary<string, float> _sampleRates = new Dictionary<string, float>();
+        private static Dictionary<SampleRateKey, float> _sampleRates = new Dictionary<SampleRateKey, float>();
 
         public string RuleName => "default-rule";
 
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Sampling
         /// Gets the lowest possible priority
         /// </summary>
         public int Priority => int.MinValue;
+
+        internal static bool UseOptim { get; set; }
 
         public bool IsMatch(Span span)
         {
@@ -34,7 +36,7 @@ namespace Datadog.Trace.Sampling
             var env = span.GetTag(Tags.Env);
             var service = span.ServiceName;
 
-            var key = $"service:{service},env:{env}";
+            var key = new SampleRateKey(service, env);
 
             if (_sampleRates.TryGetValue(key, out var sampleRate))
             {
@@ -51,21 +53,92 @@ namespace Datadog.Trace.Sampling
         {
             // to avoid locking if writers and readers can access the dictionary at the same time,
             // build the new dictionary first, then replace the old one
-            var rates = new Dictionary<string, float>(StringComparer.OrdinalIgnoreCase);
+            var rates = new Dictionary<SampleRateKey, float>();
 
             if (sampleRates != null)
             {
                 foreach (var pair in sampleRates)
                 {
                     // No point in adding default rates
-                    if (pair.Value != 1)
+                    if (pair.Value == 1.0f)
                     {
-                        rates.Add(pair.Key, pair.Value);
+                        continue;
                     }
+
+                    var key = SampleRateKey.Parse(pair.Key);
+
+                    if (key == null)
+                    {
+                        Log.Warning("Could not parse sample rate key {0}", pair.Key);
+                        continue;
+                    }
+
+                    rates.Add(key.Value, pair.Value);
                 }
             }
 
             _sampleRates = rates;
+        }
+
+        private readonly struct SampleRateKey : IEquatable<SampleRateKey>
+        {
+            private static readonly char[] PartSeparator = new[] { ',' };
+            private static readonly char[] ValueSeparator = new[] { ':' };
+
+            private readonly string _service;
+            private readonly string _env;
+
+            public SampleRateKey(string service, string env)
+            {
+                _service = service;
+                _env = env;
+            }
+
+            public static SampleRateKey? Parse(string key)
+            {
+                // Expected format:
+                // service:{service},env:{env}
+                var parts = key.Split(PartSeparator);
+
+                if (parts.Length != 2)
+                {
+                    return null;
+                }
+
+                var serviceParts = parts[0].Split(ValueSeparator, 2);
+
+                if (serviceParts.Length != 2)
+                {
+                    return null;
+                }
+
+                var envParts = parts[1].Split(ValueSeparator, 2);
+
+                if (envParts.Length != 2)
+                {
+                    return null;
+                }
+
+                return new SampleRateKey(serviceParts[1], envParts[1]);
+            }
+
+            public bool Equals(SampleRateKey other)
+            {
+                return _service == other._service && _env == other._env;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is SampleRateKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((_service != null ? _service.GetHashCode() : 0) * 397) ^ (_env != null ? _env.GetHashCode() : 0);
+                }
+            }
         }
     }
 }

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -92,18 +92,15 @@ namespace Datadog.Trace
         public IEnumerable<KeyValuePair<string, string>> ExtractHeaderTags<T>(T headers, IEnumerable<KeyValuePair<string, string>> headerToTagMap)
             where T : IHeadersCollection
         {
-            var tagsFromHeaders = new Dictionary<string, string>();
-
             foreach (KeyValuePair<string, string> headerNameToTagName in headerToTagMap)
             {
                 string headerValue = ParseString(headers, headerNameToTagName.Key);
+
                 if (headerValue != null)
                 {
-                    tagsFromHeaders.Add(headerNameToTagName.Value, headerValue);
+                    yield return new KeyValuePair<string, string>(headerNameToTagName.Value, headerValue);
                 }
             }
-
-            return tagsFromHeaders;
         }
 
         private static ulong ParseUInt64<T>(T headers, string headerName)

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -25,11 +25,13 @@ namespace Datadog.Trace.Util
 
         public static string GetRelativeUrl(Uri uri, bool tryRemoveIds)
         {
+            return GetRelativeUrl(uri.AbsolutePath, tryRemoveIds);
+        }
+
+        public static string GetRelativeUrl(string uri, bool tryRemoveIds)
+        {
             // try to remove segments that look like ids
-            string path = tryRemoveIds
-                              ? CleanUriSegment(uri.AbsolutePath)
-                              : uri.AbsolutePath;
-            return path;
+            return tryRemoveIds ? CleanUriSegment(uri) : uri;
         }
 
         public static string CleanUriSegment(string absolutePath)

--- a/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Sampling;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Sampling
+{
+    public class DefaultSamplingRuleTests
+    {
+        [Theory]
+        // Value returned by the agent per default
+        [InlineData("service:,env:", "hello", "world", 1f)]
+        // Does not match
+        [InlineData("service:nope,env:nope", "hello", "world", 1f)]
+        // Nominal case
+        [InlineData("service:hello,env:world", "hello", "world", .5f)]
+        // Too many values
+        [InlineData("service:hello,env:world,xxxx", "hello", "world", 1f)]
+        // ':' in service name
+        [InlineData("service:hello:1,env:world", "hello:1", "world", .5f)]
+        // ':' in env name
+        [InlineData("service:hello,env:world:1", "hello", "world:1", .5f)]
+        public void KeyParsing(string key, string expectedService, string expectedEnv, float expectedRate)
+        {
+            var rule = new DefaultSamplingRule();
+
+            rule.SetDefaultSampleRates(new[] { new KeyValuePair<string, float>(key, .5f) });
+
+            var span = new Span(new SpanContext(1, 1, null, serviceName: expectedService), DateTimeOffset.Now);
+            span.SetTag(Tags.Env, expectedEnv);
+
+            var samplingRate = rule.GetSamplingRate(span);
+
+            Assert.Equal(expectedRate, samplingRate);
+        }
+    }
+}


### PR DESCRIPTION
- Do not call `ExtractHeaderTags` when no header tag has been set
- Use an enumerator instead of a dictionary in `ExtractHeaderTags`
- Add an overload to `GetRelativeUrl` to avoid useless Uri creation
- Cache the string representation of status code 200 (note: this optimization can probably be applied to other code paths, and possibly be extended to other common status codes)

Benchmark: calling `AspNetCoreDiagnosticObserver.OnHostingHttpRequestInStart`:

With no header tags set:

```
|            Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
| RequestStart_Old  | 4.196 us | 0.4813 us | 0.3183 us |  1.00 |    0.00 | 0.3433 | 0.1068 |     - |   2.12 KB |
| RequestStart_New  | 4.098 us | 0.5276 us | 0.3490 us |  0.98 |    0.07 | 0.2365 | 0.0763 |     - |   1.46 KB |

```

With header tags:

```
|            Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
| RequestStart_Old  | 5.406 us | 0.5658 us | 0.3743 us |  1.00 |    0.00 | 0.4730 | 0.1373 |     - |   2.94 KB |
| RequestStart_New  | 4.642 us | 0.5638 us | 0.3729 us |  0.86 |    0.02 | 0.3662 | 0.1068 |     - |   2.28 KB |

```

(note: the benchmarks include the optimization done in https://github.com/DataDog/dd-trace-dotnet/pull/902)