### PR TITLE
Avoid segfault in NetCoreAssemblyLoadFailureOlderNuGet regression test

### DIFF
--- a/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/Program.cs
+++ b/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/Program.cs
@@ -20,6 +20,12 @@ namespace NetCoreAssemblyLoadFailureOlderNuGet
                 return (int)ExitCode.UnknownError;
             }
 
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
             return (int)ExitCode.Success;
         }
 


### PR DESCRIPTION
Adds a delay for the netcoreapp2.1 version of the NetCoreAssemblyLoadFailureOlderNuGet regression test to avoid a segfault when the application exits. We do this for all other regression tests that exit quickly so we no longer get a `Non-success exit code 139` when running the regression test.

@DataDog/apm-dotnet