### PR TITLE
Fixes ducktyping on non public structs targets

### DIFF
--- a/src/Datadog.Trace.DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.cs
@@ -140,7 +140,7 @@ namespace Datadog.Trace.DuckTyping
                 ConstructorBuilder ctorBuilder = proxyTypeBuilder.DefineConstructor(
                     MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
                     CallingConventions.Standard,
-                    new[] { targetType });
+                    new[] { instanceField.FieldType });
                 ILGenerator ctorIL = ctorBuilder.GetILGenerator();
                 ctorIL.Emit(OpCodes.Ldarg_0);
                 ctorIL.Emit(OpCodes.Ldarg_1);

--- a/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
@@ -1,0 +1,68 @@
+using Xunit;
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+#pragma warning disable SA1402 // File may only contain a single class
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class StructTests
+    {
+        [Fact]
+        public void NonPublicStructCopyTest()
+        {
+            PrivateStruct instance = default;
+            CopyStruct copy = instance.As<CopyStruct>();
+            Assert.Equal(instance.Value, copy.Value);
+        }
+
+        [Fact]
+        public void NonPublicStructInterfaceProxyTest()
+        {
+            PrivateStruct instance = default;
+            IPrivateStruct proxy = instance.As<IPrivateStruct>();
+            Assert.Equal(instance.Value, proxy.Value);
+        }
+
+        [Fact]
+        public void NonPublicStructAbstractProxyTest()
+        {
+            PrivateStruct instance = default;
+            AbstractPrivateProxy proxy = instance.As<AbstractPrivateProxy>();
+            Assert.Equal(instance.Value, proxy.Value);
+        }
+
+        [Fact]
+        public void NonPublicStructVirtualProxyTest()
+        {
+            PrivateStruct instance = default;
+            VirtualPrivateProxy proxy = instance.As<VirtualPrivateProxy>();
+            Assert.Equal(instance.Value, proxy.Value);
+        }
+
+        [DuckCopy]
+        public struct CopyStruct
+        {
+            public string Value;
+        }
+
+        public interface IPrivateStruct
+        {
+            string Value { get; }
+        }
+
+        public abstract class AbstractPrivateProxy
+        {
+            public abstract string Value { get; }
+        }
+
+        public class VirtualPrivateProxy
+        {
+            public virtual string Value { get; }
+        }
+
+        private readonly struct PrivateStruct
+        {
+            public readonly string Value => "Hello World";
+        }
+    }
+}


### PR DESCRIPTION
This PR solves an issue in the ducktyping library when the target instance is a non public value type. Also adds tests cases for this scenario.

@DataDog/apm-dotnet