### PR TITLE
Fix IIS Express fixture in Datadog.Trace.ClrProfiler.IntegrationTests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var process = ProfilerHelper.StartProcessWithProfiler(
                 EnvironmentHelper.GetSampleExecutionSource(),
-                EnvironmentHelper.GetSampleApplicationPath(),
+                EnvironmentHelper.GetSampleExecutionSource(),
                 EnvironmentHelper,
                 integrationPaths,
                 arguments: string.Join(" ", args),


### PR DESCRIPTION
Sometime after refactoring of the integration-test scaffolding, the IIS Express tests began failing because they were not launching the IIS Express executable. This replaces the path used in the StartProcessWithProfiler call to correctly start the IIS Express process.

@DataDog/apm-dotnet