### PR TITLE
Fix CLI application name in help.

### DIFF
--- a/src/Datadog.Trace.Tools.Runner/Options.cs
+++ b/src/Datadog.Trace.Tools.Runner/Options.cs
@@ -6,7 +6,7 @@ namespace Datadog.Trace.Tools.Runner
 {
     internal class Options
     {
-        [Usage(ApplicationAlias = "ddtrace")]
+        [Usage(ApplicationAlias = "dd-trace")]
         public static IEnumerable<Example> Examples
         {
             get


### PR DESCRIPTION
This PR fixes the application name in the examples of the `--help` option.

Currently the name is `dd-trace` but the helps shows `ddtrace`. This PR solves that.

![image](https://user-images.githubusercontent.com/69803/98474978-dc338480-21f5-11eb-825f-9b7f2c5a838d.png)




@DataDog/apm-dotnet