### PR TITLE
Reverts the analytics tag removal

### DIFF
--- a/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -52,6 +52,7 @@ namespace Datadog.Trace.BenchmarkDotNet
                     Span span = tracer.StartSpan("benchmarkdotnet.test", startTime: startTime);
                     double durationNanoseconds = 0;
 
+                    span.SetMetric(Tags.Analytics, 1.0d);
                     span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                     span.Type = SpanTypes.Test;
                     span.ResourceName = $"{report.BenchmarkCase.Descriptor.Type.FullName}.{report.BenchmarkCase.Descriptor.WorkloadMethod.Name}";

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -223,6 +223,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                         Span span = scope.Span;
 
                         span.Type = SpanTypes.Test;
+                        span.SetMetric(Tags.Analytics, 1.0d);
                         span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                         span.ResourceName = $"{testSuite}.{testName}";
                         span.SetTag(TestTags.Suite, testSuite);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -417,6 +417,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 Span span = scope.Span;
 
                 span.Type = SpanTypes.Test;
+                span.SetMetric(Tags.Analytics, 1.0d);
                 span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                 span.ResourceName = $"{testSuite}.{testName}";
                 span.SetTag(TestTags.Suite, testSuite);

--- a/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -94,6 +94,7 @@ namespace Datadog.Trace.MSBuild
                 Log.Debug("Build Started");
 
                 _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
+                _buildSpan.SetMetric(Tags.Analytics, 1.0d);
                 _buildSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
                 _buildSpan.Type = SpanTypes.Build;


### PR DESCRIPTION
Reverts the analytics tag removal until the `Span.Type = Test` gets handled by the backend.

@DataDog/apm-dotnet