### PR TITLE
Have each rate limit test use its own id

### DIFF
--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -100,7 +100,9 @@ namespace Datadog.Trace.Tests.Sampling
             float expectedAutoKeepRate,
             float acceptableVariancePercent)
         {
-            var id = SpanIdGenerator.CreateNew();
+            var initialId = SpanIdGenerator.CreateNew();
+
+            var id = initialId;
 
             var sampleSize = iterations;
             var autoKeeps = 0;
@@ -121,7 +123,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             Assert.True(
                 autoKeepRate >= lowerLimit && autoKeepRate <= upperLimit,
-                $"Expected between {lowerLimit} and {upperLimit}, actual rate is {autoKeepRate}.");
+                $"Expected between {lowerLimit} and {upperLimit}, actual rate is {autoKeepRate}. Test ran with initial id {initialId}. Autokeeps is {autoKeeps}, iterations is {iterations}.");
         }
 
         private class NoLimits : IRateLimiter

--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.Util;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Sampling
@@ -13,8 +14,6 @@ namespace Datadog.Trace.Tests.Sampling
         private static readonly string Env = "my-test-env";
         private static readonly string OperationName = "test";
         private static readonly IEnumerable<KeyValuePair<string, float>> MockAgentRates = new List<KeyValuePair<string, float>>() { new KeyValuePair<string, float>($"service:{ServiceName},env:{Env}", FallbackRate) };
-
-        private static ulong _id = 1;
 
         [Fact]
         public void RateLimiter_Never_Applied_For_DefaultRule()
@@ -88,9 +87,9 @@ namespace Datadog.Trace.Tests.Sampling
                 0.05f);
         }
 
-        private static Span GetMyServiceSpan()
+        private static Span GetMyServiceSpan(ref ulong id)
         {
-            var span = new Span(new SpanContext(_id++, _id++, null, serviceName: ServiceName), DateTimeOffset.Now) { OperationName = OperationName };
+            var span = new Span(new SpanContext(id++, id++, null, serviceName: ServiceName), DateTimeOffset.Now) { OperationName = OperationName };
             span.SetTag(Tags.Env, Env);
             return span;
         }
@@ -101,11 +100,13 @@ namespace Datadog.Trace.Tests.Sampling
             float expectedAutoKeepRate,
             float acceptableVariancePercent)
         {
+            var id = SpanIdGenerator.CreateNew();
+
             var sampleSize = iterations;
             var autoKeeps = 0;
             while (sampleSize-- > 0)
             {
-                var span = GetMyServiceSpan();
+                var span = GetMyServiceSpan(ref id);
                 var priority = sampler.GetSamplingPriority(span);
                 if (priority == SamplingPriority.AutoKeep)
                 {

--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Util;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Datadog.Trace.Tests.Sampling
 {
@@ -14,6 +15,13 @@ namespace Datadog.Trace.Tests.Sampling
         private static readonly string Env = "my-test-env";
         private static readonly string OperationName = "test";
         private static readonly IEnumerable<KeyValuePair<string, float>> MockAgentRates = new List<KeyValuePair<string, float>>() { new KeyValuePair<string, float>($"service:{ServiceName},env:{Env}", FallbackRate) };
+
+        private readonly ITestOutputHelper _output;
+
+        public RuleBasedSamplerTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         [Fact]
         public void RateLimiter_Never_Applied_For_DefaultRule()
@@ -100,9 +108,9 @@ namespace Datadog.Trace.Tests.Sampling
             float expectedAutoKeepRate,
             float acceptableVariancePercent)
         {
-            var initialId = SpanIdGenerator.CreateNew();
+            var initialId = 8121434747841080868;
 
-            var id = initialId;
+            var id = (ulong)initialId;
 
             var sampleSize = iterations;
             var autoKeeps = 0;
@@ -121,9 +129,11 @@ namespace Datadog.Trace.Tests.Sampling
             var lowerLimit = expectedAutoKeepRate * (1 - acceptableVariancePercent);
             var upperLimit = expectedAutoKeepRate * (1 + acceptableVariancePercent);
 
+            _output.WriteLine($"{autoKeeps} / {iterations} = {autoKeepRate}");
+
             Assert.True(
                 autoKeepRate >= lowerLimit && autoKeepRate <= upperLimit,
-                $"Expected between {lowerLimit} and {upperLimit}, actual rate is {autoKeepRate}. Test ran with initial id {initialId}. Autokeeps is {autoKeeps}, iterations is {iterations}.");
+                $"Expected between {lowerLimit} and {upperLimit}, actual rate is {autoKeepRate}. Test ran with initial id {initialId}, ended with id {id}. Autokeeps is {autoKeeps}, iterations is {iterations}.");
         }
 
         private class NoLimits : IRateLimiter


### PR DESCRIPTION
It's a long shot but it could reduce the failures in the CI.