### PR TITLE
Update Serilog automatic logs injection to use the new message property names

### DIFF
--- a/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -13,6 +13,13 @@ namespace Datadog.Trace
         internal static readonly string TraceIdKey = "dd.trace_id";
         internal static readonly string SpanIdKey = "dd.span_id";
 
+        // Serilog property names require valid C# identifiers
+        internal static readonly string SerilogServiceKey = "dd_service";
+        internal static readonly string SerilogVersionKey = "dd_version";
+        internal static readonly string SerilogEnvKey = "dd_env";
+        internal static readonly string SerilogTraceIdKey = "dd_trace_id";
+        internal static readonly string SerilogSpanIdKey = "dd_span_id";
+
         /// <summary>
         /// Gets the name of the service
         /// </summary>

--- a/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/SerilogLogProviderTests.cs
@@ -110,28 +110,28 @@ namespace Datadog.Trace.Tests.Logging
 
         internal static void Contains(Serilog.Events.LogEvent logEvent, string service, string version, string env, ulong traceId, ulong spanId)
         {
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.ServiceKey));
-            Assert.Equal(service, logEvent.Properties[CorrelationIdentifier.ServiceKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogServiceKey));
+            Assert.Equal(service, logEvent.Properties[CorrelationIdentifier.SerilogServiceKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
 
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.VersionKey));
-            Assert.Equal(version, logEvent.Properties[CorrelationIdentifier.VersionKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogVersionKey));
+            Assert.Equal(version, logEvent.Properties[CorrelationIdentifier.SerilogVersionKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
 
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.EnvKey));
-            Assert.Equal(env, logEvent.Properties[CorrelationIdentifier.EnvKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogEnvKey));
+            Assert.Equal(env, logEvent.Properties[CorrelationIdentifier.SerilogEnvKey].ToString().Trim(new[] { '\"' }), ignoreCase: true);
 
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
-            Assert.Equal(traceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.TraceIdKey].ToString().Trim(new[] { '\"' })));
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogTraceIdKey));
+            Assert.Equal(traceId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SerilogTraceIdKey].ToString().Trim(new[] { '\"' })));
 
-            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.Equal(spanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SpanIdKey].ToString().Trim(new[] { '\"' })));
+            Assert.True(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogSpanIdKey));
+            Assert.Equal(spanId, ulong.Parse(logEvent.Properties[CorrelationIdentifier.SerilogSpanIdKey].ToString().Trim(new[] { '\"' })));
         }
 
         internal static void LogEventDoesNotContainCorrelationIdentifiers(Serilog.Events.LogEvent logEvent)
         {
             // Do not assert on the version property
             // Do not assert on the service property
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SpanIdKey));
-            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.TraceIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogSpanIdKey));
+            Assert.False(logEvent.Properties.ContainsKey(CorrelationIdentifier.SerilogTraceIdKey));
         }
     }
 }


### PR DESCRIPTION
## Changes
- When using the Serilog logging library, change the message property names set by the automatic logs injection:
  - `dd.trace_id` => `dd_trace_id`
  - `dd.span_id` => `dd_span_id`
  -  `dd.env` => `dd_env`
  - `dd.service` => `dd_service`
  - `dd.version` => `dd_version`

- Update Serilog logging tests to test this behavior

## Background
Automatic logs injection for applications using Serilog has worked fine, but manual logs injection has had issues. Our documentation previously suggested users add properties such as `dd.trace_id` and `dd.span_id` to the Serilog log context, but when the users used these properties in the message output template the returned value would be a default value because Serilog message property names [must be valid C# identifiers](https://github.com/serilog/serilog/wiki/Writing-Log-Events#message-template-syntax).

The logs backend has already been updated to accept the new property values, so now we can update the automatic logs injection. Additionally, the manual logs injection public documentation is being updated so that our automatic logs injection and manual logs injection guidance aligns on the new properties: https://github.com/DataDog/documentation/pull/8964

@DataDog/apm-dotnet