### PR TITLE
Remove usages of WebClient.IsBusy

### DIFF
--- a/samples/Samples.WebRequest/RequestHelpers.cs
+++ b/samples/Samples.WebRequest/RequestHelpers.cs
@@ -38,12 +38,10 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("DownloadDataAsync"))
                     {
-                        webClient.DownloadDataAsync(new Uri(url));
-                        while (webClient.IsBusy) ;
+                        webClient.DownloadDataAsyncAndWait(new Uri(url));
                         Console.WriteLine("Received response for client.DownloadDataAsync(Uri)");
 
-                        webClient.DownloadDataAsync(new Uri(url), null);
-                        while (webClient.IsBusy) ;
+                        webClient.DownloadDataAsyncAndWait(new Uri(url), null);
                         Console.WriteLine("Received response for client.DownloadDataAsync(Uri, Object)");
                     }
 
@@ -67,12 +65,10 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("DownloadFileAsync"))
                     {
-                        webClient.DownloadFileAsync(new Uri(url), "DownloadFileAsync.uri.txt");
-                        while (webClient.IsBusy) ;
+                        webClient.DownloadFileAsyncAndWait(new Uri(url), "DownloadFileAsync.uri.txt");
                         Console.WriteLine("Received response for client.DownloadFileAsync(Uri, String)");
 
-                        webClient.DownloadFileAsync(new Uri(url), "DownloadFileAsync.uri_token.txt", null);
-                        while (webClient.IsBusy) ;
+                        webClient.DownloadFileAsyncAndWait(new Uri(url), "DownloadFileAsync.uri_token.txt", null);
                         Console.WriteLine("Received response for client.DownloadFileAsync(Uri, String, Object)");
                     }
 
@@ -96,12 +92,10 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("DownloadStringAsync"))
                     {
-                        webClient.DownloadStringAsync(new Uri(url));
-                        while (webClient.IsBusy) ;
+                        webClient.DownloadStringAsyncAndWait(new Uri(url));
                         Console.WriteLine("Received response for client.DownloadStringAsync(Uri)");
 
-                        webClient.DownloadStringAsync(new Uri(url), null);
-                        while (webClient.IsBusy) ;
+                        webClient.DownloadStringAsyncAndWait(new Uri(url), null);
                         Console.WriteLine("Received response for client.DownloadStringAsync(Uri, Object)");
                     }
 
@@ -125,12 +119,10 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("OpenReadAsync"))
                     {
-                        webClient.OpenReadAsync(new Uri(url));
-                        while (webClient.IsBusy) ;
+                        webClient.OpenReadAsyncAndWait(new Uri(url));
                         Console.WriteLine("Received response for client.OpenReadAsync(Uri)");
 
-                        webClient.OpenReadAsync(new Uri(url), null);
-                        while (webClient.IsBusy) ;
+                        webClient.OpenReadAsyncAndWait(new Uri(url), null);
                         Console.WriteLine("Received response for client.OpenReadAsync(Uri, Object)");
                     }
 
@@ -160,16 +152,13 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("UploadDataAsync"))
                     {
-                        webClient.UploadDataAsync(new Uri(url), new byte[0]);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadDataAsyncAndWait(new Uri(url), new byte[0]);
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, Byte[])");
 
-                        webClient.UploadDataAsync(new Uri(url), "POST", new byte[0]);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadDataAsyncAndWait(new Uri(url), "POST", new byte[0]);
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, String, Byte[])");
 
-                        webClient.UploadDataAsync(new Uri(url), "POST", new byte[0], null);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadDataAsyncAndWait(new Uri(url), "POST", new byte[0], null);
                         Console.WriteLine("Received response for client.UploadDataAsync(Uri, String, Byte[], Object)");
                     }
 
@@ -207,16 +196,13 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("UploadFileAsync"))
                     {
-                        webClient.UploadFileAsync(new Uri(url), "UploadFile.txt");
-                        while (webClient.IsBusy) ;
+                        webClient.UploadFileAsyncAndWait(new Uri(url), "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String)");
 
-                        webClient.UploadFileAsync(new Uri(url), "POST", "UploadFile.txt");
-                        while (webClient.IsBusy) ;
+                        webClient.UploadFileAsyncAndWait(new Uri(url), "POST", "UploadFile.txt");
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String, String)");
 
-                        webClient.UploadFileAsync(new Uri(url), "POST", "UploadFile.txt", null);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadFileAsyncAndWait(new Uri(url), "POST", "UploadFile.txt", null);
                         Console.WriteLine("Received response for client.UploadFileAsync(Uri, String, String, Object)");
                     }
 
@@ -252,16 +238,13 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("UploadStringAsync"))
                     {
-                        webClient.UploadStringAsync(new Uri(url), requestContent);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadStringAsyncAndWait(new Uri(url), requestContent);
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String)");
 
-                        webClient.UploadStringAsync(new Uri(url), "POST", requestContent);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadStringAsyncAndWait(new Uri(url), "POST", requestContent);
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String, String)");
 
-                        webClient.UploadStringAsync(new Uri(url), "POST", requestContent, null);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadStringAsyncAndWait(new Uri(url), "POST", requestContent, null);
                         Console.WriteLine("Received response for client.UploadStringAsync(Uri, String, String, Object)");
                     }
 
@@ -298,16 +281,13 @@ namespace Samples.WebRequest
 
                     using (Tracer.Instance.StartActive("UploadValuesAsync"))
                     {
-                        webClient.UploadValuesAsync(new Uri(url), values);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadValuesAsyncAndWait(new Uri(url), values);
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, NameValueCollection)");
 
-                        webClient.UploadValuesAsync(new Uri(url), "POST", values);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadValuesAsyncAndWait(new Uri(url), "POST", values);
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, String, NameValueCollection)");
 
-                        webClient.UploadValuesAsync(new Uri(url), "POST", values, null);
-                        while (webClient.IsBusy) ;
+                        webClient.UploadValuesAsyncAndWait(new Uri(url), "POST", values, null);
                         Console.WriteLine("Received response for client.UploadValuesAsync(Uri, String, NameValueCollection, Object)");
                     }
 

--- a/samples/Samples.WebRequest/WebClientExtensions.cs
+++ b/samples/Samples.WebRequest/WebClientExtensions.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Specialized;
+using System.Net;
+using System.Threading;
+
+namespace Samples.WebRequest
+{
+    internal static class WebClientExtensions
+    {
+        public static void DownloadDataAsyncAndWait(this WebClient webClient, Uri uri)
+        {
+            DownloadDataAsyncAndWait(webClient, () => webClient.DownloadDataAsync(uri));
+        }
+
+        public static void DownloadDataAsyncAndWait(this WebClient webClient, Uri uri, object state)
+        {
+            DownloadDataAsyncAndWait(webClient, () => webClient.DownloadDataAsync(uri, state));
+        }
+
+        public static void DownloadFileAsyncAndWait(this WebClient webClient, Uri uri, string file)
+        {
+            DownloadFileAsyncAndWait(webClient, () => webClient.DownloadFileAsync(uri, file));
+        }
+
+        public static void DownloadFileAsyncAndWait(this WebClient webClient, Uri uri, string file, object state)
+        {
+            DownloadFileAsyncAndWait(webClient, () => webClient.DownloadFileAsync(uri, file, state));
+        }
+
+        public static void DownloadStringAsyncAndWait(this WebClient webClient, Uri uri)
+        {
+            DownloadStringAsyncAndWait(webClient, () => webClient.DownloadStringAsync(uri));
+        }
+
+        public static void DownloadStringAsyncAndWait(this WebClient webClient, Uri uri, object state)
+        {
+            DownloadStringAsyncAndWait(webClient, () => webClient.DownloadStringAsync(uri, state));
+        }
+
+        public static void OpenReadAsyncAndWait(this WebClient webClient, Uri uri)
+        {
+            OpenReadAsyncAndWait(webClient, () => webClient.OpenReadAsync(uri));
+        }
+
+        public static void OpenReadAsyncAndWait(this WebClient webClient, Uri uri, object state)
+        {
+            OpenReadAsyncAndWait(webClient, () => webClient.OpenReadAsync(uri, state));
+        }
+
+        public static void UploadDataAsyncAndWait(this WebClient webClient, Uri uri, byte[] data)
+        {
+            UploadDataAsyncAndWait(webClient, () => webClient.UploadDataAsync(uri, data));
+        }
+
+        public static void UploadDataAsyncAndWait(this WebClient webClient, Uri uri, string method, byte[] data)
+        {
+            UploadDataAsyncAndWait(webClient, () => webClient.UploadDataAsync(uri, method, data));
+        }
+
+        public static void UploadDataAsyncAndWait(this WebClient webClient, Uri uri, string method, byte[] data, object state)
+        {
+            UploadDataAsyncAndWait(webClient, () => webClient.UploadDataAsync(uri, method, data, state));
+        }
+
+        public static void UploadFileAsyncAndWait(this WebClient webClient, Uri uri, string file)
+        {
+            UploadFileAsyncAndWait(webClient, () => webClient.UploadFileAsync(uri, file));
+        }
+
+        public static void UploadFileAsyncAndWait(this WebClient webClient, Uri uri, string file, string method)
+        {
+            UploadFileAsyncAndWait(webClient, () => webClient.UploadFileAsync(uri, file, method));
+        }
+
+        public static void UploadFileAsyncAndWait(this WebClient webClient, Uri uri, string file, string method, object state)
+        {
+            UploadFileAsyncAndWait(webClient, () => webClient.UploadFileAsync(uri, file, method, state));
+        }
+
+        public static void UploadStringAsyncAndWait(this WebClient webClient, Uri uri, string data)
+        {
+            UploadStringAsyncAndWait(webClient, () => webClient.UploadStringAsync(uri, data));
+        }
+
+        public static void UploadStringAsyncAndWait(this WebClient webClient, Uri uri, string method, string data)
+        {
+            UploadStringAsyncAndWait(webClient, () => webClient.UploadStringAsync(uri, method, data));
+        }
+
+        public static void UploadStringAsyncAndWait(this WebClient webClient, Uri uri, string method, string data, object state)
+        {
+            UploadStringAsyncAndWait(webClient, () => webClient.UploadStringAsync(uri, method, data, state));
+        }
+
+        public static void UploadValuesAsyncAndWait(this WebClient webClient, Uri uri, NameValueCollection data)
+        {
+            UploadValuesAsyncAndWait(webClient, () => webClient.UploadValuesAsync(uri, data));
+        }
+
+        public static void UploadValuesAsyncAndWait(this WebClient webClient, Uri uri, string method, NameValueCollection data)
+        {
+            UploadValuesAsyncAndWait(webClient, () => webClient.UploadValuesAsync(uri, method, data));
+        }
+
+        public static void UploadValuesAsyncAndWait(this WebClient webClient, Uri uri, string method, NameValueCollection data, object state)
+        {
+            UploadValuesAsyncAndWait(webClient, () => webClient.UploadValuesAsync(uri, method, data, state));
+        }
+
+        private static void DownloadDataAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, DownloadDataCompletedEventArgs e)
+            {
+                webClient.DownloadDataCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.DownloadDataCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void DownloadFileAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, EventArgs e)
+            {
+                webClient.DownloadFileCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.DownloadFileCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void DownloadStringAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, DownloadStringCompletedEventArgs e)
+            {
+                webClient.DownloadStringCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.DownloadStringCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void OpenReadAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, OpenReadCompletedEventArgs e)
+            {
+                webClient.OpenReadCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.OpenReadCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void UploadDataAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, UploadDataCompletedEventArgs e)
+            {
+                webClient.UploadDataCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.UploadDataCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void UploadFileAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, UploadFileCompletedEventArgs e)
+            {
+                webClient.UploadFileCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.UploadFileCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void UploadStringAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, UploadStringCompletedEventArgs e)
+            {
+                webClient.UploadStringCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.UploadStringCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+
+        private static void UploadValuesAsyncAndWait(WebClient webClient, Action operation)
+        {
+            var mutex = new ManualResetEventSlim();
+
+            void Handler(object s, UploadValuesCompletedEventArgs e)
+            {
+                webClient.UploadValuesCompleted -= Handler;
+                mutex.Set();
+            }
+
+            webClient.UploadValuesCompleted += Handler;
+
+            operation();
+
+            mutex.Wait();
+        }
+    }
+}


### PR DESCRIPTION
Using `WebClient.IsBusy` the way we do is dangerous for at least two reasons:
 - It can cause an infinite loop after JITting if the property is inlined and the value cached in a register
 - There is a race condition in the logic behind the property: https://github.com/dotnet/runtime/issues/42013

This PR converts the code to uses events and a mutex.