### PR TITLE
Fixes the truncated branch name on azure pipelines.

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/CIEnvironmentValues.cs
+++ b/src/Datadog.Trace.Ci.Shared/CIEnvironmentValues.cs
@@ -210,11 +210,11 @@ namespace Datadog.Trace.Ci
             Commit = !string.IsNullOrWhiteSpace(prCommit) ? prCommit : EnvironmentHelpers.GetEnvironmentVariable("BUILD_SOURCEVERSION");
 
             string prBranch = EnvironmentHelpers.GetEnvironmentVariable("SYSTEM_PULLREQUEST_SOURCEBRANCH");
-            Branch = !string.IsNullOrWhiteSpace(prBranch) ? prBranch : EnvironmentHelpers.GetEnvironmentVariable("BUILD_SOURCEBRANCHNAME");
+            Branch = !string.IsNullOrWhiteSpace(prBranch) ? prBranch : EnvironmentHelpers.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
 
             if (string.IsNullOrWhiteSpace(Branch))
             {
-                Branch = EnvironmentHelpers.GetEnvironmentVariable("BUILD_SOURCEBRANCH");
+                Branch = EnvironmentHelpers.GetEnvironmentVariable("BUILD_SOURCEBRANCHNAME");
             }
         }
 


### PR DESCRIPTION
This `PR` fixes: https://github.com/Microsoft/azure-pipelines-agent/issues/1631

@DataDog/apm-dotnet