### PR TITLE
Improve managed tracer logs

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Agent
 
                     if (isSocketException)
                     {
-                        Log.Error(exception, "Unable to communicate with the trace agent at {0}", _tracesEndpoint);
+                        Log.Debug(exception, "Unable to communicate with the trace agent at {0}", _tracesEndpoint);
                         TracingProcessManager.TryForceTraceAgentRefresh();
                     }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -155,7 +155,7 @@ namespace Datadog.Trace.Agent
                 }
 
                 batch.Send();
-                Log.Debug("Sucessfully sent {0} traces to the DD agent", traceCount);
+                Log.Debug("Successfully sent {0} traces to the DD agent", traceCount);
                 return true;
             }
         }

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Logging
                 }
 
                 // Ends in a dash because of the date postfix
-                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-{DomainMetadata.ProcessName}-.log");
+                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-managed-{DomainMetadata.ProcessName}-.log");
 
                 var loggerConfiguration =
                     new LoggerConfiguration()


### PR DESCRIPTION
Changes proposed in this pull request:
- Rename log files to dotnet-tracer-managed-*.log
- Add Debug level logs to document how many traces we attempt to send to the Tracer and a confirmation of how many traces succeeded or failed to send
- For exceptions when sending traces to trace agent, only log intermediate retry failures in Debug mode.


@DataDog/apm-dotnet