### PR TITLE
Add robustness to manual instrumentation code paths on .NET Framework

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -371,6 +371,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetCoreAssemblyLoadFailureOlderNuGet", "test\test-applications\regression\NetCoreAssemblyLoadFailureOlderNuGet\NetCoreAssemblyLoadFailureOlderNuGet.csproj", "{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.ManualTracing", "test\test-applications\regression\Sandbox.ManualTracing\Sandbox.ManualTracing.csproj", "{6DF72F24-D842-4F1E-948C-ED89093325D6}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1349,6 +1351,16 @@ Global
 		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x64.Build.0 = Release|x64
 		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x86.ActiveCfg = Release|x86
 		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0}.Release|x86.Build.0 = Release|x86
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|x64.ActiveCfg = Debug|x64
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|x64.Build.0 = Debug|x64
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|x86.ActiveCfg = Debug|x86
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Debug|x86.Build.0 = Debug|x86
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|Any CPU.ActiveCfg = Release|x86
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x64.ActiveCfg = Release|x64
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x64.Build.0 = Release|x64
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x86.ActiveCfg = Release|x86
+		{6DF72F24-D842-4F1E-948C-ED89093325D6}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1454,6 +1466,7 @@ Global
 		{1F146D40-8B21-4630-8049-14FA4BBBB217} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{3C493248-F1D1-4948-BBA9-76BEB5DFA9FF} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{D79491F0-CA92-439B-98CE-7AF9F57EBEB0} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{6DF72F24-D842-4F1E-948C-ED89093325D6} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/build/tools/PrepareRelease/SetAllVersions.cs
+++ b/build/tools/PrepareRelease/SetAllVersions.cs
@@ -79,6 +79,11 @@ namespace PrepareRelease
                 "src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h",
                 FullAssemblyNameReplace);
 
+            // Four-part AssemblyVersion update
+            SynchronizeVersion(
+                "src/Datadog.Trace/TracerConstants.cs",
+                FourPartVersionReplace);
+
             // Locked AssemblyVersion #.0.0.0 updates
             SynchronizeVersion(
                 "src/Datadog.Trace.AspNet/AssemblyInfo.cs",
@@ -124,6 +129,11 @@ namespace PrepareRelease
                 WixProjReplace);
 
             Console.WriteLine($"Completed synchronizing versions to {VersionString()}");
+        }
+
+        private static string FourPartVersionReplace(string text)
+        {
+            return Regex.Replace(text, VersionPattern(fourPartVersion: true), FourPartVersionString(), RegexOptions.Singleline);
         }
 
         private static string FullVersionReplace(string text, string split)
@@ -184,6 +194,11 @@ namespace PrepareRelease
             var newFileContent = transform(fileContent);
 
             File.WriteAllText(fullPath, newFileContent, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+
+        private static string FourPartVersionString(string split = ".")
+        {
+            return $"{TracerVersion.Major}{split}{TracerVersion.Minor}{split}{TracerVersion.Patch}{split}0";
         }
 
         private static string MajorVersionString(string split = ".")

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -15,7 +15,16 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
         static Startup()
         {
             ManagedProfilerDirectory = ResolveManagedProfilerDirectory();
-            AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve_ManagedProfilerDependencies;
+
+            try
+            {
+                AppDomain.CurrentDomain.AssemblyResolve += AssemblyResolve_ManagedProfilerDependencies;
+            }
+            catch (Exception ex)
+            {
+                StartupLogger.Log(ex, "Unable to register a callback to the CurrentDomain.AssemblyResolve event.");
+            }
+
             TryLoadManagedAssembly();
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler
                 {
                     return NativeMethods.IsProfilerAttached();
                 }
-                catch (DllNotFoundException)
+                catch
                 {
                     return false;
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler
                 {
                     return NativeMethods.IsProfilerAttached();
                 }
-                catch
+                catch (DllNotFoundException)
                 {
                     return false;
                 }

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -69,7 +69,17 @@ namespace Datadog.Trace.Agent
 
             while (true)
             {
-                var request = _apiRequestFactory.Create(_tracesEndpoint);
+                IApiRequest request;
+
+                try
+                {
+                    request = _apiRequestFactory.Create(_tracesEndpoint);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, $"An error occurred while generating http request to send traces to the agent at {_tracesEndpoint}");
+                    return false;
+                }
 
                 // Set additional headers
                 request.AddHeader(AgentHttpHeaderNames.TraceCount, traceCount.ToString());

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -112,6 +112,16 @@ namespace Datadog.Trace.Configuration
 #endif
             };
 
+            if (TryLoadJsonConfigurationFile(configurationSource, out var jsonConfigurationSource))
+            {
+                configurationSource.Add(jsonConfigurationSource);
+            }
+
+            return configurationSource;
+        }
+
+        private static bool TryLoadJsonConfigurationFile(IConfigurationSource configurationSource, out IConfigurationSource jsonConfigurationSource)
+        {
             try
             {
                 string currentDirectory = System.Environment.CurrentDirectory;
@@ -135,15 +145,19 @@ namespace Datadog.Trace.Configuration
                 if (Path.GetExtension(configurationFileName).ToUpperInvariant() == ".JSON" &&
                     File.Exists(configurationFileName))
                 {
-                    configurationSource.Add(JsonConfigurationSource.FromFile(configurationFileName));
+                    jsonConfigurationSource = JsonConfigurationSource.FromFile(configurationFileName);
+                    return true;
                 }
             }
             catch (Exception)
             {
-                // Uh oh
+                // Unable to load the JSON file from disk
+                // The configuration manager should not depend on a logger being bootstrapped yet
+                // so do not do anything
             }
 
-            return configurationSource;
+            jsonConfigurationSource = default;
+            return false;
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.Configuration
                                             configurationSource.GetString("DD_DOTNET_TRACER_CONFIG_FILE") ??
                                             Path.Combine(currentDirectory, "datadog.json");
 
-                if (Path.GetExtension(configurationFileName).ToUpperInvariant() == ".JSON" &&
+                if (string.Equals(Path.GetExtension(configurationFileName), ".JSON", StringComparison.OrdinalIgnoreCase) &&
                     File.Exists(configurationFileName))
                 {
                     jsonConfigurationSource = JsonConfigurationSource.FromFile(configurationFileName);

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -686,6 +686,7 @@ namespace Datadog.Trace
 
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
+            Log.Warning("Application threw an unhandled exception: {0}", e.ExceptionObject);
             RunShutdownTasks();
         }
 

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -525,7 +525,7 @@ namespace Datadog.Trace
                     writer.WriteValue(Environment.OSVersion.ToString());
 
                     writer.WritePropertyName("version");
-                    writer.WriteValue(typeof(Tracer).Assembly.GetName().Version.ToString());
+                    writer.WriteValue(TracerConstants.AssemblyVersion);
 
                     writer.WritePropertyName("platform");
                     writer.WriteValue(frameworkDescription.ProcessArchitecture);

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -148,8 +148,8 @@ namespace Datadog.Trace
             // Register callbacks to make sure we flush the traces before exiting
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            Console.CancelKeyPress += Console_CancelKeyPress;
+            // AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            // Console.CancelKeyPress += Console_CancelKeyPress;
 
             // start the heartbeat loop
             _heartbeatTimer = new Timer(HeartbeatCallback, state: null, dueTime: TimeSpan.Zero, period: TimeSpan.FromMinutes(1));
@@ -597,6 +597,7 @@ namespace Datadog.Trace
             try
             {
 #if NETFRAMEWORK
+                /*
                 // System.Web.dll is only available on .NET Framework
                 if (System.Web.Hosting.HostingEnvironment.IsHosted)
                 {
@@ -604,10 +605,12 @@ namespace Datadog.Trace
                     // note that ApplicationVirtualPath includes a leading slash.
                     return (System.Web.Hosting.HostingEnvironment.SiteName + System.Web.Hosting.HostingEnvironment.ApplicationVirtualPath).TrimEnd('/');
                 }
+                */
 #endif
 
-                return Assembly.GetEntryAssembly()?.GetName().Name ??
-                       Process.GetCurrentProcess().ProcessName;
+                // return Assembly.GetEntryAssembly()?.GetName().Name ??
+                // return Process.GetCurrentProcess().ProcessName;
+                return null;
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -626,10 +627,8 @@ namespace Datadog.Trace
                 }
                 */
 #endif
-
-                // return Assembly.GetEntryAssembly()?.GetName().Name ??
-                // return Process.GetCurrentProcess().ProcessName;
-                return null;
+                return Assembly.GetEntryAssembly()?.GetName().Name ??
+                   ProcessHelpers.GetCurrentProcessName();
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace/TracerConstants.cs
+++ b/src/Datadog.Trace/TracerConstants.cs
@@ -9,6 +9,6 @@ namespace Datadog.Trace
         /// </summary>
         public const ulong MaxTraceId = 9_223_372_036_854_775_807;
 
-        public static readonly string AssemblyVersion = typeof(Tracer).Assembly.GetName().Version.ToString();
+        public static readonly string AssemblyVersion = "1.19.6.0";
     }
 }

--- a/src/Datadog.Trace/TracerConstants.cs
+++ b/src/Datadog.Trace/TracerConstants.cs
@@ -9,6 +9,6 @@ namespace Datadog.Trace
         /// </summary>
         public const ulong MaxTraceId = 9_223_372_036_854_775_807;
 
-        public static readonly string AssemblyVersion = "1.19.6.0";
+        public static readonly string AssemblyVersion = "1.20.0.0";
     }
 }

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -10,6 +10,9 @@ namespace Datadog.Trace.Util
     {
         private const string UnknownName = "unknown";
         private static Process _currentProcess;
+        private static string _currentProcessName;
+        private static string _currentProcessMachineName;
+        private static int _currentProcessId;
         private static bool _processDataPoisoned;
         private static bool _domainDataPoisoned;
         private static bool? _isAppInsightsAppDomain;
@@ -23,15 +26,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                try
-                {
-                    return !_processDataPoisoned ? _currentProcess.ProcessName : UnknownName;
-                }
-                catch
-                {
-                    _processDataPoisoned = true;
-                    return UnknownName;
-                }
+                return !_processDataPoisoned ? _currentProcessName : UnknownName;
             }
         }
 
@@ -39,15 +34,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                try
-                {
-                    return !_processDataPoisoned ? _currentProcess.MachineName : UnknownName;
-                }
-                catch
-                {
-                    _processDataPoisoned = true;
-                    return UnknownName;
-                }
+                return !_processDataPoisoned ? _currentProcessMachineName : UnknownName;
             }
         }
 
@@ -55,15 +42,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                try
-                {
-                    return !_processDataPoisoned ? _currentProcess.Id : -1;
-                }
-                catch
-                {
-                    _processDataPoisoned = true;
-                    return -1;
-                }
+                return !_processDataPoisoned ? _currentProcessId : -1;
             }
         }
 
@@ -115,7 +94,10 @@ namespace Datadog.Trace.Util
             {
                 if (!_processDataPoisoned && _currentProcess == null)
                 {
-                    _currentProcess = Process.GetCurrentProcess();
+                    _currentProcess = ProcessHelpers.GetCurrentProcess();
+                    _currentProcessName = ProcessHelpers.GetCurrentProcessName();
+                    _currentProcessMachineName = ProcessHelpers.GetCurrentProcessMachineName();
+                    _currentProcessId = ProcessHelpers.GetCurrentProcessId();
                 }
             }
             catch

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -95,9 +95,7 @@ namespace Datadog.Trace.Util
                 if (!_processDataPoisoned && !_initialized)
                 {
                     _initialized = true;
-                    _currentProcessName = ProcessHelpers.GetCurrentProcessName();
-                    _currentProcessMachineName = ProcessHelpers.GetCurrentProcessMachineName();
-                    _currentProcessId = ProcessHelpers.GetCurrentProcessId();
+                    ProcessHelpers.GetCurrentProcessInformation(out _currentProcessName, out _currentProcessMachineName, out _currentProcessId);
                 }
             }
             catch

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Util
     internal static class DomainMetadata
     {
         private const string UnknownName = "unknown";
-        private static Process _currentProcess;
+        private static bool _initialized;
         private static string _currentProcessName;
         private static string _currentProcessMachineName;
         private static int _currentProcessId;
@@ -92,9 +92,9 @@ namespace Datadog.Trace.Util
         {
             try
             {
-                if (!_processDataPoisoned && _currentProcess == null)
+                if (!_processDataPoisoned && !_initialized)
                 {
-                    _currentProcess = ProcessHelpers.GetCurrentProcess();
+                    _initialized = true;
                     _currentProcessName = ProcessHelpers.GetCurrentProcessName();
                     _currentProcessMachineName = ProcessHelpers.GetCurrentProcessMachineName();
                     _currentProcessId = ProcessHelpers.GetCurrentProcessId();

--- a/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Util
         private static string _currentProcessName;
         private static string _currentProcessMachineName;
         private static int _currentProcessId;
-        private static bool _processDataPoisoned;
+        private static bool _processDataUnavailable;
         private static bool _domainDataPoisoned;
         private static bool? _isAppInsightsAppDomain;
 
@@ -26,7 +26,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                return !_processDataPoisoned ? _currentProcessName : UnknownName;
+                return !_processDataUnavailable ? _currentProcessName : UnknownName;
             }
         }
 
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                return !_processDataPoisoned ? _currentProcessMachineName : UnknownName;
+                return !_processDataUnavailable ? _currentProcessMachineName : UnknownName;
             }
         }
 
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                return !_processDataPoisoned ? _currentProcessId : -1;
+                return !_processDataUnavailable ? _currentProcessId : -1;
             }
         }
 
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Util
         {
             try
             {
-                if (!_processDataPoisoned && !_initialized)
+                if (!_processDataUnavailable && !_initialized)
                 {
                     _initialized = true;
                     ProcessHelpers.GetCurrentProcessInformation(out _currentProcessName, out _currentProcessMachineName, out _currentProcessId);
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Util
             }
             catch
             {
-                _processDataPoisoned = true;
+                _processDataUnavailable = true;
             }
         }
     }

--- a/src/Datadog.Trace/Util/EnvironmentHelpers.cs
+++ b/src/Datadog.Trace/Util/EnvironmentHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Serilog;
 
@@ -47,7 +48,7 @@ namespace Datadog.Trace.Util
                 Logger.Warning(ex, "Error while reading environment variables");
             }
 
-            return null;
+            return new Dictionary<object, object>();
         }
     }
 }

--- a/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+
+namespace Datadog.Trace.Util
+{
+    internal static class ProcessHelpers
+    {
+        /// <summary>
+        /// Wrapper around <see cref="Process.GetCurrentProcess"/>
+        ///
+        /// On .NET Framework the <see cref="Process"/> class is guarded by a
+        /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
+        /// This exception is thrown when the caller method is being JIT compiled, NOT
+        /// when Process.GetCurrentProcess is called, so this wrapper method allows
+        /// us to catch the exception.
+        /// </summary>
+        /// <returns>Returns the result of <see cref="Process.GetCurrentProcess"/></returns>
+        public static Process GetCurrentProcess()
+        {
+            return Process.GetCurrentProcess();
+        }
+
+        /// <summary>
+        /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.ProcessName"/>
+        ///
+        /// On .NET Framework the <see cref="Process"/> class is guarded by a
+        /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
+        /// This exception is thrown when the caller method is being JIT compiled, NOT
+        /// when Process.GetCurrentProcess is called, so this wrapper method allows
+        /// us to catch the exception.
+        /// </summary>
+        /// <returns>Returns the name of the current process</returns>
+        public static string GetCurrentProcessName()
+        {
+            return Process.GetCurrentProcess().ProcessName;
+        }
+
+        /// <summary>
+        /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.MachineName"/>
+        ///
+        /// On .NET Framework the <see cref="Process"/> class is guarded by a
+        /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
+        /// This exception is thrown when the caller method is being JIT compiled, NOT
+        /// when Process.GetCurrentProcess is called, so this wrapper method allows
+        /// us to catch the exception.
+        /// </summary>
+        /// <returns>Returns the machine name of the current process</returns>
+        public static string GetCurrentProcessMachineName()
+        {
+            return Process.GetCurrentProcess().MachineName;
+        }
+
+        /// <summary>
+        /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.Id"/>
+        ///
+        /// On .NET Framework the <see cref="Process"/> class is guarded by a
+        /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
+        /// This exception is thrown when the caller method is being JIT compiled, NOT
+        /// when Process.GetCurrentProcess is called, so this wrapper method allows
+        /// us to catch the exception.
+        /// </summary>
+        /// <returns>Returns the id of the current process</returns>
+        public static int GetCurrentProcessId()
+        {
+            return Process.GetCurrentProcess().Id;
+        }
+    }
+}

--- a/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -5,21 +5,6 @@ namespace Datadog.Trace.Util
     internal static class ProcessHelpers
     {
         /// <summary>
-        /// Wrapper around <see cref="Process.GetCurrentProcess"/>
-        ///
-        /// On .NET Framework the <see cref="Process"/> class is guarded by a
-        /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
-        /// This exception is thrown when the caller method is being JIT compiled, NOT
-        /// when Process.GetCurrentProcess is called, so this wrapper method allows
-        /// us to catch the exception.
-        /// </summary>
-        /// <returns>Returns the result of <see cref="Process.GetCurrentProcess"/></returns>
-        public static Process GetCurrentProcess()
-        {
-            return Process.GetCurrentProcess();
-        }
-
-        /// <summary>
         /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.ProcessName"/>
         ///
         /// On .NET Framework the <see cref="Process"/> class is guarded by a
@@ -31,11 +16,14 @@ namespace Datadog.Trace.Util
         /// <returns>Returns the name of the current process</returns>
         public static string GetCurrentProcessName()
         {
-            return Process.GetCurrentProcess().ProcessName;
+            using (var currentProcess = Process.GetCurrentProcess())
+            {
+                return currentProcess.ProcessName;
+            }
         }
 
         /// <summary>
-        /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.MachineName"/>
+        /// Wrapper around <see cref="Process.GetCurrentProcess"/> and its property accesses
         ///
         /// On .NET Framework the <see cref="Process"/> class is guarded by a
         /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
@@ -43,25 +31,17 @@ namespace Datadog.Trace.Util
         /// when Process.GetCurrentProcess is called, so this wrapper method allows
         /// us to catch the exception.
         /// </summary>
-        /// <returns>Returns the machine name of the current process</returns>
-        public static string GetCurrentProcessMachineName()
+        /// <param name="processName">The name of the current process</param>
+        /// <param name="machineName">The machine name of the current process</param>
+        /// <param name="processId">The ID of the current process</param>
+        public static void GetCurrentProcessInformation(out string processName, out string machineName, out int processId)
         {
-            return Process.GetCurrentProcess().MachineName;
-        }
-
-        /// <summary>
-        /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.Id"/>
-        ///
-        /// On .NET Framework the <see cref="Process"/> class is guarded by a
-        /// LinkDemand for FullTrust, so partial trust callers will throw an exception.
-        /// This exception is thrown when the caller method is being JIT compiled, NOT
-        /// when Process.GetCurrentProcess is called, so this wrapper method allows
-        /// us to catch the exception.
-        /// </summary>
-        /// <returns>Returns the id of the current process</returns>
-        public static int GetCurrentProcessId()
-        {
-            return Process.GetCurrentProcess().Id;
+            using (var currentProcess = Process.GetCurrentProcess())
+            {
+                processName = currentProcess.ProcessName;
+                machineName = currentProcess.MachineName;
+                processId = currentProcess.Id;
+            }
         }
     }
 }

--- a/src/Datadog.Trace/Vendors/Serilog/Parsing/PropertyToken.cs
+++ b/src/Datadog.Trace/Vendors/Serilog/Parsing/PropertyToken.cs
@@ -32,7 +32,10 @@ namespace Datadog.Trace.Vendors.Serilog.Parsing
     internal sealed class PropertyToken : MessageTemplateToken
     {
         readonly string _rawText;
-        readonly int? _position;
+        // Remove readonly keyword on field. This leads to code that may be evaluated as unverifiable on .NET Framework
+        // because instance method calls to Nullable<int> will require a ldflda instruction on the readonly field.
+        // See https://github.com/dotnet/roslyn/issues/22485 and https://github.com/dotnet/corert/issues/4911
+        int? _position;
 
         /// <summary>
         /// Construct a <see cref="PropertyToken"/>.

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxManualTracingSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxManualTracingSmokeTest.cs
@@ -1,0 +1,21 @@
+#if NET461
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class SandboxManualTracingSmokeTest : SmokeTestBase
+    {
+        public SandboxManualTracingSmokeTest(ITestOutputHelper output)
+            : base(output, "Sandbox.ManualTracing")
+        {
+        }
+
+        [Fact]
+        public void NoExceptions()
+        {
+            CheckForSmoke(shouldDeserializeTraces: false);
+        }
+    }
+}
+#endif

--- a/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
+++ b/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Security;
+using System.Security.Permissions;
+using System.Security.Policy;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Core.Tools;
+using Datadog.Trace;
+
+namespace Sandbox.ManualTracing
+{
+    public static class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Set the minimum permissions needed to run code in the new AppDomain
+            PermissionSet permSet = new PermissionSet(PermissionState.None);
+            permSet.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution)); // Necessary to run code.
+            // permSet.AddPermission(new WebPermission(PermissionState.Unrestricted)); // Necessary to emit traces. If commented out, the Tracer will not send Traces but it should not crash.
+            // permSet.AddPermission(new FileIOPermission(PermissionState.Unrestricted)); // Necessary to access the file system.
+
+            var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation, permSet);
+
+            try
+            {
+                remote.DoCallBack(RunWebRequestSync);
+                return (int)ExitCode.Success;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"We have encountered an exception, the smoke test fails: {ex.Message}");
+                Console.Error.WriteLine(ex);
+                return (int)ExitCode.UnknownError;
+            }
+            finally
+            {
+                AppDomain.Unload(remote);
+            }
+        }
+
+        public static void RunWebRequestSync()
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                EmitCustomSpans();
+                Thread.Sleep(2000);
+            }
+        }
+
+        private static void EmitCustomSpans()
+        {
+            using (Tracer.Instance.StartActive("custom-span"))
+            {
+                Thread.Sleep(1500);
+
+                using (Tracer.Instance.StartActive("inner-span"))
+                {
+                    Thread.Sleep(1500);
+                }
+            }
+        }
+    }
+
+    enum ExitCode : int
+    {
+        Success = 0,
+        UnknownError = -10
+    }
+}

--- a/test/test-applications/regression/Sandbox.ManualTracing/Properties/launchSettings.json
+++ b/test/test-applications/regression/Sandbox.ManualTracing/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Sandbox.ManualTracing": {
+      "commandName": "Project",
+      "environmentVariables": {
+      },
+      "nativeDebugging": false
+    }
+  }
+}

--- a/test/test-applications/regression/Sandbox.ManualTracing/Sandbox.ManualTracing.csproj
+++ b/test/test-applications/regression/Sandbox.ManualTracing/Sandbox.ManualTracing.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\tools\Datadog.Core.Tools\Datadog.Core.Tools.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Goal:
Identify and mitigate issues that arise when the .NET Tracer manual instrumentation is used in a heavily restricted .NET Framework environment. This PR avoids the automatic instrumentation code paths.

Improvements for restricted environment:
- Create a new test application that manually creates Datadog spans while running in an AppDomain with only the `SecurityPermissionFlag.Execution` permission
- Modify vendored Serilog code that produces code that may be unverifiable on .NET Framework. This throws a VerificationException when not run in full trust
- Wrap several .NET Framework method calls in try/catch blocks so SecurityException's are caught. Additionally, wrap several callsites with helper methods so that .NET Framework types and methods that require full trust callers can be enclosed in try/catch blocks
- Replace TracerConstants. with a constant string to be regenerated by the PrepareRelease tool, which avoids a SecurityException due to missing FileIOPermission when discovering the codebase of the Datadog.Trace assembly

Unrelated improvements:
- Fix possible NullReferenceException from calling GetEnvironmentVariables
- Log unhandled exceptions in Tracer logs

@DataDog/apm-dotnet