### PR TITLE
Optimize AspNetCoreDiagnosticObserver path

### DIFF
--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -22,9 +22,6 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public const int DefaultAgentPort = 8126;
 
-        private IDictionary<string, string> _headerTags;
-        private Func<bool> _headerTagsEmpty;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
         /// </summary>
@@ -247,23 +244,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets or sets the map of header keys to tag names, which are applied to the root <see cref="Span"/> of incoming requests.
         /// </summary>
-        public IDictionary<string, string> HeaderTags
-        {
-            get => _headerTags;
-            set
-            {
-                _headerTags = value;
-
-                if (value is ConcurrentDictionary<string, string> concurrentDictionary)
-                {
-                    _headerTagsEmpty = () => concurrentDictionary.IsEmpty;
-                }
-                else
-                {
-                    _headerTagsEmpty = () => value.Count == 0;
-                }
-            }
-        }
+        public IDictionary<string, string> HeaderTags { get; set; }
 
         /// <summary>
         /// Gets or sets the port where the DogStatsd server is listening for connections.
@@ -289,7 +270,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
 
-        internal bool HeaderTagsEmpty => _headerTagsEmpty();
+        internal bool HeaderTagsEmpty => HeaderTags is ConcurrentDictionary<string, string> concurrent ? concurrent.IsEmpty : HeaderTags.Count == 0;
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -270,8 +270,6 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
 
-        internal bool HeaderTagsEmpty => HeaderTags is ConcurrentDictionary<string, string> concurrent ? concurrent.IsEmpty : HeaderTags.Count == 0;
-
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources
         /// returned by <see cref="CreateDefaultConfigurationSource"/>.

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             var settings = tracer.Settings;
 
-            if (!settings.HeaderTagsEmpty)
+            if (!settings.HeaderTags.IsEmpty())
             {
                 try
                 {

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -166,7 +166,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
                 string url = GetUrl(request);
 
-                string resourceUrl = UriHelpers.GetRelativeUrl(new Uri(url), tryRemoveIds: true)
+                string resourceUrl = UriHelpers.GetRelativeUrl(url, tryRemoveIds: true)
                                                .ToLowerInvariant();
 
                 string resourceName = $"{httpMethod} {resourceUrl}";
@@ -230,7 +230,17 @@ namespace Datadog.Trace.DiagnosticListeners
             if (scope != null)
             {
                 var httpContext = HttpRequestInStopHttpContextFetcher.Fetch<HttpContext>(arg);
-                scope.Span.SetTag(Tags.HttpStatusCode, httpContext.Response.StatusCode.ToString());
+
+                var statusCode = httpContext.Response.StatusCode;
+
+                if (statusCode == 200)
+                {
+                    scope.Span.SetTag(Tags.HttpStatusCode, "200");
+                }
+                else
+                {
+                    scope.Span.SetTag(Tags.HttpStatusCode, httpContext.Response.StatusCode.ToString());
+                }
 
                 if (httpContext.Response.StatusCode / 100 == 5)
                 {

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -112,19 +112,24 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private static IEnumerable<KeyValuePair<string, string>> ExtractHeaderTags(HttpRequest request, IDatadogTracer tracer)
         {
-            try
-            {
-                // extract propagation details from http headers
-                var requestHeaders = request.Headers;
+            var settings = tracer.Settings;
 
-                if (requestHeaders != null)
-                {
-                    return SpanContextPropagator.Instance.ExtractHeaderTags(new HeadersCollectionAdapter(requestHeaders), tracer.Settings.HeaderTags);
-                }
-            }
-            catch (Exception ex)
+            if (!settings.HeaderTagsEmpty)
             {
-                Log.SafeLogError(ex, "Error extracting propagated HTTP headers.");
+                try
+                {
+                    // extract propagation details from http headers
+                    var requestHeaders = request.Headers;
+
+                    if (requestHeaders != null)
+                    {
+                        return SpanContextPropagator.Instance.ExtractHeaderTags(new HeadersCollectionAdapter(requestHeaders), settings.HeaderTags);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.SafeLogError(ex, "Error extracting propagated HTTP headers.");
+                }
             }
 
             return Enumerable.Empty<KeyValuePair<string, string>>();

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -166,7 +166,14 @@ namespace Datadog.Trace.DiagnosticListeners
                 string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
                 string url = GetUrl(request);
 
-                string resourceUrl = UriHelpers.GetRelativeUrl(url, tryRemoveIds: true)
+                string absolutePath = request.Path.Value;
+
+                if (request.PathBase.HasValue)
+                {
+                    absolutePath = request.PathBase.Value + absolutePath;
+                }
+
+                string resourceUrl = UriHelpers.GetRelativeUrl(absolutePath, tryRemoveIds: true)
                                                .ToLowerInvariant();
 
                 string resourceName = $"{httpMethod} {resourceUrl}";

--- a/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Datadog.Trace.ExtensionMethods
@@ -62,6 +63,16 @@ namespace Datadog.Trace.ExtensionMethods
                     value = default;
                     return false;
             }
+        }
+
+        public static bool IsEmpty<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+        {
+            if (dictionary is ConcurrentDictionary<TKey, TValue> concurrentDictionary)
+            {
+                return concurrentDictionary.IsEmpty;
+            }
+
+            return dictionary.Count == 0;
         }
     }
 }

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -92,18 +92,15 @@ namespace Datadog.Trace
         public IEnumerable<KeyValuePair<string, string>> ExtractHeaderTags<T>(T headers, IEnumerable<KeyValuePair<string, string>> headerToTagMap)
             where T : IHeadersCollection
         {
-            var tagsFromHeaders = new Dictionary<string, string>();
-
             foreach (KeyValuePair<string, string> headerNameToTagName in headerToTagMap)
             {
                 string headerValue = ParseString(headers, headerNameToTagName.Key);
+
                 if (headerValue != null)
                 {
-                    tagsFromHeaders.Add(headerNameToTagName.Value, headerValue);
+                    yield return new KeyValuePair<string, string>(headerNameToTagName.Value, headerValue);
                 }
             }
-
-            return tagsFromHeaders;
         }
 
         private static ulong ParseUInt64<T>(T headers, string headerName)

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -25,11 +25,13 @@ namespace Datadog.Trace.Util
 
         public static string GetRelativeUrl(Uri uri, bool tryRemoveIds)
         {
+            return GetRelativeUrl(uri.AbsolutePath, tryRemoveIds);
+        }
+
+        public static string GetRelativeUrl(string uri, bool tryRemoveIds)
+        {
             // try to remove segments that look like ids
-            string path = tryRemoveIds
-                              ? CleanUriSegment(uri.AbsolutePath)
-                              : uri.AbsolutePath;
-            return path;
+            return tryRemoveIds ? CleanUriSegment(uri) : uri;
         }
 
         public static string CleanUriSegment(string absolutePath)


### PR DESCRIPTION
- Do not call `ExtractHeaderTags` when no header tag has been set
- Use an enumerator instead of a dictionary in `ExtractHeaderTags`
- Add an overload to `GetRelativeUrl` to avoid useless Uri creation
- Cache the string representation of status code 200 (note: this optimization can probably be applied to other code paths, and possibly be extended to other common status codes)

Benchmark: calling `AspNetCoreDiagnosticObserver.OnHostingHttpRequestInStart`:

With no header tags set:

```
|            Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
| RequestStart_Old  | 4.196 us | 0.4813 us | 0.3183 us |  1.00 |    0.00 | 0.3433 | 0.1068 |     - |   2.12 KB |
| RequestStart_New  | 4.098 us | 0.5276 us | 0.3490 us |  0.98 |    0.07 | 0.2365 | 0.0763 |     - |   1.46 KB |

```

With header tags:

```
|            Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------------ |---------:|----------:|----------:|------:|--------:|-------:|-------:|------:|----------:|
| RequestStart_Old  | 5.406 us | 0.5658 us | 0.3743 us |  1.00 |    0.00 | 0.4730 | 0.1373 |     - |   2.94 KB |
| RequestStart_New  | 4.642 us | 0.5638 us | 0.3729 us |  0.86 |    0.02 | 0.3662 | 0.1068 |     - |   2.28 KB |

```

(note: the benchmarks include the optimization done in https://github.com/DataDog/dd-trace-dotnet/pull/902)