### PR TITLE
stop initializing global tracer in static constructor

### DIFF
--- a/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -22,8 +22,6 @@ namespace Benchmarks.Trace
 
         static AgentWriterBenchmark()
         {
-            TracerSettings.DisableSharedInstance = true;
-
             var settings = TracerSettings.FromDefaultSources();
 
             settings.StartupDiagnosticLogEnabled = false;

--- a/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -25,8 +25,6 @@ namespace Benchmarks.Trace
 
         static AspNetCoreBenchmark()
         {
-            TracerSettings.DisableSharedInstance = true;
-
             GlobalSettings.Source.DiagnosticSourceEnabled = true;
 
             var settings = new TracerSettings

--- a/benchmarks/Benchmarks.Trace/DbBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/DbBenchmark.cs
@@ -18,7 +18,6 @@ namespace Benchmarks.Trace
 
         static DbCommandBenchmark()
         {
-            TracerSettings.DisableSharedInstance = true;
             GlobalSettings.Source.DiagnosticSourceEnabled = false;
 
             var settings = new TracerSettings

--- a/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
@@ -22,7 +22,6 @@ namespace Benchmarks.Trace
 
         static HttpClientBenchmark()
         {
-            TracerSettings.DisableSharedInstance = true;
             GlobalSettings.Source.DiagnosticSourceEnabled = false;
 
             var settings = new TracerSettings

--- a/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
@@ -23,7 +23,6 @@ namespace Benchmarks.Trace
 
         static RedisBenchmark()
         {
-            TracerSettings.DisableSharedInstance = true;
             GlobalSettings.Source.DiagnosticSourceEnabled = false;
 
             var settings = new TracerSettings

--- a/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -17,8 +17,6 @@ namespace Benchmarks.Trace
 
         static SpanBenchmark()
         {
-            TracerSettings.DisableSharedInstance = true;
-
             var settings = new TracerSettings
             {
                 TraceEnabled = false,

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -272,12 +272,6 @@ namespace Datadog.Trace.Configuration
         public bool StartupDiagnosticLogEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the shared Tracer instance is disabled.
-        /// To be used to prevent the automatic instantiation of Tracer.Instance when running tests/benchmarks
-        /// </summary>
-        internal static bool DisableSharedInstance { get; set; }
-
-        /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources
         /// returned by <see cref="CreateDefaultConfigurationSource"/>.
         /// </summary>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -44,12 +44,6 @@ namespace Datadog.Trace
         static Tracer()
         {
             TracingProcessManager.Initialize();
-
-            if (!TracerSettings.DisableSharedInstance)
-            {
-                // create the default global Tracer
-                Instance = new Tracer();
-            }
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -36,6 +36,10 @@ namespace Datadog.Trace
         /// </summary>
         private static int _firstInitialization = 1;
 
+        private static Tracer _instance;
+        private static bool _globalInstanceInitialized;
+        private static object _globalInstanceLock;
+
         private readonly IScopeManager _scopeManager;
         private readonly Timer _heartbeatTimer;
 
@@ -175,9 +179,18 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Gets or sets the global tracer object
+        /// Gets or sets the global <see cref="Tracer"/> instance.
+        /// Used by all automatic instrumentation and recommended
+        /// as the entry point for manual instrumentation.
         /// </summary>
-        public static Tracer Instance { get; set; }
+        public static Tracer Instance
+        {
+            get
+            {
+                return LazyInitializer.EnsureInitialized(ref _instance, ref _globalInstanceInitialized, ref _globalInstanceLock);
+            }
+            set => _instance = value;
+        }
 
         /// <summary>
         /// Gets the active scope


### PR DESCRIPTION
Move initialization of default global `Tracer` instance from the static constructor to the `Tracer.Instance` property getter.

In automatic instrumentation scenarios, we will still initialize from `Instrumentation.Initialize()`.

In manual instrumentation, we delay this until the first time `Tracer.Instance` is accessed. If a user sets `Tracer.Instance` before that, the default instance is never created.