### PR TITLE
Add automatic instrumentation for apps/libraries referencing System.Data 2.0.0.0

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -373,6 +373,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreAssemblyLoadFailureO
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.ManualTracing", "test\test-applications\regression\Sandbox.ManualTracing\Sandbox.ManualTracing.csproj", "{6DF72F24-D842-4F1E-948C-ED89093325D6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.SqlServer.NetFramework20", "test\test-applications\integrations\Samples.SqlServer.NetFramework20\Samples.SqlServer.NetFramework20.csproj", "{8276E670-FC3F-4EDE-9D51-6DAD90336C32}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.DatabaseHelper.NetFramework20", "test\test-applications\integrations\dependency-libs\Samples.DatabaseHelper.NetFramework20\Samples.DatabaseHelper.NetFramework20.csproj", "{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1361,6 +1365,28 @@ Global
 		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x64.Build.0 = Release|x64
 		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x86.ActiveCfg = Release|x86
 		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x86.Build.0 = Release|x86
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|x64.ActiveCfg = Debug|x64
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|x64.Build.0 = Debug|x64
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|x86.ActiveCfg = Debug|x86
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Debug|x86.Build.0 = Debug|x86
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|Any CPU.ActiveCfg = Release|x86
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|x64.ActiveCfg = Release|x64
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|x64.Build.0 = Release|x64
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|x86.ActiveCfg = Release|x86
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32}.Release|x86.Build.0 = Release|x86
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|x64.Build.0 = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|x64.ActiveCfg = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|x64.Build.0 = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1467,6 +1493,8 @@ Global
 		{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 		{6DF72F24-D842-4F1E-948C-ED89093325D6} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{8276E670-FC3F-4EDE-9D51-6DAD90336C32} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/integrations.json
+++ b/integrations.json
@@ -104,7 +104,7 @@
           "signature_types": [
             "System.Data.Common.DbDataReader"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -177,7 +177,7 @@
             "System.Data.Common.DbDataReader",
             "System.Data.CommandBehavior"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -329,7 +329,7 @@
           "signature_types": [
             "System.Int32"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -476,7 +476,7 @@
           "signature_types": [
             "System.Object"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -865,7 +865,7 @@
           "signature_types": [
             "System.Data.IDataReader"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -938,7 +938,7 @@
             "System.Data.IDataReader",
             "System.Data.CommandBehavior"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -1012,7 +1012,7 @@
           "signature_types": [
             "System.Int32"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -1084,7 +1084,7 @@
           "signature_types": [
             "System.Object"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 5,
@@ -1562,7 +1562,7 @@
           "signature_types": [
             "System.Data.SqlClient.SqlDataReader"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 4,
@@ -1611,7 +1611,7 @@
             "System.Data.SqlClient.SqlDataReader",
             "System.Data.CommandBehavior"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 4,
@@ -1712,7 +1712,7 @@
           "signature_types": [
             "System.Int32"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 4,
@@ -1810,7 +1810,7 @@
           "signature_types": [
             "System.Object"
           ],
-          "minimum_major": 4,
+          "minimum_major": 2,
           "minimum_minor": 0,
           "minimum_patch": 0,
           "maximum_major": 4,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
@@ -30,7 +30,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetType = DbCommandTypeName,
+            TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReader },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReader },
@@ -102,7 +109,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetType = DbCommandTypeName,
+            TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReader, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReader, AdoNetConstants.TypeNames.CommandBehavior },
@@ -267,7 +281,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteNonQuery,
+            TargetType = DbCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Int32 },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteNonQuery,
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
@@ -425,7 +446,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteScalar,
+            TargetType = DbCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Object },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteScalar,
             TargetType = DbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
@@ -13,9 +13,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     /// </summary>
     public static class DbCommandIntegration
     {
+        private const string Major2 = "2";
         private const string Major4 = "4";
         private const string Major5 = "5";
-        private const string Major2 = "2";
 
         private const string DbCommandTypeName = AdoNetConstants.TypeNames.DbCommand;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
@@ -11,9 +11,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     // ReSharper disable once InconsistentNaming
     public static class IDbCommandIntegration
     {
+        private const string Major2 = "2";
         private const string Major4 = "4";
         private const string Major5 = "5";
-        private const string Major2 = "2";
 
         // ReSharper disable once InconsistentNaming
         private const string IDbCommandTypeName = AdoNetConstants.TypeNames.IDbCommand;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/IDbCommandIntegration.cs
@@ -29,7 +29,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.IDataReader },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.IDataReader },
             TargetMinimumVersion = Major4,
@@ -99,7 +105,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.IDataReader, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.IDataReader, AdoNetConstants.TypeNames.CommandBehavior },
@@ -173,7 +186,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Int32 },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
@@ -242,7 +261,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = IDbCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Object },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetType = IDbCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
     /// </summary>
     public static class SqlCommandIntegration
     {
+        private const string Major2 = "2";
         private const string Major4 = "4";
         private const string Major5 = "4";
 
@@ -31,7 +32,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataSqlClient },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = SqlCommandTypeName,
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetSignatureTypes = new[] { SqlDataReaderTypeName },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataSqlClient },
             TargetType = SqlCommandTypeName,
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetSignatureTypes = new[] { SqlDataReaderTypeName },
@@ -94,7 +102,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataSqlClient },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = SqlCommandTypeName,
+            TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
+            TargetSignatureTypes = new[] { SqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataSqlClient },
             TargetType = SqlCommandTypeName,
             TargetMethod = AdoNetConstants.MethodNames.ExecuteReader,
             TargetSignatureTypes = new[] { SqlDataReaderTypeName, AdoNetConstants.TypeNames.CommandBehavior },
@@ -269,7 +284,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataSqlClient },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = SqlCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Int32 },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataSqlClient },
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Int32 },
             TargetMinimumVersion = Major4,
@@ -411,7 +432,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         /// <param name="moduleVersionPtr">A pointer to the module version GUID.</param>
         /// <returns>The value returned by the instrumented method.</returns>
         [InterceptMethod(
-            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataSqlClient },
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData },
+            TargetType = SqlCommandTypeName,
+            TargetSignatureTypes = new[] { ClrNames.Object },
+            TargetMinimumVersion = Major2,
+            TargetMaximumVersion = Major4)]
+        [InterceptMethod(
+            TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemDataSqlClient },
             TargetType = SqlCommandTypeName,
             TargetSignatureTypes = new[] { ClrNames.Object },
             TargetMinimumVersion = Major4,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -1,0 +1,55 @@
+#if NET452
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Core.Tools;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
+{
+    public class SqlCommand20Tests : TestHelper
+    {
+        public SqlCommand20Tests(ITestOutputHelper output)
+        : base("SqlServer.NetFramework20", output)
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void SubmitsTraces()
+        {
+            var expectedSpanCount = 21; // 7 queries * 3 groups (The group of generic constraint calls is not currently supported)
+
+            const string dbType = "sql-server";
+            const string expectedOperationName = dbType + ".query";
+            const string expectedServiceName = "Samples.SqlServer.NetFramework20-" + dbType;
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
+
+                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                Assert.Equal(expectedSpanCount, spans.Count);
+
+                foreach (var span in spans)
+                {
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(SpanTypes.Sql, span.Type);
+                    Assert.Equal(dbType, span.Tags[Tags.DbType]);
+                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                }
+            }
+        }
+    }
+}
+#endif

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/DbCommandClassExecutor20Adapter.cs
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/DbCommandClassExecutor20Adapter.cs
@@ -1,0 +1,49 @@
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+using Samples.DatabaseHelper.NetFramework20;
+
+namespace Samples.SqlServer.NetFramework20
+{
+    public class DbCommandClassExecutor20Adapter : DbCommandExecutor<DbCommand>
+    {
+        private static readonly Task CompletedTask = Task.FromResult(0);
+
+        private readonly DbCommandClassExecutor20 _dbCommandClassExecutor20;
+
+        public DbCommandClassExecutor20Adapter(DbCommandClassExecutor20 dbCommandClassExecutor20)
+        {
+            _dbCommandClassExecutor20 = dbCommandClassExecutor20;
+        }
+
+        public override string CommandTypeName => _dbCommandClassExecutor20.CommandTypeName;
+
+        public override bool SupportsAsyncMethods => false;
+
+        public override void ExecuteNonQuery(DbCommand command) => _dbCommandClassExecutor20.ExecuteNonQuery(command);
+
+        public override Task ExecuteNonQueryAsync(DbCommand command) => CompletedTask;
+
+        public override Task ExecuteNonQueryAsync(DbCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteScalar(DbCommand command) => _dbCommandClassExecutor20.ExecuteScalar(command);
+
+        public override Task ExecuteScalarAsync(DbCommand command) => CompletedTask;
+
+        public override Task ExecuteScalarAsync(DbCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteReader(DbCommand command) => _dbCommandClassExecutor20.ExecuteReader(command);
+
+        public override void ExecuteReader(DbCommand command, CommandBehavior behavior) => _dbCommandClassExecutor20.ExecuteReader(command, behavior);
+
+        public override Task ExecuteReaderAsync(DbCommand command) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(DbCommand command, CommandBehavior behavior) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(DbCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(DbCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => CompletedTask;
+    }
+}

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/DbCommandInterfaceExecutor20Adapter.cs
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/DbCommandInterfaceExecutor20Adapter.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+using Samples.DatabaseHelper.NetFramework20;
+
+namespace Samples.SqlServer.NetFramework20
+{
+    class DbCommandInterfaceExecutor20Adapter : DbCommandExecutor<IDbCommand>
+    {
+        private static readonly Task CompletedTask = Task.FromResult(0);
+
+        private readonly DbCommandInterfaceExecutor20 _dbCommandInterfaceExecutor20;
+
+        public DbCommandInterfaceExecutor20Adapter(DbCommandInterfaceExecutor20 dbCommandInterfaceExecutor20)
+        {
+            _dbCommandInterfaceExecutor20 = dbCommandInterfaceExecutor20;
+        }
+
+        public override string CommandTypeName => _dbCommandInterfaceExecutor20.CommandTypeName;
+
+        public override bool SupportsAsyncMethods => false;
+
+        public override void ExecuteNonQuery(IDbCommand command) => _dbCommandInterfaceExecutor20.ExecuteNonQuery(command);
+
+        public override Task ExecuteNonQueryAsync(IDbCommand command) => CompletedTask;
+
+        public override Task ExecuteNonQueryAsync(IDbCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteScalar(IDbCommand command) => _dbCommandInterfaceExecutor20.ExecuteScalar(command);
+
+        public override Task ExecuteScalarAsync(IDbCommand command) => CompletedTask;
+
+        public override Task ExecuteScalarAsync(IDbCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteReader(IDbCommand command) => _dbCommandInterfaceExecutor20.ExecuteReader(command);
+
+        public override void ExecuteReader(IDbCommand command, CommandBehavior behavior) => _dbCommandInterfaceExecutor20.ExecuteReader(command, behavior);
+
+        public override Task ExecuteReaderAsync(IDbCommand command) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(IDbCommand command, CommandBehavior behavior) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(IDbCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(IDbCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => CompletedTask;
+    }
+}

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/DbCommandInterfaceGenericExecutor20Adapter.cs
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/DbCommandInterfaceGenericExecutor20Adapter.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+using Samples.DatabaseHelper.NetFramework20;
+
+namespace Samples.SqlServer.NetFramework20
+{
+    public class DbCommandInterfaceGenericExecutor20Adapter<TCommand> : DbCommandExecutor<TCommand>
+        where TCommand : IDbCommand
+    {
+        private static readonly Task CompletedTask = Task.FromResult(0);
+
+        private readonly DbCommandInterfaceGenericExecutor20<TCommand> _dbCommandInterfaceGenericExecutor20;
+
+        public DbCommandInterfaceGenericExecutor20Adapter(DbCommandInterfaceGenericExecutor20<TCommand> dbCommandInterfaceGenericExecutor20)
+        {
+            _dbCommandInterfaceGenericExecutor20 = dbCommandInterfaceGenericExecutor20;
+        }
+
+        public override string CommandTypeName => _dbCommandInterfaceGenericExecutor20.CommandTypeName;
+
+        public override bool SupportsAsyncMethods => false;
+
+        public override void ExecuteNonQuery(TCommand command) => _dbCommandInterfaceGenericExecutor20.ExecuteNonQuery(command);
+
+        public override Task ExecuteNonQueryAsync(TCommand command) => CompletedTask;
+
+        public override Task ExecuteNonQueryAsync(TCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteScalar(TCommand command) => _dbCommandInterfaceGenericExecutor20.ExecuteScalar(command);
+
+        public override Task ExecuteScalarAsync(TCommand command) => CompletedTask;
+
+        public override Task ExecuteScalarAsync(TCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteReader(TCommand command) => _dbCommandInterfaceGenericExecutor20.ExecuteReader(command);
+
+        public override void ExecuteReader(TCommand command, CommandBehavior behavior) => _dbCommandInterfaceGenericExecutor20.ExecuteReader(command, behavior);
+
+        public override Task ExecuteReaderAsync(TCommand command) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CommandBehavior behavior) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(TCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => CompletedTask;
+    }
+}

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Program.cs
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Program.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+using Samples.DatabaseHelper.NetFramework20;
+
+namespace Samples.SqlServer.NetFramework20
+{
+    internal static class Program
+    {
+        private static async Task Main()
+        {
+            var commandFactory = new DbCommandFactory();
+            var cts = new CancellationTokenSource();
+
+            var sqlCommandExecutor = new SqlCommandExecutor20Adapter(new SqlCommandExecutor20());
+            var dbCommandClassExecutor = new DbCommandClassExecutor20Adapter(new DbCommandClassExecutor20());
+            var dbCommandInterfaceExecutor = new DbCommandInterfaceExecutor20Adapter(new DbCommandInterfaceExecutor20());
+            var dbCommandInterfaceGenericExecutor = new DbCommandInterfaceGenericExecutor20Adapter<SqlCommand>(new DbCommandInterfaceGenericExecutor20<SqlCommand>());
+
+            using (var connection = OpenConnection())
+            {
+                await RelationalDatabaseTestHarness.RunAllAsync(
+                    connection,
+                    commandFactory,
+                    cts.Token,
+                    sqlCommandExecutor,
+                    dbCommandClassExecutor,
+                    dbCommandInterfaceExecutor,
+                    dbCommandInterfaceGenericExecutor);
+            }
+
+            // allow time to flush
+            await Task.Delay(2000, cts.Token);
+        }
+
+        private static SqlConnection OpenConnection()
+        {
+            int numAttempts = 3;
+            var connectionString = Environment.GetEnvironmentVariable("SQLSERVER_CONNECTION_STRING") ??
+@"Server=(localdb)\MSSQLLocalDB;Integrated Security=true;Connection Timeout=60";
+
+            for (int i = 0; i < numAttempts; i++)
+            {
+                SqlConnection connection = null;
+
+                try
+                {
+                    connection = new SqlConnection(connectionString);
+                    connection.Open();
+                    return connection;
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine(ex);
+                    connection?.Dispose();
+                }
+            }
+
+            throw new Exception($"Unable to open connection to connection string {connectionString} after {numAttempts} attempts");
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "Samples.SqlServer.NetFramework20": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+        "DD_VERSION": "1.0.0",
+        "DD_PROFILER_EXCLUDE_PROCESSES": "sqlservr.exe",
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Samples.SqlServer.NetFramework20.csproj
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Samples.SqlServer.NetFramework20.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- override to only build/run net452 -->
+    <TargetFrameworks>net452</TargetFrameworks>
+
+    <!-- Required to build multiple projects with the same Configuration|Platform -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Data" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper.NetFramework20\Samples.DatabaseHelper.NetFramework20.csproj" />
+    <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/test-applications/integrations/Samples.SqlServer.NetFramework20/SqlCommandExecutor20Adapter.cs
+++ b/test/test-applications/integrations/Samples.SqlServer.NetFramework20/SqlCommandExecutor20Adapter.cs
@@ -1,0 +1,50 @@
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+using Samples.DatabaseHelper.NetFramework20;
+
+namespace Samples.SqlServer.NetFramework20
+{
+    public class SqlCommandExecutor20Adapter : DbCommandExecutor<SqlCommand>
+    {
+        private static readonly Task CompletedTask = Task.FromResult(0);
+
+        private readonly SqlCommandExecutor20 _sqlCommandExecutor20;
+
+        public SqlCommandExecutor20Adapter(SqlCommandExecutor20 sqlCommandExecutor20)
+        {
+            _sqlCommandExecutor20 = sqlCommandExecutor20;
+        }
+
+        public override string CommandTypeName => _sqlCommandExecutor20.CommandTypeName;
+
+        public override bool SupportsAsyncMethods => false;
+
+        public override void ExecuteNonQuery(SqlCommand command) => _sqlCommandExecutor20.ExecuteNonQuery(command);
+
+        public override Task ExecuteNonQueryAsync(SqlCommand command) => CompletedTask;
+
+        public override Task ExecuteNonQueryAsync(SqlCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteScalar(SqlCommand command) => _sqlCommandExecutor20.ExecuteScalar(command);
+
+        public override Task ExecuteScalarAsync(SqlCommand command) => CompletedTask;
+
+        public override Task ExecuteScalarAsync(SqlCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override void ExecuteReader(SqlCommand command) => _sqlCommandExecutor20.ExecuteReader(command);
+
+        public override void ExecuteReader(SqlCommand command, CommandBehavior behavior) => _sqlCommandExecutor20.ExecuteReader(command, behavior);
+
+        public override Task ExecuteReaderAsync(SqlCommand command) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(SqlCommand command, CommandBehavior behavior) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(SqlCommand command, CancellationToken cancellationToken) => CompletedTask;
+
+        public override Task ExecuteReaderAsync(SqlCommand command, CommandBehavior behavior, CancellationToken cancellationToken) => CompletedTask;
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/DbCommandClassExecutor20.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/DbCommandClassExecutor20.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Text;
+
+namespace Samples.DatabaseHelper.NetFramework20
+{
+    public class DbCommandClassExecutor20
+    {
+        public string CommandTypeName => nameof(DbCommand) + "20";
+
+        public void ExecuteNonQuery(DbCommand command) => command.ExecuteNonQuery();
+
+        public void ExecuteScalar(DbCommand command) => command.ExecuteScalar();
+
+        public void ExecuteReader(DbCommand command)
+        {
+            using DbDataReader reader = command.ExecuteReader();
+        }
+
+        public void ExecuteReader(DbCommand command, CommandBehavior behavior)
+        {
+            using DbDataReader reader = command.ExecuteReader(behavior);
+        }
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/DbCommandInterfaceExecutor20.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/DbCommandInterfaceExecutor20.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+
+namespace Samples.DatabaseHelper.NetFramework20
+{
+    public class DbCommandInterfaceExecutor20
+    {
+        public string CommandTypeName => nameof(IDbCommand) + "20";
+
+        public void ExecuteNonQuery(IDbCommand command) => command.ExecuteNonQuery();
+
+        public void ExecuteScalar(IDbCommand command) => command.ExecuteScalar();
+
+        public void ExecuteReader(IDbCommand command)
+        {
+            using IDataReader reader = command.ExecuteReader();
+        }
+
+        public void ExecuteReader(IDbCommand command, CommandBehavior behavior)
+        {
+            using IDataReader reader = command.ExecuteReader(behavior);
+        }
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/DbCommandInterfaceGenericExecutor20.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/DbCommandInterfaceGenericExecutor20.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+
+namespace Samples.DatabaseHelper.NetFramework20
+{
+    public class DbCommandInterfaceGenericExecutor20<TCommand>
+        where TCommand : IDbCommand
+    {
+        public string CommandTypeName => nameof(TCommand) + "20";
+
+        public void ExecuteNonQuery(TCommand command) => command.ExecuteNonQuery();
+
+        public void ExecuteScalar(TCommand command) => command.ExecuteScalar();
+
+        public void ExecuteReader(TCommand command)
+        {
+            using IDataReader reader = command.ExecuteReader();
+        }
+
+        public void ExecuteReader(TCommand command, CommandBehavior behavior)
+        {
+            using IDataReader reader = command.ExecuteReader(behavior);
+        }
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/Samples.DatabaseHelper.NetFramework20.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/Samples.DatabaseHelper.NetFramework20.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net20</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/SqlCommandExecutor20.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/SqlCommandExecutor20.cs
@@ -1,0 +1,25 @@
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+namespace Samples.DatabaseHelper.NetFramework20
+{
+    public class SqlCommandExecutor20
+    {
+        public string CommandTypeName => nameof(SqlCommand) + "20";
+
+        public void ExecuteNonQuery(SqlCommand command) => command.ExecuteNonQuery();
+
+        public void ExecuteScalar(SqlCommand command) => command.ExecuteScalar();
+
+        public void ExecuteReader(SqlCommand command)
+        {
+            using DbDataReader reader = command.ExecuteReader();
+        }
+
+        public void ExecuteReader(SqlCommand command, CommandBehavior behavior)
+        {
+            using DbDataReader reader = command.ExecuteReader(behavior);
+        }
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -64,6 +64,30 @@ namespace Samples.DatabaseHelper
         }
 
         /// <summary>
+        /// Helper method that runs ADO.NET test suite for the specified <see cref="IDbCommandExecutor"/>
+        /// in addition to other built-in implementations.
+        /// </summary>
+        /// <param name="connection">The <see cref="IDbConnection"/> to use to connect to the database.</param>
+        /// <param name="commandFactory">A <see cref="DbCommandFactory"/> implementation specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand.</param>
+        /// <param name="cancellationToken">A cancellation token passed into downstream async methods.</param>
+        /// <param name="providerSpecificCommandExecutors">A list of instantiated <see cref="IDbCommandExecutor"/> objects to directly control the ADO.NET providers tested.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static async Task RunAllAsync(
+            IDbConnection connection,
+            DbCommandFactory commandFactory,
+            CancellationToken cancellationToken,
+            params IDbCommandExecutor[] providerSpecificCommandExecutors)
+        {
+            using (var root = Tracer.Instance.StartActive("root"))
+            {
+                foreach (var executor in providerSpecificCommandExecutors)
+                {
+                    await RunAsync(connection, commandFactory, executor, cancellationToken);
+                }
+            }
+        }
+
+        /// <summary>
         /// Runs ADO.NET test suite for the specified <see cref="IDbCommandExecutor"/>.
         /// </summary>
         /// <param name="connection">The <see cref="IDbConnection"/> to use to connect to the database.</param>


### PR DESCRIPTION
Fixes missing ADO.NET automatic instrumentation spans when running an application on .NET Framework 4.5 (or higher) and the application or a library was built against .NET Framework 2.0.

### Summary
When a .NET application or library is built for an older version of the .NET Framework it will have assembly references to that version of the framework assemblies (e.g. System.Data 2.0.0.0), but when it is run against a later version of the .NET Framework, the .NET Framework will automatically unify the framework assemblies to the current version. This means if a .NET Framework 2.0 application referenced System.Data 2.0.0.0 but it was run on .NET Framework 4.5, the runtime would actually load System.Data 4.0.0.0. In such a scenario, we should be performing automatic instrumentation because System.Data 4.0.0.0 is loaded. However, we currently do not instrument these call sites because our CallSite instrumentation can only see the version that the application/library referenced, which was System.Data 2.0.0.0, and our ADO.NET instrumentation has a set minimum AssemblyVersion of 4.0.0.0.

The proposed change is to lower the minimum AssemblyVersion of ADO.NET integration methods from 4.0.0.0 to 2.0.0.0 for the synchronous methods. This will be valid because:
1. The `ExecuteXXX` API's are identical between 2.0 and 4.0 (used for method replacement)
1. The `IDbCommand` interface is identical between 2.0 and 4.0 (used to populate span information)
1. If automatic instrumentation is on, then the user must be running .NET Framework 4.5 and, by extension, using System.Data 4.0.0.0 at runtime.

### Changes
- Lower the minimum AssemblyVersion for `DbCommand`, `IDbCommand` and `SqlCommand` integration methods from `4.0.0.0` to `2.0.0.0`
- Add a new Samples.SqlServer.NetFramework20 that is compiled and run against `net452`. Since the  (so automatic instrumentation is run)

### Testing
- [x] New regression test `Samples.SqlServer.NetFramework20` uses a .NET Framework 2.0 library that executes all of the database calls. This runs fine and with the propose changes, automatic instrumentation generates a corresponding span for each of the commands.
- [x] The same regression test was run on my development box (which has .NET Framework 2.0 installed) but with a bindingRedirect to force all loads of System.Data 2.0.0.0-4.0.0.0 to redirect to System.Data 2.0.0.0. Automatic instrumentation ran fine and still generated a corresponding span for each command.


@DataDog/apm-dotnet