### PR TITLE
Fix security permission issue with CallContext and cross-AppDomain method calls

### DIFF
--- a/src/Datadog.Trace/DisposableObjectHandle.cs
+++ b/src/Datadog.Trace/DisposableObjectHandle.cs
@@ -8,7 +8,9 @@ namespace Datadog.Trace
     // objects stored in the CallContext until the host AppDomain
     // no longer needs them.
     // This issue was raised in the Serilog library here: https://github.com/serilog/serilog/issues/987
-    // This solution was borrowed from the corresponding fix in the following PR: https://github.com/serilog/serilog/pull/992
+    // This solution is a combination of the following items:
+    //   1) https://github.com/serilog/serilog/pull/992
+    //   2) https://github.com/serilog/serilog/issues/835#issuecomment-242944461
     internal sealed class DisposableObjectHandle : ObjectHandle, IDisposable
     {
         private bool _disposed;

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -450,6 +450,8 @@ namespace Datadog.Trace.Tests
             Assert.Equal(2, tracker.DisconnectCount);
         }
 
+        // Static class with static methods that are publicly accessible so new sandbox AppDomain does not need special
+        // Reflection permissions to run callback code.
         public static class AppDomainHelpers
         {
             // Ensure the remote call takes long enough for the lease manager poll to occur.

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -393,7 +393,7 @@ namespace Datadog.Trace.Tests
             {
                 using (_tracer.StartActive(operationName))
                 {
-                    remote.DoCallBack(SleepForLeaseManagerPollCallback);
+                    remote.DoCallBack(AppDomainHelpers.SleepForLeaseManagerPollCallback);
 
                     // After the lease expires, access the active scope
                     Scope scope = _tracer.ActiveScope;
@@ -427,11 +427,11 @@ namespace Datadog.Trace.Tests
             {
                 using (_tracer.StartActive("test-span"))
                 {
-                    remote.DoCallBack(EmptyCallback);
+                    remote.DoCallBack(AppDomainHelpers.EmptyCallback);
 
                     using (_tracer.StartActive("test-span-inner"))
                     {
-                        remote.DoCallBack(EmptyCallback);
+                        remote.DoCallBack(AppDomainHelpers.EmptyCallback);
                     }
                 }
             }
@@ -450,17 +450,16 @@ namespace Datadog.Trace.Tests
             Assert.Equal(2, tracker.DisconnectCount);
         }
 
-        // Ensure the remote call takes long enough for the lease manager poll to occur.
-        // Even though we reset LifetimeServices.LeaseManagerPollTime to a shorter duration,
-        // the default value is 10 seconds so the first poll may not be affected by our modification
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method is marked public so the cross AppDomain call can access the public method.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements must appear before instance elements", Justification = "This method is located logically next to the cross AppDomain calls.")]
-        public static void SleepForLeaseManagerPollCallback() => Thread.Sleep(TimeSpan.FromSeconds(12));
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "xUnit1013:Public method should be marked as test", Justification = "This method is marked public so the cross AppDomain call can access the public method.")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.OrderingRules", "SA1204:Static elements must appear before instance elements", Justification = "This method is located logically next to the cross AppDomain calls.")]
-        public static void EmptyCallback()
+        public static class AppDomainHelpers
         {
+            // Ensure the remote call takes long enough for the lease manager poll to occur.
+            // Even though we reset LifetimeServices.LeaseManagerPollTime to a shorter duration,
+            // the default value is 10 seconds so the first poll may not be affected by our modification
+            public static void SleepForLeaseManagerPollCallback() => Thread.Sleep(TimeSpan.FromSeconds(12));
+
+            public static void EmptyCallback()
+            {
+            }
         }
 
         private class InMemoryRemoteObjectTracker : ITrackingHandler


### PR DESCRIPTION
### Issue
The issue manifests under three conditions:
1. The user is running .NET Tracer 1.19.2 on .NET Framework
1. The `net45` Datadog .NET Tracer is used (default scenario), which stores the ambient `Active` scope inside the CallContext because there is no AsyncLocal<T> type
1. A method call is made into a new AppDomain without the `SecurityPermissionFlag.RemotingConfiguration` enabled

### Background
For net45 where AsyncLocal<T> is not a built-in Framework class, we must propagate the ambient context using LogicalCallContext. One consequence of this is that we invoke the System.Runtime.Remoting infrastructure, and if a remote method call or cross-AppDomain method call is made, objects stored inside the LogicalCallContext are transmitted to the other side (aka the "server").

For distributed garbage collection, the "server" uses leases / sponsors to keep track of what objects are needed by "clients" (our original AppDomain) and should not be garbage collected. If we do not refresh the lease on objects stored inside the LogicalCallContext, the "server" will garbage collect them and disconnect them, meaning any accesses of the object inside the LogicalCallContext will throw a RemotingException.

The previous solution for this problem was to create a wrapper object called `DisposableObjectHandle` (which is the object stored in the CallContext and transmitted to the "server") and let it manage its Lifetime with the Remoting infrastructure, which includes calling into the `base.InitializeLifetimeService()` method which is `SecurityCritical`. However, if execution flows into an AppDomain that does not have the `SecurityPermissionFlag.RemotingConfiguration` enabled, this will result in a SecurityException.

### Fix
Modify the `DisposableObjectHandle` wrapper to return `null` for its `InitializeLifetimeService()` method, which will keep the object alive indefinitely, and only remove the object from the "server" when the ambient `Active` scope in the originating AppDomain changes. This method call will not be invoked inside the locked-down AppDomain but instead in the application AppDomain where `Datadog.Trace` is loaded from the GAC.

@DataDog/apm-dotnet