### PR TITLE
improvements to rules-based sampler tests, redux

### DIFF
--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace.Sampling
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.For<DefaultSamplingRule>();
 
-        private static Dictionary<SampleRateKey, float> _sampleRates = new Dictionary<SampleRateKey, float>();
+        private Dictionary<SampleRateKey, float> _sampleRates = new Dictionary<SampleRateKey, float>();
 
         public string RuleName => "default-rule";
 

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace
         internal SpanContext(ISpanContext parent, ITraceContext traceContext, string serviceName)
             : this(parent?.TraceId, serviceName)
         {
-            SpanId = SpanIdGenerator.CreateNew();
+            SpanId = SpanIdGenerator.ThreadInstance.CreateNew();
             Parent = parent;
             TraceContext = traceContext;
             if (parent is SpanContext spanContext)
@@ -68,7 +68,7 @@ namespace Datadog.Trace
         {
             TraceId = traceId > 0
                           ? traceId.Value
-                          : SpanIdGenerator.CreateNew();
+                          : SpanIdGenerator.ThreadInstance.CreateNew();
 
             ServiceName = serviceName;
         }

--- a/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -2,57 +2,70 @@ using System;
 
 namespace Datadog.Trace.Util
 {
-    internal static class SpanIdGenerator
+    internal class SpanIdGenerator
     {
 #if NETFRAMEWORK
         private static readonly Random GlobalSeedGenerator = new Random();
 #endif
 
         [ThreadStatic]
-        private static Random _threadRandom;
+        private static SpanIdGenerator _threadInstance;
 
-        public static ulong CreateNew()
+        private readonly Random _random;
+
+        public SpanIdGenerator()
         {
-            Random random = GetRandom();
+            _random = new Random();
+        }
 
-            long high = random.Next(int.MinValue, int.MaxValue);
-            long low = random.Next(int.MinValue, int.MaxValue);
+        public SpanIdGenerator(int seed)
+        {
+            _random = new Random(seed);
+        }
+
+        public static SpanIdGenerator ThreadInstance
+        {
+            get
+            {
+                SpanIdGenerator generator = _threadInstance;
+
+                if (_threadInstance == null)
+                {
+#if NETFRAMEWORK
+                    // On .NET Framework, the clock is used to seed the new random instances.
+                    // Resolution is too low, so if many threads are created at the same time,
+                    // some could end up using the same seed.
+                    // Instead, use a shared random instance to generate the seed.
+                    // The same approach was used for System.Random on .NET Core:
+                    // https://docs.microsoft.com/en-us/dotnet/api/system.random.-ctor?view=netcore-3.1
+                    int seed;
+
+                    lock (GlobalSeedGenerator)
+                    {
+                        seed = GlobalSeedGenerator.Next();
+                    }
+
+                    generator = new SpanIdGenerator(seed);
+#else
+                    generator = new SpanIdGenerator();
+#endif
+
+                    _threadInstance = generator;
+                }
+
+                return generator;
+            }
+        }
+
+        public ulong CreateNew()
+        {
+            long high = _random.Next(int.MinValue, int.MaxValue);
+            long low = _random.Next(int.MinValue, int.MaxValue);
 
             // Concatenate both values, and truncate the 32 top bits from low
             var value = high << 32 | (low & 0xFFFFFFFF);
 
             return (ulong)value & 0x7FFFFFFFFFFFFFFF;
-        }
-
-        private static Random GetRandom()
-        {
-            Random random = _threadRandom;
-
-            if (random == null)
-            {
-#if !NETFRAMEWORK
-                random = new Random();
-#else
-                // On .NET Framework, the clock is used to seed the new random instances.
-                // Resolution is too low, so if many threads are created at the same time,
-                // some could end up using the same seed.
-                // Instead, use a shared random instance to generate the seed.
-                // The same approach was used for System.Random on .NET Core:
-                // https://docs.microsoft.com/en-us/dotnet/api/system.random.-ctor?view=netcore-3.1
-                int seed;
-
-                lock (GlobalSeedGenerator)
-                {
-                    seed = GlobalSeedGenerator.Next();
-                }
-
-                random = new Random(seed);
-#endif
-
-                _threadRandom = random;
-            }
-
-            return random;
         }
     }
 }

--- a/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Util
             {
                 SpanIdGenerator idGenerator = _threadInstance;
 
-                if (_threadInstance == null)
+                if (idGenerator == null)
                 {
 #if NETFRAMEWORK
                     // On .NET Framework, the clock is used to seed the new random instances.

--- a/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Util
         {
             get
             {
-                SpanIdGenerator generator = _threadInstance;
+                SpanIdGenerator idGenerator = _threadInstance;
 
                 if (_threadInstance == null)
                 {
@@ -45,15 +45,15 @@ namespace Datadog.Trace.Util
                         seed = GlobalSeedGenerator.Next();
                     }
 
-                    generator = new SpanIdGenerator(seed);
+                    idGenerator = new SpanIdGenerator(seed);
 #else
-                    generator = new SpanIdGenerator();
+                    idGenerator = new SpanIdGenerator();
 #endif
 
-                    _threadInstance = generator;
+                    _threadInstance = idGenerator;
                 }
 
-                return generator;
+                return idGenerator;
             }
         }
 

--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static Span GetMyServiceSpan()
         {
-            var traceId = SpanIdGenerator.CreateNew();
+            var traceId = SpanIdGenerator.ThreadInstance.CreateNew();
             var span = new Span(new SpanContext(traceId, spanId: 1, null, serviceName: ServiceName), DateTimeOffset.Now) { OperationName = OperationName };
             span.SetTag(Tags.Env, Env);
             return span;

--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -9,10 +9,11 @@ namespace Datadog.Trace.Tests.Sampling
     [Collection(nameof(Datadog.Trace.Tests.Sampling))]
     public class RuleBasedSamplerTests
     {
-        private static readonly float FallbackRate = 0.25f;
-        private static readonly string ServiceName = "my-service-name";
-        private static readonly string Env = "my-test-env";
-        private static readonly string OperationName = "test";
+        private const float FallbackRate = 0.25f;
+        private const string ServiceName = "my-service-name";
+        private const string Env = "my-test-env";
+        private const string OperationName = "test";
+
         private static readonly IEnumerable<KeyValuePair<string, float>> MockAgentRates = new List<KeyValuePair<string, float>>() { new KeyValuePair<string, float>($"service:{ServiceName},env:{Env}", FallbackRate) };
 
         [Fact]


### PR DESCRIPTION
Follow-up of #1042

- field `DefaultSamplingRule._sampleRates` should not be `static`
- refactor `SpanIdGenerator`
  - not a static anymore (note that it was effectively static even before #1042)
  - allow seeding with a specified value
  - provide a thread static instance via `SpanIdGenerator.ThreadInstance` (used by the tracer)
- change sampler test to use it's own `SpanIdGenerator` instance and to report seed on failure to help troubleshooting