### PR TITLE
Fixes Permission denied error on the native logger implementation.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -1,7 +1,9 @@
 #include "logging.h"
 
 #include "pal.h"
+
 #include "spdlog/sinks/null_sink.h"
+#include "spdlog/sinks/basic_file_sink.h"
 
 #ifndef _WIN32
 typedef struct stat Stat;
@@ -59,8 +61,7 @@ Logger::Logger() {
   spdlog::flush_every(std::chrono::seconds(3));
 
   try {
-    m_fileout =
-        spdlog::rotating_logger_mt("Logger", GetLogPath(), 1048576 * 5, 10);
+    m_fileout = spdlog::basic_logger_mt("Logger", GetLogPath());
   }
   catch (...) {
     std::cerr << "Logger Handler: Error creating native log file." << std::endl;

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -2,7 +2,6 @@
 #define DD_CLR_PROFILER_LOGGING_H_
 #include "util.h"
 
-#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/spdlog.h>
 
 #include <iostream>


### PR DESCRIPTION
The current `rotating_file_sink` is not compatible with the way we write the native logs. 

Currently we have a fixed filename for the native logger called `dotnet-tracer-native.log`. if we launch multiple instrumented processes all of them are going to write in that single file. When the logger reach the threshold for rotation throws a `Permission Denied` error when trying to rename the file to `dotnet-tracer-native.1.log` caused by multiple handles from different process holding a handle to that file.

To avoid that error we can either remove rotation of the logger file or create multiple log files (1 per process ID). This `PR` takes the first approach and replaces the `rotating_file_sink` for a `basic_file_sink`.

@DataDog/apm-dotnet