### PR TITLE
Avoid string allocation for status code

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -8,6 +8,7 @@ using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -267,7 +268,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null)
                     {
-                        tags.HttpStatusCode = statusCode.ToString();
+                        tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString(statusCode);
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -93,7 +94,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        tags.HttpStatusCode = ((int)webResponse.StatusCode).ToString();
+                        tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString((int)webResponse.StatusCode);
                     }
 
                     return response;
@@ -178,7 +179,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        tags.HttpStatusCode = ((int)webResponse.StatusCode).ToString();
+                        tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString((int)webResponse.StatusCode);
                     }
 
                     return response;

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -230,16 +230,9 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 var httpContext = HttpRequestInStopHttpContextFetcher.Fetch<HttpContext>(arg);
 
-                var statusCode = httpContext.Response.StatusCode;
+                var statusCode = HttpTags.ConvertStatusCodeToString(httpContext.Response.StatusCode);
 
-                if (statusCode == 200)
-                {
-                    scope.Span.SetTag(Tags.HttpStatusCode, "200");
-                }
-                else
-                {
-                    scope.Span.SetTag(Tags.HttpStatusCode, httpContext.Response.StatusCode.ToString());
-                }
+                scope.Span.SetTag(Tags.HttpStatusCode, statusCode);
 
                 if (httpContext.Response.StatusCode / 100 == 5)
                 {

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ExtensionMethods
 
         internal static void SetServerStatusCode(this Span span, int statusCode)
         {
-            span.SetTag(Tags.HttpStatusCode, statusCode.ToString());
+            span.SetTag(Tags.HttpStatusCode, HttpTags.ConvertStatusCodeToString(statusCode));
 
             // 5xx codes are server-side errors
             if (statusCode / 100 == 5)

--- a/src/Datadog.Trace/Tagging/HttpTags.cs
+++ b/src/Datadog.Trace/Tagging/HttpTags.cs
@@ -33,6 +33,31 @@ namespace Datadog.Trace.Tagging
 
         public double? AnalyticsSampleRate { get; set; }
 
+        public static string ConvertStatusCodeToString(int statusCode)
+        {
+            if (statusCode == 200)
+            {
+                return "200";
+            }
+
+            if (statusCode == 302)
+            {
+                return "302";
+            }
+
+            if (statusCode == 500)
+            {
+                return "500";
+            }
+
+            if (statusCode == 503)
+            {
+                return "503";
+            }
+
+            return statusCode.ToString();
+        }
+
         protected override IProperty<string>[] GetAdditionalTags() => HttpTagsProperties;
 
         protected override IProperty<double?>[] GetAdditionalMetrics() => HttpMetricsProperties;

--- a/src/Datadog.Trace/Tagging/HttpTags.cs
+++ b/src/Datadog.Trace/Tagging/HttpTags.cs
@@ -45,6 +45,21 @@ namespace Datadog.Trace.Tagging
                 return "302";
             }
 
+            if (statusCode == 401)
+            {
+                return "401";
+            }
+
+            if (statusCode == 403)
+            {
+                return "403";
+            }
+
+            if (statusCode == 404)
+            {
+                return "404";
+            }
+
             if (statusCode == 500)
             {
                 return "500";


### PR DESCRIPTION
HttpClientHandler benchmark:

```
|         Method |     Mean |     Error |    StdDev |   Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |---------:|----------:|----------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|  SendAsync_old | 5.750 μs | 0.1072 μs | 0.1002 μs | 5.760 μs |  1.00 |    0.00 | 0.4196 |     - |     - |    2.6 KB |
|  SendAsync_new | 5.713 μs | 0.0576 μs | 0.0511 μs | 5.728 μs |  1.00 |    0.02 | 0.4120 |     - |     - |   2.57 KB |
```