### PR TITLE
Fixes broken traces when a WCF service is hosted on IIS

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -135,6 +135,11 @@ namespace Datadog.Trace.AspNet
                 tags.SetAnalyticsSampleRate(IntegrationName, tracer.Settings, enabledWithGlobalSetting: true);
 
                 httpContext.Items[_httpContextScopeKey] = scope;
+
+                // Decorate the incoming HTTP Request with distributed tracing headers
+                // in case the next processor cannot access the stored Scope
+                // (e.g. WCF being hosted in IIS)
+                SpanContextPropagator.Instance.Inject(scope.Span.Context, httpRequest.Headers.Wrap());
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Background
When a WCF service is hosted in IIS, the WCF service is hosted [side-by-side](https://docs.microsoft.com/en-us/dotnet/framework/wcf/feature-details/wcf-services-and-aspnet) with the ASP.NET pipeline so it cannot retrieve the current Datadog scope that is created by the HttpModule.

## Changes
Once the HttpModule creates an `aspnet` span, the HttpModule will also inject the trace context into the HTTP request via the distributed tracing headers. Then, when the WCF pipeline is later invoked, the trace context of the `aspnet` span will be extracted from the HTTP headers of the request object (unchanged in this PR), which then connects the spans into one trace.

## Testing
I've tested two scenarios on a local machine hosting a WCF service on IIS:
1. HTTP request from browser
  - Before
![aspnetwcfissue-before-regular-request](https://user-images.githubusercontent.com/13769665/98298774-62886600-1f6b-11eb-84f1-2ad21d1f6da6.PNG)


  - After
![aspnetwcfissue-after-regular-request](https://user-images.githubusercontent.com/13769665/98298758-5bf9ee80-1f6b-11eb-8f0e-17d42d25b0cb.PNG)

2. Distributed trace
  - Before
![aspnetwcfissue-before-distributed-tracing](https://user-images.githubusercontent.com/13769665/98298500-f574d080-1f6a-11eb-8b0f-c3312a6b474e.PNG)

  - After
![aspnetwcfissue-after-distributed-tracing](https://user-images.githubusercontent.com/13769665/98298518-fc9bde80-1f6a-11eb-81e7-eadcb06c5068.PNG)



@DataDog/apm-dotnet