### PR TITLE
Don't use string.Join for simple concatenation

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             string method = requestData.GetProperty("Method").GetValueOrDefault()?.ToString();
             var url = requestData.GetProperty("Uri").GetValueOrDefault()?.ToString();
 
-            var serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+            var serviceName = $"{tracer.DefaultServiceName} - {ServiceName}";
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             string method = requestData.GetProperty("Method").GetValueOrDefault()?.ToString();
             var url = requestData.GetProperty("Uri").GetValueOrDefault()?.ToString();
 
-            var serviceName = $"{tracer.DefaultServiceName} - {ServiceName}";
+            var serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -236,7 +236,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Tracer tracer = Tracer.Instance;
             string source = document.GetProperty<string>("OriginalQuery")
                                     .GetValueOrDefault();
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
 
             Scope scope = null;
 
@@ -283,7 +283,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                                                        .GetProperty<Enum>("OperationType")
                                                        .GetValueOrDefault()
                                                        .ToString();
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -458,7 +458,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             Tracer tracer = Tracer.Instance;
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return null;
             }
 
-            string serviceName = string.Join("-", tracer.DefaultServiceName, ServiceName);
+            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
             Scope scope = null;
 
             try


### PR DESCRIPTION
Plus, it's easier to read.

GraphQL benchmark:

```
|           Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
| ExecuteAsync_Old | 4.061 us | 0.0782 us | 0.0931 us |  1.00 |    0.00 | 0.2441 |     - |     - |    1.5 KB |
| ExecuteAsync_New | 3.956 us | 0.0773 us | 0.0920 us |  0.97 |    0.03 | 0.2365 |     - |     - |   1.46 KB |
```

I expect similar gains for other impacted integrations.