### PR TITLE
Ducktyping: DynamicMethod call through delegates.

### DIFF
--- a/Datadog.Trace.Minimal.sln
+++ b/Datadog.Trace.Minimal.sln
@@ -64,6 +64,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks.Trace", "test\be
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{64FBB8EE-5430-4BD8-95B3-DC69AD2E3D9D}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.DuckTyping.Tests", "test\Datadog.Trace.DuckTyping.Tests\Datadog.Trace.DuckTyping.Tests.csproj", "{6E635156-2BF9-471B-94A3-3BFE3D40169F}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -280,6 +282,18 @@ Global
 		{C68D858A-BAE7-4365-8A0B-CBFDDE3257E7}.Release|x64.Build.0 = Release|Any CPU
 		{C68D858A-BAE7-4365-8A0B-CBFDDE3257E7}.Release|x86.ActiveCfg = Release|Any CPU
 		{C68D858A-BAE7-4365-8A0B-CBFDDE3257E7}.Release|x86.Build.0 = Release|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Debug|x64.Build.0 = Debug|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Release|x64.ActiveCfg = Release|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Release|x64.Build.0 = Release|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -304,6 +318,7 @@ Global
 		{09BB1816-84AA-410F-AF85-8082379D3C57} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{C68D858A-BAE7-4365-8A0B-CBFDDE3257E7} = {64FBB8EE-5430-4BD8-95B3-DC69AD2E3D9D}
 		{64FBB8EE-5430-4BD8-95B3-DC69AD2E3D9D} = {8CEC2042-F11C-49F5-A674-2355793B600A}
+		{6E635156-2BF9-471B-94A3-3BFE3D40169F} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.DuckTyping
         public static class DelegateCache<TProxyDelegate>
             where TProxyDelegate : Delegate
         {
-            private static TProxyDelegate @delegate;
+            private static TProxyDelegate _delegate;
 
             /// <summary>
             /// Get cached delegate from the DynamicMethod
@@ -52,7 +52,7 @@ namespace Datadog.Trace.DuckTyping
             /// <returns>TProxyDelegate instance</returns>
             public static TProxyDelegate GetDelegate()
             {
-                return @delegate;
+                return _delegate;
             }
 
             /// <summary>
@@ -61,7 +61,7 @@ namespace Datadog.Trace.DuckTyping
             /// <param name="index">Dynamic method index</param>
             internal static void FillDelegate(int index)
             {
-                @delegate = (TProxyDelegate)ILHelpersExtensions.GetDynamicMethodForIndex(index)
+                _delegate = (TProxyDelegate)ILHelpersExtensions.GetDynamicMethodForIndex(index)
                     .CreateDelegate(typeof(TProxyDelegate));
             }
         }

--- a/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.DuckTyping
         private static AssemblyBuilder _assemblyBuilder = null;
 
         /// <summary>
-        /// Delegate caches
+        /// DynamicMethods delegates cache
         /// </summary>
         /// <typeparam name="TProxyDelegate">Proxy delegate type</typeparam>
         public static class DelegateCache<TProxyDelegate>
@@ -47,21 +47,22 @@ namespace Datadog.Trace.DuckTyping
             private static TProxyDelegate @delegate;
 
             /// <summary>
-            /// Get delegate from a DynamicMethod index
+            /// Get cached delegate from the DynamicMethod
+            /// </summary>
+            /// <returns>TProxyDelegate instance</returns>
+            public static TProxyDelegate GetDelegate()
+            {
+                return @delegate;
+            }
+
+            /// <summary>
+            /// Create delegate from a DynamicMethod index
             /// </summary>
             /// <param name="index">Dynamic method index</param>
-            /// <returns>TProxyDelegate instance</returns>
-            public static TProxyDelegate GetDelegate(int index)
+            internal static void FillDelegate(int index)
             {
-                TProxyDelegate cachedDelegate = @delegate;
-                if (cachedDelegate is null)
-                {
-                    cachedDelegate = (TProxyDelegate)ILHelpersExtensions.GetDynamicMethodForIndex(index)
-                        .CreateDelegate(typeof(TProxyDelegate));
-                    @delegate = cachedDelegate;
-                }
-
-                return cachedDelegate;
+                @delegate = (TProxyDelegate)ILHelpersExtensions.GetDynamicMethodForIndex(index)
+                    .CreateDelegate(typeof(TProxyDelegate));
             }
         }
     }

--- a/src/Datadog.Trace.DuckTyping/ILHelpersExtensions.cs
+++ b/src/Datadog.Trace.DuckTyping/ILHelpersExtensions.cs
@@ -11,23 +11,52 @@ namespace Datadog.Trace.DuckTyping
     /// </summary>
     internal static class ILHelpersExtensions
     {
-        private static Func<DynamicMethod, RuntimeMethodHandle> _dynamicGetMethodDescriptor;
-        private static List<RuntimeMethodHandle> _handles = new List<RuntimeMethodHandle>();
+        private static List<DynamicMethod> _dynamicMethods = new List<DynamicMethod>();
 
-        static ILHelpersExtensions()
+        internal static DynamicMethod GetDynamicMethodForIndex(int index)
         {
-            _dynamicGetMethodDescriptor = (Func<DynamicMethod, RuntimeMethodHandle>)typeof(DynamicMethod)
-                .GetMethod("GetMethodDescriptor", BindingFlags.NonPublic | BindingFlags.Instance)
-                .CreateDelegate(typeof(Func<DynamicMethod, RuntimeMethodHandle>));
+            lock (_dynamicMethods)
+            {
+                return _dynamicMethods[index];
+            }
+        }
+
+        internal static void CreateDelegateTypeFor(TypeBuilder proxyType, DynamicMethod dynamicMethod, out Type delType, out MethodInfo invokeMethod)
+        {
+            ModuleBuilder modBuilder = (ModuleBuilder)proxyType.Module;
+            TypeBuilder delegateType = modBuilder.DefineType($"{dynamicMethod.Name}Delegate_" + Guid.NewGuid().ToString("N"), TypeAttributes.Class | TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.AnsiClass | TypeAttributes.AutoClass, typeof(MulticastDelegate));
+
+            // Delegate .ctor
+            ConstructorBuilder constructorBuilder = delegateType.DefineConstructor(MethodAttributes.RTSpecialName | MethodAttributes.HideBySig | MethodAttributes.Public, CallingConventions.Standard, new Type[] { typeof(object), typeof(IntPtr) });
+            constructorBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+
+            // Define the Invoke method for the delegate
+            ParameterInfo[] parameters = dynamicMethod.GetParameters();
+            Type[] paramTypes = new Type[parameters.Length];
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                paramTypes[i] = parameters[i].ParameterType;
+            }
+
+            MethodBuilder methodBuilder = delegateType.DefineMethod("Invoke", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual, dynamicMethod.ReturnType, paramTypes);
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                methodBuilder.DefineParameter(i + 1, parameters[i].Attributes, parameters[i].Name);
+            }
+
+            methodBuilder.SetImplementationFlags(MethodImplAttributes.Runtime | MethodImplAttributes.Managed);
+
+            delType = delegateType.CreateTypeInfo().AsType();
+            invokeMethod = delType.GetMethod("Invoke");
         }
 
         /// <summary>
         /// Load instance argument
         /// </summary>
-        /// <param name="il">ILGenerator</param>
+        /// <param name="il">LazyILGenerator instance</param>
         /// <param name="actualType">Actual type</param>
         /// <param name="expectedType">Expected type</param>
-        internal static void LoadInstanceArgument(this ILGenerator il, Type actualType, Type expectedType)
+        internal static void LoadInstanceArgument(this LazyILGenerator il, Type actualType, Type expectedType)
         {
             il.Emit(OpCodes.Ldarg_0);
             if (actualType == expectedType)
@@ -51,10 +80,10 @@ namespace Datadog.Trace.DuckTyping
         /// <summary>
         /// Write load arguments
         /// </summary>
-        /// <param name="il">IlGenerator</param>
+        /// <param name="il">LazyILGenerator instance</param>
         /// <param name="index">Argument index</param>
         /// <param name="isStatic">Define if we need to take into account the instance argument</param>
-        internal static void WriteLoadArgument(this ILGenerator il, int index, bool isStatic)
+        internal static void WriteLoadArgument(this LazyILGenerator il, int index, bool isStatic)
         {
             if (!isStatic)
             {
@@ -84,7 +113,34 @@ namespace Datadog.Trace.DuckTyping
         /// <summary>
         /// Write load local
         /// </summary>
-        /// <param name="il">IlGenerator</param>
+        /// <param name="il">LazyILGenerator instance</param>
+        /// <param name="index">Local index</param>
+        internal static void WriteLoadLocal(this LazyILGenerator il, int index)
+        {
+            switch (index)
+            {
+                case 0:
+                    il.Emit(OpCodes.Ldloc_0);
+                    break;
+                case 1:
+                    il.Emit(OpCodes.Ldloc_1);
+                    break;
+                case 2:
+                    il.Emit(OpCodes.Ldloc_2);
+                    break;
+                case 3:
+                    il.Emit(OpCodes.Ldloc_3);
+                    break;
+                default:
+                    il.Emit(OpCodes.Ldloc_S, index);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Write load local
+        /// </summary>
+        /// <param name="il">ILGenerator instance</param>
         /// <param name="index">Local index</param>
         internal static void WriteLoadLocal(this ILGenerator il, int index)
         {
@@ -111,9 +167,9 @@ namespace Datadog.Trace.DuckTyping
         /// <summary>
         /// Write store local
         /// </summary>
-        /// <param name="il">IlGenerator</param>
+        /// <param name="il">LazyILGenerator instance</param>
         /// <param name="index">Local index</param>
-        internal static void WriteStoreLocal(this ILGenerator il, int index)
+        internal static void WriteStoreLocal(this LazyILGenerator il, int index)
         {
             switch (index)
             {
@@ -136,12 +192,65 @@ namespace Datadog.Trace.DuckTyping
         }
 
         /// <summary>
+        /// Write constant int value
+        /// </summary>
+        /// <param name="il">LazyILGenerator instance</param>
+        /// <param name="value">int value</param>
+        internal static void WriteInt(this LazyILGenerator il, int value)
+        {
+            if (value >= -1 && value <= 8)
+            {
+                switch (value)
+                {
+                    case -1:
+                        il.Emit(OpCodes.Ldc_I4_M1);
+                        break;
+                    case 0:
+                        il.Emit(OpCodes.Ldc_I4_0);
+                        break;
+                    case 1:
+                        il.Emit(OpCodes.Ldc_I4_1);
+                        break;
+                    case 2:
+                        il.Emit(OpCodes.Ldc_I4_2);
+                        break;
+                    case 3:
+                        il.Emit(OpCodes.Ldc_I4_3);
+                        break;
+                    case 4:
+                        il.Emit(OpCodes.Ldc_I4_4);
+                        break;
+                    case 5:
+                        il.Emit(OpCodes.Ldc_I4_5);
+                        break;
+                    case 6:
+                        il.Emit(OpCodes.Ldc_I4_6);
+                        break;
+                    case 7:
+                        il.Emit(OpCodes.Ldc_I4_7);
+                        break;
+                    default:
+                        il.Emit(OpCodes.Ldc_I4_8);
+                        break;
+                }
+            }
+            else if (value >= -128 && value <= 127)
+            {
+                il.Emit(OpCodes.Ldc_I4_S, value);
+            }
+            else
+            {
+                il.Emit(OpCodes.Ldc_I4, value);
+            }
+        }
+
+        /// <summary>
         /// Convert a current type to an expected type
         /// </summary>
-        /// <param name="il">ILGenerator</param>
+        /// <param name="il">LazyILGenerator instance</param>
         /// <param name="actualType">Actual type</param>
         /// <param name="expectedType">Expected type</param>
-        internal static void WriteTypeConversion(this ILGenerator il, Type actualType, Type expectedType)
+        internal static void WriteTypeConversion(this LazyILGenerator il, Type actualType, Type expectedType)
         {
             var actualUnderlyingType = actualType.IsEnum ? Enum.GetUnderlyingType(actualType) : actualType;
             var expectedUnderlyingType = expectedType.IsEnum ? Enum.GetUnderlyingType(expectedType) : expectedType;
@@ -228,36 +337,44 @@ namespace Datadog.Trace.DuckTyping
         /// <summary>
         /// Write a Call to a method using Calli
         /// </summary>
-        /// <param name="il">ILGenerator</param>
+        /// <param name="il">LazyILGenerator instance</param>
         /// <param name="method">Method to get called</param>
-        /// <param name="methodParameters">Method parameters (to avoid the allocations of calculating it)</param>
-        internal static void WriteMethodCalli(this ILGenerator il, MethodInfo method, Type[] methodParameters = null)
+        internal static void WriteMethodCalli(this LazyILGenerator il, MethodInfo method)
         {
-            RuntimeMethodHandle handle;
-
-            if (method is DynamicMethod dynMethod)
-            {
-                // Dynamic methods doesn't expose the internal function pointer
-                // so we have to get it using a delegate from reflection.
-                handle = _dynamicGetMethodDescriptor(dynMethod);
-                lock (_handles)
-                {
-                    _handles.Add(handle);
-                }
-            }
-            else
-            {
-                handle = method.MethodHandle;
-            }
-
-            il.Emit(OpCodes.Ldc_I8, (long)handle.GetFunctionPointer());
+            il.Emit(OpCodes.Ldc_I8, (long)method.MethodHandle.GetFunctionPointer());
             il.Emit(OpCodes.Conv_I);
             il.EmitCalli(
                 OpCodes.Calli,
                 method.CallingConvention,
                 method.ReturnType,
-                methodParameters ?? method.GetParameters().Select(p => p.ParameterType).ToArray(),
+                method.GetParameters().Select(p => p.ParameterType).ToArray(),
                 null);
+        }
+
+        /// <summary>
+        /// Write a DynamicMethod call by creating and injecting a custom delegate in the proxyType
+        /// </summary>
+        /// <param name="il">LazyILGenerator instance</param>
+        /// <param name="dynamicMethod">Dynamic method to get called</param>
+        /// <param name="proxyType">ProxyType builder</param>
+        internal static void WriteDynamicMethodCall(this LazyILGenerator il, DynamicMethod dynamicMethod, TypeBuilder proxyType)
+        {
+            CreateDelegateTypeFor(proxyType, dynamicMethod, out Type delegateType, out MethodInfo invokeMethod);
+            int index;
+            lock (_dynamicMethods)
+            {
+                _dynamicMethods.Add(dynamicMethod);
+                index = _dynamicMethods.Count - 1;
+            }
+
+            il.SetOffset(0);
+            il.WriteInt(index);
+            MethodInfo getDelegateMethodInfo = typeof(DuckType.DelegateCache<>).MakeGenericType(delegateType).GetMethod("GetDelegate");
+            getDelegateMethodInfo.Invoke(null, new object[] { index });
+            il.EmitCall(OpCodes.Call, getDelegateMethodInfo, null);
+            il.ResetOffset();
+
+            il.EmitCall(OpCodes.Callvirt, invokeMethod, null);
         }
     }
 }

--- a/src/Datadog.Trace.DuckTyping/LazyILGenerator.cs
+++ b/src/Datadog.Trace.DuckTyping/LazyILGenerator.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Datadog.Trace.DuckTyping
+{
+    internal class LazyILGenerator
+    {
+        private ILGenerator _generator;
+        private List<Action<ILGenerator>> _instructions;
+        private int _offset;
+
+        public LazyILGenerator(ILGenerator generator)
+        {
+            _generator = generator;
+            _instructions = new List<Action<ILGenerator>>(16);
+        }
+
+        public int Offset => _offset;
+
+        public int Count => _instructions.Count;
+
+        public void SetOffset(int value)
+        {
+            if (value > _instructions.Count)
+            {
+                _offset = _instructions.Count;
+            }
+            else
+            {
+                _offset = value;
+            }
+        }
+
+        public void ResetOffset()
+        {
+            _offset = _instructions.Count;
+        }
+
+        public void BeginScope()
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.BeginScope());
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.BeginScope());
+            }
+
+            _offset++;
+        }
+
+        public LocalBuilder DeclareLocal(Type localType, bool pinned)
+        {
+            return _generator.DeclareLocal(localType, pinned);
+        }
+
+        public LocalBuilder DeclareLocal(Type localType)
+        {
+            return _generator.DeclareLocal(localType);
+        }
+
+        public Label DefineLabel()
+        {
+            return _generator.DefineLabel();
+        }
+
+        public void Emit(OpCode opcode, string str)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, str));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, str));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, FieldInfo field)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, field));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, field));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, Label[] labels)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, labels));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, labels));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, Label label)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, label));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, label));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, LocalBuilder local)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, local));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, local));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, float arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, byte arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, sbyte arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, short arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, double arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, MethodInfo meth)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, meth));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, meth));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, int arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, long arg)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, arg));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, arg));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, Type cls)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, cls));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, cls));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, SignatureHelper signature)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, signature));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, signature));
+            }
+
+            _offset++;
+        }
+
+        public void Emit(OpCode opcode, ConstructorInfo con)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.Emit(opcode, con));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.Emit(opcode, con));
+            }
+
+            _offset++;
+        }
+
+        public void EmitCall(OpCode opcode, MethodInfo methodInfo, Type[] optionalParameterTypes)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.EmitCall(opcode, methodInfo, optionalParameterTypes));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.EmitCall(opcode, methodInfo, optionalParameterTypes));
+            }
+
+            _offset++;
+        }
+
+        public void EmitCalli(OpCode opcode, CallingConventions callingConvention, Type returnType, Type[] parameterTypes, Type[] optionalParameterTypes)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.EmitCalli(opcode, callingConvention, returnType, parameterTypes, optionalParameterTypes));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.EmitCalli(opcode, callingConvention, returnType, parameterTypes, optionalParameterTypes));
+            }
+
+            _offset++;
+        }
+
+        public void EmitWriteLine(string value)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.EmitWriteLine(value));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.EmitWriteLine(value));
+            }
+
+            _offset++;
+        }
+
+        public void EmitWriteLine(FieldInfo fld)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.EmitWriteLine(fld));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.EmitWriteLine(fld));
+            }
+
+            _offset++;
+        }
+
+        public void EmitWriteLine(LocalBuilder localBuilder)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.EmitWriteLine(localBuilder));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.EmitWriteLine(localBuilder));
+            }
+
+            _offset++;
+        }
+
+        public void EndScope()
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.EndScope());
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.EndScope());
+            }
+
+            _offset++;
+        }
+
+        public void MarkLabel(Label loc)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.MarkLabel(loc));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.MarkLabel(loc));
+            }
+
+            _offset++;
+        }
+
+        public void ThrowException(Type excType)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.ThrowException(excType));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.ThrowException(excType));
+            }
+
+            _offset++;
+        }
+
+        public void UsingNamespace(string usingNamespace)
+        {
+            if (_offset == _instructions.Count)
+            {
+                _instructions.Add(il => il.UsingNamespace(usingNamespace));
+            }
+            else
+            {
+                _instructions.Insert(_offset, il => il.UsingNamespace(usingNamespace));
+            }
+
+            _offset++;
+        }
+
+        public void Flush()
+        {
+            foreach (Action<ILGenerator> instr in _instructions)
+            {
+                instr(_generator);
+            }
+
+            _instructions.Clear();
+            _offset = 0;
+        }
+    }
+}

--- a/src/Datadog.Trace.DuckTyping/README.md
+++ b/src/Datadog.Trace.DuckTyping/README.md
@@ -221,12 +221,12 @@ In order to support all accessor modifiers for: instance types, parameters and r
 | Public                       | Property           | Private, Protected, Internal | Direct using function pointers (Calli opcode) |
 | Public                       | Method             | Public                       | Direct                                        |
 | Public                       | Method             | Private, Protected, Internal | Direct using function pointers (Calli opcode) |
-| Private, Protected, Internal | Field              | Public                       | through DynamicMethod                         |
-| Private, Protected, Internal | Field              | Private, Protected, Internal | through DynamicMethod                         |
-| Private, Protected, Internal | Property           | Public                       | through DynamicMethod                         |
-| Private, Protected, Internal | Property           | Private, Protected, Internal | through DynamicMethod                         |
-| Private, Protected, Internal | Method             | Public                       | through DynamicMethod                         |
-| Private, Protected, Internal | Method             | Private, Protected, Internal | through DynamicMethod                         |
+| Private, Protected, Internal | Field              | Public                       | through DynamicMethod delegate                |
+| Private, Protected, Internal | Field              | Private, Protected, Internal | through DynamicMethod delegate                |
+| Private, Protected, Internal | Property           | Public                       | through DynamicMethod delegate                |
+| Private, Protected, Internal | Property           | Private, Protected, Internal | through DynamicMethod delegate                |
+| Private, Protected, Internal | Method             | Public                       | through DynamicMethod delegate                |
+| Private, Protected, Internal | Method             | Private, Protected, Internal | through DynamicMethod delegate                |
 
 ## Generics methods
 


### PR DESCRIPTION
This `PR` changes the implementation of DynamicMethod calls in the DuckTyping library. 

The motivation to this change is because by stressing the current implementation running the ducktyping tests several times we can hit a `BadImageException` with a signature problem happening randomly. With this changes and running the same tests we are not seeing this exception anymore.

Before this change the calls were made using the `calli` instruction by getting the inner function pointer of the DynamicMethod, the DynamicMethod doesn't exposes function pointers so we have to get it through reflection.

After this change we avoid this unsafe scenario by creating a custom delegate inside the ModuleBuilder when DynamicMethod call is needed, then the call is made using that delegate.

### Testing

This can't be tested using unit-tests because it's has a flaky / random behavior.

For this PR I ran test in a Desktop PC running the same unit tests more than 4500 times. I was able to reproduce the crash in the master branch as a baseline (with less than 2000 times), and with this PR I was unable to crash the test suite after all runs were executed.

@DataDog/apm-dotnet