### PR TITLE
DuckTyping fixes

### DIFF
--- a/src/Datadog.Trace.DuckTyping/DuckType.Fields.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Fields.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // We create the dynamic method
                 Type[] dynParameters = targetField.IsStatic ? Type.EmptyTypes : new[] { typeof(object) };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, typeof(DuckType).Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
 
                 // We store the dynamic method in a bag to avoid getting collected by the GC.
                 DynamicMethods.Add(dynMethod);
@@ -94,6 +94,7 @@ namespace Datadog.Trace.DuckTyping
             }
 
             il.Emit(OpCodes.Ret);
+            _methodBuilderGetToken.Invoke(proxyMethod, null);
             return proxyMethod;
         }
 
@@ -156,7 +157,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // Create dynamic method
                 Type[] dynParameters = targetField.IsStatic ? new[] { dynValueType } : new[] { typeof(object), dynValueType };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, typeof(DuckType).Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, _moduleBuilder, true);
                 DynamicMethods.Add(dynMethod);
 
                 // Write the dynamic method body
@@ -187,6 +188,7 @@ namespace Datadog.Trace.DuckTyping
             }
 
             il.Emit(OpCodes.Ret);
+            _methodBuilderGetToken.Invoke(method, null);
             return method;
         }
     }

--- a/src/Datadog.Trace.DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Methods.cs
@@ -42,6 +42,9 @@ namespace Datadog.Trace.DuckTyping
             {
                 foreach (MethodInfo method in baseType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
                 {
+                    // Avoid proxying object methods like ToString(), GetHashCode()
+                    // or the Finalize() that creates problems by keeping alive the object to another collection.
+                    // You can still proxy those methods if they are defined in an interface.
                     if (method.DeclaringType == typeof(object))
                     {
                         continue;

--- a/src/Datadog.Trace.DuckTyping/DuckType.Properties.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Properties.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertyGetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, typeof(DuckType).Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
 
                 // We store the dynamic method in a bag to avoid getting collected by the GC.
                 DynamicMethods.Add(dynMethod);
@@ -160,6 +160,7 @@ namespace Datadog.Trace.DuckTyping
             }
 
             il.Emit(OpCodes.Ret);
+            _methodBuilderGetToken.Invoke(proxyMethod, null);
             return proxyMethod;
         }
 
@@ -260,7 +261,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertySetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, typeof(DuckType).Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, _moduleBuilder, true);
 
                 // We store the dynamic method in a bag to avoid getting collected by the GC.
                 DynamicMethods.Add(dynMethod);
@@ -287,6 +288,7 @@ namespace Datadog.Trace.DuckTyping
             }
 
             il.Emit(OpCodes.Ret);
+            _methodBuilderGetToken.Invoke(proxyMethod, null);
             return proxyMethod;
         }
 

--- a/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 
 namespace Datadog.Trace.DuckTyping
 {
@@ -33,10 +31,22 @@ namespace Datadog.Trace.DuckTyping
         private static readonly ConcurrentBag<DynamicMethod> DynamicMethods = new ConcurrentBag<DynamicMethod>();
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly PropertyInfo DuckTypeInstancePropertyInfo = typeof(IDuckType).GetProperty(nameof(IDuckType.Instance));
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static readonly MethodInfo _methodBuilderGetToken = typeof(MethodBuilder).GetMethod("GetToken", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static ModuleBuilder _moduleBuilder = null;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static AssemblyBuilder _assemblyBuilder = null;
+
+        /// <summary>
+        /// Gets the function pointer from a method handler index
+        /// </summary>
+        /// <param name="index">Index of the method handler</param>
+        /// <returns>Function pointer</returns>
+        public static IntPtr GetFunctionPointerFromMethodHandlerIndex(int index)
+        {
+            return ILHelpersExtensions.GetHandleFromIndex(index).GetFunctionPointer();
+        }
     }
 }

--- a/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
@@ -38,15 +38,5 @@ namespace Datadog.Trace.DuckTyping
         private static ModuleBuilder _moduleBuilder = null;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static AssemblyBuilder _assemblyBuilder = null;
-
-        /// <summary>
-        /// Gets the function pointer from a method handler index
-        /// </summary>
-        /// <param name="index">Index of the method handler</param>
-        /// <returns>Function pointer</returns>
-        public static IntPtr GetFunctionPointerFromMethodHandlerIndex(int index)
-        {
-            return ILHelpersExtensions.GetHandleFromIndex(index).GetFunctionPointer();
-        }
     }
 }


### PR DESCRIPTION
This PR includes a couple of fixes when proxying `out` and `ref` methods parameters. 

Also adds a couple of changes to reduce the chances of the random crash in CI, like: 
- Locking the ModuleBuilder when creating a new type. 
- Storing the DynamicMethod handler where we extract the function pointer in order to avoid GC collection.
- Change the owner of DynamicMethods to the ModuleBuilder.
- Forcing the Token generation of each MethodBuilder after finishing emitting IL.

@DataDog/apm-dotnet