### PR TITLE
bump Datadog.Trace.ServiceFabric to 1.20.0-alpha1

### DIFF
--- a/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
+++ b/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Nullable>enable</Nullable>
 
     <!-- Microsoft.ServiceFabric.Services.Remoting only supports x64 -->
     <Platforms>x64</Platforms>
 
     <!-- NuGet -->
-    <Version>1.19.4-alpha1</Version>
+    <Version>1.20.0-alpha1</Version>
     <Title>Datadog APM</Title>
     <Description>Service Remoting instrumentation for Datadog APM</Description>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
In prerelease NuGet package `Datadog.Trace.ServiceFabric`:
- bump version to `1.20.0-alpha1` which takes a dependency on `Datadog.Trace` `1.20.0` (required to access internal members)
- add `net461` target as [recommended](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting):

> Using .NET Standard 2.0 from .NET Framework has some issues that were addressed in .NET Framework 4.7.2. You can improve the experience for developers that are still on .NET Framework 4.6.1 - 4.7.1 by offering them a binary that is built for .NET Framework 4.6.1.
