### PR TITLE
Fix tags serialization

### DIFF
--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.Vendors.MessagePack;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Tagging
@@ -30,6 +32,49 @@ namespace Datadog.Trace.Tests.Tagging
 
                 ValidateProperties<string>(type, "GetAdditionalTags", () => Guid.NewGuid().ToString());
                 ValidateProperties<double?>(type, "GetAdditionalMetrics", () => random.NextDouble());
+            }
+        }
+
+        [Fact]
+        public void Serialization()
+        {
+            var tags = new CommonTags();
+            var span = new Span(new SpanContext(42, 41), DateTimeOffset.UtcNow, tags);
+
+            // The span has 1 "common" tag and 15 additional tags (and same number of metrics)
+            // Those numbers are picked to test the variable-size header of MessagePack
+            // The header is resized when there are 16 or more elements in the collection
+            // Neither common or additional tags have enough elements, but put together they will cause to use a bigger header
+            tags.Environment = "Test";
+            tags.SamplingLimitDecision = 0.5;
+
+            for (int i = 0; i < 15; i++)
+            {
+                span.SetTag(i.ToString(), i.ToString());
+            }
+
+            for (int i = 0; i < 15; i++)
+            {
+                span.SetMetric(i.ToString(), i);
+            }
+
+            var buffer = new byte[0];
+
+            var resolver = new FormatterResolverWrapper(SpanFormatterResolver.Instance);
+            MessagePackSerializer.Serialize(ref buffer, 0, span, resolver);
+
+            var deserializedSpan = MessagePack.MessagePackSerializer.Deserialize<FakeSpan>(buffer);
+
+            Assert.Equal(16, deserializedSpan.Tags.Count);
+            Assert.Equal(16, deserializedSpan.Metrics.Count);
+
+            Assert.Equal("Test", deserializedSpan.Tags[Tags.Env]);
+            Assert.Equal(0.5, deserializedSpan.Metrics[Metrics.SamplingLimitDecision]);
+
+            for (int i = 0; i < 15; i++)
+            {
+                Assert.Equal(i.ToString(), deserializedSpan.Tags[i.ToString()]);
+                Assert.Equal((double)i, deserializedSpan.Metrics[i.ToString()]);
             }
         }
 
@@ -65,6 +110,46 @@ namespace Datadog.Trace.Tests.Tagging
             {
                 Assert.True(remainingValues.Remove((T)property.GetValue(instance)), $"Property {property.Name} of type {type.Name} is not mapped");
             }
+        }
+
+        [MessagePack.MessagePackObject]
+        public struct FakeSpan
+        {
+            [MessagePack.Key("trace_id")]
+            public ulong TraceId { get; set; }
+
+            [MessagePack.Key("span_id")]
+            public ulong SpanId { get; set; }
+
+            [MessagePack.Key("name")]
+            public string Name { get; set; }
+
+            [MessagePack.Key("resource")]
+            public string Resource { get; set; }
+
+            [MessagePack.Key("service")]
+            public string Service { get; set; }
+
+            [MessagePack.Key("type")]
+            public string Type { get; set; }
+
+            [MessagePack.Key("start")]
+            public long Start { get; set; }
+
+            [MessagePack.Key("duration")]
+            public long Duration { get; set; }
+
+            [MessagePack.Key("parent_id")]
+            public ulong? ParentId { get; set; }
+
+            [MessagePack.Key("error")]
+            public byte Error { get; set; }
+
+            [MessagePack.Key("meta")]
+            public Dictionary<string, string> Tags { get; set; }
+
+            [MessagePack.Key("metrics")]
+            public Dictionary<string, double> Metrics { get; set; }
         }
     }
 }


### PR DESCRIPTION
Rewriting the map header was too optimistic: I didn't consider that MessagePack maps actually had variable-size headers.

Instead, I rewrote the logic to get the exact number of tags/metrics before writing the header. It means iterating once more on the list of additional tags/metrics, but I don't expect the overhead to be significant.