### PR TITLE
Add .NET 5 target to integration tests

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -23,6 +23,7 @@ variables:
   buildConfiguration: Debug
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.107
+  dotnetCoreSdk5Version: 5.0.100-rc.2.20475.5
 
 jobs:
 
@@ -33,6 +34,11 @@ jobs:
     displayName: install dotnet core sdk 3.1
     inputs:
       version: $(dotnetCoreSdkVersion)
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 5
+    inputs:
+      version: $(dotnetCoreSdk5Version)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
@@ -81,7 +87,9 @@ jobs:
         publishTargetFramework: netcoreapp3.0
       netcoreapp3_1:
         publishTargetFramework: netcoreapp3.1
-
+      net5_0:
+        publishTargetFramework: net5.0
+        
   variables:
     TestAllPackageVersions: true
 
@@ -249,6 +257,12 @@ jobs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
 
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 5
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdk5Version)
+      
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
@@ -356,6 +370,12 @@ jobs:
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 5
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdk5Version)
 
   - task: NuGetToolInstaller@1
     displayName: install nuget

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -178,6 +178,8 @@ jobs:
         publishTargetFramework: netcoreapp3.0
       netcoreapp3_1:
         publishTargetFramework: netcoreapp3.1
+      net5_0:
+        publishTargetFramework: net5.0
 
   variables:
     TestAllPackageVersions: true
@@ -214,6 +216,13 @@ jobs:
   - task: DockerCompose@0
     displayName: docker-compose run IntegrationTests.Alpine.Core31
     condition: eq(variables['publishTargetFramework'], 'netcoreapp3.1')
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core31
+
+  - task: DockerCompose@0
+    displayName: docker-compose run IntegrationTests.Alpine.Core50
+    condition: eq(variables['publishTargetFramework'], 'net5.0')
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core31

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -225,7 +225,7 @@ jobs:
     condition: eq(variables['publishTargetFramework'], 'net5.0')
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core31
+      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core50
 
   - task: PublishTestResults@2
     displayName: publish test results

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -23,7 +23,7 @@ variables:
   buildConfiguration: Debug
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100-rc.2.20475.5
+  dotnetCoreSdk5Version: 5.0.100-rc.2.20479.15
 
 jobs:
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -38,7 +38,9 @@ jobs:
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5
     inputs:
+      packageType: sdk
       version: $(dotnetCoreSdk5Version)
+      includePreviewVersions: true
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
@@ -262,6 +264,7 @@ jobs:
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdk5Version)
+      includePreviewVersions: true
       
   - task: NuGetToolInstaller@1
     displayName: install nuget
@@ -376,6 +379,7 @@ jobs:
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdk5Version)
+      includePreviewVersions: true
 
   - task: NuGetToolInstaller@1
     displayName: install nuget

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -12,6 +12,7 @@ trigger:
 variables:
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.107
+  dotnetCoreSdk5Version: 5.0.100-rc.2.20479.15
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
 
@@ -32,9 +33,11 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core sdk 5.0
     inputs:
-      version: $(dotnetCoreSdkVersion)
+      packageType: sdk
+      version: $(dotnetCoreSdk5Version)
+      includePreviewVersions: true
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
@@ -119,7 +122,14 @@ jobs:
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
-
+      
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 5.0
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdk5Version)
+      includePreviewVersions: true
+      
   - task: DotNetCoreCLI@2
     displayName: dotnet build
     inputs:

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -12,6 +12,7 @@ trigger:
 variables:
   buildConfiguration: Debug
   dotnetCoreSdkVersion: 3.1.107
+  dotnetCoreSdk5Version: 5.0.100-rc.2.20479.15
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
 
@@ -68,6 +69,12 @@ jobs:
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 5.0
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdk5Version)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build

--- a/build/docker/dotnet.alpine.core50.dockerfile
+++ b/build/docker/dotnet.alpine.core50.dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine3.12
+
+RUN apk update && apk upgrade && apk add --no-cache --update bash
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
+RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.dockerfile
+++ b/build/docker/dotnet.dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y aspnetcore-runtime-2.1 && \
     apt-get install -y aspnetcore-runtime-3.0 && \
-	apt-get install -y aspnetcore-runtime-3.1 && \
+	apt-get install -y aspnetcore-runtime-3.1
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.dockerfile
+++ b/build/docker/dotnet.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 # Instructions to install .NET Core runtimes from
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10

--- a/build/docker/dotnet.dockerfile
+++ b/build/docker/dotnet.dockerfile
@@ -2,12 +2,8 @@ FROM mcr.microsoft.com/dotnet/sdk:5.0
 
 # Instructions to install .NET Core runtimes from
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10
-RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
-    mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
-    wget -q https://packages.microsoft.com/config/debian/10/prod.list && \
-    mv prod.list /etc/apt/sources.list.d/microsoft-prod.list && \
-    chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
-    chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
+    dpkg -i packages-microsoft-prod.deb 
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \

--- a/build/docker/dotnet.dockerfile
+++ b/build/docker/dotnet.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/core/sdk:5.0
 
 # Instructions to install .NET Core runtimes from
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10

--- a/build/docker/dotnet.dockerfile
+++ b/build/docker/dotnet.dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
     apt-get install -y apt-transport-https && \
     apt-get update && \
     apt-get install -y aspnetcore-runtime-2.1 && \
-    apt-get install -y aspnetcore-runtime-3.0
+    apt-get install -y aspnetcore-runtime-3.0 && \
+	apt-get install -y aspnetcore-runtime-3.1 && \
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it

--- a/build/docker/linux-build.dockerfile
+++ b/build/docker/linux-build.dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG PUBLISH_FOLDER=/workspace/publish
 ARG TRACER_HOME=/dd-tracer-dotnet
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-managed-base
+FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-managed-base
 # Instructions to install .NET Core runtimes from
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10
 RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \

--- a/build/docker/linux-build.dockerfile
+++ b/build/docker/linux-build.dockerfile
@@ -8,7 +8,7 @@ ARG WORKSPACE=/workspace
 ARG PUBLISH_FOLDER=/workspace/publish
 ARG TRACER_HOME=/dd-tracer-dotnet
 
-FROM mcr.microsoft.com/dotnet/core/sdk:5.0 AS build-managed-base
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-managed-base
 # Instructions to install .NET Core runtimes from
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10
 RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -328,6 +328,36 @@ services:
     - postgres
     - mysql
 
+  IntegrationTests.Alpine.Core50:
+    build:
+      context: ./
+      dockerfile: ./build/docker/dotnet.alpine.core50.dockerfile
+    image: datadog-dotnet-alpine-core50
+    command: /project/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+    volumes:
+    - ./:/project
+    environment:
+    - MONGO_HOST=mongo
+    - SERVICESTACK_REDIS_HOST=servicestackredis:6379
+    - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
+    - ELASTICSEARCH6_HOST=elasticsearch6:9200
+    - ELASTICSEARCH5_HOST=elasticsearch5:9200
+    - SQLSERVER_CONNECTION_STRING=Server=sqlserver;User=sa;Password=Strong!Passw0rd
+    - POSTGRES_HOST=postgres
+    - MYSQL_HOST=mysql
+    - MYSQL_PORT=3306
+    - buildConfiguration=${buildConfiguration}
+    - publishTargetFramework=net5.0
+    depends_on:
+    - servicestackredis
+    - stackexchangeredis
+    - elasticsearch6
+    - elasticsearch5
+    - sqlserver
+    - mongo
+    - postgres
+    - mysql
+
   IntegrationTests:
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     - "127.0.0.1:5432:5432"
 
   mysql:
-    image: mysql/mysql-server:5.7
+    image: mysql/mysql-server:8.0
     environment:
     - MYSQL_DATABASE=world
     - MYSQL_ROOT_PASSWORD=mysqldb

--- a/integrations.json
+++ b/integrations.json
@@ -107,7 +107,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -131,7 +131,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -180,7 +180,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -205,7 +205,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -256,7 +256,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -282,7 +282,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -332,7 +332,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -356,7 +356,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -405,7 +405,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -430,7 +430,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -479,7 +479,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -503,7 +503,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -552,7 +552,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -577,7 +577,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -813,7 +813,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -839,7 +839,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -868,7 +868,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -892,7 +892,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -941,7 +941,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -966,7 +966,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -1015,7 +1015,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -1039,7 +1039,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -1087,7 +1087,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -1111,7 +1111,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -1447,7 +1447,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -1472,7 +1472,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -2177,7 +2177,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },
@@ -2225,7 +2225,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 4,
+          "maximum_major": 5,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     {
         private const string IntegrationName = "AdoNet";
         private const string Major4 = "4";
+        private const string Major5 = "5";
         private const string Major2 = "2";
 
         private const string DbCommandTypeName = AdoNetConstants.TypeNames.DbCommand;
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReader },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
@@ -107,7 +108,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReader, AdoNetConstants.TypeNames.CommandBehavior },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
@@ -182,7 +183,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
@@ -272,7 +273,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteNonQuery,
@@ -343,7 +344,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
@@ -430,7 +431,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteScalar,
@@ -501,7 +502,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
@@ -13,6 +13,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     {
         private const string IntegrationName = "AdoNet";
         private const string Major4 = "4";
+        private const string Major5 = "5";
         private const string Major2 = "2";
 
         // ReSharper disable once InconsistentNaming
@@ -33,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.IDataReader },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = IDbCommandTypeName,
@@ -104,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.IDataReader, AdoNetConstants.TypeNames.CommandBehavior },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
@@ -177,7 +178,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = IDbCommandTypeName,
@@ -246,7 +247,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = IDbCommandTypeName,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     {
         private const string IntegrationName = "AdoNet";
         private const string Major4 = "4";
+        private const string Major5 = "5";
 
         private const string NpgsqlAssemblyName = "Npgsql";
         private const string NpgsqlCommandTypeName = "Npgsql.NpgsqlCommand";
@@ -538,7 +539,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = NpgsqlCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteScalarAsync(
             object command,
             object boxedCancellationToken,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     {
         private const string IntegrationName = "AdoNet";
         private const string Major4 = "4";
+        private const string Major5 = "4";
 
         private const string SqlCommandTypeName = "System.Data.SqlClient.SqlCommand";
         private const string SqlDataReaderTypeName = "System.Data.SqlClient.SqlDataReader";
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetSignatureTypes = new[] { SqlDataReaderTypeName },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteReader(
             object command,
             int opCode,
@@ -98,7 +99,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetSignatureTypes = new[] { SqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteReaderWithBehavior(
             object command,
             int behavior,
@@ -164,7 +165,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.SqlClient.SqlDataReader>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteReaderAsync(
             object command,
             int behavior,
@@ -245,7 +246,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static int ExecuteNonQuery(
             object command,
             int opCode,
@@ -309,7 +310,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteNonQueryAsync(
             object command,
             object boxedCancellationToken,
@@ -387,7 +388,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteScalar(
             object command,
             int opCode,
@@ -451,7 +452,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object ExecuteScalarAsync(
             object command,
             object boxedCancellationToken,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string IntegrationName = "HttpMessageHandler";
         private const string SystemNetHttp = "System.Net.Http";
         private const string Major4 = "4";
+        private const string Major5 = "5";
 
         private const string HttpMessageHandlerTypeName = "HttpMessageHandler";
         private const string HttpClientHandlerTypeName = "HttpClientHandler";
@@ -50,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = SendAsync,
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object HttpMessageHandler_SendAsync(
             object handler,
             object request,
@@ -152,7 +153,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetMethod = SendAsync,
             TargetSignatureTypes = new[] { ClrNames.HttpResponseMessageTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object HttpClientHandler_SendAsync(
             object handler,
             object request,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private const string WebRequestTypeName = "System.Net.WebRequest";
         private const string IntegrationName = "WebRequest";
         private const string Major4 = "4";
+        private const string Major5 = "5";
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(WebRequestIntegration));
 
@@ -38,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = WebRequestTypeName,
             TargetSignatureTypes = new[] { "System.Net.WebResponse" },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object GetResponse(object webRequest, int opCode, int mdToken, long moduleVersionPtr)
         {
             if (webRequest == null)
@@ -126,7 +127,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             TargetType = WebRequestTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Net.WebResponse>" },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major4)]
+            TargetMaximumVersion = Major5)]
         public static object GetResponseAsync(object webRequest, int opCode, int mdToken, long moduleVersionPtr)
         {
             const string methodName = nameof(GetResponseAsync);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition="  !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+++ b/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -10,7 +10,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -15,7 +15,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.TestHelpers
 
         public static bool IsCoreClr()
         {
-            return RuntimeFrameworkDescription.Contains("core");
+            return RuntimeFrameworkDescription.Contains("core") || Environment.Version.Major >= 5;
         }
 
         public static string GetRuntimeIdentifier()

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -391,6 +391,11 @@ namespace Datadog.Trace.TestHelpers
         {
             if (_isCoreClr)
             {
+                if (_major >= 5)
+                {
+                    return $"net{_major}.{_minor}";
+                }
+
                 return $"netcoreapp{_major}.{_minor}";
             }
 

--- a/test/Datadog.Trace.TestHelpers/TestRunners.cs
+++ b/test/Datadog.Trace.TestHelpers/TestRunners.cs
@@ -8,6 +8,8 @@ namespace Datadog.Trace.TestHelpers
                                                                 {
                                                                     "testhost",
                                                                     "testhost.x86",
+                                                                    "testhost.net452.x86",
+                                                                    "testhost.net461.x86",
                                                                     "vstest.console",
                                                                     "xunit.console.x86",
                                                                     "xunit.console.x64",

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -20,7 +20,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,8 +2,9 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,8 +2,8 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/Directory.Build.props
+++ b/test/test-applications/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <LangVersion>latest</LangVersion>

--- a/test/test-applications/Directory.Build.props
+++ b/test/test-applications/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
   <PropertyGroup>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <LangVersion>latest</LangVersion>

--- a/test/test-applications/integrations/Samples.Dapper/Samples.Dapper.csproj
+++ b/test/test-applications/integrations/Samples.Dapper/Samples.Dapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
      <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.Dapper/Samples.Dapper.csproj
+++ b/test/test-applications/integrations/Samples.Dapper/Samples.Dapper.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
      <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <ApiVersion Condition="'$(ApiVersion)' == ''">5.3.0</ApiVersion>
 
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->

--- a/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
     <ApiVersion Condition="'$(ApiVersion)' == ''">5.3.0</ApiVersion>
 
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->

--- a/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
 
     <ApiVersion Condition="'$(ApiVersion)' == ''">6.1.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'>='6.1.0'">$(DefineConstants);ELASTICSEARCH_6_1</DefineConstants>

--- a/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <ApiVersion Condition="'$(ApiVersion)' == ''">6.1.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'>='6.1.0'">$(DefineConstants);ELASTICSEARCH_6_1</DefineConstants>

--- a/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="NEST" Version="$(ApiVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
   </ItemGroup>
 

--- a/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.SqlServer/Samples.SqlServer.csproj
+++ b/test/test-applications/integrations/Samples.SqlServer/Samples.SqlServer.csproj
@@ -9,11 +9,11 @@
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Data" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.Data.SqlClient" Version="$(ApiVersion)" />
   </ItemGroup>
 

--- a/test/test-applications/integrations/Samples.WcfClient/Samples.WcfClient.csproj
+++ b/test/test-applications/integrations/Samples.WcfClient/Samples.WcfClient.csproj
@@ -4,11 +4,11 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <PackageReference Include="System.ServiceModel.Http" Version="4.5.3" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="4.5.3" />
   </ItemGroup>

--- a/test/test-applications/regression/AspNetMvcCorePerformance/AspNetMvcCorePerformance.csproj
+++ b/test/test-applications/regression/AspNetMvcCorePerformance/AspNetMvcCorePerformance.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/test-applications/regression/AspNetMvcCorePerformance/AspNetMvcCorePerformance.csproj
+++ b/test/test-applications/regression/AspNetMvcCorePerformance/AspNetMvcCorePerformance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/test-applications/regression/AssemblyResolveMscorlibResources.InfiniteRecursionCrash/AssemblyResolveMscorlibResources.InfiniteRecursionCrash.csproj
+++ b/test/test-applications/regression/AssemblyResolveMscorlibResources.InfiniteRecursionCrash/AssemblyResolveMscorlibResources.InfiniteRecursionCrash.csproj
@@ -3,7 +3,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/test-applications/regression/AutomapperTest/AutomapperTest.csproj
+++ b/test/test-applications/regression/AutomapperTest/AutomapperTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;net5.0</TargetFrameworks>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>

--- a/test/test-applications/regression/AutomapperTest/AutomapperTest.csproj
+++ b/test/test-applications/regression/AutomapperTest/AutomapperTest.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>..\..</DockerfileContext>
   </PropertyGroup>

--- a/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
+++ b/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
@@ -3,7 +3,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/test-applications/regression/OrleansCrash/OrleansCrash.csproj
+++ b/test/test-applications/regression/OrleansCrash/OrleansCrash.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/test/test-applications/regression/OrleansCrash/OrleansCrash.csproj
+++ b/test/test-applications/regression/OrleansCrash/OrleansCrash.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
 
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
+++ b/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 

--- a/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
+++ b/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 

--- a/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
+++ b/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
+++ b/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Summary of the changes:

- Edited the major version of integrations to target 5.x assemblies
- Added a job to run .NET 5 integration tests
- Added the .NET 5 SDK to all impacted pipelines
- Updated the framework detection logic in tests because the TFM does not contain "netcoreapp"
- Updated MySQL in Alpine because of weird failures with Alpine 3.12 (the .NET 5 image is not available for Alpine 3.10)