### PR TITLE
Fix InvalidProgramException when instrumenting a constrained virtual method call

### DIFF
--- a/devenv.bat
+++ b/devenv.bat
@@ -48,7 +48,7 @@ SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 SET CORECLR_PROFILER_PATH=%~dp0\src\Datadog.Trace.ClrProfiler.Native\bin\%profiler_configuration%\%profiler_platform%\Datadog.Trace.ClrProfiler.Native.dll
 
 rem Don't attach the profiler to these processes
-SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;ServiceHub.TestWindowStoreHost.exe;ServiceHub.DataWarehouseHost.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe
+SET DD_PROFILER_EXCLUDE_PROCESSES=devenv.exe;Microsoft.ServiceHub.Controller.exe;ServiceHub.Host.CLR.exe;ServiceHub.TestWindowStoreHost.exe;ServiceHub.DataWarehouseHost.exe;sqlservr.exe;VBCSCompiler.exe;iisexpresstray.exe;msvsmon.exe;PerfWatson2.exe;ServiceHub.IdentityHost.exe;ServiceHub.VSDetouredHost.exe;ServiceHub.SettingsHost.exe;ServiceHub.Host.CLR.x86.exe;vstest.console.exe;ServiceHub.RoslynCodeAnalysisService32.exe;testhost.x86.exe;MSBuild.exe;ServiceHub.ThreadedWaitDialog.exe
 
 rem Set dotnet tracer home path
 SET DD_DOTNET_TRACER_HOME=%~dp0

--- a/sample-libs/Samples.DatabaseHelper.netstandard/DbCommandNetStandardInterfaceExecutor.cs
+++ b/sample-libs/Samples.DatabaseHelper.netstandard/DbCommandNetStandardInterfaceExecutor.cs
@@ -4,40 +4,40 @@ using System.Threading.Tasks;
 
 namespace Samples.DatabaseHelper
 {
-    public class DbCommandNetStandardInterfaceExecutor : IDbCommandExecutor
+    public class DbCommandNetStandardInterfaceExecutor : DbCommandExecutor<IDbCommand>
     {
-        public string CommandTypeName => nameof(IDbCommand) + "-netstandard";
+        public override string CommandTypeName => nameof(IDbCommand) + "-netstandard";
 
-        public bool SupportsAsyncMethods => false;
+        public override bool SupportsAsyncMethods => false;
 
-        public void ExecuteNonQuery(IDbCommand command) => command.ExecuteNonQuery();
+        public override void ExecuteNonQuery(IDbCommand command) => command.ExecuteNonQuery();
 
-        public Task ExecuteNonQueryAsync(IDbCommand command) => Task.CompletedTask;
+        public override Task ExecuteNonQueryAsync(IDbCommand command) => Task.CompletedTask;
 
-        public Task ExecuteNonQueryAsync(IDbCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override Task ExecuteNonQueryAsync(IDbCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public void ExecuteScalar(IDbCommand command) => command.ExecuteScalar();
+        public override void ExecuteScalar(IDbCommand command) => command.ExecuteScalar();
 
-        public Task ExecuteScalarAsync(IDbCommand command) => Task.CompletedTask;
+        public override Task ExecuteScalarAsync(IDbCommand command) => Task.CompletedTask;
 
-        public Task ExecuteScalarAsync(IDbCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override Task ExecuteScalarAsync(IDbCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public void ExecuteReader(IDbCommand command)
+        public override void ExecuteReader(IDbCommand command)
         {
             using IDataReader reader = command.ExecuteReader();
         }
 
-        public void ExecuteReader(IDbCommand command, CommandBehavior behavior)
+        public override void ExecuteReader(IDbCommand command, CommandBehavior behavior)
         {
             using IDataReader reader = command.ExecuteReader(behavior);
         }
 
-        public Task ExecuteReaderAsync(IDbCommand command) => Task.CompletedTask;
+        public override Task ExecuteReaderAsync(IDbCommand command) => Task.CompletedTask;
 
-        public Task ExecuteReaderAsync(IDbCommand command, CommandBehavior behavior) => Task.CompletedTask;
+        public override Task ExecuteReaderAsync(IDbCommand command, CommandBehavior behavior) => Task.CompletedTask;
 
-        public Task ExecuteReaderAsync(IDbCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override Task ExecuteReaderAsync(IDbCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
 
-        public Task ExecuteReaderAsync(IDbCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => Task.CompletedTask;
+        public override Task ExecuteReaderAsync(IDbCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => Task.CompletedTask;
     }
 }

--- a/sample-libs/Samples.DatabaseHelper.netstandard/DbCommandNetStandardInterfaceGenericExecutor.cs
+++ b/sample-libs/Samples.DatabaseHelper.netstandard/DbCommandNetStandardInterfaceGenericExecutor.cs
@@ -7,7 +7,7 @@ namespace Samples.DatabaseHelper
     public class DbCommandNetStandardInterfaceGenericExecutor<TCommand> : DbCommandExecutor<TCommand>
         where TCommand : IDbCommand
     {
-        public override string CommandTypeName => nameof(IDbCommand) + "-netstandard";
+        public override string CommandTypeName => "IDbCommandGenericConstraint<" + typeof(TCommand).Name + ">-netstandard";
 
         public override bool SupportsAsyncMethods => false;
 

--- a/sample-libs/Samples.DatabaseHelper.netstandard/DbCommandNetStandardInterfaceGenericExecutor.cs
+++ b/sample-libs/Samples.DatabaseHelper.netstandard/DbCommandNetStandardInterfaceGenericExecutor.cs
@@ -1,0 +1,44 @@
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.DatabaseHelper
+{
+    public class DbCommandNetStandardInterfaceGenericExecutor<TCommand> : DbCommandExecutor<TCommand>
+        where TCommand : IDbCommand
+    {
+        public override string CommandTypeName => nameof(IDbCommand) + "-netstandard";
+
+        public override bool SupportsAsyncMethods => false;
+
+        public override void ExecuteNonQuery(TCommand command) => command.ExecuteNonQuery();
+
+        public override Task ExecuteNonQueryAsync(TCommand command) => Task.CompletedTask;
+
+        public override Task ExecuteNonQueryAsync(TCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override void ExecuteScalar(TCommand command) => command.ExecuteScalar();
+
+        public override Task ExecuteScalarAsync(TCommand command) => Task.CompletedTask;
+
+        public override Task ExecuteScalarAsync(TCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override void ExecuteReader(TCommand command)
+        {
+            using IDataReader reader = command.ExecuteReader();
+        }
+
+        public override void ExecuteReader(TCommand command, CommandBehavior behavior)
+        {
+            using IDataReader reader = command.ExecuteReader(behavior);
+        }
+
+        public override Task ExecuteReaderAsync(TCommand command) => Task.CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CommandBehavior behavior) => Task.CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+}

--- a/sample-libs/Samples.DatabaseHelper/DbCommandInterfaceGenericExecutor.cs
+++ b/sample-libs/Samples.DatabaseHelper/DbCommandInterfaceGenericExecutor.cs
@@ -9,7 +9,7 @@ namespace Samples.DatabaseHelper
     {
         private static readonly Task CompletedTask = Task.FromResult(0);
 
-        public override string CommandTypeName => nameof(IDbCommand);
+        public override string CommandTypeName => "IDbCommandGenericConstraint<" + typeof(TCommand).Name + ">";
 
         public override bool SupportsAsyncMethods => false;
 

--- a/sample-libs/Samples.DatabaseHelper/DbCommandInterfaceGenericExecutor.cs
+++ b/sample-libs/Samples.DatabaseHelper/DbCommandInterfaceGenericExecutor.cs
@@ -1,0 +1,46 @@
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.DatabaseHelper
+{
+    public class DbCommandInterfaceGenericExecutor<TCommand> : DbCommandExecutor<TCommand>
+        where TCommand : IDbCommand
+    {
+        private static readonly Task CompletedTask = Task.FromResult(0);
+
+        public override string CommandTypeName => nameof(IDbCommand);
+
+        public override bool SupportsAsyncMethods => false;
+
+        public override void ExecuteNonQuery(TCommand command) => command.ExecuteNonQuery();
+
+        public override Task ExecuteNonQueryAsync(TCommand command) => CompletedTask;
+
+        public override Task ExecuteNonQueryAsync(TCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteScalar(TCommand command) => command.ExecuteScalar();
+
+        public override Task ExecuteScalarAsync(TCommand command) => CompletedTask;
+
+        public override Task ExecuteScalarAsync(TCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteReader(TCommand command)
+        {
+            using IDataReader reader = command.ExecuteReader();
+        }
+
+        public override void ExecuteReader(TCommand command, CommandBehavior behavior)
+        {
+            using IDataReader reader = command.ExecuteReader(behavior);
+        }
+
+        public override Task ExecuteReaderAsync(TCommand command) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CommandBehavior behavior) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => CompletedTask;
+    }
+}

--- a/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -25,12 +25,16 @@ namespace Samples.DatabaseHelper
             IDbConnection connection,
             DbCommandFactory commandFactory,
             IDbCommandExecutor providerSpecificCommandExecutor,
+            IDbCommandExecutor genericCommandExecutor,
             CancellationToken cancellationToken)
         {
             var executors = new List<IDbCommandExecutor>
                             {
                                 // call methods directly like SqlCommand.ExecuteScalar(), provided by caller
                                 providerSpecificCommandExecutor,
+
+                                // call methods directly using a generic constraint, like TCommand.ExecuteScalar() where TCommand : IDbCommand, provided by caller
+                                genericCommandExecutor,
 
                                 // call methods through DbCommand reference
                                 new DbCommandClassExecutor(),

--- a/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/sample-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -20,33 +20,37 @@ namespace Samples.DatabaseHelper
         /// <param name="commandFactory">A <see cref="DbCommandFactory"/> implementation specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand.</param>
         /// <param name="providerSpecificCommandExecutor">A <see cref="IDbCommandExecutor"/> specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand, used to call DbCommand methods.</param>
         /// <param name="cancellationToken">A cancellation token passed into downstream async methods.</param>
+        /// <typeparam name="TCommand">The DbCommand implementation specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand.</typeparam>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public static async Task RunAllAsync(
+        public static async Task RunAllAsync<TCommand>(
             IDbConnection connection,
             DbCommandFactory commandFactory,
             IDbCommandExecutor providerSpecificCommandExecutor,
-            IDbCommandExecutor genericCommandExecutor,
             CancellationToken cancellationToken)
+            where TCommand : IDbCommand
         {
             var executors = new List<IDbCommandExecutor>
                             {
                                 // call methods directly like SqlCommand.ExecuteScalar(), provided by caller
                                 providerSpecificCommandExecutor,
 
-                                // call methods directly using a generic constraint, like TCommand.ExecuteScalar() where TCommand : IDbCommand, provided by caller
-                                genericCommandExecutor,
-
                                 // call methods through DbCommand reference
                                 new DbCommandClassExecutor(),
 
                                 // call methods through IDbCommand reference
                                 new DbCommandInterfaceExecutor(),
+
+                                // call methods through IDbCommand reference, but using a generic constraint
+                                new DbCommandInterfaceGenericExecutor<TCommand>(),
 #if !NET45
                                 // call methods through DbCommand reference (referencing netstandard.dll)
                                 new DbCommandNetStandardClassExecutor(),
 
                                 // call methods through IDbCommand reference (referencing netstandard.dll)
                                 new DbCommandNetStandardInterfaceExecutor(),
+
+                                // call methods through IDbCommand reference (referencing netstandard.dll), but using a generic constraint
+                                new DbCommandNetStandardInterfaceGenericExecutor<TCommand>(),
 #endif
                             };
 

--- a/samples/Samples.MySql/Program.cs
+++ b/samples/Samples.MySql/Program.cs
@@ -12,12 +12,13 @@ namespace Samples.MySql
         {
             var commandFactory = new DbCommandFactory();
             var commandExecutor = new MySqlCommandExecutor();
+            var genericCommandExecutor = new DbCommandInterfaceGenericExecutor<MySqlCommand>();
             var cts = new CancellationTokenSource();
 
 
             using (var connection = OpenConnection())
             {
-                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, genericCommandExecutor, cts.Token);
             }
 
             // allow time to flush

--- a/samples/Samples.MySql/Program.cs
+++ b/samples/Samples.MySql/Program.cs
@@ -12,13 +12,12 @@ namespace Samples.MySql
         {
             var commandFactory = new DbCommandFactory();
             var commandExecutor = new MySqlCommandExecutor();
-            var genericCommandExecutor = new DbCommandInterfaceGenericExecutor<MySqlCommand>();
             var cts = new CancellationTokenSource();
 
 
             using (var connection = OpenConnection())
             {
-                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, genericCommandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync<MySqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
             }
 
             // allow time to flush

--- a/samples/Samples.MySql/Properties/launchSettings.json
+++ b/samples/Samples.MySql/Properties/launchSettings.json
@@ -13,7 +13,9 @@
 
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
-        "DD_VERSION": "1.0.0"
+        "DD_VERSION": "1.0.0",
+
+        "DD_TRACE_NETSTANDARD_ENABLED": "true"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.Npgsql/Program.cs
+++ b/samples/Samples.Npgsql/Program.cs
@@ -12,11 +12,12 @@ namespace Samples.Npgsql
         {
             var commandFactory = new DbCommandFactory();
             var commandExecutor = new NpgsqlCommandExecutor();
+            var genericCommandExecutor = new DbCommandInterfaceGenericExecutor<NpgsqlCommand>();
             var cts = new CancellationTokenSource();
 
             using (var connection = OpenConnection())
             {
-                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, genericCommandExecutor, cts.Token);
             }
 
             // allow time to flush

--- a/samples/Samples.Npgsql/Program.cs
+++ b/samples/Samples.Npgsql/Program.cs
@@ -12,12 +12,11 @@ namespace Samples.Npgsql
         {
             var commandFactory = new DbCommandFactory();
             var commandExecutor = new NpgsqlCommandExecutor();
-            var genericCommandExecutor = new DbCommandInterfaceGenericExecutor<NpgsqlCommand>();
             var cts = new CancellationTokenSource();
 
             using (var connection = OpenConnection())
             {
-                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, genericCommandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync<NpgsqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
             }
 
             // allow time to flush

--- a/samples/Samples.Npgsql/Properties/launchSettings.json
+++ b/samples/Samples.Npgsql/Properties/launchSettings.json
@@ -13,7 +13,9 @@
 
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
-        "DD_VERSION": "1.0.0"
+        "DD_VERSION": "1.0.0",
+
+        "DD_TRACE_NETSTANDARD_ENABLED": "true"
       },
       "nativeDebugging": true
     }

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -12,11 +12,12 @@ namespace Samples.SqlServer
         {
             var commandFactory = new DbCommandFactory();
             var commandExecutor = new SqlCommandExecutor();
+            var genericCommandExecutor = new DbCommandInterfaceGenericExecutor<SqlCommand>();
             var cts = new CancellationTokenSource();
 
             using (var connection = OpenConnection())
             {
-                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, genericCommandExecutor, cts.Token);
             }
 
             // allow time to flush

--- a/samples/Samples.SqlServer/Program.cs
+++ b/samples/Samples.SqlServer/Program.cs
@@ -12,12 +12,11 @@ namespace Samples.SqlServer
         {
             var commandFactory = new DbCommandFactory();
             var commandExecutor = new SqlCommandExecutor();
-            var genericCommandExecutor = new DbCommandInterfaceGenericExecutor<SqlCommand>();
             var cts = new CancellationTokenSource();
 
             using (var connection = OpenConnection())
             {
-                await RelationalDatabaseTestHarness.RunAllAsync(connection, commandFactory, commandExecutor, genericCommandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunAllAsync<SqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
             }
 
             // allow time to flush

--- a/samples/Samples.SqlServer/Properties/launchSettings.json
+++ b/samples/Samples.SqlServer/Properties/launchSettings.json
@@ -14,7 +14,9 @@
         "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
         "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
         "DD_VERSION": "1.0.0",
-        "DD_PROFILER_EXCLUDE_PROCESSES": "sqlservr.exe"
+        "DD_PROFILER_EXCLUDE_PROCESSES": "sqlservr.exe",
+
+        "DD_TRACE_NETSTANDARD_ENABLED": "true"
       },
       "nativeDebugging": true
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -17,6 +17,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTracesWithNetStandard()
         {
+            // Note: The automatic instrumentation currently bails out on the generic wrappers.
+            // Once this is implemented, this will add another 1 group for the direct assembly reference
+            // and another 1 group for the netstandard assembly reference
 #if NET452
             var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
 #else

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -18,6 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTracesWithNetStandard(string packageVersion)
         {
+            // Note: The automatic instrumentation currently bails out on the generic wrappers.
+            // Once this is implemented, this will add another 1 group for the direct assembly reference
+            // and another 1 group for the netstandard assembly reference
 #if NET452
             var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
 #else

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -18,9 +18,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         public void SubmitsTracesWithNetStandard(string packageVersion)
         {
-            // Note: The automatic instrumentation currently bails out on the generic wrappers.
-            // Once this is implemented, this will add another 1 group for the direct assembly reference
-            // and another 1 group for the netstandard assembly reference
+            // Note: The automatic instrumentation currently does not instrument on the generic wrappers
+            // due to an issue with constrained virtual method calls. This leads to an inconsistency where
+            // a newer library version may have 4 more spans than an older one (2 ExecuteReader calls *
+            // 2 interfaces: IDbCommand and IDbCommand-netstandard).
+            // Once this is fully supported, this will add another 2 complete groups instead.
 #if NET452
             var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
 #else
@@ -43,7 +45,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
-                Assert.Equal(expectedSpanCount, spans.Count);
+                // Assert.Equal(expectedSpanCount, spans.Count); // Assert an exact match once we can correctly instrument the generic constraint case
+                Assert.True(spans.Count == expectedSpanCount || spans.Count == expectedSpanCount + 4);
 
                 foreach (var span in spans)
                 {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
@@ -19,14 +19,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("RunOnWindows", "True")]
         public void SubmitsTracesWithNetStandard(string packageVersion)
         {
-            // Note: The automatic instrumentation currently bails out on the generic wrappers.
-            // Once this is implemented, this will add another 1 group for the direct assembly reference
-            // and another 1 group for the netstandard assembly reference
             // Note: The automatic instrumentation currently does not instrument on the generic wrappers
             // due to an issue with constrained virtual method calls. This leads to an inconsistency where
             // the .NET Core apps generate 4 more spans than .NET Framework apps (2 ExecuteReader calls *
             // 2 interfaces: IDbCommand and IDbCommand-netstandard).
-            // Once this is fully supported, this will add another 2 complete groups instead to both net461 and netcoreappX.X.
+            // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
+            // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET452
             var expectedSpanCount = 49; // 7 queries * 7 groups
 #elif NET461

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
@@ -22,10 +22,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Note: The automatic instrumentation currently bails out on the generic wrappers.
             // Once this is implemented, this will add another 1 group for the direct assembly reference
             // and another 1 group for the netstandard assembly reference
+            // Note: The automatic instrumentation currently does not instrument on the generic wrappers
+            // due to an issue with constrained virtual method calls. This leads to an inconsistency where
+            // the .NET Core apps generate 4 more spans than .NET Framework apps (2 ExecuteReader calls *
+            // 2 interfaces: IDbCommand and IDbCommand-netstandard).
+            // Once this is fully supported, this will add another 2 complete groups instead to both net461 and netcoreappX.X.
 #if NET452
             var expectedSpanCount = 49; // 7 queries * 7 groups
-#else
+#elif NET461
             var expectedSpanCount = 77; // 7 queries * 11 groups
+#else
+            var expectedSpanCount = 81; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             const string dbType = "sql-server";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommandTests.cs
@@ -19,6 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("RunOnWindows", "True")]
         public void SubmitsTracesWithNetStandard(string packageVersion)
         {
+            // Note: The automatic instrumentation currently bails out on the generic wrappers.
+            // Once this is implemented, this will add another 1 group for the direct assembly reference
+            // and another 1 group for the netstandard assembly reference
 #if NET452
             var expectedSpanCount = 49; // 7 queries * 7 groups
 #else


### PR DESCRIPTION
### Error Message
`System.InvalidProgramException: Common Language Runtime detected an invalid program.`

### Issue
The issue occurs when the automatic instrumentation tries to redirect a constrained virtual method call. A constrained virtual method call is a `constrained` IL instruction followed by a `callvirt` IL instruction. This can occur when making a method call to an object whose type is a generic type variable. Since the automatic instrumentation modifies the original method call to a `call` IL instruction to invoke any one of the static integration methods, the `constrained` IL instruction is no longer valid because it does not prefix a `callvirt` IL instruction, and the result is an `InvalidProgramException`.

### Fix
When trying to apply automatic instrumentation, check if the original `callvirt` IL instruction is preceded by a `constrained` IL instruction and, if so, bail out on instrumentation in this specific method.

### Changes
- Implement profiler fix
- Add the constrained virtual method call scenario to the AdoNet sample apps, which simultaneously tests that we do not crash and will test that, in the future when CallTarget instrumentation is performed, we correctly instrument these calls
- Set the environment variable `DD_TRACE_NETSTANDARD_ENABLED=true` for all AdoNet sample apps by default
- Add to the process exclusion list in `devenv.bat`

@DataDog/apm-dotnet