### PR TITLE
Add error message when http response code is 5xx

### DIFF
--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -224,22 +224,13 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            IScope scope = tracer.ActiveScope;
+            var scope = tracer.ActiveScope;
 
             if (scope != null)
             {
                 var httpContext = HttpRequestInStopHttpContextFetcher.Fetch<HttpContext>(arg);
 
-                var statusCode = HttpTags.ConvertStatusCodeToString(httpContext.Response.StatusCode);
-
-                scope.Span.SetTag(Tags.HttpStatusCode, statusCode);
-
-                if (httpContext.Response.StatusCode / 100 == 5)
-                {
-                    // 5xx codes are server-side errors
-                    scope.Span.Error = true;
-                }
-
+                scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
                 scope.Dispose();
             }
         }
@@ -253,12 +244,11 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            ISpan span = tracer.ActiveScope?.Span;
+            var span = tracer.ActiveScope?.Span;
 
             if (span != null)
             {
                 var exception = UnhandledExceptionExceptionFetcher.Fetch<Exception>(arg);
-                var httpContext = UnhandledExceptionHttpContextFetcher.Fetch<HttpContext>(arg);
 
                 span.SetException(exception);
             }

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -2,13 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Datadog.Trace.Abstractions;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
-using Datadog.Trace.Vendors.Serilog.Events;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 
@@ -35,13 +33,11 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private static readonly PropertyFetcher HttpRequestInStartHttpContextFetcher = new PropertyFetcher("HttpContext");
         private static readonly PropertyFetcher HttpRequestInStopHttpContextFetcher = new PropertyFetcher("HttpContext");
-        private static readonly PropertyFetcher UnhandledExceptionHttpContextFetcher = new PropertyFetcher("HttpContext");
         private static readonly PropertyFetcher UnhandledExceptionExceptionFetcher = new PropertyFetcher("Exception");
         private static readonly PropertyFetcher BeforeActionHttpContextFetcher = new PropertyFetcher("httpContext");
         private static readonly PropertyFetcher BeforeActionActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");
 
         private readonly Tracer _tracer;
-        private readonly bool _isLogLevelDebugEnabled = Log.IsEnabled(LogEventLevel.Debug);
 
         public AspNetCoreDiagnosticObserver()
             : this(null)

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -71,12 +71,14 @@ namespace Datadog.Trace.ExtensionMethods
 
         internal static void SetServerStatusCode(this Span span, int statusCode)
         {
-            span.SetTag(Tags.HttpStatusCode, HttpTags.ConvertStatusCodeToString(statusCode));
+            string statusCodeString = HttpTags.ConvertStatusCodeToString(statusCode);
+            span.SetTag(Tags.HttpStatusCode, statusCodeString);
 
             // 5xx codes are server-side errors
             if (statusCode / 100 == 5)
             {
                 span.Error = true;
+                span.SetTag(Trace.Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
             }
         }
     }

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -79,6 +79,7 @@ namespace Datadog.Trace.ExtensionMethods
             {
                 span.Error = true;
 
+                // if an error message already exists (e.g. from a previous exception), don't replace it
                 if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
                 {
                     span.SetTag(Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -78,7 +78,11 @@ namespace Datadog.Trace.ExtensionMethods
             if (statusCode / 100 == 5)
             {
                 span.Error = true;
-                span.SetTag(Trace.Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
+
+                if (string.IsNullOrEmpty(span.GetTag(Tags.ErrorMsg)))
+                {
+                    span.SetTag(Tags.ErrorMsg, $"The HTTP response has status code {statusCodeString}.");
+                }
             }
         }
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -23,15 +23,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET /home/index", HttpStatusCode.OK, false)]
-        [InlineData("/Home/BadRequest", "GET /home/badrequest", HttpStatusCode.InternalServerError, true)]
-        [InlineData("/Home/StatusCode?value=201", "GET /home/statuscode", HttpStatusCode.Created, false)]
-        [InlineData("/Home/StatusCode?value=503", "GET /home/statuscode", HttpStatusCode.ServiceUnavailable, true)]
+        [InlineData("/Home/Index", "GET /home/index", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/Home/BadRequest", "GET /home/badrequest", HttpStatusCode.InternalServerError, true, null, null)]
+        [InlineData("/Home/StatusCode?value=201", "GET /home/statuscode", HttpStatusCode.Created, false, null, null)]
+        [InlineData("/Home/StatusCode?value=503", "GET /home/statuscode", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.")]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,
             HttpStatusCode expectedStatusCode,
-            bool isError)
+            bool isError,
+            string expectedErrorType,
+            string expectedErrorMessage)
         {
             await AssertWebServerSpan(
                 path,
@@ -39,6 +41,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.HttpPort,
                 expectedStatusCode,
                 isError,
+                expectedErrorType,
+                expectedErrorMessage,
                 "web",
                 "aspnet-mvc.request",
                 expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -24,18 +24,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET", "/home/index", HttpStatusCode.OK, false)]
-        [InlineData("/delay/0", "GET", "/delay/{seconds}", HttpStatusCode.OK, false)]
-        [InlineData("/delay-async/0", "GET", "/delay-async/{seconds}", HttpStatusCode.OK, false)]
-        [InlineData("/badrequest", "GET", "/badrequest", HttpStatusCode.InternalServerError, true)]
-        [InlineData("/statuscode/201", "GET", "/statuscode/{value}", HttpStatusCode.Created, false)]
-        [InlineData("/statuscode/503", "GET", "/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true)]
+        [InlineData("/Home/Index", "GET", "/home/index", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/delay/0", "GET", "/delay/{seconds}", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/delay-async/0", "GET", "/delay-async/{seconds}", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/badrequest", "GET", "/badrequest", HttpStatusCode.InternalServerError, true, null, null)]
+        [InlineData("/statuscode/201", "GET", "/statuscode/{value}", HttpStatusCode.Created, false, null, null)]
+        [InlineData("/statuscode/503", "GET", "/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.")]
         public async Task SubmitsTraces(
             string path,
             string expectedVerb,
             string expectedResourceSuffix,
             HttpStatusCode expectedStatusCode,
-            bool isError)
+            bool isError,
+            string expectedErrorType,
+            string expectedErrorMessage)
         {
             await AssertWebServerSpan(
                 path,
@@ -43,6 +45,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.HttpPort,
                 expectedStatusCode,
                 isError,
+                expectedErrorType,
+                expectedErrorMessage,
                 "web",
                 "aspnet-mvc.request",
                 $"{expectedVerb} {expectedResourceSuffix}",

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -24,18 +24,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
-        [InlineData("/api/environment", "GET api/environment", HttpStatusCode.OK, false)]
-        [InlineData("/api/delay/0", "GET api/delay/{seconds}", HttpStatusCode.OK, false)]
-        [InlineData("/api/delay-async/0", "GET api/delay-async/{seconds}", HttpStatusCode.OK, false)]
-        [InlineData("/api/transient-failure/true", "GET api/transient-failure/{value}", HttpStatusCode.OK, false)]
-        [InlineData("/api/transient-failure/false", "GET api/transient-failure/{value}", HttpStatusCode.InternalServerError, true)]
-        [InlineData("/api/statuscode/201", "GET api/statuscode/{value}", HttpStatusCode.Created, false)]
-        [InlineData("/api/statuscode/503", "GET api/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true)]
+        [InlineData("/api/environment", "GET api/environment", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/api/delay/0", "GET api/delay/{seconds}", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/api/delay-async/0", "GET api/delay-async/{seconds}", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/api/transient-failure/true", "GET api/transient-failure/{value}", HttpStatusCode.OK, false, null, null)]
+        [InlineData("/api/transient-failure/false", "GET api/transient-failure/{value}", HttpStatusCode.InternalServerError, true, null, null)]
+        [InlineData("/api/statuscode/201", "GET api/statuscode/{value}", HttpStatusCode.Created, false, null, null)]
+        [InlineData("/api/statuscode/503", "GET api/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.")]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,
             HttpStatusCode expectedStatusCode,
-            bool isError)
+            bool isError,
+            string expectedErrorType,
+            string expectedErrorMessage)
         {
             await AssertWebServerSpan(
                 path,
@@ -43,6 +45,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.HttpPort,
                 expectedStatusCode,
                 isError,
+                expectedErrorType,
+                expectedErrorMessage,
                 "web",
                 "aspnet-webapi.request",
                 expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -40,6 +40,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 _iisFixture.HttpPort,
                 HttpStatusCode.OK,
                 isError,
+                expectedErrorType: null,
+                expectedErrorMessage: null,
                 SpanTypes.Web,
                 "aspnet.request",
                 expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -38,6 +38,36 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             CreateTopLevelExpectation(url: "/status-code/203", httpMethod: "GET", httpStatus: "203", resourceUrl: "status-code/{statusCode}", serviceVersion: ServiceVersion);
 
             CreateTopLevelExpectation(
+                url: "/status-code/500",
+                httpMethod: "GET",
+                httpStatus: "500",
+                resourceUrl: "status-code/{statusCode}",
+                serviceVersion: ServiceVersion,
+                additionalCheck: span =>
+                                 {
+                                     var failures = new List<string>();
+
+                                     if (span.Error == 0)
+                                     {
+                                         failures.Add($"Expected Error flag set within {span.Resource}");
+                                     }
+
+                                     if (SpanExpectation.GetTag(span, Tags.ErrorType) != null)
+                                     {
+                                         failures.Add($"Did not expect exception type within {span.Resource}");
+                                     }
+
+                                     var errorMessage = SpanExpectation.GetTag(span, Tags.ErrorMsg);
+
+                                     if (errorMessage != "The HTTP response has status code 500.")
+                                     {
+                                         failures.Add($"Expected specific error message within {span.Resource}. Found \"{errorMessage}\"");
+                                     }
+
+                                     return failures;
+                                 });
+
+            CreateTopLevelExpectation(
                 url: "/bad-request",
                 httpMethod: "GET",
                 httpStatus: "500",

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -234,6 +234,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int httpPort,
             HttpStatusCode expectedHttpStatusCode,
             bool isError,
+            string expectedErrorType,
+            string expectedErrorMessage,
             string expectedSpanType,
             string expectedOperationName,
             string expectedResourceName,
@@ -260,10 +262,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             MockTracerAgent.Span span = spans[0];
-            Assert.Equal(isError, span.Error == 1);
+
+            // base properties
             Assert.Equal(expectedSpanType, span.Type);
             Assert.Equal(expectedOperationName, span.Name);
             Assert.Equal(expectedResourceName, span.Resource);
+
+            // errors
+            Assert.Equal(isError, span.Error == 1);
+            Assert.Equal(expectedErrorType, span.Tags.GetValueOrDefault(Tags.ErrorType));
+            Assert.Equal(expectedErrorMessage, span.Tags.GetValueOrDefault(Tags.ErrorMsg));
+
+            // other tags
             Assert.Equal(SpanKinds.Server, span.Tags.GetValueOrDefault(Tags.SpanKind));
             Assert.Equal(expectedServiceVersion, span.Tags.GetValueOrDefault(Tags.Version));
         }


### PR DESCRIPTION
When the Tracer `Span.Error = true` on web server spans due to an HTTP response code of 5xx, also add an error message (span tag `error.msg`). Otherwise, the APM UI shows only `error: true` as the error message.

Bonus: fix the ASP.NET Core integration to use the `Span.SetServerStatusCode()` extension method like the other web integrations.