### PR TITLE
Fix DuckType chaining on underlying public structs bug

### DIFF
--- a/src/Datadog.Trace.DuckTyping/DuckType.Fields.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Fields.cs
@@ -76,6 +76,11 @@ namespace Datadog.Trace.DuckTyping
             // Check if the type can be converted or if we need to enable duck chaining
             if (NeedsDuckChaining(targetField.FieldType, proxyMemberReturnType))
             {
+                if (UseDirectAccessTo(targetField.FieldType) && targetField.FieldType.IsValueType)
+                {
+                    il.Emit(OpCodes.Box, targetField.FieldType);
+                }
+
                 // We call DuckType.CreateCache<>.Create()
                 MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
                     .MakeGenericType(proxyMemberReturnType).GetMethod("Create");

--- a/src/Datadog.Trace.DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Methods.cs
@@ -383,6 +383,11 @@ namespace Datadog.Trace.DuckTyping
                         // If we detect duck chaining we create a new proxy instance with the output of the original target method
                         if (NeedsDuckChaining(localType, proxyArgumentType))
                         {
+                            if (localType.IsValueType)
+                            {
+                                il.Emit(OpCodes.Box, localType);
+                            }
+
                             // We call DuckType.CreateCache<>.Create()
                             MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
                                 .MakeGenericType(proxyArgumentType).GetMethod("Create");
@@ -406,6 +411,11 @@ namespace Datadog.Trace.DuckTyping
                     // Check if the type can be converted or if we need to enable duck chaining
                     if (NeedsDuckChaining(targetMethod.ReturnType, proxyMethodDefinition.ReturnType))
                     {
+                        if (UseDirectAccessTo(targetMethod.ReturnType) && targetMethod.ReturnType.IsValueType)
+                        {
+                            il.Emit(OpCodes.Box, targetMethod.ReturnType);
+                        }
+
                         // We call DuckType.CreateCache<>.Create()
                         MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
                             .MakeGenericType(proxyMethodDefinition.ReturnType).GetMethod("Create");

--- a/src/Datadog.Trace.DuckTyping/DuckType.Properties.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Properties.cs
@@ -142,6 +142,11 @@ namespace Datadog.Trace.DuckTyping
             // Check if the type can be converted or if we need to enable duck chaining
             if (NeedsDuckChaining(targetProperty.PropertyType, proxyMemberReturnType))
             {
+                if (UseDirectAccessTo(targetProperty.PropertyType) && targetProperty.PropertyType.IsValueType)
+                {
+                    il.Emit(OpCodes.Box, targetProperty.PropertyType);
+                }
+
                 // We call DuckType.CreateCache<>.Create()
                 MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
                     .MakeGenericType(proxyMemberReturnType).GetMethod("Create");

--- a/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
@@ -64,5 +64,69 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
             public readonly string Value => "Hello World";
         }
+
+        [Fact]
+        public void DuckChainingStructInterfaceProxyTest()
+        {
+            PrivateDuckChainingTarget instance = new PrivateDuckChainingTarget();
+            IPrivateDuckChainingTarget proxy = instance.As<IPrivateDuckChainingTarget>();
+            Assert.Equal(instance.ChainingTestField.Name, proxy.ChainingTestField.Name);
+            Assert.Equal(instance.ChainingTest.Name, proxy.ChainingTest.Name);
+            Assert.Equal(instance.ChainingTestMethod().Name, proxy.ChainingTestMethod().Name);
+
+            PublicDuckChainingTarget instance2 = new PublicDuckChainingTarget();
+            IPrivateDuckChainingTarget proxy2 = instance2.As<IPrivateDuckChainingTarget>();
+            Assert.Equal(instance2.ChainingTestField.Name, proxy2.ChainingTestField.Name);
+            Assert.Equal(instance2.ChainingTest.Name, proxy2.ChainingTest.Name);
+            Assert.Equal(instance2.ChainingTestMethod().Name, proxy2.ChainingTestMethod().Name);
+        }
+
+        public interface IPrivateDuckChainingTarget
+        {
+            [Duck(Kind = DuckKind.Field)]
+            IPrivateTarget ChainingTestField { get; }
+
+            IPrivateTarget ChainingTest { get; }
+
+            IPrivateTarget ChainingTestMethod();
+        }
+
+        public interface IPrivateTarget
+        {
+            [Duck(Kind = DuckKind.Field)]
+            public string Name { get; }
+        }
+
+        private class PrivateDuckChainingTarget
+        {
+#pragma warning disable SA1401 // Fields must be private
+            public PrivateTarget ChainingTestField = new PrivateTarget { Name = "Hello World 1" };
+#pragma warning restore SA1401 // Fields must be private
+
+            public PrivateTarget ChainingTest => new PrivateTarget { Name = "Hello World 2" };
+
+            public PrivateTarget ChainingTestMethod() => new PrivateTarget { Name = "Hello World 3" };
+        }
+
+        private struct PrivateTarget
+        {
+            public string Name;
+        }
+
+        public class PublicDuckChainingTarget
+        {
+#pragma warning disable SA1401 // Fields must be private
+            public PublicTarget ChainingTestField = new PublicTarget { Name = "Hello World 1" };
+#pragma warning restore SA1401 // Fields must be private
+
+            public PublicTarget ChainingTest => new PublicTarget { Name = "Hello World 2" };
+
+            public PublicTarget ChainingTestMethod() => new PublicTarget { Name = "Hello World 3" };
+        }
+
+        public struct PublicTarget
+        {
+            public string Name;
+        }
     }
 }


### PR DESCRIPTION
Fixes an exception when the ducktype chaining is used with a public struct (private structs works fine).


@DataDog/apm-dotnet