### PR TITLE
Make Datadog.Trace.Tests.AgentWriterTests.WriteTrace_2Traces_SendToApi more reliable

### DIFF
--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -32,12 +32,12 @@ namespace Datadog.Trace.Tests
             // TODO:bertrand it is too complicated to setup such a simple test
             var trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
 
             trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
         }
 

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -32,12 +32,12 @@ namespace Datadog.Trace.Tests
             // TODO:bertrand it is too complicated to setup such a simple test
             var trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(3)); // The default delay between flushing is 1 second but add 2 additional seconds for test reliability purposes
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
 
             trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(2));
+            await Task.Delay(TimeSpan.FromSeconds(3)); // The default delay between flushing is 1 second but add 2 additional seconds for test reliability purposes
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
         }
 

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -32,12 +32,12 @@ namespace Datadog.Trace.Tests
             // TODO:bertrand it is too complicated to setup such a simple test
             var trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(3)); // The default delay between flushing is 1 second but add 2 additional seconds for test reliability purposes
+            await Task.Delay(TimeSpan.FromSeconds(2));
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
 
             trace = new[] { new Span(_spanContext, start: null) };
             _agentWriter.WriteTrace(trace);
-            await Task.Delay(TimeSpan.FromSeconds(3)); // The default delay between flushing is 1 second but add 2 additional seconds for test reliability purposes
+            await Task.Delay(TimeSpan.FromSeconds(2));
             _api.Verify(x => x.SendTracesAsync(It.Is<Span[][]>(y => y.Single().Equals(trace))), Times.Once);
         }
 


### PR DESCRIPTION
Force a flush in Datadog.Trace.Tests.AgentWriterTests.WriteTrace_2Traces_SendToApi to make sure the trace is written to the API

@DataDog/apm-dotnet