### PR TITLE
fix compiler warning in sample project

### DIFF
--- a/samples/Samples.FakeAzureAppServices/Samples.FakeAzureAppServices.csproj
+++ b/samples/Samples.FakeAzureAppServices/Samples.FakeAzureAppServices.csproj
@@ -8,10 +8,6 @@
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
   <!--<ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <None Include="$(ProjectDir)$(OutputPath)Samples.FakeAzureAppServices.exe"
           CopyToOutputDirectory="Always"


### PR DESCRIPTION
remove assembly reference to `System.Net.Http` to fix compiler warning