### PR TITLE
fix assembly names in NpgsqlCommand.ExecuteScalarAsync() integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1447,7 +1447,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 5,
+          "maximum_major": 4,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },

--- a/integrations.json
+++ b/integrations.json
@@ -1437,32 +1437,7 @@
       {
         "caller": {},
         "target": {
-          "assembly": "System.Data",
-          "type": "Npgsql.NpgsqlCommand",
-          "method": "ExecuteScalarAsync",
-          "signature_types": [
-            "System.Threading.Tasks.Task`1<System.Object>",
-            "System.Threading.CancellationToken"
-          ],
-          "minimum_major": 4,
-          "minimum_minor": 0,
-          "minimum_patch": 0,
-          "maximum_major": 5,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.20.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.Integrations.AdoNet.NpgsqlCommandIntegration",
-          "method": "ExecuteScalarAsync",
-          "signature": "00 05 1C 1C 1C 08 08 0A",
-          "action": "ReplaceTargetMethod"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
-          "assembly": "System.Data.SqlClient",
+          "assembly": "Npgsql",
           "type": "Npgsql.NpgsqlCommand",
           "method": "ExecuteScalarAsync",
           "signature_types": [

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -575,7 +575,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for NpgsqlCommand.CancellationToken().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteScalarAsync(CancellationToken).
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -585,7 +585,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataSqlClient },
+            TargetAssemblies = new[] { NpgsqlAssemblyName },
             TargetType = NpgsqlCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(NpgsqlCommandIntegration));
 
         /// <summary>
-        /// Instrumentation wrapper for NpgsqlCommand />
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteReader() />
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteReader().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteReader(CommandBehavior).
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
@@ -151,7 +151,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteReaderAsync().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteReaderAsync(CancellationToken).
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteReaderAsync().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteReaderAsync(CommandBehavior, CancellationToken).
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="behavior">The <see cref="CommandBehavior"/> value used in the original method call.</param>
@@ -368,7 +368,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteNonQuery().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteNonQuery().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -431,7 +431,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteNonQueryAsync().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteNonQueryAsync(CancellationToken).
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>
@@ -512,7 +512,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteScalar().
+        /// Instrumentation wrapper for NpgsqlCommand.ExecuteScalar().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="opCode">The OpCode used in the original method call.</param>
@@ -575,7 +575,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         }
 
         /// <summary>
-        /// Instrumentation wrapper for SqlCommand.ExecuteScalarAsync().
+        /// Instrumentation wrapper for NpgsqlCommand.CancellationToken().
         /// </summary>
         /// <param name="command">The object referenced by this in the instrumented method.</param>
         /// <param name="boxedCancellationToken">The <see cref="CancellationToken"/> value used in the original method call.</param>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -15,7 +15,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     public static class NpgsqlCommandIntegration
     {
         private const string Major4 = "4";
-        private const string Major5 = "5";
 
         private const string NpgsqlAssemblyName = "Npgsql";
         private const string NpgsqlCommandTypeName = "Npgsql.NpgsqlCommand";
@@ -589,7 +588,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetType = NpgsqlCommandTypeName,
             TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
-            TargetMaximumVersion = Major5)]
+            TargetMaximumVersion = Major4)]
         public static object ExecuteScalarAsync(
             object command,
             object boxedCancellationToken,


### PR DESCRIPTION
Instrumenting `NpgsqlCommand.ExecuteScalarAsync(CancellationToken)` works now because the C# compiler emits a virtual a call to `DbCommand.ExecuteScalarAsync(CancellationToken)` which we instrument correctly.

If `NpgsqlCommand.ExecuteScalarAsync(CancellationToken)` stops being an override in the future, we would not be able to instrument it until we fix this.

Bonus: fix the xml-doc comments in `NpgsqlCommand`