### PR TITLE
Split smoke tests into separate jobs

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -313,7 +313,7 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True" -p:Platform=$(buildPlatform)
+      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True&IIS!=True" -p:Platform=$(buildPlatform)
 
   - task: DockerCompose@0
     displayName: docker-compose stop services
@@ -442,7 +442,15 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True" -p:Platform=$(buildPlatform)
+      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True&IIS!=True" -p:Platform=$(buildPlatform)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test IIS
+    inputs:
+      command: test
+      configuration: $(buildConfiguration)
+      projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+      arguments: --filter "(IIS=True)" -p:Platform=$(buildPlatform)
 
   - task: DockerCompose@0
     displayName: docker-compose stop services

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -307,13 +307,22 @@ jobs:
         test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
       arguments: -p:Platform=$(buildPlatform)
 
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      configuration: $(buildConfiguration)
+      projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True" -p:Platform=$(buildPlatform)
+
   - task: DockerCompose@0
     displayName: docker-compose stop services
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: down
     condition: succeededOrFailed()
-- job: Windows_Smoke_tests
+    
+- job: Windows_IIS
   timeoutInMinutes: 80
   strategy:
     matrix:
@@ -420,14 +429,6 @@ jobs:
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: up -d IntegrationTests.IIS.LoaderOptimizationRegKey
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      configuration: $(buildConfiguration)
-      projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True" -p:Platform=$(buildPlatform)
 
   - powershell: |
       [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -297,6 +297,104 @@ jobs:
         samples/**/*.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false
 
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      configuration: $(buildConfiguration)
+      projects: |
+        test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+        test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+      arguments: -p:Platform=$(buildPlatform)
+
+  - task: DockerCompose@0
+    displayName: docker-compose stop services
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: down
+    condition: succeededOrFailed()
+- job: Windows_Smoke_tests
+  timeoutInMinutes: 80
+  strategy:
+    matrix:
+      x64:
+        buildPlatform: x64
+        enable32bit: false
+      x86:
+        buildPlatform: x86
+        enable32bit: true
+  pool:
+    vmImage: windows-2019
+  variables:
+    msiOutputDirectory: deploy/Datadog.Trace.ClrProfiler.WindowsInstaller/bin/$(buildConfiguration)/$(buildPlatform)/en-us
+
+  steps:
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 2.1
+    inputs:
+      packageType: sdk
+      version: 2.1.x
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 3.0
+    inputs:
+      packageType: sdk
+      version: 3.0.x
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 3.1
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdkVersion)
+
+  - task: NuGetToolInstaller@1
+    displayName: install nuget
+
+  - task: NuGetCommand@2
+    displayName: nuget restore
+    inputs:
+      restoreSolution: Datadog.Trace.sln
+      verbosityRestore: Normal
+
+  # this triggers a dependency chain that builds all the managed and native dlls
+  - task: MSBuild@1
+    displayName: msbuild tracer-home
+    inputs:
+      solution: Datadog.Trace.proj
+      platform: $(buildPlatform)
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:msi /p:RunWixToolsOutOfProc=true /p:TracerHomeDirectory=$(publishOutput)
+      maximumCpuCount: true
+
+  - task: MSBuild@1
+    displayName: Build .NET Framework projects (not SDK-based projects)
+    inputs:
+      solution: Datadog.Trace.proj
+      platform: $(buildPlatform)
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:BuildFrameworkReproductions
+      maximumCpuCount: true
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build integration tests
+    inputs:
+      command: build
+      projects: |
+        reproductions/**/*.csproj
+        test/*.IntegrationTests/*.IntegrationTests.csproj
+        !reproductions/**/ExpenseItDemo*.csproj
+        !reproductions/**/EntityFramework6x*.csproj
+        !reproductions/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build samples
+    inputs:
+      command: build
+      projects: |
+        samples/**/*.csproj
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false
+
   - task: NuGetCommand@2
     displayName: nuget restore IIS samples
     inputs:
@@ -322,16 +420,6 @@ jobs:
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: up -d IntegrationTests.IIS.LoaderOptimizationRegKey
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      configuration: $(buildConfiguration)
-      projects: |
-        test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
-        test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
-      arguments: -p:Platform=$(buildPlatform)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/LoaderOptimizationStartup.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/LoaderOptimizationStartup.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.IIS
 
         [Fact]
         [Trait("RunOnWindows", "True")]
+        [Trait("IIS", "True")]
         public async Task ApplicationDoesNotReturnErrors()
         {
             var intervalMilliseconds = 500;


### PR DESCRIPTION
`Windows_IIS` runs IIS tests and GAC. `Windows` runs everything else.

edit: added screenshot - Lucas
![image](https://user-images.githubusercontent.com/1851278/96287953-a9102380-0fb0-11eb-9d8e-408e6cefe6fb.png)
