### PR TITLE
Increase benchmarks iteration time to reduce noise

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -73,7 +73,7 @@ stages:
       inputs:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
-        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * '
+        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
     - task: PowerShell@2
       inputs:
         targetType: 'inline'


### PR DESCRIPTION
Trying to strike a good balance between execution time and precision.

With this change, the benchmarks iteration time is quadrupled, and the whole run takes ~25 minutes in the CI.