### PR TITLE
CleanUriSegment optimization.

### DIFF
--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -6,8 +6,6 @@ namespace Datadog.Trace.Util
 {
     internal static class UriHelpers
     {
-        public const string UrlIdPlaceholder = "?";
-
         public static string CleanUri(Uri uri, bool removeScheme, bool tryRemoveIds)
         {
             var path = GetRelativeUrl(uri, tryRemoveIds);
@@ -42,8 +40,48 @@ namespace Datadog.Trace.Util
                 return absolutePath;
             }
 
+#if NETCOREAPP
+            ReadOnlySpan<char> absPath = absolutePath.AsSpan();
+
             // Sanitized url will be at worse as long as the original
-            var sb = new StringBuilder(absolutePath.Length);
+            var sb = StringBuilderCache.Acquire(absPath.Length);
+
+            int previousIndex = 0;
+            int index;
+
+            do
+            {
+                ReadOnlySpan<char> nStart = absPath.Slice(previousIndex);
+                index = nStart.IndexOf('/');
+                ReadOnlySpan<char> segment = index == -1 ? nStart : nStart.Slice(0, index);
+
+                // replace path segments that look like numbers or guid
+                // GUID format N "d85b1407351d4694939203acc5870eb1" length: 32
+                // GUID format D "d85b1407-351d-4694-9392-03acc5870eb1" length: 36 with dashes in indices 8, 13, 18 and 23.
+                if (long.TryParse(segment, out _) ||
+                    (segment.Length == 32 && IsAGuid(segment, "N")) ||
+                    (segment.Length == 36 && IsAGuid(segment, "D")))
+                {
+                    sb.Append('?');
+                }
+                else
+                {
+                    sb.Append(segment);
+                }
+
+                if (index != -1)
+                {
+                    sb.Append('/');
+                }
+
+                previousIndex += index + 1;
+            }
+            while (index != -1);
+
+            return StringBuilderCache.GetStringAndRelease(sb);
+#else
+            // Sanitized url will be at worse as long as the original
+            var sb = StringBuilderCache.Acquire(absolutePath.Length);
 
             int previousIndex = 0;
             int index = 0;
@@ -71,7 +109,7 @@ namespace Datadog.Trace.Util
                     (segment.Length == 32 && IsAGuid(segment, "N")) ||
                     (segment.Length == 36 && IsAGuid(segment, "D")))
                 {
-                    segment = UrlIdPlaceholder;
+                    segment = "?";
                 }
 
                 sb.Append(segment);
@@ -84,10 +122,62 @@ namespace Datadog.Trace.Util
                 previousIndex = index + 1;
             }
 
-            return sb.ToString();
+            return StringBuilderCache.GetStringAndRelease(sb);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool IsAGuid(string segment, string format) => Guid.TryParseExact(segment, format, out _);
+
+#if NETCOREAPP
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool IsAGuid(ReadOnlySpan<char> segment, string format) => Guid.TryParseExact(segment, format, out _);
+#endif
+
+        /// <summary>
+        /// Provide a cached reusable instance of stringbuilder per thread.
+        /// </summary>
+        /// <remarks>
+        /// Based on https://source.dot.net/#System.Private.CoreLib/StringBuilderCache.cs,a6dbe82674916ac0
+        /// </remarks>
+        internal static class StringBuilderCache
+        {
+            internal const int MaxBuilderSize = 360;
+
+            [ThreadStatic]
+            private static StringBuilder _cachedInstance;
+
+            public static StringBuilder Acquire(int capacity)
+            {
+                if (capacity <= MaxBuilderSize)
+                {
+                    StringBuilder sb = _cachedInstance;
+                    if (sb != null)
+                    {
+                        // Avoid stringbuilder block fragmentation by getting a new StringBuilder
+                        // when the requested size is larger than the current capacity
+                        if (capacity <= sb.Capacity)
+                        {
+                            _cachedInstance = null;
+                            sb.Clear();
+                            return sb;
+                        }
+                    }
+                }
+
+                return new StringBuilder(capacity);
+            }
+
+            public static string GetStringAndRelease(StringBuilder sb)
+            {
+                string result = sb.ToString();
+                if (sb.Capacity <= MaxBuilderSize)
+                {
+                    _cachedInstance = sb;
+                }
+
+                return result;
+            }
+        }
     }
 }

--- a/test/Datadog.Trace.Tests/Util/CleanUriSegmentTests.cs
+++ b/test/Datadog.Trace.Tests/Util/CleanUriSegmentTests.cs
@@ -1,0 +1,22 @@
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util
+{
+    public class CleanUriSegmentTests
+    {
+        [Theory]
+        [InlineData("/", "/")]
+        [InlineData("/controller/action/b37855d4bae34bd3b3357fc554ad334e", "/controller/action/?")]
+        [InlineData("/controller/action/14bb2eed-34f0-4aa2-b2c3-09c0e2166d4d", "/controller/action/?")]
+        [InlineData("/controller/action/14bb2eed-34f0X4aa2-b2c3-09c0e2166d4d", "/controller/action/14bb2eed-34f0X4aa2-b2c3-09c0e2166d4d")]
+        [InlineData("/controller/action/14bb2eed-34f0-4aa2Xb2c3-09c0e2166d4d", "/controller/action/14bb2eed-34f0-4aa2Xb2c3-09c0e2166d4d")]
+        [InlineData("/controller/action/14bb2eed-34f0A4aa2Bb2c3C09c0e2166d4d", "/controller/action/14bb2eed-34f0A4aa2Bb2c3C09c0e2166d4d")]
+        [InlineData("/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs", "/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs")]
+        [InlineData("/controller/action/2022", "/controller/action/?")]
+        [InlineData("/controller/action/", "/controller/action/")]
+        public void CleanUriSegmentTest(string url, string expected)
+        {
+            Assert.Equal(expected, Trace.Util.UriHelpers.CleanUriSegment(url));
+        }
+    }
+}


### PR DESCRIPTION
This PR includes optimizations to the `CleanUriSegment` method by introducing a no allocating span algorithm for `netcoreapp`, a `StringBuilderCache` based on the one in the BCL and prioritize chars over string in the Append method. Also includes missing unit tests.

#### Some benchmarks:

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
Intel Core i7-1068NG7 CPU 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  Job-PZAJGD : .NET Framework 4.8 (4.8.4250.0), X64 RyuJIT
  Job-CNRSOZ : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT


```
|             Method |     Toolchain |         absolutePath |       Mean |      Error |     StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |-------------- |--------------------- |-----------:|-----------:|-----------:|------:|--------:|-------:|------:|------:|----------:|
|    CleanUriSegment |        net472 |                    / |   4.040 ns |  0.0702 ns |  0.0622 ns |  1.00 |    0.00 |      - |     - |     - |         - |
|    CleanUriSegment | netcoreapp3.1 |                    / |   4.010 ns |  0.0392 ns |  0.0367 ns |  0.99 |    0.02 |      - |     - |     - |         - |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 |                    / |   4.144 ns |  0.0295 ns |  0.0246 ns |  1.00 |    0.00 |      - |     - |     - |         - |
| CleanUriSegmentNew | netcoreapp3.1 |                    / |   4.026 ns |  0.1097 ns |  0.1347 ns |  0.95 |    0.03 |      - |     - |     - |         - |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
|    CleanUriSegment |        net472 |  /Dat(...)s.cs [107] | 699.948 ns | 12.0800 ns | 11.2997 ns |  1.00 |    0.00 | 0.2289 |     - |     - |     963 B |
|    CleanUriSegment | netcoreapp3.1 |  /Dat(...)s.cs [107] | 358.188 ns |  6.8910 ns |  6.7679 ns |  0.51 |    0.01 | 0.2198 |     - |     - |     920 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 |  /Dat(...)s.cs [107] | 704.657 ns | 14.0551 ns | 16.7316 ns |  1.00 |    0.00 | 0.1602 |     - |     - |     674 B |
| CleanUriSegmentNew | netcoreapp3.1 |  /Dat(...)s.cs [107] | 222.460 ns |  3.4643 ns |  3.2405 ns |  0.32 |    0.01 | 0.0572 |     - |     - |     240 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
|    CleanUriSegment |        net472 | /cont(...)66d4d [55] | 647.279 ns | 11.3619 ns | 10.6279 ns |  1.00 |    0.00 | 0.1068 |     - |     - |     449 B |
|    CleanUriSegment | netcoreapp3.1 | /cont(...)66d4d [55] | 247.928 ns |  4.8938 ns |  8.1764 ns |  0.39 |    0.01 | 0.1030 |     - |     - |     432 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 | /cont(...)66d4d [55] | 648.606 ns | 12.8090 ns | 11.9816 ns |  1.00 |    0.00 | 0.0629 |     - |     - |     265 B |
| CleanUriSegmentNew | netcoreapp3.1 | /cont(...)66d4d [55] | 190.178 ns |  2.9059 ns |  2.7182 ns |  0.29 |    0.01 | 0.0153 |     - |     - |      64 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
|    CleanUriSegment |        net472 | /cont(...)66d4d [55] | 449.936 ns |  5.9746 ns |  5.2963 ns |  1.00 |    0.00 | 0.1221 |     - |     - |     514 B |
|    CleanUriSegment | netcoreapp3.1 | /cont(...)66d4d [55] | 197.503 ns |  3.5414 ns |  3.3126 ns |  0.44 |    0.01 | 0.1204 |     - |     - |     504 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 | /cont(...)66d4d [55] | 451.972 ns |  8.9948 ns |  8.4137 ns |  1.00 |    0.00 | 0.0782 |     - |     - |     329 B |
| CleanUriSegmentNew | netcoreapp3.1 | /cont(...)66d4d [55] | 136.092 ns |  2.1910 ns |  2.0495 ns |  0.30 |    0.01 | 0.0324 |     - |     - |     136 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
|    CleanUriSegment |        net472 | /cont(...)66d4d [55] | 451.443 ns |  6.6462 ns |  6.2168 ns |  1.00 |    0.00 | 0.1221 |     - |     - |     514 B |
|    CleanUriSegment | netcoreapp3.1 | /cont(...)66d4d [55] | 198.143 ns |  2.3514 ns |  1.9636 ns |  0.44 |    0.01 | 0.1204 |     - |     - |     504 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 | /cont(...)66d4d [55] | 446.901 ns |  7.1954 ns |  6.7306 ns |  1.00 |    0.00 | 0.0782 |     - |     - |     329 B |
| CleanUriSegmentNew | netcoreapp3.1 | /cont(...)66d4d [55] | 133.722 ns |  1.9480 ns |  1.8221 ns |  0.30 |    0.01 | 0.0324 |     - |     - |     136 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
|    CleanUriSegment |        net472 | /cont(...)66d4d [55] | 445.394 ns |  7.2481 ns |  6.7799 ns |  1.00 |    0.00 | 0.1221 |     - |     - |     514 B |
|    CleanUriSegment | netcoreapp3.1 | /cont(...)66d4d [55] | 203.372 ns |  3.2887 ns |  2.9154 ns |  0.46 |    0.01 | 0.1204 |     - |     - |     504 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 | /cont(...)66d4d [55] | 447.919 ns |  6.8444 ns |  7.6075 ns |  1.00 |    0.00 | 0.0782 |     - |     - |     329 B |
| CleanUriSegmentNew | netcoreapp3.1 | /cont(...)66d4d [55] | 135.899 ns |  2.6486 ns |  3.3496 ns |  0.30 |    0.01 | 0.0324 |     - |     - |     136 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
|    CleanUriSegment |        net472 | /cont(...)d334e [51] | 749.808 ns | 14.3617 ns | 13.4340 ns |  1.00 |    0.00 | 0.1431 |     - |     - |     602 B |
|    CleanUriSegment | netcoreapp3.1 | /cont(...)d334e [51] | 236.155 ns |  3.6571 ns |  3.7556 ns |  0.31 |    0.01 | 0.0992 |     - |     - |     416 B |
|                    |               |                      |            |            |            |       |         |        |       |       |           |
| CleanUriSegmentNew |        net472 | /cont(...)d334e [51] | 743.738 ns | 13.8776 ns | 13.6297 ns |  1.00 |    0.00 | 0.1011 |     - |     - |     425 B |
| CleanUriSegmentNew | netcoreapp3.1 | /cont(...)d334e [51] | 186.414 ns |  3.3248 ns |  3.1100 ns |  0.25 |    0.01 | 0.0153 |     - |     - |      64 B |



@DataDog/apm-dotnet