### PR TITLE
Do not use GitVersion in packages build pipeline

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -201,7 +201,7 @@ stages:
 
     - script: |
         INDEX_FILE=$(pwd)/s3_upload/index.txt
-        git branch --show-current >> $INDEX_FILE
+        echo $(Build.SourceBranch) | sed 's/refs\/heads\///g' >> $INDEX_FILE
         git rev-parse HEAD >> $INDEX_FILE
         pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
         git show -s --format='%ae' HEAD >> $INDEX_FILE

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -201,7 +201,7 @@ stages:
 
     - script: |
         INDEX_FILE=$(pwd)/s3_upload/index.txt
-        echo $(Build.SourceBranch) | sed 's/refs\/heads\///g' >> $INDEX_FILE
+        echo $(Build.SourceBranch) | sed 's/refs\/heads\///g' | sed 's/refs\/tags\//tags\//g' >> $INDEX_FILE
         git rev-parse HEAD >> $INDEX_FILE
         pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
         git show -s --format='%ae' HEAD >> $INDEX_FILE

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -201,7 +201,7 @@ stages:
 
     - script: |
         INDEX_FILE=$(pwd)/s3_upload/index.txt
-        git rev-parse --abbrev-ref HEAD >> $INDEX_FILE
+        git branch --show-current >> $INDEX_FILE
         git rev-parse HEAD >> $INDEX_FILE
         pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
         git show -s --format='%ae' HEAD >> $INDEX_FILE

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -206,7 +206,7 @@ stages:
 
     - script: |
         INDEX_FILE=$(pwd)/s3_upload/index.txt
-        echo $(GitVersion.BranchName) >> $INDEX_FILE
+        git rev-parse --abbrev-ref HEAD >> $INDEX_FILE
         echo $(GitVersion.Sha) >> $INDEX_FILE
         pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
         git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -175,11 +175,6 @@ stages:
       vmImage: ubuntu-18.04
 
     steps:
-    - task: GitVersion@5
-      displayName: GitVersion
-      inputs:
-        preferBundledVersion: false
-
     - download: current
       artifact: windows-msi
       patterns: '**/*x64.msi'
@@ -207,9 +202,9 @@ stages:
     - script: |
         INDEX_FILE=$(pwd)/s3_upload/index.txt
         git rev-parse --abbrev-ref HEAD >> $INDEX_FILE
-        echo $(GitVersion.Sha) >> $INDEX_FILE
+        git rev-parse HEAD >> $INDEX_FILE
         pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
-        git show -s --format='%ae' $(GitVersion.Sha) >> $INDEX_FILE
+        git show -s --format='%ae' HEAD >> $INDEX_FILE
         echo Generated index.txt file:
         cat $INDEX_FILE
       displayName: Write index.txt

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -199,6 +199,12 @@ stages:
         mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
       displayName: Rename deb package name to match MSI name
 
+    # Create index.txt file with the following format:
+    # BRANCH_NAME
+    # SHA
+    # ARTIFACT WILDCARD (datadog-dotnet-apm-vX.X.X-*)
+    # COMMIT AUTHOR
+    # Note: For the branch name, normalize 'refs/heads/<branch>' to '<branch>' and 'refs/tags/<tag_name>' to 'tags/<tag_name>'
     - script: |
         INDEX_FILE=$(pwd)/s3_upload/index.txt
         echo $(Build.SourceBranch) | sed 's/refs\/heads\///g' | sed 's/refs\/tags\//tags\//g' >> $INDEX_FILE


### PR DESCRIPTION
We only use GitVersion to print out a commit descriptor file index.txt for testing purposes, but we can do this without a third-party external Azure Pipelines task.

@DataDog/apm-dotnet