### PR TITLE
don't use global tracer in rate limiter tests

### DIFF
--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -157,9 +157,10 @@ namespace Datadog.Trace.Tests.Sampling
 
                             for (int j = 0; j < numberPerThread; j++)
                             {
-                                // trace id and span id are not used in rate-limiting,
-                                // pass a specific start time since there is no TraceContext
+                                // trace id and span id are not used in rate-limiting
                                 var spanContext = new SpanContext(traceId: 1, spanId: 1, serviceName: "Weeeee");
+
+                                // pass a specific start time since there is no TraceContext
                                 var span = new Span(spanContext, DateTimeOffset.UtcNow);
 
                                 Interlocked.Increment(ref totalAttempted);

--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -1,9 +1,9 @@
 using System;
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Sampling;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Sampling
@@ -135,11 +135,12 @@ namespace Datadog.Trace.Tests.Sampling
                 parallelism = 10;
             }
 
-            var result = new RateLimitResult();
             var limiter = new RateLimiter(maxTracesPerInterval: intervalLimit);
             var barrier = new Barrier(parallelism + 1);
             var numberPerThread = test.NumberPerBurst / parallelism;
             var workers = new Task[parallelism];
+            int totalAttempted = 0;
+            int totalAllowed = 0;
 
             for (int i = 0; i < workers.Length; i++)
             {
@@ -162,13 +163,11 @@ namespace Datadog.Trace.Tests.Sampling
                                 var spanContext = new SpanContext(traceId: 1, spanId: 1, serviceName: "Weeeee");
                                 var span = new Span(spanContext, DateTimeOffset.UtcNow);
 
+                                Interlocked.Increment(ref totalAttempted);
+
                                 if (limiter.Allowed(span))
                                 {
-                                    result.Allowed.Add(span.SpanId);
-                                }
-                                else
-                                {
-                                    result.Denied.Add(span.SpanId);
+                                    Interlocked.Increment(ref totalAllowed);
                                 }
                             }
 
@@ -194,9 +193,14 @@ namespace Datadog.Trace.Tests.Sampling
             // Wait for workers to finish
             Task.WaitAll(workers);
 
-            result.TimeElapsed = sw.Elapsed;
-            result.RateLimiter = limiter;
-            result.ReportedRate = limiter.GetEffectiveRate();
+            var result = new RateLimitResult
+            {
+                TimeElapsed = sw.Elapsed,
+                RateLimiter = limiter,
+                ReportedRate = limiter.GetEffectiveRate(),
+                TotalAttempted = totalAttempted,
+                TotalAllowed = totalAllowed
+            };
 
             return result;
         }
@@ -216,15 +220,11 @@ namespace Datadog.Trace.Tests.Sampling
 
             public TimeSpan TimeElapsed { get; set; }
 
-            public ConcurrentBag<ulong> Allowed { get; } = new ConcurrentBag<ulong>();
-
-            public ConcurrentBag<ulong> Denied { get; } = new ConcurrentBag<ulong>();
-
             public float ReportedRate { get; set; }
 
-            public int TotalAttempted => Allowed.Count + Denied.Count;
+            public int TotalAttempted { get; set; }
 
-            public int TotalAllowed => Allowed.Count;
+            public int TotalAllowed { get; set; }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Sampling;
-using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Sampling

--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -137,7 +137,6 @@ namespace Datadog.Trace.Tests.Sampling
 
             var result = new RateLimitResult();
             var limiter = new RateLimiter(maxTracesPerInterval: intervalLimit);
-            var traceContext = new TraceContext(Tracer.Instance);
             var barrier = new Barrier(parallelism + 1);
             var numberPerThread = test.NumberPerBurst / parallelism;
             var workers = new Task[parallelism];
@@ -158,8 +157,10 @@ namespace Datadog.Trace.Tests.Sampling
 
                             for (int j = 0; j < numberPerThread; j++)
                             {
-                                var spanContext = new SpanContext(null, traceContext, "Weeeee");
-                                var span = new Span(spanContext, null);
+                                // trace id and span id are not used in rate-limiting,
+                                // pass a specific start time since there is no TraceContext
+                                var spanContext = new SpanContext(traceId: 1, spanId: 1, serviceName: "Weeeee");
+                                var span = new Span(spanContext, DateTimeOffset.UtcNow);
 
                                 if (limiter.Allowed(span))
                                 {

--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -136,15 +136,10 @@ namespace Datadog.Trace.Tests.Sampling
             }
 
             var result = new RateLimitResult();
-
             var limiter = new RateLimiter(maxTracesPerInterval: intervalLimit);
-
             var traceContext = new TraceContext(Tracer.Instance);
-
             var barrier = new Barrier(parallelism + 1);
-
             var numberPerThread = test.NumberPerBurst / parallelism;
-
             var workers = new Task[parallelism];
 
             for (int i = 0; i < workers.Length; i++)


### PR DESCRIPTION
Follow-up of #1034.

- don't use the global tracer from `Tracer.Instance` or create a `TraceContext`
- count total attempts and allowed attempts instead of collecting all span ids