### PR TITLE
add value of new setting to profiler log

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -22,6 +22,7 @@ namespace trace {
     environment::disabled_integrations,
     environment::clr_disable_optimizations,
     environment::domain_neutral_instrumentation,
+    environment::netstandard_enabled,
     environment::azure_app_services,
     environment::azure_app_services_app_pool_id,
     environment::azure_app_services_cli_telemetry_profile_value};


### PR DESCRIPTION
Add value of `DD_TRACE_NETSTANDARD_ENABLED` to profiler log.

Before:
```
[info] Datadog CLR Profiler 1.19.2 64-bit
[info] Environment variables:
[info]   DD_TRACE_ENABLED=
[info]   DD_TRACE_DEBUG=
[info]   DD_DUMP_ILREWRITE_ENABLED=
[info]   DD_DOTNET_TRACER_HOME=<...>\profiler-lib
[info]   DD_INTEGRATIONS=<...>\profiler-lib\integrations.json
[info]   DD_PROFILER_PROCESSES=
[info]   DD_PROFILER_EXCLUDE_PROCESSES=
[info]   DD_AGENT_HOST=
[info]   DD_TRACE_AGENT_PORT=
[info]   DD_ENV=lucas.pimentel
[info]   DD_SERVICE=
[info]   DD_VERSION=1.0.0
[info]   DD_DISABLED_INTEGRATIONS=
[info]   DD_CLR_DISABLE_OPTIMIZATIONS=
[info]   DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION=
[info]   DD_AZURE_APP_SERVICES=
[info]   APP_POOL_ID=
[info]   DOTNET_CLI_TELEMETRY_PROFILE=
[info] Profiler attached.
```

After:
```
[info] Datadog CLR Profiler 1.19.2 64-bit
[info] Environment variables:
[info]   DD_TRACE_ENABLED=
[info]   DD_TRACE_DEBUG=
[info]   DD_DUMP_ILREWRITE_ENABLED=
[info]   DD_DOTNET_TRACER_HOME=<...>\profiler-lib
[info]   DD_INTEGRATIONS=<...>\profiler-lib\integrations.json
[info]   DD_PROFILER_PROCESSES=
[info]   DD_PROFILER_EXCLUDE_PROCESSES=
[info]   DD_AGENT_HOST=
[info]   DD_TRACE_AGENT_PORT=
[info]   DD_ENV=lucas.pimentel
[info]   DD_SERVICE=
[info]   DD_VERSION=1.0.0
[info]   DD_DISABLED_INTEGRATIONS=
[info]   DD_CLR_DISABLE_OPTIMIZATIONS=
[info]   DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION=
[info]   DD_TRACE_NETSTANDARD_ENABLED=                 <----- not set
[info]   DD_AZURE_APP_SERVICES=
[info]   APP_POOL_ID=
[info]   DOTNET_CLI_TELEMETRY_PROFILE=
[info] Profiler attached.
```