### PR TITLE
Redis instrumentation to ducktyping

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using Datadog.Trace.ClrProfiler.Emit;
@@ -86,8 +87,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             using (var scope = RedisHelper.CreateScope(
                 Tracer.Instance,
                 IntegrationName,
-                clientData.Host,
-                clientData.Port.ToString(),
+                clientData.Host ?? string.Empty,
+                clientData.Port.ToString(CultureInfo.InvariantCulture),
                 GetRawCommand(cmdWithBinaryArgs)))
             {
                 try
@@ -123,12 +124,21 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         /*
          * Ducktyping types
          */
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable SA1600 // Elements must be documented
+
+        /// <summary>
+        /// Redis native client struct data for duck typing
+        /// </summary>
         [DuckCopy]
         public struct RedisNativeClientData
         {
+            /// <summary>
+            /// Client Hostname
+            /// </summary>
             public string Host;
+
+            /// <summary>
+            /// Client Port
+            /// </summary>
             public int Port;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -239,18 +239,28 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /*
          * DuckTyping Types
          */
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable SA1600 // Elements must be documented
 
+        /// <summary>
+        /// Multiplexer data structure for duck typing
+        /// </summary>
         [DuckCopy]
         public struct MultiplexerData
         {
+            /// <summary>
+            /// Multiplexer configuration
+            /// </summary>
             public string Configuration;
         }
 
+        /// <summary>
+        /// Message data structure for duck typing
+        /// </summary>
         [DuckCopy]
         public struct MessageData
         {
+            /// <summary>
+            /// Message command and key
+            /// </summary>
             public string CommandAndKey;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -156,25 +156,41 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
         /*
          * DuckTyping Types
          */
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-#pragma warning disable SA1600 // Elements must be documented
 
+        /// <summary>
+        /// Batch data structure for duck typing
+        /// </summary>
         [DuckCopy]
         public struct BatchData
         {
+            /// <summary>
+            /// Multiplexer data structure
+            /// </summary>
             [Duck(Name = "multiplexer", Kind = DuckKind.Field)]
             public MultiplexerData Multiplexer;
         }
 
+        /// <summary>
+        /// Multiplexer data structure for duck typing
+        /// </summary>
         [DuckCopy]
         public struct MultiplexerData
         {
+            /// <summary>
+            /// Multiplexer configuration
+            /// </summary>
             public string Configuration;
         }
 
+        /// <summary>
+        /// Message data structure for duck typing
+        /// </summary>
         [DuckCopy]
         public struct MessageData
         {
+            /// <summary>
+            /// Message command and key
+            /// </summary>
             public string CommandAndKey;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/StackExchangeRedisHelper.cs
@@ -10,21 +10,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
     internal static class StackExchangeRedisHelper
     {
         /// <summary>
-        /// Get the configuration for the multiplexer.
-        /// </summary>
-        /// <param name="multiplexer">The multiplexer</param>
-        /// <returns>The configuration</returns>
-        public static string GetConfiguration(object multiplexer)
-        {
-            return multiplexer.GetProperty<string>("Configuration").GetValueOrDefault();
-        }
-
-        /// <summary>
         /// Get the host and port from the config
         /// </summary>
         /// <param name="config">The config</param>
         /// <returns>The host and port</returns>
-        public static Tuple<string, string> GetHostAndPort(string config)
+        public static HostAndPort GetHostAndPort(string config)
         {
             string host = null;
             string port = null;
@@ -50,28 +40,19 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                 }
             }
 
-            return new Tuple<string, string>(host, port);
+            return new HostAndPort(host, port);
         }
 
-        /// <summary>
-        /// Get the raw command.
-        /// </summary>
-        /// <param name="multiplexer">The multiplexer</param>
-        /// <param name="message">The message</param>
-        /// <returns>The raw command</returns>
-        public static string GetRawCommand(object multiplexer, object message)
+        internal readonly struct HostAndPort
         {
-            return message.GetProperty<string>("CommandAndKey").GetValueOrDefault() ?? "COMMAND";
-        }
+            public readonly string Host;
+            public readonly string Port;
 
-        /// <summary>
-        /// GetMultiplexer returns the Multiplexer for an object
-        /// </summary>
-        /// <param name="obj">The object</param>
-        /// <returns>The multiplexer</returns>
-        public static object GetMultiplexer(object obj)
-        {
-            return obj.GetField<object>("multiplexer").GetValueOrDefault();
+            public HostAndPort(string host, string port)
+            {
+                Host = host;
+                Port = port;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR changes the redis instrumentation to use ducktyping.

#### Old version:
```ini
|      Method |        Job |       Runtime |     Toolchain |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |----------- |-------------- |-------------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| SendReceive | Job-EMMLQQ |    .NET 4.7.2 |        net472 | 3.959 us | 0.0771 us | 0.0824 us |  1.00 | 0.3548 |     - |     - |   1.46 KB |
| SendReceive | Job-ESEYBH | .NET Core 3.1 | netcoreapp3.1 | 2.096 us | 0.0221 us | 0.0207 us |  0.53 | 0.3510 |     - |     - |   1.44 KB |
```

#### New version:
```ini
|      Method |        Job |       Runtime |     Toolchain |     Mean |     Error |    StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |----------- |-------------- |-------------- |---------:|----------:|----------:|------:|-------:|------:|------:|----------:|
| SendReceive | Job-TPTCVP |    .NET 4.7.2 |        net472 | 3.476 us | 0.0388 us | 0.0363 us |  1.00 | 0.3548 |     - |     - |   1.46 KB |
| SendReceive | Job-DMAWYZ | .NET Core 3.1 | netcoreapp3.1 | 1.830 us | 0.0179 us | 0.0159 us |  0.53 | 0.3510 |     - |     - |   1.44 KB |
```
@DataDog/apm-dotnet