### PR TITLE
Skip publishing the standalone CLI if the build is running inside VS

### DIFF
--- a/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Standalone.csproj
+++ b/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Standalone.csproj
@@ -13,10 +13,13 @@
     <OutputPath>bin\$(Configuration)\Console\build</OutputPath>
     <PublishDir>bin\$(Configuration)\Console\publish\$(RuntimeIdentifier)</PublishDir>
     <PublishTrimmed>true</PublishTrimmed>
-    <PublishSingleFile>true</PublishSingleFile>
     <AssemblyName>dd-trace</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == ''">
+    <PublishSingleFile>true</PublishSingleFile>
+  </PropertyGroup>
+  
   <ItemGroup>
     <None Include="..\..\build\docker\linux-build.dockerfile" Link="linux-build.dockerfile" />
     <None Include="Datadog.Trace.Tools.Runner.proj" />


### PR DESCRIPTION
This `PR` changes the Standalone CLI publishing if the build is running inside VS


@DataDog/apm-dotnet