### PR TITLE
Use HttpClient to send traces on netcoreapp target

### DIFF
--- a/src/Datadog.Trace/Agent/ApiWebResponse.cs
+++ b/src/Datadog.Trace/Agent/ApiWebResponse.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent

--- a/src/Datadog.Trace/Agent/HttpClientRequest.cs
+++ b/src/Datadog.Trace/Agent/HttpClientRequest.cs
@@ -1,0 +1,39 @@
+#if NETCOREAPP
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent.MessagePack;
+
+namespace Datadog.Trace.Agent
+{
+    internal class HttpClientRequest : IApiRequest
+    {
+        private readonly HttpClient _client;
+        private readonly HttpRequestMessage _request;
+
+        public HttpClientRequest(HttpClient client, Uri endpoint)
+        {
+            _client = client;
+            _request = new HttpRequestMessage(HttpMethod.Post, endpoint);
+        }
+
+        public void AddHeader(string name, string value)
+        {
+            _request.Headers.Add(name, value);
+        }
+
+        public async Task<IApiResponse> PostAsync(Span[][] traces, FormatterResolverWrapper formatterResolver)
+        {
+            // re-create HttpContent on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
+            using (var content = new TracesMessagePackContent(traces, formatterResolver))
+            {
+                _request.Content = content;
+
+                var response = await _client.SendAsync(_request).ConfigureAwait(false);
+
+                return new HttpClientResponse(response);
+            }
+        }
+    }
+}
+#endif

--- a/src/Datadog.Trace/Agent/HttpClientRequestFactory.cs
+++ b/src/Datadog.Trace/Agent/HttpClientRequestFactory.cs
@@ -6,7 +6,19 @@ namespace Datadog.Trace.Agent
 {
     internal class HttpClientRequestFactory : IApiRequestFactory
     {
-        private readonly HttpClient _client = new HttpClient();
+        private readonly HttpClient _client;
+
+        public HttpClientRequestFactory()
+        {
+            _client = new HttpClient();
+
+            // Default headers
+            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");
+            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, TracerConstants.AssemblyVersion);
+
+            // don't add automatic instrumentation to requests from this HttpClient
+            _client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+        }
 
         public IApiRequest Create(Uri endpoint)
         {

--- a/src/Datadog.Trace/Agent/HttpClientRequestFactory.cs
+++ b/src/Datadog.Trace/Agent/HttpClientRequestFactory.cs
@@ -1,0 +1,17 @@
+#if NETCOREAPP
+using System;
+using System.Net.Http;
+
+namespace Datadog.Trace.Agent
+{
+    internal class HttpClientRequestFactory : IApiRequestFactory
+    {
+        private readonly HttpClient _client = new HttpClient();
+
+        public IApiRequest Create(Uri endpoint)
+        {
+            return new HttpClientRequest(_client, endpoint);
+        }
+    }
+}
+#endif

--- a/src/Datadog.Trace/Agent/HttpClientRequestFactory.cs
+++ b/src/Datadog.Trace/Agent/HttpClientRequestFactory.cs
@@ -8,9 +8,9 @@ namespace Datadog.Trace.Agent
     {
         private readonly HttpClient _client;
 
-        public HttpClientRequestFactory()
+        public HttpClientRequestFactory(HttpMessageHandler handler = null)
         {
-            _client = new HttpClient();
+            _client = handler == null ? new HttpClient() : new HttpClient(handler);
 
             // Default headers
             _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");

--- a/src/Datadog.Trace/Agent/HttpClientResponse.cs
+++ b/src/Datadog.Trace/Agent/HttpClientResponse.cs
@@ -1,0 +1,31 @@
+#if NETCOREAPP
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Agent
+{
+    internal class HttpClientResponse : IApiResponse
+    {
+        private readonly HttpResponseMessage _response;
+
+        public HttpClientResponse(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        public int StatusCode => (int)_response.StatusCode;
+
+        public long ContentLength => _response.Content.Headers.ContentLength ?? -1;
+
+        public void Dispose()
+        {
+            _response.Dispose();
+        }
+
+        public Task<string> ReadAsStringAsync()
+        {
+            return _response.Content.ReadAsStringAsync();
+        }
+    }
+}
+#endif

--- a/src/Datadog.Trace/Agent/MessagePack/TracesMessagePackContent.cs
+++ b/src/Datadog.Trace/Agent/MessagePack/TracesMessagePackContent.cs
@@ -1,0 +1,47 @@
+#if NETCOREAPP
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Datadog.Trace.Vendors.MessagePack;
+
+namespace Datadog.Trace.Agent.MessagePack
+{
+    internal class TracesMessagePackContent : HttpContent
+    {
+        private readonly FormatterResolverWrapper _resolver;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TracesMessagePackContent"/> class.
+        /// </summary>
+        /// <param name="traces">The value to serialize into the content stream as MessagePack.</param>
+        /// <param name="resolver">The <see cref="IFormatterResolver"/> to use when serializing <paramref name="traces"/>.</param>
+        public TracesMessagePackContent(Span[][] traces, FormatterResolverWrapper resolver)
+        {
+            Traces = traces;
+            _resolver = resolver;
+
+            Headers.ContentType = new MediaTypeHeaderValue("application/msgpack");
+        }
+
+        public Span[][] Traces { get; }
+
+        /// <summary>Serialize the HTTP content to a stream as an asynchronous operation.</summary>
+        /// <param name="stream">The target stream.</param>
+        /// <param name="context">Information about the transport (channel binding token, for example). This parameter may be <see langword="null" />.</param>
+        /// <returns>The task object representing the asynchronous operation.</returns>
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+        {
+            return CachedSerializer.Instance.SerializeAsync(stream, Traces, _resolver);
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            // We don't want compute the length beforehand
+            length = -1;
+            return false;
+        }
+    }
+}
+#endif

--- a/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
+++ b/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
@@ -1,0 +1,64 @@
+#if NETCOREAPP3_1
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.MessagePack;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class HttpClientRequestTests
+    {
+        [Fact]
+        public async Task SetHeaders()
+        {
+            var handler = new CustomHandler();
+
+            var factory = new HttpClientRequestFactory(handler);
+            var request = factory.Create(new Uri("http://localhost/"));
+
+            request.AddHeader("Hello", "World");
+
+            await request.PostAsync(new Span[0][], new FormatterResolverWrapper(SpanFormatterResolver.Instance));
+
+            var message = handler.Message;
+
+            Assert.NotNull(message);
+            Assert.Equal(".NET", message.Headers.GetValues(AgentHttpHeaderNames.Language).First());
+            Assert.Equal(TracerConstants.AssemblyVersion, message.Headers.GetValues(AgentHttpHeaderNames.TracerVersion).First());
+            Assert.Equal("false", message.Headers.GetValues(HttpHeaderNames.TracingEnabled).First());
+            Assert.Equal("World", message.Headers.GetValues("Hello").First());
+        }
+
+        [Fact]
+        public async Task SerializeSpans()
+        {
+            var handler = new CustomHandler();
+
+            var factory = new HttpClientRequestFactory(handler);
+            var request = factory.Create(new Uri("http://localhost/"));
+
+            await request.PostAsync(new Span[0][], new FormatterResolverWrapper(SpanFormatterResolver.Instance));
+
+            var message = handler.Message;
+
+            Assert.IsAssignableFrom<TracesMessagePackContent>(message.Content);
+        }
+
+        private class CustomHandler : DelegatingHandler
+        {
+            public HttpRequestMessage Message { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Message = request;
+                return Task.FromResult(new HttpResponseMessage());
+            }
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Using HttpClient should be safe when targeting netcoreapp (because it's bundled with the framework). It's better than HttpWebRequest on .NET Core because the latter does not support keep-alive.

**Benchmark:**  (with a dummy agent)

```csharp
for (int i = 0; i < 10; i++)
{
     AgentWriter.WriteTrace(Spans);
     await AgentWriter.FlushTracesAsync();
}
```

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.329 (2004/?/20H1)
Intel Core i7-9750H CPU 2.60GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=3.1.402
  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  DefaultJob : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT


```
|                        Method |      Mean |     Error |    StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------------------ |----------:|----------:|----------:|------:|--------:|---------:|---------:|---------:|----------:|
| WriteAndFlushTracesWebRequest | 12.182 ms | 0.2247 ms | 0.4836 ms |  1.00 |    0.00 | 421.8750 | 281.2500 | 265.6250 | 1843.3 KB |
| WriteAndFlushTracesHttpClient |  5.098 ms | 0.1004 ms | 0.1933 ms |  0.42 |    0.03 | 125.0000 |  15.6250 |        - | 768.64 KB |
