### PR TITLE
AspNetCoreDiagnosticObserver optimizations.

### DIFF
--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -24,6 +24,10 @@
     <PackageReference Include="LibLog" Version="5.0.6" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Datadog.Trace.DuckTyping\Datadog.Trace.DuckTyping.csproj" />
+  </ItemGroup>
+
   <!-- Below this point is reserved for vendor items -->
   <!--Newtonsoft.Json-->
   <!-- Modifications: Original condition was only for net45, but we include net461 here so that net45 and net461 generate the same Newtonsoft.Json -->

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -59,13 +59,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 't')
             {
-                if (ReferenceEquals(eventName, hostingHttpRequestInStartEventKey))
+                if (ReferenceEquals(eventName, _hostingHttpRequestInStartEventKey))
                 {
                     OnHostingHttpRequestInStart(arg);
                 }
                 else if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Start"))
                 {
-                    hostingHttpRequestInStartEventKey = eventName;
+                    _hostingHttpRequestInStartEventKey = eventName;
                     OnHostingHttpRequestInStart(arg);
                 }
 
@@ -74,13 +74,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'n')
             {
-                if (ReferenceEquals(eventName, mvcBeforeActionEventKey))
+                if (ReferenceEquals(eventName, _mvcBeforeActionEventKey))
                 {
                     OnMvcBeforeAction(arg);
                     return;
                 }
-                else if (ReferenceEquals(eventName, hostingUnhandledExceptionEventKey) ||
-                    ReferenceEquals(eventName, diagnosticsUnhandledExceptionEventKey))
+                else if (ReferenceEquals(eventName, _hostingUnhandledExceptionEventKey) ||
+                    ReferenceEquals(eventName, _diagnosticsUnhandledExceptionEventKey))
                 {
                     OnHostingUnhandledException(arg);
                     return;
@@ -90,17 +90,17 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (suffix.SequenceEqual("Mvc.BeforeAction"))
                 {
-                    mvcBeforeActionEventKey = eventName;
+                    _mvcBeforeActionEventKey = eventName;
                     OnMvcBeforeAction(arg);
                 }
                 else if (suffix.SequenceEqual("Hosting.UnhandledException"))
                 {
-                    hostingUnhandledExceptionEventKey = eventName;
+                    _hostingUnhandledExceptionEventKey = eventName;
                     OnHostingUnhandledException(arg);
                 }
                 else if (suffix.SequenceEqual("Diagnostics.UnhandledException"))
                 {
-                    diagnosticsUnhandledExceptionEventKey = eventName;
+                    _diagnosticsUnhandledExceptionEventKey = eventName;
                     OnHostingUnhandledException(arg);
                 }
 
@@ -109,13 +109,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'p')
             {
-                if (ReferenceEquals(eventName, hostingHttpRequestInStopEventKey))
+                if (ReferenceEquals(eventName, _hostingHttpRequestInStopEventKey))
                 {
                     OnHostingHttpRequestInStop(arg);
                 }
                 else if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Stop"))
                 {
-                    hostingHttpRequestInStopEventKey = eventName;
+                    _hostingHttpRequestInStopEventKey = eventName;
                     OnHostingHttpRequestInStop(arg);
                 }
 
@@ -129,13 +129,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 't')
             {
-                if (ReferenceEquals(eventName, hostingHttpRequestInStartEventKey))
+                if (ReferenceEquals(eventName, _hostingHttpRequestInStartEventKey))
                 {
                     OnHostingHttpRequestInStart(arg);
                 }
                 else if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start")
                 {
-                    hostingHttpRequestInStartEventKey = eventName;
+                    _hostingHttpRequestInStartEventKey = eventName;
                     OnHostingHttpRequestInStart(arg);
                 }
 
@@ -144,13 +144,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'n')
             {
-                if (ReferenceEquals(eventName, mvcBeforeActionEventKey))
+                if (ReferenceEquals(eventName, _mvcBeforeActionEventKey))
                 {
                     OnMvcBeforeAction(arg);
                     return;
                 }
-                else if (ReferenceEquals(eventName, hostingUnhandledExceptionEventKey) ||
-                    ReferenceEquals(eventName, diagnosticsUnhandledExceptionEventKey))
+                else if (ReferenceEquals(eventName, _hostingUnhandledExceptionEventKey) ||
+                    ReferenceEquals(eventName, _diagnosticsUnhandledExceptionEventKey))
                 {
                     OnHostingUnhandledException(arg);
                     return;
@@ -159,16 +159,16 @@ namespace Datadog.Trace.DiagnosticListeners
                 switch (eventName)
                 {
                     case "Microsoft.AspNetCore.Mvc.BeforeAction":
-                        mvcBeforeActionEventKey = eventName;
+                        _mvcBeforeActionEventKey = eventName;
                         OnMvcBeforeAction(arg);
                         break;
 
                     case "Microsoft.AspNetCore.Hosting.UnhandledException":
-                        hostingUnhandledExceptionEventKey = eventName;
+                        _hostingUnhandledExceptionEventKey = eventName;
                         OnHostingUnhandledException(arg);
                         break;
                     case "Microsoft.AspNetCore.Diagnostics.UnhandledException":
-                        diagnosticsUnhandledExceptionEventKey = eventName;
+                        _diagnosticsUnhandledExceptionEventKey = eventName;
                         OnHostingUnhandledException(arg);
                         break;
                 }
@@ -178,13 +178,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'p')
             {
-                if (ReferenceEquals(eventName, hostingHttpRequestInStopEventKey))
+                if (ReferenceEquals(eventName, _hostingHttpRequestInStopEventKey))
                 {
                     OnHostingHttpRequestInStop(arg);
                 }
                 else if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop")
                 {
-                    hostingHttpRequestInStopEventKey = eventName;
+                    _hostingHttpRequestInStopEventKey = eventName;
                     OnHostingHttpRequestInStop(arg);
                 }
 

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -34,11 +34,11 @@ namespace Datadog.Trace.DiagnosticListeners
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<AspNetCoreDiagnosticObserver>();
         private readonly Tracer _tracer;
 
-        private string hostingHttpRequestInStartEventKey;
-        private string mvcBeforeActionEventKey;
-        private string hostingUnhandledExceptionEventKey;
-        private string diagnosticsUnhandledExceptionEventKey;
-        private string hostingHttpRequestInStopEventKey;
+        private string _hostingHttpRequestInStartEventKey;
+        private string _mvcBeforeActionEventKey;
+        private string _hostingUnhandledExceptionEventKey;
+        private string _diagnosticsUnhandledExceptionEventKey;
+        private string _hostingHttpRequestInStopEventKey;
 
         public AspNetCoreDiagnosticObserver()
             : this(null)

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
@@ -31,14 +32,13 @@ namespace Datadog.Trace.DiagnosticListeners
         private static readonly int PrefixLength = "Microsoft.AspNetCore.".Length;
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<AspNetCoreDiagnosticObserver>();
-
-        private static readonly PropertyFetcher HttpRequestInStartHttpContextFetcher = new PropertyFetcher("HttpContext");
-        private static readonly PropertyFetcher HttpRequestInStopHttpContextFetcher = new PropertyFetcher("HttpContext");
-        private static readonly PropertyFetcher UnhandledExceptionExceptionFetcher = new PropertyFetcher("Exception");
-        private static readonly PropertyFetcher BeforeActionHttpContextFetcher = new PropertyFetcher("httpContext");
-        private static readonly PropertyFetcher BeforeActionActionDescriptorFetcher = new PropertyFetcher("actionDescriptor");
-
         private readonly Tracer _tracer;
+
+        private string hostingHttpRequestInStartEventKey;
+        private string mvcBeforeActionEventKey;
+        private string hostingUnhandledExceptionEventKey;
+        private string diagnosticsUnhandledExceptionEventKey;
+        private string hostingHttpRequestInStopEventKey;
 
         public AspNetCoreDiagnosticObserver()
             : this(null)
@@ -59,8 +59,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 't')
             {
-                if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Start"))
+                if (ReferenceEquals(eventName, hostingHttpRequestInStartEventKey))
                 {
+                    OnHostingHttpRequestInStart(arg);
+                }
+                else if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Start"))
+                {
+                    hostingHttpRequestInStartEventKey = eventName;
                     OnHostingHttpRequestInStart(arg);
                 }
 
@@ -69,15 +74,33 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'n')
             {
+                if (ReferenceEquals(eventName, mvcBeforeActionEventKey))
+                {
+                    OnMvcBeforeAction(arg);
+                    return;
+                }
+                else if (ReferenceEquals(eventName, hostingUnhandledExceptionEventKey) ||
+                    ReferenceEquals(eventName, diagnosticsUnhandledExceptionEventKey))
+                {
+                    OnHostingUnhandledException(arg);
+                    return;
+                }
+
                 var suffix = eventName.AsSpan().Slice(PrefixLength);
 
                 if (suffix.SequenceEqual("Mvc.BeforeAction"))
                 {
+                    mvcBeforeActionEventKey = eventName;
                     OnMvcBeforeAction(arg);
                 }
-                else if (suffix.SequenceEqual("Hosting.UnhandledException")
-                    || suffix.SequenceEqual("Diagnostics.UnhandledException"))
+                else if (suffix.SequenceEqual("Hosting.UnhandledException"))
                 {
+                    hostingUnhandledExceptionEventKey = eventName;
+                    OnHostingUnhandledException(arg);
+                }
+                else if (suffix.SequenceEqual("Diagnostics.UnhandledException"))
+                {
+                    diagnosticsUnhandledExceptionEventKey = eventName;
                     OnHostingUnhandledException(arg);
                 }
 
@@ -86,8 +109,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'p')
             {
-                if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Stop"))
+                if (ReferenceEquals(eventName, hostingHttpRequestInStopEventKey))
                 {
+                    OnHostingHttpRequestInStop(arg);
+                }
+                else if (eventName.AsSpan().Slice(PrefixLength).SequenceEqual("Hosting.HttpRequestIn.Stop"))
+                {
+                    hostingHttpRequestInStopEventKey = eventName;
                     OnHostingHttpRequestInStop(arg);
                 }
 
@@ -101,8 +129,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 't')
             {
-                if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start")
+                if (ReferenceEquals(eventName, hostingHttpRequestInStartEventKey))
                 {
+                    OnHostingHttpRequestInStart(arg);
+                }
+                else if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Start")
+                {
+                    hostingHttpRequestInStartEventKey = eventName;
                     OnHostingHttpRequestInStart(arg);
                 }
 
@@ -111,14 +144,31 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'n')
             {
+                if (ReferenceEquals(eventName, mvcBeforeActionEventKey))
+                {
+                    OnMvcBeforeAction(arg);
+                    return;
+                }
+                else if (ReferenceEquals(eventName, hostingUnhandledExceptionEventKey) ||
+                    ReferenceEquals(eventName, diagnosticsUnhandledExceptionEventKey))
+                {
+                    OnHostingUnhandledException(arg);
+                    return;
+                }
+
                 switch (eventName)
                 {
                     case "Microsoft.AspNetCore.Mvc.BeforeAction":
+                        mvcBeforeActionEventKey = eventName;
                         OnMvcBeforeAction(arg);
                         break;
 
                     case "Microsoft.AspNetCore.Hosting.UnhandledException":
+                        hostingUnhandledExceptionEventKey = eventName;
+                        OnHostingUnhandledException(arg);
+                        break;
                     case "Microsoft.AspNetCore.Diagnostics.UnhandledException":
+                        diagnosticsUnhandledExceptionEventKey = eventName;
                         OnHostingUnhandledException(arg);
                         break;
                 }
@@ -128,8 +178,13 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (lastChar == 'p')
             {
-                if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop")
+                if (ReferenceEquals(eventName, hostingHttpRequestInStopEventKey))
                 {
+                    OnHostingHttpRequestInStop(arg);
+                }
+                else if (eventName == "Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop")
+                {
+                    hostingHttpRequestInStopEventKey = eventName;
                     OnHostingHttpRequestInStop(arg);
                 }
 
@@ -207,8 +262,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            var httpContext = HttpRequestInStartHttpContextFetcher.Fetch<HttpContext>(arg);
-            HttpRequest request = httpContext.Request;
+            HttpRequest request = arg.As<HttpRequestInStartStruct>().HttpContext.Request;
             string host = request.Host.Value;
             string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
             string url = GetUrl(request);
@@ -245,16 +299,15 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            var httpContext = BeforeActionHttpContextFetcher.Fetch<HttpContext>(arg);
-
             Span span = tracer.ActiveScope?.Span;
 
             if (span != null)
             {
                 // NOTE: This event is the start of the action pipeline. The action has been selected, the route
                 //       has been selected but no filters have run and model binding hasn't occurred.
-                var actionDescriptor = BeforeActionActionDescriptorFetcher.Fetch<ActionDescriptor>(arg);
-                HttpRequest request = httpContext.Request;
+                BeforeActionStruct typedArg = arg.As<BeforeActionStruct>();
+                ActionDescriptor actionDescriptor = typedArg.ActionDescriptor;
+                HttpRequest request = typedArg.HttpContext.Request;
 
                 string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
                 string controllerName = actionDescriptor.RouteValues["controller"];
@@ -280,7 +333,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (scope != null)
             {
-                var httpContext = HttpRequestInStopHttpContextFetcher.Fetch<HttpContext>(arg);
+                HttpContext httpContext = arg.As<HttpRequestInStopStruct>().HttpContext;
 
                 scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
                 scope.Dispose();
@@ -300,10 +353,34 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (span != null)
             {
-                var exception = UnhandledExceptionExceptionFetcher.Fetch<Exception>(arg);
-
-                span.SetException(exception);
+                span.SetException(arg.As<UnhandledExceptionStruct>().Exception);
             }
+        }
+
+        [DuckCopy]
+        public struct HttpRequestInStartStruct
+        {
+            public HttpContext HttpContext;
+        }
+
+        [DuckCopy]
+        public struct HttpRequestInStopStruct
+        {
+            public HttpContext HttpContext;
+        }
+
+        [DuckCopy]
+        public struct UnhandledExceptionStruct
+        {
+            public Exception Exception;
+        }
+
+        [DuckCopy]
+        public struct BeforeActionStruct
+        {
+            public HttpContext HttpContext;
+
+            public ActionDescriptor ActionDescriptor;
         }
 
         private readonly struct HeadersCollectionAdapter : IHeadersCollection


### PR DESCRIPTION
- Adds DuckTyping mechanism.
- Adds ReferenceEquals optimization

#### Benchmark for the ReferenceEquals: (*Changed*)

```ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.630 (2004/?/20H1)
Intel Core i7-1068NG7 CPU 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  Job-AIVVBG : .NET Framework 4.8 (4.8.4250.0), X64 RyuJIT
  Job-KHFMMM : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
```

|           Method |        Job |       Runtime |     Toolchain |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |----------- |-------------- |-------------- |---------:|--------:|--------:|------:|-------:|------:|------:|----------:|
|    CurrentOnNext | Job-AIVVBG |    .NET 4.7.2 |        net472 | 185.0 ns | 1.43 ns | 1.19 ns |  1.00 | 0.0668 |     - |     - |     281 B |
|    CurrentOnNext | Job-KHFMMM | .NET Core 3.1 | netcoreapp3.1 | 183.4 ns | 0.76 ns | 0.63 ns |  0.99 | 0.0668 |     - |     - |     280 B |
|                  |            |               |               |          |         |         |       |        |       |       |           |
| CurrentOnNextNew | Job-AIVVBG |    .NET 4.7.2 |        net472 | 178.4 ns | 0.92 ns | 0.86 ns |  1.00 | 0.0668 |     - |     - |     281 B |
| CurrentOnNextNew | Job-KHFMMM | .NET Core 3.1 | netcoreapp3.1 | 174.6 ns | 0.94 ns | 0.88 ns |  0.98 | 0.0668 |     - |     - |     280 B |


@DataDog/apm-dotnet