### PR TITLE
Adds PlatformTarget in the ServiceFabric project file

### DIFF
--- a/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
+++ b/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
@@ -6,6 +6,7 @@
 
     <!-- Microsoft.ServiceFabric.Services.Remoting only supports x64 -->
     <Platforms>x64</Platforms>
+    <PlatformTarget>x64</PlatformTarget>
 
     <!-- NuGet -->
     <Version>1.20.0-alpha1</Version>


### PR DESCRIPTION
Solves the warnings when running: `msbuild Datadog.Trace.proj /t:BuildCsharp /p:Configuration=Release`


@DataDog/apm-dotnet