### PR TITLE
[opentracing] Make it possible to pass a "span logger"

### DIFF
--- a/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingSpan.cs
@@ -8,10 +8,13 @@ namespace Datadog.Trace.OpenTracing
 {
     internal class OpenTracingSpan : ISpan
     {
-        internal OpenTracingSpan(Span span)
+        private OpenTracingTracerFactory.SpanLogger _spanLogger;
+
+        internal OpenTracingSpan(Span span, OpenTracingTracerFactory.SpanLogger spanLogger)
         {
             Span = span;
             Context = new OpenTracingSpanContext(span.Context);
+            _spanLogger = spanLogger;
         }
 
         public OpenTracingSpanContext Context { get; }
@@ -30,13 +33,29 @@ namespace Datadog.Trace.OpenTracing
 
         public string GetBaggageItem(string key) => null;
 
-        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields) => this;
+        public ISpan Log(DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            _spanLogger(timestamp, fields);
+            return this;
+        }
 
-        public ISpan Log(string eventName) => this;
+        public ISpan Log(string eventName)
+        {
+            _spanLogger(null, new Dictionary<string, object> { ["eventName"] = eventName });
+            return this;
+        }
 
-        public ISpan Log(DateTimeOffset timestamp, string eventName) => this;
+        public ISpan Log(DateTimeOffset timestamp, string eventName)
+        {
+            _spanLogger(timestamp, new Dictionary<string, object> { ["eventName"] = eventName });
+            return this;
+        }
 
-        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields) => this;
+        public ISpan Log(IEnumerable<KeyValuePair<string, object>> fields)
+        {
+            _spanLogger(null, fields);
+            return this;
+        }
 
         public ISpan SetBaggageItem(string key, string value) => this;
 

--- a/src/Datadog.Trace.OpenTracing/OpenTracingSpanBuilder.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingSpanBuilder.cs
@@ -19,11 +19,13 @@ namespace Datadog.Trace.OpenTracing
         private Dictionary<string, string> _tags;
         private string _serviceName;
         private bool _ignoreActiveSpan;
+        private OpenTracingTracerFactory.SpanLogger _spanLogger;
 
-        internal OpenTracingSpanBuilder(OpenTracingTracer tracer, string operationName)
+        internal OpenTracingSpanBuilder(OpenTracingTracer tracer, string operationName, OpenTracingTracerFactory.SpanLogger spanLogger)
         {
             _tracer = tracer;
             _operationName = operationName;
+            _spanLogger = spanLogger;
         }
 
         public ISpanBuilder AddReference(string referenceType, global::OpenTracing.ISpanContext referencedContext)
@@ -71,7 +73,7 @@ namespace Datadog.Trace.OpenTracing
             {
                 ISpanContext parentContext = GetParentContext();
                 Span ddSpan = _tracer.DatadogTracer.StartSpan(_operationName, parentContext, _serviceName, _start, _ignoreActiveSpan);
-                var otSpan = new OpenTracingSpan(ddSpan);
+                var otSpan = new OpenTracingSpan(ddSpan, _spanLogger);
 
                 if (_tags != null)
                 {

--- a/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using OpenTracing;
 
@@ -10,31 +11,50 @@ namespace Datadog.Trace.OpenTracing
     public static class OpenTracingTracerFactory
     {
         /// <summary>
+        /// A method invoked in Span.Log calls
+        /// </summary>
+        /// <param name="timestamp">Timestamp of the log</param>
+        /// <param name="fields">Log fields</param>
+        public delegate void SpanLogger(DateTimeOffset? timestamp, IEnumerable<KeyValuePair<string, object>> fields);
+
+        /// <summary>
         /// Create a new Datadog compatible ITracer implementation with the given parameters
         /// </summary>
         /// <param name="agentEndpoint">The agent endpoint where the traces will be sent (default is http://localhost:8126).</param>
         /// <param name="defaultServiceName">Default name of the service (default is the name of the executing assembly).</param>
         /// <param name="isDebugEnabled">Turns on all debug logging (this may have an impact on application performance).</param>
+        /// <param name="spanLogger">Delegate used in Span.Log calls</param>
         /// <returns>A Datadog compatible ITracer implementation</returns>
-        public static ITracer CreateTracer(Uri agentEndpoint = null, string defaultServiceName = null, bool isDebugEnabled = false)
+        public static ITracer CreateTracer(Uri agentEndpoint = null, string defaultServiceName = null, bool isDebugEnabled = false, SpanLogger spanLogger = null)
         {
-            return CreateTracer(agentEndpoint, defaultServiceName, null, isDebugEnabled);
+            if (spanLogger is null)
+            {
+                spanLogger = (DateTimeOffset? timestamp, IEnumerable<KeyValuePair<string, object>> fields) => { };
+            }
+
+            return CreateTracer(agentEndpoint, defaultServiceName, null, isDebugEnabled, spanLogger);
         }
 
         /// <summary>
         /// Create a new Datadog compatible ITracer implementation using an existing Datadog Tracer instance
         /// </summary>
         /// <param name="tracer">Existing Datadog Tracer instance</param>
+        /// <param name="spanLogger">Delegate used in Span.Log calls</param>
         /// <returns>A Datadog compatible ITracer implementation</returns>
-        public static ITracer WrapTracer(Tracer tracer)
+        public static ITracer WrapTracer(Tracer tracer, SpanLogger spanLogger)
         {
-            return new OpenTracingTracer(tracer);
+            if (spanLogger is null)
+            {
+                spanLogger = (DateTimeOffset? timestamp, IEnumerable<KeyValuePair<string, object>> fields) => { };
+            }
+
+            return new OpenTracingTracer(tracer, spanLogger);
         }
 
-        internal static OpenTracingTracer CreateTracer(Uri agentEndpoint, string defaultServiceName, DelegatingHandler delegatingHandler, bool isDebugEnabled)
+        internal static OpenTracingTracer CreateTracer(Uri agentEndpoint, string defaultServiceName, DelegatingHandler delegatingHandler, bool isDebugEnabled, SpanLogger spanLogger)
         {
             var tracer = Tracer.Create(agentEndpoint, defaultServiceName, isDebugEnabled);
-            return new OpenTracingTracer(tracer);
+            return new OpenTracingTracer(tracer, spanLogger);
         }
     }
 }


### PR DESCRIPTION
Fixes #909

Changes proposed in this pull request:

One of the pitfalls of the OpenTracing implementation for the datadog
tracer is that it doesn't support logging within a span (span.Log()).

I totally understand that since "logs within a span" is not a feature
of the Datadog API platform, sending span logs inside a span object
would take quite a lot, and may not even be on the roadmap.

However, giving end users the ability to pass a "span logger" to the
OpenTracing tracer seemed like a good workaround: when instantiating
the Tracer, we can also provide a delegate that will be called when
span.Log() is.

Typically, this enables users to use their favorite logging library
to have the log appear on stdout, injecting Trace and Span ids in the
process. These logs can later be collected by the log agent, and they
will appear on the APM interface as one would expect :)

In a sense, it "fixes" (or at least offers a workaround for) this
issue: https://github.com/DataDog/dd-trace-dotnet/issues/909

@DataDog/apm-dotnet