### PR TITLE
Changes test spans sampling priority

### DIFF
--- a/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -51,9 +51,8 @@ namespace Datadog.Trace.BenchmarkDotNet
                     Span span = tracer.StartSpan("benchmarkdotnet.test", startTime: startTime);
                     double durationNanoseconds = 0;
 
-                    span.SetMetric(Tags.Analytics, 1.0d);
-                    span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
-                    span.Type = "test";
+                    span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+                    span.Type = SpanTypes.Test;
                     span.ResourceName = $"{report.BenchmarkCase.Descriptor.Type.FullName}.{report.BenchmarkCase.Descriptor.WorkloadMethod.Name}";
                     CIEnvironmentValues.DecorateSpan(span);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -223,7 +223,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                         Span span = scope.Span;
 
                         span.Type = SpanTypes.Test;
-                        span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+                        span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                         span.ResourceName = $"{testSuite}.{testName}";
                         span.SetTag(TestTags.Suite, testSuite);
                         span.SetTag(TestTags.Name, testName);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -415,10 +415,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
 
                 scope = tracer.StartActive("xunit.test");
                 Span span = scope.Span;
-                span.SetMetric(Tags.Analytics, 1.0d);
 
                 span.Type = SpanTypes.Test;
-                span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+                span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                 span.ResourceName = $"{testSuite}.{testName}";
                 span.SetTag(TestTags.Suite, testSuite);
                 span.SetTag(TestTags.Name, testName);


### PR DESCRIPTION
Changes the UserKeep sampling priority (2) to AutoKeep (1) and removes the Analytics tags according to the CiApp specification.

@DataDog/apm-dotnet