### PR TITLE
Don't build samples in parallel

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -263,12 +263,19 @@ jobs:
       command: build
       projects: |
         reproductions/**/*.csproj
-        samples/**/*.csproj
         test/*.IntegrationTests/*.IntegrationTests.csproj
         !reproductions/**/ExpenseItDemo*.csproj
         !reproductions/**/EntityFramework6x*.csproj
         !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build samples
+    inputs:
+      command: build
+      projects: |
+        samples/**/*.csproj
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false
 
   - task: NuGetCommand@2
     displayName: nuget restore IIS samples


### PR DESCRIPTION
Building projects Samples.MultiDomainHost.* in parallel causes errors in the CI.

I did a previous tentative to disable parallel building (https://github.com/DataDog/dd-trace-dotnet/pull/883) but it didn't work. At that level, I can't disable the multiple target frameworks from being built in parallel. This time I'm setting the property at the parent level, on the `dotnet build` command.

To reduce the impact on compilation time, I introduced a separate task to build the samples.

