### PR TITLE
No static instance for rate limiter test

### DIFF
--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -139,7 +139,9 @@ namespace Datadog.Trace.Tests.Sampling
 
             var limiter = new RateLimiter(maxTracesPerInterval: intervalLimit);
 
-            var traceContext = new TraceContext(Tracer.Instance);
+            var tracerInstance = new Tracer();
+
+            var traceContext = new TraceContext(tracerInstance);
 
             var barrier = new Barrier(parallelism + 1);
 


### PR DESCRIPTION
Test theory on static tracer instance for flaky test.

@DataDog/apm-dotnet