### PR TITLE
Automatic Instrumentation: Load Datadog.Trace.dll into a separate AssemblyLoadContext on .NET Core

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -369,6 +369,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.Standalone", "src\Datadog.Trace.Tools.Runner\Datadog.Trace.Tools.Runner.Standalone.csproj", "{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreAssemblyLoadFailureOlderNuGet", "test\test-applications\regression\NetCoreAssemblyLoadFailureOlderNuGet\NetCoreAssemblyLoadFailureOlderNuGet.csproj", "{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1337,6 +1339,16 @@ Global
 		{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF}.Release|x64.Build.0 = Release|Any CPU
 		{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF}.Release|x86.Build.0 = Release|Any CPU
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|x64.ActiveCfg = Debug|x64
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|x64.Build.0 = Debug|x64
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|x86.ActiveCfg = Debug|x86
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Debug|x86.Build.0 = Debug|x86
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|Any CPU.ActiveCfg = Release|x86
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x64.ActiveCfg = Release|x64
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x64.Build.0 = Release|x64
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x86.ActiveCfg = Release|x86
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1441,6 +1453,7 @@ Global
 		{E5439139-6F94-44FA-9590-C32FCC1C7A93} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{1F146D40-8B21-4630-8049-14FA4BBBB217} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -41,7 +41,7 @@ for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStac
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 
-for sample in OrleansCrash DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject ; do
+for sample in OrleansCrash DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject NetCoreAssemblyLoadFailureOlderNuGet ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/regression/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/NetCoreAssemblyLoadFailureOlderNuGetSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/NetCoreAssemblyLoadFailureOlderNuGetSmokeTest.cs
@@ -1,0 +1,22 @@
+#if !NETFRAMEWORK
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class NetCoreAssemblyLoadFailureOlderNuGetSmokeTest : SmokeTestBase
+    {
+        public NetCoreAssemblyLoadFailureOlderNuGetSmokeTest(ITestOutputHelper output)
+            : base(output, "NetCoreAssemblyLoadFailureOlderNuGet")
+        {
+        }
+
+        [Fact]
+        [Trait("Category", "Smoke")]
+        public void NoExceptions()
+        {
+            CheckForSmoke(shouldDeserializeTraces: false);
+        }
+    }
+}
+#endif

--- a/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
+++ b/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 

--- a/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
+++ b/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Datadog.Trace" Version="1.19.0" />
+  </ItemGroup>
+
+</Project>

--- a/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/Program.cs
+++ b/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/Program.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Datadog.Trace;
+
+namespace NetCoreAssemblyLoadFailureOlderNuGet
+{
+    public class Program
+    {
+        static async Task<int> Main()
+        {
+            try
+            {
+                var url = GetUrl();
+                await RunProgramAsync(url);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                return (int)ExitCode.UnknownError;
+            }
+
+            return (int)ExitCode.Success;
+        }
+
+        private static string GetUrl()
+        {
+            return "http://www.example.com";
+        }
+
+        private static async Task RunProgramAsync(string url)
+        {
+            using (Tracer.Instance.StartActive("RunProgramAsync"))
+            using (var client = new HttpClient())
+            using (Tracer.Instance.StartActive("GetAsync"))
+            {
+                await client.GetAsync(url);
+            }
+        }
+    }
+
+    enum ExitCode : int
+    {
+        Success = 0,
+        UnknownError = -10
+    }
+}

--- a/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/Properties/launchSettings.json
+++ b/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/Properties/launchSettings.json
@@ -1,0 +1,17 @@
+{
+  "profiles": {
+    "NetCoreAssemblyLoadFailureOlderNuGet": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+        "DD_VERSION": "1.0.0"
+      },
+      "nativeDebugging": true
+    }
+  }
+}


### PR DESCRIPTION
Load Datadog.Trace.dll into a separate AssemblyLoadContext on .NET Core so it doesn't clash with the one provided by the NuGet package.

This fixes the error `System.IO.FileLoadException: Could not load file or assembly 'Datadog.Trace, Version=1.X.X.X Culture=neutral, PublicKeyToken=def86d061d0d2eeb'` when combining manual instrumentation (Datadog.Trace NuGet package) and automatic instrumentation on .NET Core

@DataDog/apm-dotnet