### PR TITLE
Make Datadog.Trace.Tests.Sampling.RateLimiterTests.Limits_Approximately_To_Defaults more reliable

### DIFF
--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Limits_Approximately_To_Defaults()
         {
-            Run_Limit_Test(intervalLimit: null, numberPerBurst: 200, numberOfBursts: 18, millisecondsBetweenBursts: 247);
+            Run_Limit_Test(intervalLimit: null, numberPerBurst: 100, numberOfBursts: 18, millisecondsBetweenBursts: 247);
         }
 
         [Fact]


### PR DESCRIPTION
In Datadog.Trace.Tests.Sampling.RateLimiterTests.Limits_Approximately_To_Defaults, reduce the number of spans sent in each burst to unit-test rate limiter in a non-overloaded state.

The current unit test sends approximately 800 spans a second whereas the default threshold is 100 spans a second. In this scenario, the rate limiter is more aggressive than anticipated and leads to transient test failures. Instead, reduce the load to 400 spans a second.

@DataDog/apm-dotnet