### PR TITLE
Properly instrument custom HttpClientHandler implementations

### DIFF
--- a/samples/Samples.HttpMessageHandler/CustomHandler.cs
+++ b/samples/Samples.HttpMessageHandler/CustomHandler.cs
@@ -1,0 +1,8 @@
+﻿using System.Net.Http;
+
+namespace Samples.HttpMessageHandler
+{
+    public class CustomHandler : HttpClientHandler
+    {
+    }
+}

--- a/samples/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/samples/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -156,6 +157,20 @@ namespace Samples.HttpMessageHandler
                         await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
                         Console.WriteLine("Received response for client.PostAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                     }
+                }
+            }
+            
+            using (var clientWithCustomHandler = new HttpClient(new CustomHandler()))
+            {
+                if (tracingDisabled)
+                {
+                    clientWithCustomHandler.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                }
+
+                using (Tracer.Instance.StartActive("CustomHandler"))
+                {
+                    await clientWithCustomHandler.GetAsync(url);
+                    Console.WriteLine("Received response for clientWithCustomHandler.GetAsync");
                 }
             }
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -97,7 +97,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var reportedType = callOpCode == OpCodeValue.Call ? httpMessageHandler : handler.GetType();
             var headers = request.GetProperty<object>("Headers").GetValueOrDefault();
 
-            if (!(reportedType.FullName.Equals(HttpClientHandler, StringComparison.OrdinalIgnoreCase) || IsSocketsHttpHandlerEnabled(reportedType)) ||
+            var isHttpClientHandler = handler.GetInstrumentedType(SystemNetHttp, HttpClientHandlerTypeName) != null;
+
+            if (!(isHttpClientHandler || IsSocketsHttpHandlerEnabled(reportedType)) ||
                 !IsTracingEnabled(headers))
             {
                 // skip instrumentation
@@ -197,8 +199,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             var headers = request.GetProperty<object>("Headers").GetValueOrDefault();
             var reportedType = callOpCode == OpCodeValue.Call ? httpClientHandler : handler.GetType();
 
-            if (!(reportedType.FullName.Equals(HttpClientHandler, StringComparison.OrdinalIgnoreCase) || IsSocketsHttpHandlerEnabled(reportedType)) ||
-                !IsTracingEnabled(headers))
+            if (!IsTracingEnabled(headers))
             {
                 // skip instrumentation
                 return instrumentedMethod(handler, request, cancellationToken);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void SubmitsTraces()
         {
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 34 : 30;
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 35 : 31;
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "Samples.HttpMessageHandler-http-client";
 


### PR DESCRIPTION
We currently don't instrument types inheriting from HttpClientHandler because of a strict type check.

I changed the check in HttpMessageHandler_SendAsync and removed it from HttpClientHandler_SendAsync (since in this path we already know we have a HttpClientHandler).