### PR TITLE
Include Datadog.Trace.MSBuild project to PreRelease versions

### DIFF
--- a/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
+++ b/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>1.18.4-prerelease</Version>
+    <Version>1.19.3</Version>
   </PropertyGroup>
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the

--- a/tools/PrepareRelease/SetAllVersions.cs
+++ b/tools/PrepareRelease/SetAllVersions.cs
@@ -54,6 +54,10 @@ namespace PrepareRelease
                 "src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj",
                 NugetVersionReplace);
 
+            SynchronizeVersion(
+                "src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj",
+                NugetVersionReplace);
+
             // Fully qualified name updates
             SynchronizeVersion(
                 "src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs",


### PR DESCRIPTION
Include Datadog.Trace.MSBuild project to PreRelease versions

@DataDog/apm-dotnet