### PR TITLE
Further adjustments to avoid netcoreapp2.1 profiler shudown bug in smoke tests

### DIFF
--- a/reproductions/AssemblyLoad.FileNotFoundException/Program.cs
+++ b/reproductions/AssemblyLoad.FileNotFoundException/Program.cs
@@ -8,12 +8,6 @@ namespace AssemblyLoad.FileNotFoundException
     {
         private static async Task<int> Main()
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 var baseAddress = new Uri("https://www.example.com/");
@@ -28,6 +22,12 @@ namespace AssemblyLoad.FileNotFoundException
                 Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return (int)ExitCode.Success;
         }

--- a/reproductions/AssemblyResolveMscorlibResources.InfiniteRecursionCrash/Program.cs
+++ b/reproductions/AssemblyResolveMscorlibResources.InfiniteRecursionCrash/Program.cs
@@ -11,12 +11,6 @@ namespace AssemblyResolveMscorlibResources.InfiniteRecursionCrash
     {
         public static int Main()
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             var ci = new CultureInfo("fr-FR");
             Thread.CurrentThread.CurrentUICulture = ci;
 
@@ -38,6 +32,14 @@ namespace AssemblyResolveMscorlibResources.InfiniteRecursionCrash
                 {
                     Console.WriteLine("The AssemblyResolve event didn't cause infinite recusion. The original System.IO.DirectoryNotFoundException exception was correctly thrown and caught.");
                     return (int)ExitCode.Success;
+                }
+                finally
+                {
+#if NETCOREAPP2_1
+                    // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+                    // This would cause a segmentation fault on .net core 2.x
+                    System.Threading.Thread.Sleep(5000);
+#endif
                 }
             }
 

--- a/reproductions/DataDogThreadTest/Program.cs
+++ b/reproductions/DataDogThreadTest/Program.cs
@@ -17,12 +17,6 @@ namespace DataDogThreadTest
 
         static int Main(string[] args)
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 InMemoryLog4NetLogger.Setup();
@@ -165,6 +159,12 @@ namespace DataDogThreadTest
                 Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return (int)ExitCode.Success;
         }

--- a/reproductions/EntityFramework6x.MdTokenLookupFailure/Program.cs
+++ b/reproductions/EntityFramework6x.MdTokenLookupFailure/Program.cs
@@ -12,12 +12,6 @@ namespace EntityFramework6x.MdTokenLookupFailure
     {
         static int Main(string[] args)
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 using (var ctx = new SchoolDbContextEntities())
@@ -114,6 +108,12 @@ namespace EntityFramework6x.MdTokenLookupFailure
                 Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return (int)ExitCode.Success;
         }

--- a/reproductions/HttpMessageHandler.StackOverflowException/Program.cs
+++ b/reproductions/HttpMessageHandler.StackOverflowException/Program.cs
@@ -11,12 +11,6 @@ namespace HttpMessageHandler.StackOverflowException
     {
         private static async Task<int> Main()
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
@@ -44,6 +38,12 @@ namespace HttpMessageHandler.StackOverflowException
                 Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return (int)ExitCode.Success;
         }

--- a/reproductions/Log4Net.SerializationException/Program.cs
+++ b/reproductions/Log4Net.SerializationException/Program.cs
@@ -10,12 +10,6 @@ namespace Log4Net.SerializationException
     {
         public static int Main(string[] args)
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             // The library we want to run was built and copied to the ApplicationFiles subdirectory
             // Create an AppDomain with that directory as the appBasePath
             var entryDirectory = Directory.GetParent(Assembly.GetEntryAssembly().Location);
@@ -38,6 +32,12 @@ namespace Log4Net.SerializationException
                 Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return (int)ExitCode.Success;
         }

--- a/reproductions/NLog10LogsInjection.NullReferenceException/Program.cs
+++ b/reproductions/NLog10LogsInjection.NullReferenceException/Program.cs
@@ -11,12 +11,6 @@ namespace NLog10LogsInjection.NullReferenceException
 
         static int Main(string[] args)
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             using (var scope = Tracer.Instance.StartActive("Main"))
             {
                 Logger.Info("Message during a trace.");
@@ -29,6 +23,13 @@ namespace NLog10LogsInjection.NullReferenceException
 
             Console.WriteLine("Successfully created a trace with two spans and didn't crash. Delay for five seconds to flush the trace.");
             Task.Delay(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             return 0;
         }
     }

--- a/reproductions/OrleansCrash/Program.cs
+++ b/reproductions/OrleansCrash/Program.cs
@@ -20,12 +20,6 @@ namespace OrleansCrash
     {
         public static int Main(string[] args)
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 var orleansTasks = new List<Task>();
@@ -100,6 +94,12 @@ namespace OrleansCrash
                 Console.Error.WriteLine(ex);
                 return -10;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return 0;
         }

--- a/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.LegacyProject/Program.cs
@@ -11,12 +11,6 @@ namespace StackExchange.Redis.AssemblyConflict.LegacyProject
     {
         public static async Task Main()
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 await RunTest();
@@ -36,6 +30,12 @@ namespace StackExchange.Redis.AssemblyConflict.LegacyProject
                 Console.WriteLine($"Sigil.dll path: {sigilAssemblyLocation}");
                 Console.WriteLine();
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
         }
 
         private static async Task RunTest()

--- a/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/reproductions/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -11,12 +11,6 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
     {
         public static async Task Main()
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 await RunTest();
@@ -36,6 +30,12 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
                 Console.WriteLine($"Sigil.dll path: {sigilAssemblyLocation}");
                 Console.WriteLine();
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
         }
 
         private static async Task RunTest()

--- a/reproductions/StackExchange.Redis.StackOverflowException/Program.cs
+++ b/reproductions/StackExchange.Redis.StackOverflowException/Program.cs
@@ -10,12 +10,6 @@ namespace StackExchange.Redis.StackOverflowException
     {
         private static async Task<int> Main()
         {
-#if NETCOREAPP2_1
-            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
-            // This would cause a segmentation fault on .net core 2.x
-            System.Threading.Thread.Sleep(5000);
-#endif
-
             try
             {
                 Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
@@ -51,6 +45,12 @@ namespace StackExchange.Redis.StackOverflowException
                 Console.Error.WriteLine(ex);
                 return (int)ExitCode.UnknownError;
             }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
 
             return (int)ExitCode.Success;
         }


### PR DESCRIPTION
Move the Thread.Sleep call to the end of the Main methods in the smoke tests to avoid netcoreapp2.1 profiler shutdown race condition.

@DataDog/apm-dotnet