### PR TITLE
keep Datadog.Trace.DuckTyping.dll assembly version at 1.0.0

### DIFF
--- a/src/Datadog.Trace.DuckTyping/AssemblyInfo.cs
+++ b/src/Datadog.Trace.DuckTyping/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+[assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]

--- a/src/Datadog.Trace.DuckTyping/Datadog.Trace.DuckTyping.csproj
+++ b/src/Datadog.Trace.DuckTyping/Datadog.Trace.DuckTyping.csproj
@@ -5,6 +5,11 @@
     <Version>1.19.3</Version>
     <Title>Datadog APM</Title>
     <Description>DuckType library for Datadog APM</Description>
+
+    <!-- Allow the GenerateAssemblyInfo task in the .NET SDK to generate all
+         assembly attributes except for the AssemblyVersionAttribute. This will
+         be locked at Major.0.0.0 and is defined in AssemblyInfo.cs -->
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the

--- a/tools/PrepareRelease/SetAllVersions.cs
+++ b/tools/PrepareRelease/SetAllVersions.cs
@@ -80,6 +80,10 @@ namespace PrepareRelease
                 "src/Datadog.Trace.ClrProfiler.Managed.Core/AssemblyInfo.cs",
                 text => MajorAssemblyVersionReplace(text, "."));
 
+            SynchronizeVersion(
+                "src/Datadog.Trace.DuckTyping/AssemblyInfo.cs",
+                text => MajorAssemblyVersionReplace(text, "."));
+
             // Native profiler updates
             SynchronizeVersion(
                 "src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",


### PR DESCRIPTION
Keep `[AssemblyVersion]` attribute of `Datadog.Trace.DuckTyping.dl` at 1.0.0 while still updating the `[AssemblyFileVersion]` and `[AssemblyInformationalVersion]`. This allows this assembly to be shared by different tracer versions when strict assembly binding kicks in. We already do this for `Datadog.Trace.AspNet.dll` and `Datadog.Trace.ClrProfiler.Managed.Core.dll`.

From [.NET Open-source library guidance - Assembly version](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/versioning#assembly-version):

> ✔️ CONSIDER only including a major version in the AssemblyVersion.
>
> e.g. Library 1.0 and Library 1.0.1 both have an AssemblyVersion of 1.0.0.0, while Library 2.0 has AssemblyVersion of 2.0.0.0. When the assembly version changes less often, it reduces binding redirects.
