### PR TITLE
Clean workspace between builds

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -31,6 +31,9 @@ stages:
 
   - job: Windows
     pool: Benchmarks
+    
+    workspace:
+      clean: all
 
     # Enable the Datadog Agent service for this job
     services:


### PR DESCRIPTION
There are still weird anomalies in the benchmark results, trying to remove anything that could cause them.