### PR TITLE
Changes the span duration of a benchmark test to the mean duration.

### DIFF
--- a/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.BenchmarkDotNet
                             span.SetMetric("benchmark.statistics.p99", stats.Percentiles.Percentile(99));
                         }
 
-                        durationNanoseconds = stats.N * stats.Mean;
+                        durationNanoseconds = stats.Mean;
                     }
 
                     if (report.Metrics != null)


### PR DESCRIPTION
Changes the span duration of a benchmark test to the mean duration.

@DataDog/apm-dotnet