### PR TITLE
Use ICorProfilerInfo4 in the profiler

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -12,7 +12,7 @@
 
 namespace trace {
 
-RuntimeInformation GetRuntimeInformation(ICorProfilerInfo3* info) {
+RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info) {
   COR_PRF_RUNTIME_TYPE runtime_type;
   USHORT major_version;
   USHORT minor_version;
@@ -27,7 +27,7 @@ RuntimeInformation GetRuntimeInformation(ICorProfilerInfo3* info) {
   return {runtime_type, major_version, minor_version, build_version, qfe_version};
 }
 
-AssemblyInfo GetAssemblyInfo(ICorProfilerInfo3* info,
+AssemblyInfo GetAssemblyInfo(ICorProfilerInfo4* info,
                              const AssemblyID& assembly_id) {
   WCHAR assembly_name[kNameMaxSize];
   DWORD assembly_name_len = 0;
@@ -183,7 +183,7 @@ FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
           MethodSignature(final_signature_bytes)};
 }
 
-ModuleInfo GetModuleInfo(ICorProfilerInfo3* info, const ModuleID& module_id) {
+ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id) {
   const DWORD module_path_size = 260;
   WCHAR module_path[module_path_size]{};
   DWORD module_path_len = 0;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -297,9 +297,9 @@ struct FunctionInfo {
   bool IsValid() const { return id != 0; }
 };
 
-RuntimeInformation GetRuntimeInformation(ICorProfilerInfo3* info);
+RuntimeInformation GetRuntimeInformation(ICorProfilerInfo4* info);
 
-AssemblyInfo GetAssemblyInfo(ICorProfilerInfo3* info,
+AssemblyInfo GetAssemblyInfo(ICorProfilerInfo4* info,
                              const AssemblyID& assembly_id);
 
 AssemblyMetadata GetAssemblyMetadata(
@@ -316,7 +316,7 @@ AssemblyMetadata GetReferencedAssemblyMetadata(
 FunctionInfo GetFunctionInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                              const mdToken& token);
 
-ModuleInfo GetModuleInfo(ICorProfilerInfo3* info, const ModuleID& module_id);
+ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id);
 
 TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                      const mdToken& token);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -81,10 +81,10 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   }
 
   // get Profiler interface
-  HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo3>(
+  HRESULT hr = cor_profiler_info_unknown->QueryInterface<ICorProfilerInfo4>(
       &this->info_);
   if (FAILED(hr)) {
-    Warn("DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo3 not found.");
+    Warn("DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo4 not found.");
     return E_FAIL;
   }
 
@@ -526,7 +526,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
                                             &function_token);
 
   if (FAILED(hr)) {
-    Warn("JITCompilationStarted: Call to ICorProfilerInfo3.GetFunctionInfo() failed for ", function_id);
+    Warn("JITCompilationStarted: Call to ICorProfilerInfo4.GetFunctionInfo() failed for ", function_id);
     return S_OK;
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.h
@@ -12,7 +12,7 @@ class CorProfilerBase : public ICorProfilerCallback8 {
   std::atomic<int> ref_count_;
 
  protected:
-  ICorProfilerInfo3* info_;
+  ICorProfilerInfo4* info_;
 
  public:
   CorProfilerBase();


### PR DESCRIPTION
This way, we ensure that we do not attach to processes running a version of .NET older than 4.5.
