### PR TITLE
Adds IgnoresAccessChecksToAttribute trick to Duck Typing

### DIFF
--- a/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 
 namespace Datadog.Trace.DuckTyping
 {
@@ -34,5 +36,12 @@ namespace Datadog.Trace.DuckTyping
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static ModuleBuilder _moduleBuilder = null;
-     }
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static AssemblyBuilder _assemblyBuilder = null;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static ConstructorInfo _ignoresAccessChecksToAttributeCtor = typeof(IgnoresAccessChecksToAttribute).GetConstructor(new Type[] { typeof(string) });
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static HashSet<string> _ignoresAccessChecksToAssembliesSet = new HashSet<string>();
+    }
 }

--- a/src/Datadog.Trace.DuckTyping/IgnoresAccessChecksToAttribute.cs
+++ b/src/Datadog.Trace.DuckTyping/IgnoresAccessChecksToAttribute.cs
@@ -1,0 +1,23 @@
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// This attribute is recognized by the CLR and allow us to disable visibility checks for certain assemblies (only from 4.6+)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class IgnoresAccessChecksToAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IgnoresAccessChecksToAttribute"/> class.
+        /// </summary>
+        /// <param name="assemblyName">Assembly name</param>
+        public IgnoresAccessChecksToAttribute(string assemblyName)
+        {
+            AssemblyName = assemblyName;
+        }
+
+        /// <summary>
+        /// Gets the assembly name
+        /// </summary>
+        public string AssemblyName { get; }
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
@@ -215,7 +215,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         }
 
         // *
-
+#if NET452
         [Fact]
         public void TypeIsNotPublicException()
         {
@@ -241,7 +241,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
             public string Name { get; set; }
         }
-
+#endif
         // *
 
         [Fact]
@@ -407,7 +407,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         }
 
         // *
-
+#if NET452
         [Fact]
         public void ProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException()
         {
@@ -430,7 +430,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             {
             }
         }
-
+#endif
         // *
 
         [Fact]

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -281,43 +281,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [MemberData(nameof(Data))]
         public void DefaultGenericsMethods(object obscureObject)
         {
-            if (obscureObject.GetType().IsPublic || obscureObject.GetType().IsNestedPublic)
-            {
-                var duckInterface = obscureObject.As<IDefaultGenericMethodDuckType>();
-                var duckAbstract = obscureObject.As<DefaultGenericMethodDuckTypeAbstractClass>();
-                var duckVirtual = obscureObject.As<DefaultGenericMethodDuckTypeVirtualClass>();
-
-                // GetDefault int
-                Assert.Equal(0, duckInterface.GetDefault<int>());
-                Assert.Equal(0, duckAbstract.GetDefault<int>());
-                Assert.Equal(0, duckVirtual.GetDefault<int>());
-
-                // GetDefault double
-                Assert.Equal(0d, duckInterface.GetDefault<double>());
-                Assert.Equal(0d, duckAbstract.GetDefault<double>());
-                Assert.Equal(0d, duckVirtual.GetDefault<double>());
-
-                // GetDefault string
-                Assert.Null(duckInterface.GetDefault<string>());
-                Assert.Null(duckAbstract.GetDefault<string>());
-                Assert.Null(duckVirtual.GetDefault<string>());
-
-                // Wrap ints
-                Tuple<int, int> wrapper = duckInterface.Wrap(10, 20);
-                Assert.Equal(10, wrapper.Item1);
-                Assert.Equal(20, wrapper.Item2);
-
-                // Wrap string
-                Tuple<string, string> wrapper2 = duckAbstract.Wrap("Hello", "World");
-                Assert.Equal("Hello", wrapper2.Item1);
-                Assert.Equal("World", wrapper2.Item2);
-
-                // Wrap object
-                Tuple<object, string> wrapper3 = duckAbstract.Wrap<object, string>(null, "World");
-                Assert.Null(wrapper3.Item1);
-                Assert.Equal("World", wrapper3.Item2);
-            }
-            else
+#if NET452
+            if (!obscureObject.GetType().IsPublic && !obscureObject.GetType().IsNestedPublic)
             {
                 Assert.Throws<DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>(
                     () =>
@@ -334,7 +299,43 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
                     {
                         obscureObject.As<DefaultGenericMethodDuckTypeVirtualClass>();
                     });
+                return;
             }
+#endif
+
+            var duckInterface = obscureObject.As<IDefaultGenericMethodDuckType>();
+            var duckAbstract = obscureObject.As<DefaultGenericMethodDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.As<DefaultGenericMethodDuckTypeVirtualClass>();
+
+            // GetDefault int
+            Assert.Equal(0, duckInterface.GetDefault<int>());
+            Assert.Equal(0, duckAbstract.GetDefault<int>());
+            Assert.Equal(0, duckVirtual.GetDefault<int>());
+
+            // GetDefault double
+            Assert.Equal(0d, duckInterface.GetDefault<double>());
+            Assert.Equal(0d, duckAbstract.GetDefault<double>());
+            Assert.Equal(0d, duckVirtual.GetDefault<double>());
+
+            // GetDefault string
+            Assert.Null(duckInterface.GetDefault<string>());
+            Assert.Null(duckAbstract.GetDefault<string>());
+            Assert.Null(duckVirtual.GetDefault<string>());
+
+            // Wrap ints
+            Tuple<int, int> wrapper = duckInterface.Wrap(10, 20);
+            Assert.Equal(10, wrapper.Item1);
+            Assert.Equal(20, wrapper.Item2);
+
+            // Wrap string
+            Tuple<string, string> wrapper2 = duckAbstract.Wrap("Hello", "World");
+            Assert.Equal("Hello", wrapper2.Item1);
+            Assert.Equal("World", wrapper2.Item2);
+
+            // Wrap object
+            Tuple<object, string> wrapper3 = duckAbstract.Wrap<object, string>(null, "World");
+            Assert.Null(wrapper3.Item1);
+            Assert.Equal("World", wrapper3.Item2);
         }
 
         [Theory]


### PR DESCRIPTION
This `PR` adds the `IgnoresAccessChecksToAttribute` trick to proxy and target assemblies for the DuckTyping and disabling the visibility checks, allowing us to remove the double indirection call (through the DynamicMethod) to non public members, so improves the performance for those types.

Note: This tricks works only .NET Framework 4.6+ and netcore. For .NET 4.5 we disable the trick.

## Benchmark

Now the numbers are similar regardless is a public instance or non public instance:

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.508 (2004/?/20H1)
Intel Core i7-1068NG7 CPU 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=3.1.402
  [Host]     : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT
  Job-GFIUAH : .NET Framework 4.8 (4.8.4220.0), X64 RyuJIT
  Job-LDKTXH : .NET Core 3.1.8 (CoreCLR 4.700.20.41105, CoreFX 4.700.20.41903), X64 RyuJIT


```
|                     Method |       Runtime |     Categories |    proxy |     Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |-------------- |--------------- |--------- |---------:|----------:|----------:|------:|--------:|------:|------:|------:|----------:|
|          GetPublicProperty |    .NET 4.7.2 |         Getter |        ? | 1.074 ns | 0.0213 ns | 0.0188 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          GetPublicProperty | .NET Core 3.1 |         Getter |        ? | 1.113 ns | 0.0174 ns | 0.0162 ns |  1.04 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          SetPublicProperty |    .NET 4.7.2 |         Setter |        ? | 1.362 ns | 0.0205 ns | 0.0160 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          SetPublicProperty | .NET Core 3.1 |         Setter |        ? | 1.120 ns | 0.0208 ns | 0.0174 ns |  0.82 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetIndexerProperty |    .NET 4.7.2 | Indexer Getter |        ? | 1.070 ns | 0.0113 ns | 0.0106 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetIndexerProperty | .NET Core 3.1 | Indexer Getter |        ? | 1.069 ns | 0.0163 ns | 0.0152 ns |  1.00 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetIndexerProperty |    .NET 4.7.2 | Indexer Setter |        ? | 1.381 ns | 0.0266 ns | 0.0236 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetIndexerProperty | .NET Core 3.1 | Indexer Setter |        ? | 1.406 ns | 0.0136 ns | 0.0121 ns |  1.02 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|    GetPublicStaticProperty |    .NET 4.7.2 |  Static Getter | Internal | 2.051 ns | 0.0146 ns | 0.0136 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    GetPublicStaticProperty | .NET Core 3.1 |  Static Getter | Internal | 2.349 ns | 0.0188 ns | 0.0176 ns |  1.15 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|  GetInternalStaticProperty |    .NET 4.7.2 |  Static Getter | Internal | 2.822 ns | 0.0255 ns | 0.0238 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|  GetInternalStaticProperty | .NET Core 3.1 |  Static Getter | Internal | 3.190 ns | 0.0321 ns | 0.0300 ns |  1.13 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
| GetProtectedStaticProperty |    .NET 4.7.2 |  Static Getter | Internal | 2.807 ns | 0.0181 ns | 0.0169 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| GetProtectedStaticProperty | .NET Core 3.1 |  Static Getter | Internal | 3.150 ns | 0.0254 ns | 0.0238 ns |  1.12 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|   GetPrivateStaticProperty |    .NET 4.7.2 |  Static Getter | Internal | 2.773 ns | 0.0258 ns | 0.0229 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|   GetPrivateStaticProperty | .NET Core 3.1 |  Static Getter | Internal | 3.458 ns | 0.0524 ns | 0.0490 ns |  1.25 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|    SetPublicStaticProperty |    .NET 4.7.2 |  Static Setter | Internal | 1.991 ns | 0.0215 ns | 0.0180 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    SetPublicStaticProperty | .NET Core 3.1 |  Static Setter | Internal | 2.217 ns | 0.0162 ns | 0.0136 ns |  1.11 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|  SetInternalStaticProperty |    .NET 4.7.2 |  Static Setter | Internal | 2.730 ns | 0.0337 ns | 0.0315 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|  SetInternalStaticProperty | .NET Core 3.1 |  Static Setter | Internal | 3.154 ns | 0.0203 ns | 0.0190 ns |  1.16 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
| SetProtectedStaticProperty |    .NET 4.7.2 |  Static Setter | Internal | 2.736 ns | 0.0433 ns | 0.0384 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| SetProtectedStaticProperty | .NET Core 3.1 |  Static Setter | Internal | 3.089 ns | 0.0269 ns | 0.0252 ns |  1.13 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|   SetPrivateStaticProperty |    .NET 4.7.2 |  Static Setter | Internal | 2.729 ns | 0.0323 ns | 0.0302 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|   SetPrivateStaticProperty | .NET Core 3.1 |  Static Setter | Internal | 3.183 ns | 0.0240 ns | 0.0212 ns |  1.17 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          GetPublicProperty |    .NET 4.7.2 |         Getter | Internal | 2.023 ns | 0.0272 ns | 0.0254 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          GetPublicProperty | .NET Core 3.1 |         Getter | Internal | 2.635 ns | 0.0356 ns | 0.0333 ns |  1.30 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|        GetInternalProperty |    .NET 4.7.2 |         Getter | Internal | 2.756 ns | 0.0257 ns | 0.0240 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|        GetInternalProperty | .NET Core 3.1 |         Getter | Internal | 3.121 ns | 0.0637 ns | 0.0596 ns |  1.13 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|       GetProtectedProperty |    .NET 4.7.2 |         Getter | Internal | 2.746 ns | 0.0270 ns | 0.0252 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|       GetProtectedProperty | .NET Core 3.1 |         Getter | Internal | 3.092 ns | 0.0346 ns | 0.0307 ns |  1.13 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetPrivateProperty |    .NET 4.7.2 |         Getter | Internal | 2.746 ns | 0.0363 ns | 0.0339 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetPrivateProperty | .NET Core 3.1 |         Getter | Internal | 3.379 ns | 0.0284 ns | 0.0252 ns |  1.23 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          SetPublicProperty |    .NET 4.7.2 |         Setter | Internal | 1.905 ns | 0.0176 ns | 0.0156 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          SetPublicProperty | .NET Core 3.1 |         Setter | Internal | 2.261 ns | 0.0519 ns | 0.0433 ns |  1.19 |    0.03 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|        SetInternalProperty |    .NET 4.7.2 |         Setter | Internal | 2.813 ns | 0.0288 ns | 0.0270 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|        SetInternalProperty | .NET Core 3.1 |         Setter | Internal | 3.060 ns | 0.0439 ns | 0.0389 ns |  1.09 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|       SetProtectedProperty |    .NET 4.7.2 |         Setter | Internal | 2.792 ns | 0.0315 ns | 0.0279 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|       SetProtectedProperty | .NET Core 3.1 |         Setter | Internal | 3.319 ns | 0.0525 ns | 0.0439 ns |  1.19 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetPrivateProperty |    .NET 4.7.2 |         Setter | Internal | 2.808 ns | 0.0366 ns | 0.0324 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetPrivateProperty | .NET Core 3.1 |         Setter | Internal | 3.343 ns | 0.0283 ns | 0.0265 ns |  1.19 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetIndexerProperty |    .NET 4.7.2 | Indexer Getter | Internal | 1.997 ns | 0.0246 ns | 0.0230 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetIndexerProperty | .NET Core 3.1 | Indexer Getter | Internal | 2.324 ns | 0.0193 ns | 0.0171 ns |  1.16 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetIndexerProperty |    .NET 4.7.2 | Indexer Setter | Internal | 1.892 ns | 0.0368 ns | 0.0307 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetIndexerProperty | .NET Core 3.1 | Indexer Setter | Internal | 2.221 ns | 0.0187 ns | 0.0156 ns |  1.17 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|    GetPublicStaticProperty |    .NET 4.7.2 |  Static Getter |  Private | 2.019 ns | 0.0208 ns | 0.0195 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    GetPublicStaticProperty | .NET Core 3.1 |  Static Getter |  Private | 2.287 ns | 0.0279 ns | 0.0247 ns |  1.13 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|  GetInternalStaticProperty |    .NET 4.7.2 |  Static Getter |  Private | 2.766 ns | 0.0320 ns | 0.0284 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|  GetInternalStaticProperty | .NET Core 3.1 |  Static Getter |  Private | 3.448 ns | 0.0434 ns | 0.0362 ns |  1.25 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
| GetProtectedStaticProperty |    .NET 4.7.2 |  Static Getter |  Private | 2.810 ns | 0.0236 ns | 0.0209 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| GetProtectedStaticProperty | .NET Core 3.1 |  Static Getter |  Private | 3.149 ns | 0.0239 ns | 0.0223 ns |  1.12 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|   GetPrivateStaticProperty |    .NET 4.7.2 |  Static Getter |  Private | 2.783 ns | 0.0323 ns | 0.0302 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|   GetPrivateStaticProperty | .NET Core 3.1 |  Static Getter |  Private | 3.640 ns | 0.0541 ns | 0.0479 ns |  1.31 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|    SetPublicStaticProperty |    .NET 4.7.2 |  Static Setter |  Private | 1.978 ns | 0.0135 ns | 0.0126 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    SetPublicStaticProperty | .NET Core 3.1 |  Static Setter |  Private | 2.198 ns | 0.0146 ns | 0.0137 ns |  1.11 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|  SetInternalStaticProperty |    .NET 4.7.2 |  Static Setter |  Private | 2.745 ns | 0.0303 ns | 0.0283 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|  SetInternalStaticProperty | .NET Core 3.1 |  Static Setter |  Private | 3.185 ns | 0.0403 ns | 0.0377 ns |  1.16 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
| SetProtectedStaticProperty |    .NET 4.7.2 |  Static Setter |  Private | 2.730 ns | 0.0223 ns | 0.0208 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| SetProtectedStaticProperty | .NET Core 3.1 |  Static Setter |  Private | 3.196 ns | 0.0408 ns | 0.0382 ns |  1.17 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|   SetPrivateStaticProperty |    .NET 4.7.2 |  Static Setter |  Private | 2.742 ns | 0.0251 ns | 0.0235 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|   SetPrivateStaticProperty | .NET Core 3.1 |  Static Setter |  Private | 3.185 ns | 0.0162 ns | 0.0136 ns |  1.16 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          GetPublicProperty |    .NET 4.7.2 |         Getter |  Private | 2.027 ns | 0.0243 ns | 0.0227 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          GetPublicProperty | .NET Core 3.1 |         Getter |  Private | 2.514 ns | 0.0277 ns | 0.0259 ns |  1.24 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|        GetInternalProperty |    .NET 4.7.2 |         Getter |  Private | 2.759 ns | 0.0307 ns | 0.0287 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|        GetInternalProperty | .NET Core 3.1 |         Getter |  Private | 3.386 ns | 0.0329 ns | 0.0292 ns |  1.23 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|       GetProtectedProperty |    .NET 4.7.2 |         Getter |  Private | 2.730 ns | 0.0256 ns | 0.0240 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|       GetProtectedProperty | .NET Core 3.1 |         Getter |  Private | 3.102 ns | 0.0368 ns | 0.0344 ns |  1.14 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetPrivateProperty |    .NET 4.7.2 |         Getter |  Private | 2.758 ns | 0.0339 ns | 0.0301 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetPrivateProperty | .NET Core 3.1 |         Getter |  Private | 3.081 ns | 0.0213 ns | 0.0188 ns |  1.12 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          SetPublicProperty |    .NET 4.7.2 |         Setter |  Private | 1.908 ns | 0.0130 ns | 0.0121 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          SetPublicProperty | .NET Core 3.1 |         Setter |  Private | 2.245 ns | 0.0290 ns | 0.0271 ns |  1.18 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|        SetInternalProperty |    .NET 4.7.2 |         Setter |  Private | 2.796 ns | 0.0206 ns | 0.0192 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|        SetInternalProperty | .NET Core 3.1 |         Setter |  Private | 3.050 ns | 0.0267 ns | 0.0250 ns |  1.09 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|       SetProtectedProperty |    .NET 4.7.2 |         Setter |  Private | 2.800 ns | 0.0240 ns | 0.0224 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|       SetProtectedProperty | .NET Core 3.1 |         Setter |  Private | 3.337 ns | 0.0312 ns | 0.0292 ns |  1.19 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetPrivateProperty |    .NET 4.7.2 |         Setter |  Private | 2.821 ns | 0.0379 ns | 0.0355 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetPrivateProperty | .NET Core 3.1 |         Setter |  Private | 3.336 ns | 0.0275 ns | 0.0244 ns |  1.18 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetIndexerProperty |    .NET 4.7.2 | Indexer Getter |  Private | 2.007 ns | 0.0165 ns | 0.0155 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetIndexerProperty | .NET Core 3.1 | Indexer Getter |  Private | 2.298 ns | 0.0159 ns | 0.0148 ns |  1.14 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetIndexerProperty |    .NET 4.7.2 | Indexer Setter |  Private | 1.891 ns | 0.0210 ns | 0.0196 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetIndexerProperty | .NET Core 3.1 | Indexer Setter |  Private | 2.491 ns | 0.0314 ns | 0.0294 ns |  1.32 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|    GetPublicStaticProperty |    .NET 4.7.2 |  Static Getter |   Public | 2.028 ns | 0.0087 ns | 0.0072 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    GetPublicStaticProperty | .NET Core 3.1 |  Static Getter |   Public | 2.362 ns | 0.0268 ns | 0.0251 ns |  1.16 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|  GetInternalStaticProperty |    .NET 4.7.2 |  Static Getter |   Public | 2.764 ns | 0.0356 ns | 0.0333 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|  GetInternalStaticProperty | .NET Core 3.1 |  Static Getter |   Public | 3.458 ns | 0.0219 ns | 0.0194 ns |  1.25 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
| GetProtectedStaticProperty |    .NET 4.7.2 |  Static Getter |   Public | 2.809 ns | 0.0153 ns | 0.0119 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| GetProtectedStaticProperty | .NET Core 3.1 |  Static Getter |   Public | 3.447 ns | 0.0386 ns | 0.0322 ns |  1.23 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|   GetPrivateStaticProperty |    .NET 4.7.2 |  Static Getter |   Public | 2.799 ns | 0.0352 ns | 0.0329 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|   GetPrivateStaticProperty | .NET Core 3.1 |  Static Getter |   Public | 3.172 ns | 0.0182 ns | 0.0171 ns |  1.13 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|    SetPublicStaticProperty |    .NET 4.7.2 |  Static Setter |   Public | 2.005 ns | 0.0332 ns | 0.0294 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|    SetPublicStaticProperty | .NET Core 3.1 |  Static Setter |   Public | 2.199 ns | 0.0186 ns | 0.0165 ns |  1.10 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|  SetInternalStaticProperty |    .NET 4.7.2 |  Static Setter |   Public | 2.721 ns | 0.0239 ns | 0.0224 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|  SetInternalStaticProperty | .NET Core 3.1 |  Static Setter |   Public | 3.168 ns | 0.0269 ns | 0.0252 ns |  1.16 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
| SetProtectedStaticProperty |    .NET 4.7.2 |  Static Setter |   Public | 2.719 ns | 0.0301 ns | 0.0282 ns |  1.00 |    0.00 |     - |     - |     - |         - |
| SetProtectedStaticProperty | .NET Core 3.1 |  Static Setter |   Public | 3.287 ns | 0.0675 ns | 0.0598 ns |  1.21 |    0.03 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|   SetPrivateStaticProperty |    .NET 4.7.2 |  Static Setter |   Public | 2.729 ns | 0.0257 ns | 0.0228 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|   SetPrivateStaticProperty | .NET Core 3.1 |  Static Setter |   Public | 3.100 ns | 0.0193 ns | 0.0161 ns |  1.14 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          GetPublicProperty |    .NET 4.7.2 |         Getter |   Public | 2.029 ns | 0.0117 ns | 0.0110 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          GetPublicProperty | .NET Core 3.1 |         Getter |   Public | 2.310 ns | 0.0189 ns | 0.0168 ns |  1.14 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|        GetInternalProperty |    .NET 4.7.2 |         Getter |   Public | 2.757 ns | 0.0209 ns | 0.0195 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|        GetInternalProperty | .NET Core 3.1 |         Getter |   Public | 3.104 ns | 0.0244 ns | 0.0228 ns |  1.13 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|       GetProtectedProperty |    .NET 4.7.2 |         Getter |   Public | 2.736 ns | 0.0380 ns | 0.0355 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|       GetProtectedProperty | .NET Core 3.1 |         Getter |   Public | 3.403 ns | 0.0262 ns | 0.0232 ns |  1.24 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetPrivateProperty |    .NET 4.7.2 |         Getter |   Public | 2.738 ns | 0.0268 ns | 0.0251 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetPrivateProperty | .NET Core 3.1 |         Getter |   Public | 3.083 ns | 0.0261 ns | 0.0244 ns |  1.13 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|          SetPublicProperty |    .NET 4.7.2 |         Setter |   Public | 1.899 ns | 0.0144 ns | 0.0135 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|          SetPublicProperty | .NET Core 3.1 |         Setter |   Public | 2.255 ns | 0.0227 ns | 0.0190 ns |  1.19 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|        SetInternalProperty |    .NET 4.7.2 |         Setter |   Public | 2.779 ns | 0.0295 ns | 0.0276 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|        SetInternalProperty | .NET Core 3.1 |         Setter |   Public | 3.330 ns | 0.0499 ns | 0.0467 ns |  1.20 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|       SetProtectedProperty |    .NET 4.7.2 |         Setter |   Public | 2.775 ns | 0.0326 ns | 0.0289 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|       SetProtectedProperty | .NET Core 3.1 |         Setter |   Public | 3.381 ns | 0.0251 ns | 0.0223 ns |  1.22 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetPrivateProperty |    .NET 4.7.2 |         Setter |   Public | 2.790 ns | 0.0314 ns | 0.0294 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetPrivateProperty | .NET Core 3.1 |         Setter |   Public | 3.374 ns | 0.0431 ns | 0.0403 ns |  1.21 |    0.01 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         GetIndexerProperty |    .NET 4.7.2 | Indexer Getter |   Public | 2.017 ns | 0.0335 ns | 0.0313 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         GetIndexerProperty | .NET Core 3.1 | Indexer Getter |   Public | 2.612 ns | 0.0236 ns | 0.0221 ns |  1.29 |    0.02 |     - |     - |     - |         - |
|                            |               |                |          |          |           |           |       |         |       |       |       |           |
|         SetIndexerProperty |    .NET 4.7.2 | Indexer Setter |   Public | 1.920 ns | 0.0295 ns | 0.0262 ns |  1.00 |    0.00 |     - |     - |     - |         - |
|         SetIndexerProperty | .NET Core 3.1 | Indexer Setter |   Public | 2.540 ns | 0.0281 ns | 0.0249 ns |  1.32 |    0.02 |     - |     - |     - |         - |


@DataDog/apm-dotnet