### PR TITLE
Ci App - unit tests dogfooding

### DIFF
--- a/.azure-pipelines/setup_tracer.ps1
+++ b/.azure-pipelines/setup_tracer.ps1
@@ -1,0 +1,76 @@
+$ProgressPreference = 'SilentlyContinue'
+
+echo "Getting latest release version"
+# Get the latest release tag from the github release page
+$release_version = (Invoke-WebRequest https://api.github.com/repos/datadog/dd-trace-dotnet/releases | ConvertFrom-Json)[0].tag_name.SubString(1)
+
+$dd_tracer_workingfolder = $env:DD_TRACER_WORKINGFOLDER
+$dd_tracer_home = ""
+$dd_tracer_msbuild = ""
+$dd_tracer_integrations = ""
+$dd_tracer_profiler_32 = ""
+$dd_tracer_profiler_64 = ""
+
+
+# Download the binary file depending of the current operating system and extract the content to the "release" folder 
+echo "Downloading tracer v$release_version"
+if ($env:os -eq "Windows_NT") 
+{
+    $url = "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$($release_version)/windows-tracer-home.zip"
+
+    Invoke-WebRequest -Uri $url -OutFile windows.zip
+    echo "Extracting windows.zip"
+    Expand-Archive windows.zip -DestinationPath .\release
+    Remove-Item windows.zip
+
+    if ([string]::IsNullOrEmpty($dd_tracer_workingfolder)) {
+        $dd_tracer_home = "$(pwd)\release"
+    } else {
+        $dd_tracer_home = "$dd_tracer_workingfolder\release"
+    }
+
+    $dd_tracer_msbuild = "$dd_tracer_home\netstandard2.0\Datadog.Trace.MSBuild.dll"
+    $dd_tracer_integrations = "$dd_tracer_home\integrations.json"
+    $dd_tracer_profiler_32 = "$dd_tracer_home\win-x86\Datadog.Trace.ClrProfiler.Native.dll"
+    $dd_tracer_profiler_64 = "$dd_tracer_home\win-x64\Datadog.Trace.ClrProfiler.Native.dll"
+} 
+else 
+{
+    $url = "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$($release_version)/datadog-dotnet-apm-$($release_version).tar.gz"
+
+    Invoke-WebRequest -Uri $url -OutFile linux.tar.gz
+    mkdir release
+    echo "Extracting linux.tar.gz"
+    tar -xvzf linux.tar.gz -C ./release
+    Remove-Item linux.tar.gz
+    
+    if ([string]::IsNullOrEmpty($dd_tracer_workingfolder)) {
+        $dd_tracer_home = "$(pwd)/release"
+    } else {
+        $dd_tracer_home = "$dd_tracer_workingfolder/release"
+    }
+
+    $dd_tracer_msbuild = "$dd_tracer_home/netstandard2.0/Datadog.Trace.MSBuild.dll"
+    $dd_tracer_integrations = "$dd_tracer_home/integrations.json"
+    $dd_tracer_profiler_64 = "$dd_tracer_home/Datadog.Trace.ClrProfiler.Native.so"
+}
+
+# Set all environment variables to attach the profiler to the following pipeline steps
+echo "Setting environment variables..."
+
+echo "##vso[task.setvariable variable=DD_ENV]CI"
+echo "##vso[task.setvariable variable=DD_DOTNET_TRACER_HOME]$dd_tracer_home"
+echo "##vso[task.setvariable variable=DD_DOTNET_TRACER_MSBUILD]$dd_tracer_msbuild"
+echo "##vso[task.setvariable variable=DD_INTEGRATIONS]$dd_tracer_integrations"
+
+echo "##vso[task.setvariable variable=CORECLR_ENABLE_PROFILING]1"
+echo "##vso[task.setvariable variable=CORECLR_PROFILER]{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+echo "##vso[task.setvariable variable=CORECLR_PROFILER_PATH_32]$dd_tracer_profiler_32"
+echo "##vso[task.setvariable variable=CORECLR_PROFILER_PATH_64]$dd_tracer_profiler_64"
+
+echo "##vso[task.setvariable variable=COR_ENABLE_PROFILING]1"
+echo "##vso[task.setvariable variable=COR_PROFILER]{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+echo "##vso[task.setvariable variable=COR_PROFILER_PATH_32]$dd_tracer_profiler_32"
+echo "##vso[task.setvariable variable=COR_PROFILER_PATH_64]$dd_tracer_profiler_64"
+
+echo "Done."

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -12,6 +12,26 @@ trigger:
 variables:
   buildConfiguration: Debug
   dotnetCoreSdkVersion: 3.1.107
+  ddApiKey: $(DD_API_KEY)
+  DD_DOTNET_TRACER_MSBUILD:
+
+# Declare the datadog agent as a resource to be used as a pipeline service
+resources:
+  containers:
+  - container: dd_agent_dev_windows
+    image: datadog/agent-dev:olivielpeau-ci-container-defaults-py3-win1809
+    ports:
+    - 8126:8126
+    env:
+      DD_API_KEY: $(ddApiKey)
+      DD_INSIDE_CI: true
+  - container: dd_agent_dev_linux
+    image: datadog/agent-dev:olivielpeau-ci-container-defaults-py3
+    ports:
+    - 8126:8126
+    env:
+      DD_API_KEY: $(ddApiKey)
+      DD_INSIDE_CI: true
 
 jobs:
 
@@ -20,12 +40,26 @@ jobs:
     matrix:
       windows:
         imageName: windows-2019
+        serviceName: dd_agent_dev_windows
       linux:
         imageName: ubuntu-18.04
+        serviceName: dd_agent_dev_linux
   pool:
     vmImage: $(imageName)
 
+  # Enable the Datadog Agent service for this job
+  services:
+    dd_agent: $[ variables['serviceName'] ]
+
   steps:
+
+  # Install the tracer latest stable release to attach the profiler to the build and test steps.
+  # The script exposes the required environment variables to the following steps
+  - task: PowerShell@2
+    displayName: Install profiler latest release
+    inputs:
+      filePath: ./.azure-pipelines/setup_tracer.ps1
+
   - task: UseDotNet@2
     displayName: install dotnet core runtime 2.1
     inputs:
@@ -49,10 +83,13 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
+      arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj
         benchmarks/**/*.csproj
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -60,6 +97,8 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet
 
 - job: native_windows
   strategy:

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -156,8 +156,10 @@ jobs:
       solution: Datadog.Trace.proj
       platform: $(buildPlatform)
       configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp;BuildCppTests
+      msbuildArguments: /t:BuildCpp;BuildCppTests /l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       maximumCpuCount: true
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet-native
 
   - script: Datadog.Trace.ClrProfiler.Native.Tests.exe --gtest_output=xml
     displayName: run tests

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -110,7 +110,18 @@ jobs:
   pool:
     vmImage: windows-2019
 
+  # Enable the Datadog Agent service for this job
+  services:
+    dd_agent: dd_agent_dev_windows
+
   steps:
+
+  # Install the tracer latest stable release to attach the profiler to the build and test steps.
+  # The script exposes the required environment variables to the following steps
+  - task: PowerShell@2
+    displayName: Install profiler latest release
+    inputs:
+      filePath: ./.azure-pipelines/setup_tracer.ps1
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 3.1
@@ -126,6 +137,9 @@ jobs:
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
         sample-libs/**/Samples.ExampleLibrary*.csproj
+      arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet-native
 
   - task: NuGetToolInstaller@1
     displayName: install nuget

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -244,6 +244,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".azure-pipelines", ".azure-
 		.azure-pipelines\benchmarks.yml = .azure-pipelines\benchmarks.yml
 		.azure-pipelines\integration-tests.yml = .azure-pipelines\integration-tests.yml
 		.azure-pipelines\packages.yml = .azure-pipelines\packages.yml
+		.azure-pipelines\setup_tracer.ps1 = .azure-pipelines\setup_tracer.ps1
 		.azure-pipelines\unit-tests.yml = .azure-pipelines\unit-tests.yml
 	EndProjectSection
 EndProject

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -241,6 +241,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docker", "docker", "{6ABAD0
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".azure-pipelines", ".azure-pipelines", "{C52D6695-4E05-4930-88F8-0EFF8056A967}"
 	ProjectSection(SolutionItems) = preProject
+		.azure-pipelines\benchmarks.yml = .azure-pipelines\benchmarks.yml
 		.azure-pipelines\integration-tests.yml = .azure-pipelines\integration-tests.yml
 		.azure-pipelines\packages.yml = .azure-pipelines\packages.yml
 		.azure-pipelines\unit-tests.yml = .azure-pipelines\unit-tests.yml

--- a/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Reflection;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using Moq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Datadog.Trace.Tests
 {
+    [CollectionDefinition(nameof(CorrelationIdentifierTests), DisableParallelization = true)]
+    [TracerRestorer]
     public class CorrelationIdentifierTests
     {
         [Fact]
@@ -97,6 +101,24 @@ namespace Datadog.Trace.Tests
             }
 
             Assert.Equal(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
+        }
+
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+        private class TracerRestorerAttribute : BeforeAfterTestAttribute
+        {
+            private Tracer _tracer;
+
+            public override void Before(MethodInfo methodUnderTest)
+            {
+                _tracer = Tracer.Instance;
+                base.Before(methodUnderTest);
+            }
+
+            public override void After(MethodInfo methodUnderTest)
+            {
+                Tracer.Instance = _tracer;
+                base.After(methodUnderTest);
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace.Tests
             Assert.Equal(CorrelationIdentifier.Service, Tracer.Instance.DefaultServiceName);
         }
 
-        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+        [AttributeUsage(AttributeTargets.Class, Inherited = true)]
         private class TracerRestorerAttribute : BeforeAfterTestAttribute
         {
             private Tracer _tracer;

--- a/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
+++ b/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
@@ -2,11 +2,15 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Datadog.Trace.PlatformHelpers;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Datadog.Trace.Tests.PlatformHelpers
 {
+    [CollectionDefinition(nameof(AzureAppServicesMetadataTests), DisableParallelization = true)]
+    [AzureAppServicesRestorer]
     public class AzureAppServicesMetadataTests
     {
         private static readonly List<string> EnvVars = new List<string>()
@@ -130,6 +134,24 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             vars.Add(AzureAppServices.ResourceGroupKey, siteResourceGroup);
             vars.Add(AzureAppServices.SiteNameKey, deploymentId);
             return vars;
+        }
+
+        [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+        private class AzureAppServicesRestorerAttribute : BeforeAfterTestAttribute
+        {
+            private AzureAppServices _metadata;
+
+            public override void Before(MethodInfo methodUnderTest)
+            {
+                _metadata = AzureAppServices.Metadata;
+                base.Before(methodUnderTest);
+            }
+
+            public override void After(MethodInfo methodUnderTest)
+            {
+                AzureAppServices.Metadata = _metadata;
+                base.After(methodUnderTest);
+            }
         }
     }
 }


### PR DESCRIPTION
This `PR` adds ci tracer dogfooding for tracer and native profiler builds and unit tests.

- Adds missing benchmark pipeline to the complete project solution.
- Adds the agent, the msbuild logger and the tracer to the test process to the unit test pipeline.
- Changes `CorrelationIdentifierTests` and `AzureAppServicesMetadataTests` to be run sequentially after the parallel tests, also to restore the changes made by a single test so doesn't change the behavior of other tests. 


@DataDog/apm-dotnet