### PR TITLE
Tail logs only once in Linux integration tests

### DIFF
--- a/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -3,13 +3,13 @@ set -euxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../
 
-docker/with-profiler-logs.bash \
+docker/with-profiler.bash \
     dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
 
-docker/with-profiler-logs.bash \
+docker/with-profiler.bash \
     dotnet vstest test/Datadog.Trace.OpenTracing.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.OpenTracing.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.OpenTracing.IntegrationTests/results
 
-docker/with-profiler-logs.bash \
+docker/with-profiler.bash \
     wait-for-it servicestackredis:6379 -- \
     wait-for-it stackexchangeredis:6379 -- \
     wait-for-it elasticsearch6:9200 -- \

--- a/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -10,18 +10,15 @@ tail -f /var/log/datadog/dotnet/dotnet-profiler.log | awk '
   /warn/ {print "\033[31m" $0 "\033[39m"}
 ' &
 
-docker/with-profiler-logs.bash \
-    dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
+dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
 
-docker/with-profiler-logs.bash \
-    dotnet vstest test/Datadog.Trace.OpenTracing.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.OpenTracing.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.OpenTracing.IntegrationTests/results
+dotnet vstest test/Datadog.Trace.OpenTracing.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.OpenTracing.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.OpenTracing.IntegrationTests/results
 
-docker/with-profiler-logs.bash \
-    wait-for-it servicestackredis:6379 -- \
-    wait-for-it stackexchangeredis:6379 -- \
-    wait-for-it elasticsearch6:9200 -- \
-    wait-for-it elasticsearch5:9200 -- \
-    wait-for-it sqlserver:1433 -- \
-    wait-for-it mongo:27017 -- \
-    wait-for-it postgres:5432 -- \
-    dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results
+wait-for-it servicestackredis:6379 -- \
+wait-for-it stackexchangeredis:6379 -- \
+wait-for-it elasticsearch6:9200 -- \
+wait-for-it elasticsearch5:9200 -- \
+wait-for-it sqlserver:1433 -- \
+wait-for-it mongo:27017 -- \
+wait-for-it postgres:5432 -- \
+dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results

--- a/docker/with-profiler-logs.bash
+++ b/docker/with-profiler-logs.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
 set -euxo pipefail
 
+mkdir -p /var/log/datadog/dotnet
+touch /var/log/datadog/dotnet/dotnet-profiler.log
+tail -f /var/log/datadog/dotnet/dotnet-profiler.log | awk '
+  /info/ {print "\033[32m" $0 "\033[39m"}
+  /warn/ {print "\033[31m" $0 "\033[39m"}
+' &
+
 eval "$@"

--- a/docker/with-profiler-logs.bash
+++ b/docker/with-profiler-logs.bash
@@ -1,11 +1,4 @@
 #!/bin/bash
 set -euxo pipefail
 
-mkdir -p /var/log/datadog/dotnet
-touch /var/log/datadog/dotnet/dotnet-profiler.log
-tail -f /var/log/datadog/dotnet/dotnet-profiler.log | awk '
-  /info/ {print "\033[32m" $0 "\033[39m"}
-  /warn/ {print "\033[31m" $0 "\033[39m"}
-' &
-
 eval "$@"


### PR DESCRIPTION
Previously, we were calling tail three times, and getting duplicated output from the logs. For unknown reason, it has started causing trouble with the CI.