### PR TITLE
Add support for token resolution in DumpIL

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -760,7 +760,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
   std::string original_code;
   if (dump_il_rewrite_enabled) {
     original_code =
-        GetILCodes("***   IL original code for caller: ", &rewriter, caller);
+        GetILCodes("***   IL original code for caller: ", &rewriter, caller, module_metadata);
   }
 
   // Perform method call replacements
@@ -1132,7 +1132,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
 
     if (dump_il_rewrite_enabled) {
       Info(original_code);
-      Info(GetILCodes("***   IL modification  for caller: ", &rewriter, caller));
+      Info(GetILCodes("***   IL modification  for caller: ", &rewriter, caller, module_metadata));
     }
   }
 
@@ -1285,7 +1285,7 @@ bool CorProfiler::ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_i
 }
 
 std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
-                                    const FunctionInfo& caller) {
+                                    const FunctionInfo& caller, ModuleMetadata* module_metadata) {
   std::stringstream orig_sstream;
   orig_sstream << title;
   orig_sstream << ToString(caller.type.name);
@@ -1307,8 +1307,44 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
                    << cInstr->m_opcode;
     }
     if (cInstr->m_pTarget != NULL) {
-      orig_sstream << " ";
+      orig_sstream << "  ";
       orig_sstream << cInstr->m_pTarget;
+
+      if (cInstr->m_opcode == CEE_CALL || cInstr->m_opcode == CEE_CALLVIRT || cInstr->m_opcode == CEE_NEWOBJ) {
+        const auto memberInfo = GetFunctionInfo(module_metadata->metadata_import,
+                                            (mdMemberRef)cInstr->m_Arg32);
+        orig_sstream << "  | ";
+        orig_sstream << ToString(memberInfo.type.name);
+        orig_sstream << ".";
+        orig_sstream << ToString(memberInfo.name);
+        if (memberInfo.signature.NumberOfArguments() > 0) {
+          orig_sstream << "(";
+          orig_sstream << memberInfo.signature.NumberOfArguments();
+          orig_sstream << " argument{s}";
+          orig_sstream << ")";
+
+        } else {
+          orig_sstream << "()";
+        }
+      } else if (cInstr->m_opcode == CEE_CASTCLASS || cInstr->m_opcode == CEE_BOX ||
+          cInstr->m_opcode == CEE_UNBOX_ANY || cInstr->m_opcode == CEE_NEWARR || 
+          cInstr->m_opcode == CEE_INITOBJ) {
+        const auto typeInfo = GetTypeInfo(module_metadata->metadata_import,
+                                      (mdTypeRef)cInstr->m_Arg32);
+        orig_sstream << "  | ";
+        orig_sstream << ToString(typeInfo.name);
+      } else if (cInstr->m_opcode == CEE_LDSTR) {
+        LPWSTR szString = new WCHAR[1024];
+        ULONG szStringLength;
+        auto hr = module_metadata->metadata_import->GetUserString(
+            (mdString)cInstr->m_Arg32, szString, 1024, &szStringLength);
+        if (SUCCEEDED(hr)) {
+          orig_sstream << "  | ";
+          orig_sstream << "\"";
+          orig_sstream << ToString(WSTRING(szString).substr(0, szStringLength));
+          orig_sstream << "\"";
+        }
+      }
     } else if (cInstr->m_Arg64 != 0) {
       orig_sstream << " ";
       orig_sstream << cInstr->m_Arg64;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -68,7 +68,8 @@ class CorProfiler : public CorProfilerBase {
                                          const std::vector<MethodReplacement> method_replacements);
   bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
   std::string GetILCodes(std::string title, ILRewriter* rewriter,
-                         const FunctionInfo& caller);
+                         const FunctionInfo& caller,
+                         ModuleMetadata* module_metadata);
   //
   // Startup methods
   //


### PR DESCRIPTION
Adds support for token resolution when dump IL code for mdTokens on method calls, types and user strings.

#### Example
```
[dotnet.exe] 5628: [info] *** JITCompilationStarted() replaced calls from System.Net.Http.HttpMessageInvoker.SendAsync() to System.Net.Http.HttpMessageHandler.SendAsync() 100663996 with calls to Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration.HttpMessageHandler_SendAsync() 167773584
[dotnet.exe] 5628: [info] ***   IL original code for caller: System.Net.Http.HttpMessageInvoker.SendAsync => (max_stack: 24)
00000137410A5FD0:    ldarg.1
00000137410A62D0:   brtrue.s  00000137410A5D60
00000137410A6330:      ldstr  0000000070003DD1  | "request"
00000137410A5D00:     newobj  000000000A00007A  | System.ArgumentNullException..ctor(1 argument{s})
00000137410A6210:      throw
00000137410A5D60:    ldarg.0
00000137410A6000:       call  00000000060002C4  | System.Net.Http.HttpMessageInvoker.CheckDisposed()
00000137410A5EB0:       call  000000000600011D  | System.Net.NetEventSource.get_IsEnabled()
00000137410A60F0:  brfalse.s  00000137410A4E60
00000137410A4BF0:    ldarg.0
00000137410A4530:    ldarg.1
00000137410A4EF0:      ldstr  0000000070004059  | "SendAsync"
00000137410A50A0:       call  000000000600010B  | System.Net.NetEventSource.Enter(3 argument{s})
00000137410A4E60:    ldarg.0
00000137410A47A0:      ldfld  00000000040001A6
00000137410A4680:    ldarg.1
00000137410A4AA0:    ldarg.2
00000137410A4B30:   callvirt  00000000060002BC  | System.Net.Http.HttpMessageHandler.SendAsync(2 argument{s})
00000137410A4FE0:    stloc.0
00000137410A4C20:       call  000000000600011D  | System.Net.NetEventSource.get_IsEnabled()
00000137410A44D0:  brfalse.s  00000137410A4E30
00000137410A4590:    ldarg.0
00000137410A4C50:    ldloc.0
00000137410A46B0:      ldstr  0000000070004059  | "SendAsync"
00000137410A45F0:       call  0000000006000110  | System.Net.NetEventSource.Exit(3 argument{s})
00000137410A4E30:    ldloc.0
00000137410A46E0:        ret

[dotnet.exe] 5628: [info] ***   IL modification  for caller: System.Net.Http.HttpMessageInvoker.SendAsync => (max_stack: 29)
00000137410A5FD0:    ldarg.1
00000137410A62D0:   brtrue.s  00000137410A5D60
00000137410A6330:      ldstr  0000000070003DD1  | "request"
00000137410A5D00:     newobj  000000000A00007A  | System.ArgumentNullException..ctor(1 argument{s})
00000137410A6210:      throw
00000137410A5D60:    ldarg.0
00000137410A6000:       call  00000000060002C4  | System.Net.Http.HttpMessageInvoker.CheckDisposed()
00000137410A5EB0:       call  000000000600011D  | System.Net.NetEventSource.get_IsEnabled()
00000137410A60F0:  brfalse.s  00000137410A4E60
00000137410A4BF0:    ldarg.0
00000137410A4530:    ldarg.1
00000137410A4EF0:      ldstr  0000000070004059  | "SendAsync"
00000137410A50A0:       call  000000000600010B  | System.Net.NetEventSource.Enter(3 argument{s})
00000137410A4E60:    ldarg.0
00000137410A47A0:      ldfld  00000000040001A6
00000137410A4680:    ldarg.1
00000137410A4AA0:    ldarg.2
00000137410A4B30:        nop  00000000060002BC
00000137410A4F20:        box  0000000001000024  | System.Threading.CancellationToken
00000137410A4710:   ldc.i4.s  000000000000006F
00000137410A4740:     ldc.i4  00000000060002BC
00000137410A4F80:     ldc.i8  000001374103A478
00000137410A49B0:       call  000000000A000590  | Datadog.Trace.ClrProfiler.Integrations.HttpMessageHandlerIntegration.HttpMessageHandler_SendAsync(6 argument{s})
00000137410A4FE0:    stloc.0
00000137410A4C20:       call  000000000600011D  | System.Net.NetEventSource.get_IsEnabled()
00000137410A44D0:  brfalse.s  00000137410A4E30
00000137410A4590:    ldarg.0
00000137410A4C50:    ldloc.0
00000137410A46B0:      ldstr  0000000070004059  | "SendAsync"
00000137410A45F0:       call  0000000006000110  | System.Net.NetEventSource.Exit(3 argument{s})
00000137410A4E30:    ldloc.0
00000137410A46E0:        ret


```

@DataDog/apm-dotnet