### PR TITLE
Remove dependency on Sigil 4.7.0 / Sigil-vNext 4.8.41 (updated)

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -34,11 +34,8 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp3.1'">

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -32,20 +32,20 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <ProjectReference Include="..\Datadog.Trace.DuckTyping\Datadog.Trace.DuckTyping.csproj" />
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
- 
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.6.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'netcoreapp3.1'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
 
     <ProjectReference Include="..\Datadog.Trace.AspNet\Datadog.Trace.AspNet.csproj" PrivateAssets="all" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Sigil" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <PackageReference Include="Sigil-vNext" Version="4.8.41" />
   </ItemGroup>
 
   <Import Project="..\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems" Label="Shared" />

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
@@ -166,7 +166,24 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 Type delegateParameterType = parameterTypes[argumentIndex];
                 Type underlyingParameterType = effectiveParameterTypes[argumentIndex];
 
-                il.Emit(OpCodes.Ldarg, argumentIndex);
+                switch (argumentIndex)
+                {
+                    case 0:
+                        il.Emit(OpCodes.Ldarg_0);
+                        break;
+                    case 1:
+                        il.Emit(OpCodes.Ldarg_1);
+                        break;
+                    case 2:
+                        il.Emit(OpCodes.Ldarg_2);
+                        break;
+                    case 3:
+                        il.Emit(OpCodes.Ldarg_3);
+                        break;
+                    default:
+                        il.Emit(OpCodes.Ldarg_S, argumentIndex);
+                        break;
+                }
 
                 if (underlyingParameterType.IsValueType && delegateParameterType == typeof(object))
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using Sigil;
 
 namespace Datadog.Trace.ClrProfiler.Emit
 {
@@ -158,7 +157,8 @@ namespace Datadog.Trace.ClrProfiler.Emit
                                          .ToArray();
             }
 
-            Emit<TDelegate> dynamicMethod = Emit<TDelegate>.NewDynamicMethod(methodInfo.Name);
+            DynamicMethod dynamicMethod = new DynamicMethod(methodInfo.Name, returnType, parameterTypes, ObjectExtensions.Module, skipVisibility: true);
+            ILGenerator il = dynamicMethod.GetILGenerator();
 
             // load each argument and cast or unbox as necessary
             for (ushort argumentIndex = 0; argumentIndex < parameterTypes.Length; argumentIndex++)
@@ -166,28 +166,28 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 Type delegateParameterType = parameterTypes[argumentIndex];
                 Type underlyingParameterType = effectiveParameterTypes[argumentIndex];
 
-                dynamicMethod.LoadArgument(argumentIndex);
+                il.Emit(OpCodes.Ldarg, argumentIndex);
 
                 if (underlyingParameterType.IsValueType && delegateParameterType == typeof(object))
                 {
-                    dynamicMethod.UnboxAny(underlyingParameterType);
+                    il.Emit(OpCodes.Unbox_Any, underlyingParameterType);
                 }
                 else if (underlyingParameterType != delegateParameterType)
                 {
-                    dynamicMethod.CastClass(underlyingParameterType);
+                    il.Emit(OpCodes.Castclass, underlyingParameterType);
                 }
             }
 
             if (callOpCode == OpCodeValue.Call || methodInfo.IsStatic)
             {
                 // non-virtual call (e.g. static method, or method override calling overriden implementation)
-                dynamicMethod.Call(methodInfo);
+                il.Emit(OpCodes.Call, methodInfo);
             }
             else if (callOpCode == OpCodeValue.Callvirt)
             {
                 // Note: C# compiler uses CALLVIRT for non-virtual
                 // instance methods to get the cheap null check
-                dynamicMethod.CallVirtual(methodInfo);
+                il.Emit(OpCodes.Callvirt, methodInfo);
             }
             else
             {
@@ -196,15 +196,15 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             if (methodInfo.ReturnType.IsValueType && returnType == typeof(object))
             {
-                dynamicMethod.Box(methodInfo.ReturnType);
+                il.Emit(OpCodes.Box, methodInfo.ReturnType);
             }
             else if (methodInfo.ReturnType != returnType)
             {
-                dynamicMethod.CastClass(returnType);
+                il.Emit(OpCodes.Castclass, returnType);
             }
 
-            dynamicMethod.Return();
-            return dynamicMethod.CreateDelegate();
+            il.Emit(OpCodes.Ret);
+            return (TDelegate)dynamicMethod.CreateDelegate(delegateType);
         }
 
         private struct Key

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/DynamicMethodBuilder.cs
@@ -211,11 +211,19 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 throw new NotSupportedException($"OpCode {callOpCode} not supported when calling a method.");
             }
 
-            if (methodInfo.ReturnType.IsValueType && returnType == typeof(object))
+            if (methodInfo.ReturnType.IsValueType && !returnType.IsValueType)
             {
                 il.Emit(OpCodes.Box, methodInfo.ReturnType);
             }
-            else if (methodInfo.ReturnType != returnType)
+            else if (methodInfo.ReturnType.IsValueType && returnType.IsValueType && methodInfo.ReturnType != returnType)
+            {
+                throw new ArgumentException($"Cannot convert the target method's return type {methodInfo.ReturnType.FullName} (valuetype) to the delegate method's return type {returnType.FullName} (valuetype)");
+            }
+            else if (!methodInfo.ReturnType.IsValueType && returnType.IsValueType)
+            {
+                throw new ArgumentException($"Cannot reliably convert the target method's return type {methodInfo.ReturnType.FullName} (reference type) to the delegate method's return type {returnType.FullName} (value type)");
+            }
+            else if (!methodInfo.ReturnType.IsValueType && !returnType.IsValueType && methodInfo.ReturnType != returnType)
             {
                 il.Emit(OpCodes.Castclass, returnType);
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -366,11 +366,19 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 throw new NotSupportedException($"OpCode {_originalOpCodeValue} not supported when calling a method.");
             }
 
-            if (methodInfo.ReturnType.IsValueType && returnType == typeof(object))
+            if (methodInfo.ReturnType.IsValueType && !returnType.IsValueType)
             {
                 il.Emit(OpCodes.Box, methodInfo.ReturnType);
             }
-            else if (methodInfo.ReturnType != returnType)
+            else if (methodInfo.ReturnType.IsValueType && returnType.IsValueType && methodInfo.ReturnType != returnType)
+            {
+                throw new ArgumentException($"Cannot convert the target method's return type {methodInfo.ReturnType.FullName} (value type) to the delegate method's return type {returnType.FullName} (value type)");
+            }
+            else if (!methodInfo.ReturnType.IsValueType && returnType.IsValueType)
+            {
+                throw new ArgumentException($"Cannot reliably convert the target method's return type {methodInfo.ReturnType.FullName} (reference type) to the delegate method's return type {returnType.FullName} (value type)");
+            }
+            else if (!methodInfo.ReturnType.IsValueType && !returnType.IsValueType && methodInfo.ReturnType != returnType)
             {
                 il.Emit(OpCodes.Castclass, returnType);
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -321,7 +321,24 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 Type delegateParameterType = delegateParameterTypes[argumentIndex];
                 Type underlyingParameterType = effectiveParameterTypes[argumentIndex];
 
-                il.Emit(OpCodes.Ldarg, argumentIndex);
+                switch (argumentIndex)
+                {
+                    case 0:
+                        il.Emit(OpCodes.Ldarg_0);
+                        break;
+                    case 1:
+                        il.Emit(OpCodes.Ldarg_1);
+                        break;
+                    case 2:
+                        il.Emit(OpCodes.Ldarg_2);
+                        break;
+                    case 3:
+                        il.Emit(OpCodes.Ldarg_3);
+                        break;
+                    default:
+                        il.Emit(OpCodes.Ldarg_S, argumentIndex);
+                        break;
+                }
 
                 if (underlyingParameterType.IsValueType && delegateParameterType == typeof(object))
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -252,7 +252,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             if (containerType.IsValueType)
             {
-                il.Emit(OpCodes.Unbox, containerType);
+                il.Emit(OpCodes.Unbox_Any, containerType);
             }
             else
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/ObjectExtensions.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Reflection.Emit;
 using Datadog.Trace.Util;
-using Sigil;
 
 namespace Datadog.Trace.ClrProfiler.Emit
 {
@@ -11,8 +11,22 @@ namespace Datadog.Trace.ClrProfiler.Emit
     /// </summary>
     internal static class ObjectExtensions
     {
+        // A new module to be emitted in the current AppDomain which will contain DynamicMethods
+        // and have same evidence/permissions as this AppDomain
+        internal static readonly ModuleBuilder Module;
+
         private static readonly ConcurrentDictionary<PropertyFetcherCacheKey, object> Cache = new ConcurrentDictionary<PropertyFetcherCacheKey, object>();
         private static readonly ConcurrentDictionary<PropertyFetcherCacheKey, PropertyFetcher> PropertyFetcherCache = new ConcurrentDictionary<PropertyFetcherCacheKey, PropertyFetcher>();
+
+        static ObjectExtensions()
+        {
+#if NETFRAMEWORK
+            var asm = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName("Datadog.Trace.ClrProfiler.Emit.DynamicAssembly"), AssemblyBuilderAccess.Run);
+#else
+            var asm = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Datadog.Trace.ClrProfiler.Emit.DynamicAssembly"), AssemblyBuilderAccess.Run);
+#endif
+            Module = asm.DefineDynamicModule("DynamicModule");
+        }
 
         /// <summary>
         /// Tries to call an instance method with the specified name, a single parameter, and a return value.
@@ -231,31 +245,33 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 return null;
             }
 
-            var dynamicMethod = Emit<Func<object, TResult>>.NewDynamicMethod($"{containerType.FullName}.{fieldName}");
-            dynamicMethod.LoadArgument(0);
+            DynamicMethod dynamicMethod = new DynamicMethod($"{containerType.FullName}.{fieldName}", typeof(TResult), new Type[] { typeof(object) }, ObjectExtensions.Module, skipVisibility: true);
+            ILGenerator il = dynamicMethod.GetILGenerator();
+
+            il.Emit(OpCodes.Ldarg_0);
 
             if (containerType.IsValueType)
             {
-                dynamicMethod.UnboxAny(containerType);
+                il.Emit(OpCodes.Unbox, containerType);
             }
             else
             {
-                dynamicMethod.CastClass(containerType);
+                il.Emit(OpCodes.Castclass, containerType);
             }
 
-            dynamicMethod.LoadField(fieldInfo);
+            il.Emit(OpCodes.Ldfld, fieldInfo);
 
             if (fieldInfo.FieldType.IsValueType && typeof(TResult) == typeof(object))
             {
-                dynamicMethod.Box(fieldInfo.FieldType);
+                il.Emit(OpCodes.Box, fieldInfo.FieldType);
             }
             else if (fieldInfo.FieldType != typeof(TResult))
             {
-                dynamicMethod.CastClass(typeof(TResult));
+                il.Emit(OpCodes.Castclass, typeof(TResult));
             }
 
-            dynamicMethod.Return();
-            return dynamicMethod.CreateDelegate();
+            il.Emit(OpCodes.Ret);
+            return (Func<object, TResult>)dynamicMethod.CreateDelegate(typeof(Func<object, TResult>));
         }
 
         private readonly struct PropertyFetcherCacheKey : IEquatable<PropertyFetcherCacheKey>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -174,7 +174,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         {
             const string methodName = AdoNetConstants.MethodNames.ExecuteReaderAsync;
             var cancellationToken = (CancellationToken)boxedCancellationToken;
-            Func<DbCommand, CancellationToken, object> instrumentedMethod;
 
             Type npgsqlComandType;
             Type npgsqlDataReaderType;
@@ -191,6 +190,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                 Log.Error(ex, "Error finding the Npgsql.NpgsqlDataReader type");
                 throw;
             }
+
+            Func<DbCommand, CancellationToken, object> instrumentedMethod;
 
             try
             {
@@ -278,34 +279,34 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             int mdToken,
             long moduleVersionPtr)
         {
-            var cancellationToken = (CancellationToken)boxedCancellationToken;
-
-            return ExecuteReaderAsyncWithBehaviorAndCancellationInternal(
-                (DbCommand)command,
-                (CommandBehavior)behavior,
-                cancellationToken,
-                opCode,
-                mdToken,
-                moduleVersionPtr);
-        }
-
-        private static async Task<DbDataReader> ExecuteReaderAsyncWithBehaviorAndCancellationInternal(
-            DbCommand command,
-            CommandBehavior commandBehavior,
-            CancellationToken cancellationToken,
-            int opCode,
-            int mdToken,
-            long moduleVersionPtr)
-        {
             const string methodName = AdoNetConstants.MethodNames.ExecuteReaderAsync;
-            Func<DbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>> instrumentedMethod;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
+            var commandBehavior = (CommandBehavior)behavior;
+
+            Type npgsqlComandType;
+            Type npgsqlDataReaderType;
+
+            try
+            {
+                npgsqlComandType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+                npgsqlDataReaderType = npgsqlComandType.Assembly.GetType(NpgsqlDataReaderTypeName);
+            }
+            catch (Exception ex)
+            {
+                // This shouldn't happen because the assembly holding the Npgsql.NpgsqlDataReader type should have been loaded already
+                // profiled app will not continue working as expected without this method
+                Log.Error(ex, "Error finding the Npgsql.NpgsqlDataReader type");
+                throw;
+            }
+
+            Func<DbCommand, CommandBehavior, CancellationToken, object> instrumentedMethod;
 
             try
             {
                 var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
 
                 instrumentedMethod =
-                    MethodBuilder<Func<DbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>>>
+                    MethodBuilder<Func<DbCommand, CommandBehavior, CancellationToken, object>>
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(commandBehavior, cancellationToken)
@@ -325,11 +326,38 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                 throw;
             }
 
+            return AsyncHelper.InvokeGenericTaskDelegate(
+                owningType: command.GetType(),
+                taskResultType: npgsqlDataReaderType,
+                nameOfIntegrationMethod: nameof(ExecuteReaderAsyncWithBehaviorAndCancellationInternal),
+                integrationType: typeof(NpgsqlCommandIntegration),
+                (DbCommand)command,
+                commandBehavior,
+                cancellationToken,
+                instrumentedMethod);
+        }
+
+        /// <summary>
+        /// Calls the underlying ExecuteReaderAsync and traces the request.
+        /// </summary>
+        /// <typeparam name="T">The type of the generic Task instantiation</typeparam>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="commandBehavior">The command behavior</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="instrumentedMethod">A delegate for the method we are instrumenting</param>
+        /// <returns>A task with the result</returns>
+        private static async Task<T> ExecuteReaderAsyncWithBehaviorAndCancellationInternal<T>(
+            DbCommand command,
+            CommandBehavior commandBehavior,
+            CancellationToken cancellationToken,
+            Func<DbCommand, CommandBehavior, CancellationToken, object> instrumentedMethod)
+        {
             using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command))
             {
                 try
                 {
-                    return await instrumentedMethod(command, commandBehavior, cancellationToken).ConfigureAwait(false);
+                    var task = (Task<T>)instrumentedMethod(command, commandBehavior, cancellationToken);
+                    return await task.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
@@ -171,34 +172,32 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             int mdToken,
             long moduleVersionPtr)
         {
-            var cancellationToken = (CancellationToken)boxedCancellationToken;
-
-            return ExecuteReaderAsyncInternal(
-                (DbCommand)command,
-                cancellationToken,
-                opCode,
-                mdToken,
-                moduleVersionPtr);
-        }
-
-        private static async Task<DbDataReader> ExecuteReaderAsyncInternal(
-            DbCommand command,
-            CancellationToken cancellationToken,
-            int opCode,
-            int mdToken,
-            long moduleVersionPtr)
-        {
             const string methodName = AdoNetConstants.MethodNames.ExecuteReaderAsync;
-            Func<DbCommand, CancellationToken, Task<DbDataReader>> instrumentedMethod;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
+            Func<DbCommand, CancellationToken, object> instrumentedMethod;
+
+            Type npgsqlComandType;
+            Type npgsqlDataReaderType;
 
             try
             {
-                var targetType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+                npgsqlComandType = command.GetInstrumentedType(NpgsqlCommandTypeName);
+                npgsqlDataReaderType = npgsqlComandType.Assembly.GetType(NpgsqlDataReaderTypeName);
+            }
+            catch (Exception ex)
+            {
+                // This shouldn't happen because the assembly holding the Npgsql.NpgsqlDataReader type should have been loaded already
+                // profiled app will not continue working as expected without this method
+                Log.Error(ex, "Error finding the Npgsql.NpgsqlDataReader type");
+                throw;
+            }
 
+            try
+            {
                 instrumentedMethod =
-                    MethodBuilder<Func<DbCommand, CancellationToken, Task<DbDataReader>>>
+                    MethodBuilder<Func<DbCommand, CancellationToken, object>>
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
-                       .WithConcreteType(targetType)
+                       .WithConcreteType(npgsqlComandType)
                        .WithParameters(cancellationToken)
                        .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
                        .Build();
@@ -216,11 +215,35 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                 throw;
             }
 
+            return AsyncHelper.InvokeGenericTaskDelegate(
+                owningType: command.GetType(),
+                taskResultType: npgsqlDataReaderType,
+                nameOfIntegrationMethod: nameof(ExecuteReaderAsyncInternal),
+                integrationType: typeof(NpgsqlCommandIntegration),
+                (DbCommand)command,
+                cancellationToken,
+                instrumentedMethod);
+        }
+
+        /// <summary>
+        /// Calls the underlying ExecuteReaderAsync and traces the request.
+        /// </summary>
+        /// <typeparam name="T">The type of the generic Task instantiation</typeparam>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="instrumentedMethod">A delegate for the method we are instrumenting</param>
+        /// <returns>A task with the result</returns>
+        private static async Task<T> ExecuteReaderAsyncInternal<T>(
+            DbCommand command,
+            CancellationToken cancellationToken,
+            Func<DbCommand, CancellationToken, object> instrumentedMethod)
+        {
             using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command))
             {
                 try
                 {
-                    return await instrumentedMethod(command, cancellationToken).ConfigureAwait(false);
+                    var task = (Task<T>)instrumentedMethod(command, cancellationToken);
+                    return await task.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -177,15 +177,17 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             var cancellationToken = (CancellationToken)boxedCancellationToken;
             var commandBehavior = (CommandBehavior)behavior;
 
+            Type sqlCommandType;
             Type sqlDataReaderType;
+
             try
             {
-                var sqlCommandType = command.GetInstrumentedType(SqlCommandTypeName);
+                sqlCommandType = command.GetInstrumentedType(SqlCommandTypeName);
                 sqlDataReaderType = sqlCommandType.Assembly.GetType(SqlDataReaderTypeName);
             }
             catch (Exception ex)
             {
-                // This shouldn't happen because the System.Data.SqlClient.SqlDataReader type should have been loaded already
+                // This shouldn't happen because the assembly holding the System.Data.SqlClient.SqlDataReader type should have been loaded already
                 // profiled app will not continue working as expected without this method
                 Log.Error(ex, "Error finding the System.Data.SqlClient.SqlDataReader type");
                 throw;
@@ -195,12 +197,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
 
             try
             {
-                var targetType = command.GetInstrumentedType(SqlCommandTypeName);
-
                 instrumentedMethod =
                     MethodBuilder<Func<DbCommand, CommandBehavior, CancellationToken, object>>
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
-                       .WithConcreteType(targetType)
+                       .WithConcreteType(sqlCommandType)
                        .WithParameters(commandBehavior, cancellationToken)
                        .WithNamespaceAndNameFilters(ClrNames.GenericTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
                        .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -4,6 +4,7 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Emit;
+using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
@@ -172,32 +173,32 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             int mdToken,
             long moduleVersionPtr)
         {
-            return ExecuteReaderAsyncInternal(
-                (DbCommand)command,
-                (CommandBehavior)behavior,
-                (CancellationToken)boxedCancellationToken,
-                opCode,
-                mdToken,
-                moduleVersionPtr);
-        }
-
-        private static async Task<DbDataReader> ExecuteReaderAsyncInternal(
-            DbCommand command,
-            CommandBehavior commandBehavior,
-            CancellationToken cancellationToken,
-            int opCode,
-            int mdToken,
-            long moduleVersionPtr)
-        {
             const string methodName = AdoNetConstants.MethodNames.ExecuteReaderAsync;
-            Func<DbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>> instrumentedMethod;
+            var cancellationToken = (CancellationToken)boxedCancellationToken;
+            var commandBehavior = (CommandBehavior)behavior;
+
+            Type sqlDataReaderType;
+            try
+            {
+                var sqlCommandType = command.GetInstrumentedType(SqlCommandTypeName);
+                sqlDataReaderType = sqlCommandType.Assembly.GetType(SqlDataReaderTypeName);
+            }
+            catch (Exception ex)
+            {
+                // This shouldn't happen because the System.Data.SqlClient.SqlDataReader type should have been loaded already
+                // profiled app will not continue working as expected without this method
+                Log.Error(ex, "Error finding the System.Data.SqlClient.SqlDataReader type");
+                throw;
+            }
+
+            Func<DbCommand, CommandBehavior, CancellationToken, object> instrumentedMethod;
 
             try
             {
                 var targetType = command.GetInstrumentedType(SqlCommandTypeName);
 
                 instrumentedMethod =
-                    MethodBuilder<Func<DbCommand, CommandBehavior, CancellationToken, Task<DbDataReader>>>
+                    MethodBuilder<Func<DbCommand, CommandBehavior, CancellationToken, object>>
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(commandBehavior, cancellationToken)
@@ -217,11 +218,38 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                 throw;
             }
 
+            return AsyncHelper.InvokeGenericTaskDelegate(
+                owningType: command.GetType(),
+                taskResultType: sqlDataReaderType,
+                nameOfIntegrationMethod: nameof(ExecuteReaderAsyncInternal),
+                integrationType: typeof(SqlCommandIntegration),
+                (DbCommand)command,
+                commandBehavior,
+                cancellationToken,
+                instrumentedMethod);
+        }
+
+        /// <summary>
+        /// Calls the underlying ExecuteReaderAsync and traces the request.
+        /// </summary>
+        /// <typeparam name="T">The type of the generic Task instantiation</typeparam>
+        /// <param name="command">The object referenced by this in the instrumented method.</param>
+        /// <param name="commandBehavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
+        /// <param name="cancellationToken">The cancellation token</param>
+        /// <param name="instrumentedMethod">A delegate for the method we are instrumenting</param>
+        /// <returns>A task with the result</returns>
+        private static async Task<T> ExecuteReaderAsyncInternal<T>(
+            DbCommand command,
+            CommandBehavior commandBehavior,
+            CancellationToken cancellationToken,
+            Func<DbCommand, CommandBehavior, CancellationToken, object> instrumentedMethod)
+        {
             using (var scope = ScopeFactory.CreateDbCommandScope(Tracer.Instance, command))
             {
                 try
                 {
-                    return await instrumentedMethod(command, commandBehavior, cancellationToken).ConfigureAwait(false);
+                    var task = (Task<T>)instrumentedMethod(command, commandBehavior, cancellationToken);
+                    return await task.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.DuckTyping/Datadog.Trace.DuckTyping.csproj
+++ b/src/Datadog.Trace.DuckTyping/Datadog.Trace.DuckTyping.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/WindowsInstaller/Files.Managed.Net45.GAC.wxs
+++ b/src/WindowsInstaller/Files.Managed.Net45.GAC.wxs
@@ -41,12 +41,6 @@
               Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.MSBuild.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <Condition>NOT WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED</Condition>
-        <File Id="net45_GAC_Sigil.dll"
-              Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
-              KeyPath="yes" Checksum="yes" Assembly=".net"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/WindowsInstaller/Files.Managed.Net45.wxs
+++ b/src/WindowsInstaller/Files.Managed.Net45.wxs
@@ -35,11 +35,6 @@
               Source="$(var.TracerHomeDirectory)\net45\Datadog.Trace.MSBuild.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net45_Sigil.dll"
-              Source="$(var.TracerHomeDirectory)\net45\Sigil.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/WindowsInstaller/Files.Managed.Net461.GAC.wxs
+++ b/src/WindowsInstaller/Files.Managed.Net461.GAC.wxs
@@ -41,12 +41,6 @@
               Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.MSBuild.dll"
               KeyPath="yes" Checksum="yes" Assembly=".net"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <Condition>WIX_IS_NETFRAMEWORK_461_OR_LATER_INSTALLED</Condition>
-        <File Id="net461_GAC_Sigil.dll"
-              Source="$(var.TracerHomeDirectory)\net461\Sigil.dll"
-              KeyPath="yes" Checksum="yes" Assembly=".net"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/WindowsInstaller/Files.Managed.Net461.wxs
+++ b/src/WindowsInstaller/Files.Managed.Net461.wxs
@@ -35,11 +35,6 @@
               Source="$(var.TracerHomeDirectory)\net461\Datadog.Trace.MSBuild.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="net461_Sigil.dll"
-              Source="$(var.TracerHomeDirectory)\net461\Sigil.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/src/WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/src/WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -31,11 +31,6 @@
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_Sigil.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\Sigil.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Collections.Immutable.dll"
               Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.Immutable.dll"
               KeyPath="yes" Checksum="yes"/>

--- a/src/WindowsInstaller/Files.Managed.NetStandard20.wxs
+++ b/src/WindowsInstaller/Files.Managed.NetStandard20.wxs
@@ -31,11 +31,6 @@
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_System.Collections.Immutable.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Collections.Immutable.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Diagnostics.DiagnosticSource.dll"
               Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Diagnostics.DiagnosticSource.dll"
               KeyPath="yes" Checksum="yes"/>
@@ -53,16 +48,6 @@
       <Component Win64="$(var.Win64)">
         <File Id="netstandard20_System.Reflection.Emit.Lightweight.dll"
               Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Emit.Lightweight.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_System.Reflection.Metadata.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.Metadata.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="netstandard20_System.Reflection.TypeExtensions.dll"
-              Source="$(var.TracerHomeDirectory)\netstandard2.0\System.Reflection.TypeExtensions.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
       <Component Win64="$(var.Win64)">

--- a/src/WindowsInstaller/Files.Managed.Netcoreapp31.wxs
+++ b/src/WindowsInstaller/Files.Managed.Netcoreapp31.wxs
@@ -30,11 +30,6 @@
               Source="$(var.TracerHomeDirectory)\netcoreapp3.1\Datadog.Trace.MSBuild.dll"
               KeyPath="yes" Checksum="yes"/>
       </Component>
-      <Component Win64="$(var.Win64)">
-        <File Id="netcoreapp31_Sigil.dll"
-              Source="$(var.TracerHomeDirectory)\netcoreapp3.1\Sigil.dll"
-              KeyPath="yes" Checksum="yes"/>
-      </Component>
     </ComponentGroup>
   </Fragment>
 </Wix>

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
@@ -253,6 +253,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         }
 
         private MethodBuilder<T> Build<T>(string methodName, Type overrideType = null)
+            where T : Delegate
         {
             return MethodBuilder<T>
                   .Start(_moduleVersionId, 0, (int)OpCodeValue.Callvirt, methodName)

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/MethodBuilderTests.cs
@@ -252,6 +252,125 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(expected: expected.ToString(), instance.LastCall.MethodString);
         }
 
+        [Fact]
+        public void TargetReturnsValueType_DelegateReturnsSameValueType_IsOk()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            int arg = 42;
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputInt(arg));
+            var methodCall = MethodBuilder<Func<object, int, int>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputInt")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build();
+
+            var actual = methodCall(instance, arg);
+            Assert.Equal(arg, actual);
+        }
+
+        [Fact]
+        public void TargetReturnsValueType_DelegateReturnsObject_IsOk()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            int arg = 42;
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputInt(arg));
+            var methodCall = MethodBuilder<Func<object, int, object>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputInt")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build();
+
+            var actual = methodCall(instance, arg);
+            Assert.Equal(arg, actual);
+        }
+
+        [Fact]
+        public void TargetReturnsValueType_DelegateReturnsDifferentValueType_ThrowsException()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            int arg = 42;
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputInt(arg));
+
+            // Throws
+            Assert.ThrowsAny<Exception>(() =>
+                MethodBuilder<Func<object, int, double>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputInt")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build());
+        }
+
+        [Fact]
+        public void TargetReturnsObject_DelegateReturnsObject_IsOk()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            object arg = new ClassA();
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputObject(arg));
+            var methodCall = MethodBuilder<Func<object, object, object>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputObject")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build();
+
+            var actual = methodCall(instance, arg);
+            Assert.Equal(arg, actual);
+        }
+
+        [Fact]
+        public void TargetReturnsReferenceType_DelegateReturnsObject_IsOk()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            ClassA arg = new ClassA();
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputClassA(arg));
+            var methodCall = MethodBuilder<Func<object, object, object>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputClassA")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build();
+
+            var actual = methodCall(instance, arg);
+            Assert.Equal(arg, actual);
+        }
+
+        [Fact]
+        public void TargetReturnsReferenceType_DelegateReturnsDifferentReferenceType_IsOk()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            ClassB arg = new ClassB();
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputClassA(arg));
+            var methodCall = MethodBuilder<Func<object, object, ClassB>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputClassA")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build();
+
+            var actual = methodCall(instance, arg);
+            Assert.Equal(arg, actual);
+        }
+
+        [Fact]
+        public void TargetReturnsReferenceType_DelegateReturnsValueType_ThrowsException()
+        {
+            var instance = new ObscenelyAnnoyingClass();
+            object arg = new ClassA();
+
+            var methodToInvoke = MethodReference.Get(() => instance.ReturnInputObject(arg));
+
+            // Throws
+            Assert.ThrowsAny<Exception>(() =>
+                MethodBuilder<Func<object, object, int>>
+                                .Start(_moduleVersionId, methodToInvoke.MetadataToken, (int)OpCodeValue.Callvirt, "ReturnInputObject")
+                                .WithConcreteType(typeof(ObscenelyAnnoyingClass))
+                                .WithParameters(arg)
+                                .Build());
+        }
+
         private MethodBuilder<T> Build<T>(string methodName, Type overrideType = null)
             where T : Delegate
         {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ObscenelyAnnoyingClass.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Reflection/ObscenelyAnnoyingClass.cs
@@ -69,6 +69,24 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             SetLastCall(MethodBase.GetCurrentMethod(), p1, p2, p3);
         }
 
+        public int ReturnInputInt(int ret)
+        {
+            SetLastCall(MethodBase.GetCurrentMethod(), ret);
+            return ret;
+        }
+
+        public object ReturnInputObject(object obj)
+        {
+            SetLastCall(MethodBase.GetCurrentMethod(), obj);
+            return obj;
+        }
+
+        public ClassA ReturnInputClassA(ClassA obj)
+        {
+            SetLastCall(MethodBase.GetCurrentMethod(), obj);
+            return obj;
+        }
+
         // There is intentionally no method matching double ClassC signature to force non-explicit fuzzy matching
         // public void Method(ClassC p1, ClassC p2)
 


### PR DESCRIPTION
### Summary
This PR removes usages of `Sigil 4.7.0` and `Sigil-vNext 4.8.41`, removing `Sigil.dll` dependency on all target frameworks.

### Changes
- Remove `Sigil` NuGet packages from `Datadog.Trace.ClrProfiler.Managed.csproj` and add direct NuGet package references to `System.Reflection.Emit` NuGet packages that were previously transitively referenced for the `netstandard2.0` build target
- `Datadog.Trace.ClrProfiler.Emit.ObjectExtensions`
  - Replace all usages of `Sigil.Emit<T>` with `System.Reflection.Emit.ILGenerator`
  - Store static field `System.Reflection.Emit.ModuleBuilder Module` to hold single module in which `MethodBuilder` dynamic methods will be emitted
- `Datadog.Trace.ClrProfiler.Emit.MethodBuilder`
  - Replace all usages of `Sigil.Emit<T>` with `System.Reflection.Emit.ILGenerator`
- `Datadog.Trace.ClrProfiler.Emit.DynamicMethodBuilder'1`
  - Replace all usages of `Sigil.Emit<T>` with `System.Reflection.Emit.ILGenerator`
- Fix `ExecuteReaderAsync` in the `SqlCommandIntegration` and `NpgsqlCommandIntegration` classes that began failing after removing Sigil. The return types were specified by the delegate to be `Task<DbDataReader>` even though the public interfaces were specified to return `Task<SqlDataReader>` and `Task<NpqgsqlDataReader>`

### Benchmarks
```
|                               Method |     Toolchain |     Mean |     Error |    StdDev | Ratio | RatioSD |
|------------------------------------- |-------------- |---------:|----------:|----------:|------:|--------:|
|                   GetField_Old_Sigil |        net472 | 4.911 ns | 0.0865 ns | 0.0676 ns |  1.48 |    0.02 |
|                  GetField_New_ILEmit |        net472 | 4.810 ns | 0.0530 ns | 0.0414 ns |  1.36 |    0.01 |
|                                      |               |          |           |           |       |         |
|                   GetField_Old_Sigil | netcoreapp3.1 | 3.310 ns | 0.0164 ns | 0.0154 ns |  1.00 |    0.00 |
|                  GetField_New_ILEmit | netcoreapp3.1 | 3.549 ns | 0.0373 ns | 0.0291 ns |  1.00 |    0.00 |
|                                      |               |          |           |           |       |         |
|   CreateMethodCallDelegate_Old_Sigil |        net472 | 5.643 ns | 0.1426 ns | 0.1191 ns |  1.29 |    0.03 |
|  CreateMethodCallDelegate_New_ILEmit |        net472 | 4.619 ns | 0.1156 ns | 0.1331 ns |  1.38 |    0.04 |
|                                      |               |          |           |           |       |         |
|   CreateMethodCallDelegate_Old_Sigil | netcoreapp3.1 | 4.375 ns | 0.0439 ns | 0.0411 ns |  1.00 |    0.00 |
|  CreateMethodCallDelegate_New_ILEmit | netcoreapp3.1 | 3.367 ns | 0.0713 ns | 0.0595 ns |  1.00 |    0.00 |
|                                      |               |          |           |           |       |         |
|  MethodBuilderEmitDelegate_Old_Sigil |        net472 | 3.382 ns | 0.0280 ns | 0.0219 ns |  0.97 |    0.01 |
| MethodBuilderEmitDelegate_New_ILEmit |        net472 | 2.212 ns | 0.0746 ns | 0.0733 ns |  1.09 |    0.04 |
|                                      |               |          |           |           |       |         |
|  MethodBuilderEmitDelegate_Old_Sigil | netcoreapp3.1 | 3.486 ns | 0.0304 ns | 0.0269 ns |  1.00 |    0.00 |
| MethodBuilderEmitDelegate_New_ILEmit | netcoreapp3.1 | 2.023 ns | 0.0114 ns | 0.0089 ns |  1.00 |    0.00 |
```
@DataDog/apm-dotnet