### PR TITLE
Add PropertyFetcher tests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/PropertyFetcherTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/PropertyFetcherTests.cs
@@ -1,0 +1,85 @@
+using Datadog.Trace.Util;
+using Xunit;
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+#pragma warning disable SA1402 // File may only contain a single class
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class PropertyFetcherTests
+    {
+        [Fact]
+        public void ReferenceTypeObject_FetchesReferenceTypeProperty()
+        {
+            const string expected = "ReferenceType";
+
+            var element = new ExampleReferenceType(123, expected);
+            var fetcher = new PropertyFetcher("Name");
+            var actual = fetcher.Fetch<string>(element);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReferenceTypeObject_FetchesValueTypeProperty()
+        {
+            const int expected = 123;
+
+            var element = new ExampleReferenceType(expected, "ReferenceType");
+            var fetcher = new PropertyFetcher("Id");
+            var actual = fetcher.Fetch<int>(element);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ValueTypeObject_FetchesReferenceTypeProperty()
+        {
+            const string expected = "ValueType";
+
+            var element = new ExampleValueType(123, expected);
+            var fetcher = new PropertyFetcher("Name");
+            var actual = fetcher.Fetch<string>(element);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ValueTypeObject_FetchesValueTypeProperty()
+        {
+            const int expected = 123;
+
+            var element = new ExampleValueType(expected, "ValueType");
+            var fetcher = new PropertyFetcher("Id");
+            var actual = fetcher.Fetch<int>(element);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    internal class ExampleReferenceType
+    {
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public ExampleReferenceType(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+    }
+
+    internal struct ExampleValueType
+    {
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public ExampleValueType(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+    }
+}


### PR DESCRIPTION
Add PropertyFetcher tests to make sure behavior for both reference types and value types are tested

These tests were also run against the pre-1.18.2 implementation of PropertyFetcher where retrieving properties on value types failed.

@DataDog/apm-dotnet