### PR TITLE
Do not apply RateLimiter when using Agent sampling rates

### DIFF
--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using Datadog.Trace.Sampling;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -92,9 +91,9 @@ namespace Datadog.Trace.Configuration
                                    // default value
                                    false;
 
-            var maxTracesPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond);
-
-            MaxTracesSubmittedPerSecond = maxTracesPerSecond ?? 100;
+            MaxTracesSubmittedPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond) ??
+                                          // default value
+                                          100;
 
             Integrations = new IntegrationSettingsCollection(source);
 

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -94,17 +94,7 @@ namespace Datadog.Trace.Configuration
 
             var maxTracesPerSecond = source?.GetInt32(ConfigurationKeys.MaxTracesSubmittedPerSecond);
 
-            if (maxTracesPerSecond != null)
-            {
-                // Ensure our flag for the rate limiter is enabled
-                RuleBasedSampler.OptInTracingWithoutLimits();
-            }
-            else
-            {
-                maxTracesPerSecond = 100; // default
-            }
-
-            MaxTracesSubmittedPerSecond = maxTracesPerSecond.Value;
+            MaxTracesSubmittedPerSecond = maxTracesPerSecond ?? 100;
 
             Integrations = new IntegrationSettingsCollection(source);
 

--- a/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -8,7 +8,6 @@ namespace Datadog.Trace.Sampling
         private const ulong KnuthFactor = 1_111_111_111_111_111_111;
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<RuleBasedSampler>();
-        private static bool _tracingWithoutLimitsEnabled = false;
 
         private readonly IRateLimiter _limiter;
         private readonly DefaultSamplingRule _defaultRule = new DefaultSamplingRule();
@@ -18,11 +17,6 @@ namespace Datadog.Trace.Sampling
         {
             _limiter = limiter ?? new RateLimiter(null);
             RegisterRule(_defaultRule);
-        }
-
-        public static void OptInTracingWithoutLimits()
-        {
-            _tracingWithoutLimitsEnabled = true;
         }
 
         public void SetDefaultSampleRates(IEnumerable<KeyValuePair<string, float>> sampleRates)

--- a/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -79,14 +79,11 @@ namespace Datadog.Trace.Sampling
 
             if (sample)
             {
-                if (!agentSampling)
+                if (agentSampling)
                 {
-                    if (_limiter.Allowed(span))
-                    {
-                        priority = SamplingPriority.AutoKeep;
-                    }
+                    priority = SamplingPriority.AutoKeep;
                 }
-                else
+                else if (_limiter.Allowed(span))
                 {
                     priority = SamplingPriority.AutoKeep;
                 }

--- a/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -77,16 +77,9 @@ namespace Datadog.Trace.Sampling
             var sample = ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
             var priority = SamplingPriority.AutoReject;
 
-            if (sample)
+            if (sample && (agentSampling || _limiter.Allowed(span)))
             {
-                if (agentSampling)
-                {
-                    priority = SamplingPriority.AutoKeep;
-                }
-                else if (_limiter.Allowed(span))
-                {
-                    priority = SamplingPriority.AutoKeep;
-                }
+                priority = SamplingPriority.AutoKeep;
             }
 
             return priority;

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -124,9 +124,6 @@ namespace Datadog.Trace
 
             if (!string.IsNullOrWhiteSpace(Settings.CustomSamplingRules))
             {
-                // User has opted in, ensure rate limiter is used
-                RuleBasedSampler.OptInTracingWithoutLimits();
-
                 foreach (var rule in CustomSamplingRule.BuildFromConfigurationString(Settings.CustomSamplingRules))
                 {
                     Sampler.RegisterRule(rule);

--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -17,6 +17,17 @@ namespace Datadog.Trace.Tests.Sampling
         private static ulong _id = 1;
 
         [Fact]
+        public void RateLimiter_Never_Applied_For_DefaultRule()
+        {
+            var sampler = new RuleBasedSampler(new DenyAll());
+            RunSamplerTest(
+                sampler,
+                500,
+                1,
+                0);
+        }
+
+        [Fact]
         public void RateLimiter_Denies_All_Traces()
         {
             var sampler = new RuleBasedSampler(new DenyAll());


### PR DESCRIPTION
Expected behavior:
 - `_dd.limit_psr` is always set when `_dd.rule_psr` is set
 - `_dd.limit_psr` is never set when `_dd.agent_psr` is set
 - Do not apply the Rate Limiter when sampling is from the agent.