### PR TITLE
remove setter from GlobalSettings.DiagnosticSourceEnabled

### DIFF
--- a/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -27,8 +27,6 @@ namespace Benchmarks.Trace
         {
             TracerSettings.DisableSharedInstance = true;
 
-            GlobalSettings.Source.DiagnosticSourceEnabled = true;
-
             var settings = new TracerSettings
             {
                 StartupDiagnosticLogEnabled = false,

--- a/benchmarks/Benchmarks.Trace/DbBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/DbBenchmark.cs
@@ -19,7 +19,6 @@ namespace Benchmarks.Trace
         static DbCommandBenchmark()
         {
             TracerSettings.DisableSharedInstance = true;
-            GlobalSettings.Source.DiagnosticSourceEnabled = false;
 
             var settings = new TracerSettings
             {

--- a/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
@@ -23,7 +23,6 @@ namespace Benchmarks.Trace
         static HttpClientBenchmark()
         {
             TracerSettings.DisableSharedInstance = true;
-            GlobalSettings.Source.DiagnosticSourceEnabled = false;
 
             var settings = new TracerSettings
             {

--- a/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
@@ -24,7 +24,6 @@ namespace Benchmarks.Trace
         static RedisBenchmark()
         {
             TracerSettings.DisableSharedInstance = true;
-            GlobalSettings.Source.DiagnosticSourceEnabled = false;
 
             var settings = new TracerSettings
             {

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -42,17 +42,17 @@ namespace Datadog.Trace.Configuration
         public bool DebugEnabled { get; private set; }
 
         /// <summary>
+        /// Gets or sets the global settings instance.
+        /// </summary>
+        internal static GlobalSettings Source { get; set; } = FromDefaultSources();
+
+        /// <summary>
         /// Gets a value indicating whether the use
         /// of System.Diagnostics.DiagnosticSource is enabled.
         /// This value can only be set with environment variables
         /// or a configuration file, not through code.
         /// </summary>
-        public bool DiagnosticSourceEnabled { get; }
-
-        /// <summary>
-        /// Gets or sets the global settings instance.
-        /// </summary>
-        internal static GlobalSettings Source { get; set; } = FromDefaultSources();
+        internal bool DiagnosticSourceEnabled { get; }
 
         /// <summary>
         /// Set whether debug mode is enabled.

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -1,5 +1,4 @@
 using System.IO;
-using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Serilog.Events;
 
@@ -10,8 +9,6 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     public class GlobalSettings
     {
-        private bool _diagnosticSourceEnabled;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="GlobalSettings"/> class with default values.
         /// </summary>
@@ -45,28 +42,12 @@ namespace Datadog.Trace.Configuration
         public bool DebugEnabled { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the use
+        /// Gets a value indicating whether the use
         /// of System.Diagnostics.DiagnosticSource is enabled.
+        /// This value can only be set with environment variables
+        /// or a configuration file, not through code.
         /// </summary>
-        public bool DiagnosticSourceEnabled
-        {
-            get => _diagnosticSourceEnabled;
-            set
-            {
-                _diagnosticSourceEnabled = value;
-
-#if NETSTANDARD || NETCOREAPP
-                if (value)
-                {
-                    DiagnosticManager.Instance?.Start();
-                }
-                else
-                {
-                    DiagnosticManager.Instance?.Stop();
-                }
-#endif
-            }
-        }
+        public bool DiagnosticSourceEnabled { get; }
 
         /// <summary>
         /// Gets or sets the global settings instance.

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -263,7 +263,7 @@ namespace Datadog.Trace.Configuration
         public bool DiagnosticSourceEnabled
         {
             get => GlobalSettings.Source.DiagnosticSourceEnabled;
-            set => GlobalSettings.Source.DiagnosticSourceEnabled = value;
+            set { }
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -258,8 +258,13 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets or sets a value indicating whether the use
         /// of System.Diagnostics.DiagnosticSource is enabled.
+        /// Default is <c>true</c>.
         /// </summary>
-        [Obsolete("Use Datadog.Trace.Configuration.GlobalSettings.DiagnosticSourceEnabled", error: false)]
+        /// <remark>
+        /// This value cannot be set in code. Instead,
+        /// set it using the <c>DD_TRACE_DIAGNOSTIC_SOURCE_ENABLED</c>
+        /// environment variable or in configuration files.
+        /// </remark>
         public bool DiagnosticSourceEnabled
         {
             get => GlobalSettings.Source.DiagnosticSourceEnabled;


### PR DESCRIPTION
PR #903 added a `GlobalSettings.DiagnosticSourceEnabled` property. This PR removes the setter from `GlobalSettings.DiagnosticSourceEnabled` to resolve an issue introduced there. The steps are as follows:

- Calling `GlobalSettings.Source` calls `FromDefaultSources()`
- This creates a new instance of `GlobalSettings` with default values, which sets `DiagnosticSourceEnabled` to `true`
- Setting `DiagnosticSourceEnabled` to `true` calls `DiagnosticManager.Instance?.Start()`
- The static constructor of `DiagnosticManager` initializes the logger (`Log = DatadogLogging.For<DiagnosticManager>()`)
- The logger tries to read `GlobalSettings.Source.DebugEnabled`, but `GlobalSettings.Source` is still null

With the changes in this PR, the only way to disable subscribing to `DiagnosticListener` events is through environment variables or configuration files. This is consistent with the way other integrations work, where IL writing cannot be disabled through code.

Thanks @kevingosse for reporting this issue.