### PR TITLE
Optimize event matching in DiagnosticsObserver

### DIFF
--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -28,6 +28,8 @@ namespace Datadog.Trace.DiagnosticListeners
         private const string HttpRequestInOperationName = "aspnet_core.request";
         private const string NoHostSpecified = "UNKNOWN_HOST";
 
+        private static readonly int PrefixLength = "Microsoft.AspNetCore.".Length;
+
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<AspNetCoreDiagnosticObserver>();
 
         private static readonly PropertyFetcher HttpRequestInStartHttpContextFetcher = new PropertyFetcher("HttpContext");
@@ -50,28 +52,92 @@ namespace Datadog.Trace.DiagnosticListeners
 
         protected override string ListenerName => DiagnosticListenerName;
 
+#if NETCOREAPP
         protected override void OnNext(string eventName, object arg)
         {
-            switch (eventName)
+            var lastChar = eventName[^1];
+
+            if (lastChar == 't')
             {
-                case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start":
+                if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Start"))
+                {
                     OnHostingHttpRequestInStart(arg);
-                    break;
+                }
 
-                case "Microsoft.AspNetCore.Mvc.BeforeAction":
+                return;
+            }
+
+            if (lastChar == 'n')
+            {
+                var suffix = eventName.AsSpan().Slice(PrefixLength);
+
+                if (suffix.SequenceEqual("Mvc.BeforeAction"))
+                {
                     OnMvcBeforeAction(arg);
-                    break;
+                }
 
-                case "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop":
-                    OnHostingHttpRequestInStop(arg);
-                    break;
-
-                case "Microsoft.AspNetCore.Hosting.UnhandledException":
-                case "Microsoft.AspNetCore.Diagnostics.UnhandledException":
+                if (suffix.SequenceEqual("Hosting.UnhandledException")
+                    || suffix.SequenceEqual("Diagnostics.UnhandledException"))
+                {
                     OnHostingUnhandledException(arg);
-                    break;
+                }
+
+                return;
+            }
+
+            if (lastChar == 'p')
+            {
+                if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Stop"))
+                {
+                    OnHostingHttpRequestInStop(arg);
+                }
+
+                return;
             }
         }
+#else
+        protected override void OnNext(string eventName, object arg)
+        {
+            var lastChar = eventName[eventName.Length - 1];
+
+            if (lastChar == 't')
+            {
+                if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start")
+                {
+                    OnHostingHttpRequestInStart(arg);
+                }
+
+                return;
+            }
+
+            if (lastChar == 'n')
+            {
+                switch (eventName)
+                {
+                    case "Microsoft.AspNetCore.Mvc.BeforeAction":
+                        OnMvcBeforeAction(arg);
+                        break;
+
+                    case "Microsoft.AspNetCore.Hosting.UnhandledException":
+                    case "Microsoft.AspNetCore.Diagnostics.UnhandledException":
+                        OnHostingUnhandledException(arg);
+                        break;
+                }
+
+                return;
+            }
+
+            if (lastChar == 'p')
+            {
+                if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop")
+                {
+                    OnHostingHttpRequestInStop(arg);
+                }
+
+                return;
+            }
+        }
+#endif
 
         private static string GetUrl(HttpRequest request)
         {

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -75,8 +75,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 {
                     OnMvcBeforeAction(arg);
                 }
-
-                if (suffix.SequenceEqual("Hosting.UnhandledException")
+                else if (suffix.SequenceEqual("Hosting.UnhandledException")
                     || suffix.SequenceEqual("Diagnostics.UnhandledException"))
                 {
                     OnHostingUnhandledException(arg);


### PR DESCRIPTION
I tried filtering with length or last letter, last letter was faster.

Dictionary was slower than the current implementation.

The benchmark tries to match all the events expected during a normal request, + the 2 "unhandled exception" events:

```
"Microsoft.AspNetCore.Hosting.HttpRequestIn.Start",
"Microsoft.AspNetCore.Hosting.BeginRequest",
"Microsoft.AspNetCore.Routing.EndpointMatched",
"Microsoft.AspNetCore.Mvc.BeforeAction",
"Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuting",
"Microsoft.AspNetCore.Mvc.AfterOnResourceExecuting",
"Microsoft.AspNetCore.Mvc.BeforeOnActionExecution",
"Microsoft.AspNetCore.Mvc.BeforeOnActionExecuting",
"Microsoft.AspNetCore.Mvc.AfterOnActionExecuting",
"Microsoft.AspNetCore.Mvc.BeforeActionMethod",
"Microsoft.AspNetCore.Mvc.BeforeControllerActionMethod",
"Microsoft.AspNetCore.Mvc.AfterControllerActionMethod",
"Microsoft.AspNetCore.Mvc.AfterActionMethod",
"Microsoft.AspNetCore.Mvc.BeforeOnActionExecuted",
"Microsoft.AspNetCore.Mvc.AfterOnActionExecuted",
"Microsoft.AspNetCore.Mvc.AfterOnActionExecution",
"Microsoft.AspNetCore.Mvc.BeforeOnResultExecuting",
"Microsoft.AspNetCore.Mvc.AfterOnResultExecuting",
"Microsoft.AspNetCore.Mvc.BeforeActionResult",
"Microsoft.AspNetCore.Mvc.ViewFound",
"Microsoft.AspNetCore.Mvc.BeforeView",
"Microsoft.AspNetCore.Mvc.Razor.BeforeViewPage",
"Microsoft.AspNetCore.Mvc.Razor.AfterViewPage",
"Microsoft.AspNetCore.Mvc.AfterView",
"Microsoft.AspNetCore.Mvc.AfterActionResult",
"Microsoft.AspNetCore.Mvc.BeforeOnResultExecuted",
"Microsoft.AspNetCore.Mvc.AfterOnResultExecuted",
"Microsoft.AspNetCore.Mvc.BeforeOnResourceExecuted",
"Microsoft.AspNetCore.Mvc.AfterOnResourceExecuted",
"Microsoft.AspNetCore.Mvc.AfterAction",
"Microsoft.AspNetCore.Hosting.EndRequest",
"Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop",
"Microsoft.AspNetCore.Hosting.UnhandledException",
"Microsoft.AspNetCore.Diagnostics.UnhandledException"
```


|               Method |     Mean |   Error |  StdDev | Ratio |
|--------------------- |---------:|--------:|--------:|------:|
|                  Old | 494.5 ns | 7.16 ns | 6.70 ns |  1.00 |
|    netcoreapp (span) | 132.3 ns | 1.50 ns | 1.33 ns |  0.27 |
| netstandard (equals) | 155.1 ns | 1.79 ns | 1.50 ns |  0.31 |
|           Dictionary | 827.0 ns | 8.28 ns | 6.92 ns |  1.67 |
