### PR TITLE
avoid null reference exceptions when setting special span tags

### DIFF
--- a/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -31,6 +31,11 @@ namespace Datadog.Trace.ExtensionMethods
         {
             if (value == null) { throw new ArgumentNullException(nameof(value)); }
 
+            if (value.Length == 0)
+            {
+                return null;
+            }
+
             if (value.Length == 1)
             {
                 if (value[0] == 'T' || value[0] == 't' ||

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -198,14 +198,14 @@ namespace Datadog.Trace
 
                     // value is a string and can represent a bool ("true") or a double ("0.5"),
                     // so try to parse both. note that "1" and "0" will parse as boolean, which is fine.
-                    bool? boolean = value.ToBoolean();
+                    bool? analyticsSamplingRate = value.ToBoolean();
 
-                    if (boolean == true)
+                    if (analyticsSamplingRate == true)
                     {
                         // always sample
                         SetMetric(Trace.Tags.Analytics, 1.0);
                     }
-                    else if (boolean == false)
+                    else if (analyticsSamplingRate == false)
                     {
                         // never sample
                         SetMetric(Trace.Tags.Analytics, 0.0);

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -171,7 +171,7 @@ namespace Datadog.Trace
 #pragma warning disable CS0618 // Type or member is obsolete
                 case Trace.Tags.ForceKeep:
                 case Trace.Tags.ManualKeep:
-                    if (value.ToBoolean() ?? false)
+                    if (value?.ToBoolean() == true)
                     {
                         // user-friendly tag to set UserKeep priority
                         Context.TraceContext.SamplingPriority = SamplingPriority.UserKeep;
@@ -180,7 +180,7 @@ namespace Datadog.Trace
                     break;
                 case Trace.Tags.ForceDrop:
                 case Trace.Tags.ManualDrop:
-                    if (value.ToBoolean() ?? false)
+                    if (value?.ToBoolean() == true)
                     {
                         // user-friendly tag to set UserReject priority
                         Context.TraceContext.SamplingPriority = SamplingPriority.UserReject;
@@ -189,10 +189,15 @@ namespace Datadog.Trace
                     break;
 #pragma warning restore CS0618 // Type or member is obsolete
                 case Trace.Tags.Analytics:
+                    if (string.IsNullOrEmpty(value))
+                    {
+                        // remove metric
+                        SetMetric(Trace.Tags.Analytics, null);
+                        return this;
+                    }
+
                     // value is a string and can represent a bool ("true") or a double ("0.5"),
-                    // so try to parse both.
-                    // note that "1" and "0" can parse as either type,
-                    // but they mean the same thing in this case, so it's fine.
+                    // so try to parse both. note that "1" and "0" will parse as boolean, which is fine.
                     bool? boolean = value.ToBoolean();
 
                     if (boolean == true)


### PR DESCRIPTION
When setting special span tags, check the tag value for `null` to avoid possible `NullReferenceException`.

Bonus: in `String.ToBoolean()` extension method, check for empty string and exit early.
