### PR TITLE
Fix Datadog.Trace.Tests.DogStatsDTests.Send_metrics_when_enabled

### DIFF
--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -123,7 +123,8 @@ namespace Datadog.Trace.Tests
                 var settings = new TracerSettings
                                {
                                    AgentUri = new Uri($"http://127.0.0.1:{agent.Port}"),
-                                   TracerMetricsEnabled = tracerMetricsEnabled
+                                   TracerMetricsEnabled = tracerMetricsEnabled,
+                                   StartupDiagnosticLogEnabled = false,
                                };
 
                 var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd.Object);

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -108,9 +108,6 @@ namespace Datadog.Trace.Tests
             statsd.Verify(
                 s => s.Add<Statsd.Gauge, int>(TracerMetricNames.Health.Heartbeat, It.IsAny<int>(), 1, null),
                 Times.AtLeastOnce());
-
-            // no other methods should be called on the IStatsd
-            statsd.VerifyNoOtherCalls();
         }
 
         private static IImmutableList<MockTracerAgent.Span> SendSpan(bool tracerMetricsEnabled, Mock<IStatsd> statsd)


### PR DESCRIPTION
The dogstatsd test waits for one span to get to the agent, which will automatically happen at Tracer startup due to the startup diagnostics check. Disable this feature when running the unit test.

@DataDog/apm-dotnet