### PR TITLE
Improve HttpMessageHandler benchmark

### DIFF
--- a/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -70,16 +70,14 @@ namespace Benchmarks.Trace
     /// </summary>
     public class HomeController : Controller
     {
-        private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage();
-        private static readonly HttpMessageHandler Handler = new CustomHttpMessageHandler();
+        private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };
+        private static readonly HttpMessageHandler Handler = new CustomHttpClientHandler();
         private static readonly object BoxedCancellationToken = new CancellationToken();
         private static int _mdToken;
         private static IntPtr _guidPtr;
 
         internal static void Initialize()
         {
-            HttpMessageHandlerIntegration.HttpClientHandler = typeof(CustomHttpMessageHandler).FullName;
-
             var methodInfo = typeof(HttpMessageHandler).GetMethod("SendAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             _mdToken = methodInfo.MetadataToken;
@@ -105,7 +103,7 @@ namespace Benchmarks.Trace
             return "OK";
         }
 
-        internal class CustomHttpMessageHandler : HttpMessageHandler
+        internal class CustomHttpClientHandler : HttpClientHandler
         {
             private static readonly Task<HttpResponseMessage> CachedResult = Task.FromResult(new HttpResponseMessage());
 

--- a/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
+++ b/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
@@ -14,8 +14,8 @@ namespace Benchmarks.Trace
     [MemoryDiagnoser]
     public class HttpClientBenchmark
     {
-        private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage();
-        private static readonly HttpMessageHandler Handler = new CustomHttpMessageHandler();
+        private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };
+        private static readonly HttpMessageHandler Handler = new CustomHttpClientHandler();
         private static readonly object BoxedCancellationToken = new CancellationToken();
         private static readonly int MdToken;
         private static readonly IntPtr GuidPtr;
@@ -29,8 +29,6 @@ namespace Benchmarks.Trace
 
             Tracer.Instance = new Tracer(settings, new DummyAgentWriter(), null, null, null);
 
-            HttpMessageHandlerIntegration.HttpClientHandler = typeof(CustomHttpMessageHandler).FullName;
-
             var methodInfo = typeof(HttpMessageHandler).GetMethod("SendAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             MdToken = methodInfo.MetadataToken;
@@ -43,7 +41,7 @@ namespace Benchmarks.Trace
             new HttpClientBenchmark().SendAsync().GetAwaiter().GetResult();
         }
 
-        internal class CustomHttpMessageHandler : HttpMessageHandler
+        internal class CustomHttpClientHandler : HttpClientHandler
         {
             private static readonly Task<HttpResponseMessage> CachedResult = Task.FromResult(new HttpResponseMessage());
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string HttpClientHandlerTypeName = "HttpClientHandler";
 
         private const string HttpMessageHandler = SystemNetHttp + "." + HttpMessageHandlerTypeName;
-        private const string HttpClientHandlerConst = SystemNetHttp + "." + HttpClientHandlerTypeName;
+        private const string HttpClientHandler = SystemNetHttp + "." + HttpClientHandlerTypeName;
         private const string SendAsync = "SendAsync";
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(HttpMessageHandlerIntegration));
@@ -30,8 +30,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static Type _httpMessageHandlerResultType;
         private static Type _httpClientHandlerResultType;
-
-        internal static string HttpClientHandler { get; set; } = HttpClientHandlerConst;
 
         /// <summary>
         /// Instrumentation wrapper for HttpMessageHandler.SendAsync/>.
@@ -147,7 +145,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /// <returns>Returns the value returned by the inner method call.</returns>
         [InterceptMethod(
             TargetAssembly = SystemNetHttp,
-            TargetType = HttpClientHandlerConst,
+            TargetType = HttpClientHandler,
             TargetMethod = SendAsync,
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,


### PR DESCRIPTION
- Since we accept type inheriting from HttpClientHandler, no need to override the type name in the integration
- Fill the RequestUri, otherwise some code is skipped