### PR TITLE
Ensures the managed loader is loaded only once.

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -387,6 +387,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Microsoft.Data.SqlC
 		{85F35AAF-D102-4960-8B41-3BD9CBD0E77F} = {85F35AAF-D102-4960-8B41-3BD9CBD0E77F}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.NoMultiLoader", "test\test-applications\integrations\Samples.NoMultiLoader\Samples.NoMultiLoader.csproj", "{472B69A0-956F-42C0-9CB8-30107821C43B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.NoMultiLoader.Deps", "test\test-applications\integrations\dependency-libs\Samples.NoMultiLoader.Deps\Samples.NoMultiLoader.Deps.csproj", "{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1407,6 +1411,28 @@ Global
 		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Release|x64.Build.0 = Release|x64
 		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Release|x86.ActiveCfg = Release|x86
 		{AA88952E-9393-4A4B-85B5-CC7F03629CE1}.Release|x86.Build.0 = Release|x86
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|x64.ActiveCfg = Debug|x64
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|x64.Build.0 = Debug|x64
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|x86.ActiveCfg = Debug|x86
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Debug|x86.Build.0 = Debug|x86
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|Any CPU.ActiveCfg = Release|x86
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|x64.ActiveCfg = Release|x64
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|x64.Build.0 = Release|x64
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|x86.ActiveCfg = Release|x86
+		{472B69A0-956F-42C0-9CB8-30107821C43B}.Release|x86.Build.0 = Release|x86
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|x64.Build.0 = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1516,6 +1542,8 @@ Global
 		{8276E670-FC3F-4EDE-9D51-6DAD90336C32} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{EC3C54CE-A3CD-434A-9E3C-DB6C5F5248EA} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 		{AA88952E-9393-4A4B-85B5-CC7F03629CE1} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{472B69A0-956F-42C0-9CB8-30107821C43B} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{2A161C2D-DAA5-4F97-BA2B-783CF363C05B} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -37,7 +37,7 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1566,7 +1566,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   pALNewInstr->m_opcode = CEE_LDC_I4_0;
   rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
 
-  // call System.AppDomain System.AppDomain.CurrentDomain property
+  // call int Interlocked.CompareExchange(ref int, int, int) method
   pALNewInstr = rewriter_already_loaded.NewILInstr();
   pALNewInstr->m_opcode = CEE_CALL;
   pALNewInstr->m_Arg32 = interlocked_compare_member_ref;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1467,6 +1467,135 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
     return hr;
   }
 
+  /////////////////////////////////////////////
+  // Define a new static field _isAssemblyLoaded on the new type type that has a int value.
+  BYTE field_signature[] = {
+      IMAGE_CEE_CS_CALLCONV_FIELD,
+      ELEMENT_TYPE_I4
+  };
+  mdFieldDef isAssemblyLoadedFieldToken;
+  hr = metadata_emit->DefineField(new_type_def, 
+                          "_isAssemblyLoaded"_W.c_str(),
+                          fdStatic | fdPrivate, 
+                          field_signature, 
+                          sizeof(field_signature),
+                          0,
+                          nullptr,
+                          0,
+                          &isAssemblyLoadedFieldToken);
+  if (FAILED(hr)) {
+    Warn("GenerateVoidILStartupMethod: DefineField _isAssemblyLoaded failed");
+    return hr;
+  }
+
+  // Define a new static method IsAlreadyLoaded on the new type that has a bool return type and takes no arguments;
+  BYTE already_loaded_signature[] = {
+      IMAGE_CEE_CS_CALLCONV_DEFAULT,
+      0,
+      ELEMENT_TYPE_BOOLEAN,
+      ELEMENT_TYPE_OBJECT
+  };
+  mdMethodDef alreadyLoadedMethodToken;
+  hr = metadata_emit->DefineMethod(
+      new_type_def, "IsAlreadyLoaded"_W.c_str(), mdStatic | mdPrivate,
+      already_loaded_signature, sizeof(already_loaded_signature), 0, 0,
+      &alreadyLoadedMethodToken);
+  if (FAILED(hr)) {
+    Warn("GenerateVoidILStartupMethod: DefineMethod IsAlreadyLoaded failed");
+    return hr;
+  }
+
+  // Get a TypeRef for System.Threading.Interlocked
+  mdTypeRef interlocked_type_ref;
+  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, "System.Threading.Interlocked"_W.c_str(), &interlocked_type_ref);
+  if (FAILED(hr)) {
+    Warn("GenerateVoidILStartupMethod: DefineTypeRefByName interlocked_type_ref failed");
+    return hr;
+  }
+
+  // Create method signature for System.Threading.Interlocked::CompareExchange(int32&, int32, int32)
+  COR_SIGNATURE interlocked_compare_exchange_signature[] = {
+      IMAGE_CEE_CS_CALLCONV_DEFAULT,
+      3,
+      ELEMENT_TYPE_I4,
+      ELEMENT_TYPE_BYREF,
+      ELEMENT_TYPE_I4,
+      ELEMENT_TYPE_I4,
+      ELEMENT_TYPE_I4
+  };
+
+  mdMemberRef interlocked_compare_member_ref;
+  hr = metadata_emit->DefineMemberRef(
+      interlocked_type_ref, "CompareExchange"_W.c_str(),
+      interlocked_compare_exchange_signature,
+      sizeof(interlocked_compare_exchange_signature),
+      &interlocked_compare_member_ref);
+  if (FAILED(hr)) {
+    Warn("GenerateVoidILStartupMethod: DefineMemberRef CompareExchange failed");
+    return hr;
+  }
+
+  /////////////////////////////////////////////
+  // Add IL instructions into the IsAlreadyLoaded method
+  //
+  //  static int _isAssemblyLoaded = 0;
+  //  
+  //  public static bool IsAlreadyLoaded() {
+  //      return Interlocked.CompareExchange(ref _isAssemblyLoaded, 1, 0) == 1;
+  //  }
+  //
+  ILRewriter rewriter_already_loaded(this->info_, nullptr, module_id, alreadyLoadedMethodToken);
+  rewriter_already_loaded.InitializeTiny();
+
+  ILInstr* pALFirstInstr = rewriter_already_loaded.GetILList()->m_pNext;
+  ILInstr* pALNewInstr = NULL;
+
+  // ldsflda _isAssemblyLoaded : Load the address of the "_isAssemblyLoaded" static var
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_LDSFLDA;
+  pALNewInstr->m_Arg32 = isAssemblyLoadedFieldToken;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+  
+  // ldc.i4.1 : Load the constant 1 (int) to the stack
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_LDC_I4_1;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+
+  // ldc.i4.0 : Load the constant 0 (int) to the stack
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_LDC_I4_0;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+
+  // call System.AppDomain System.AppDomain.CurrentDomain property
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_CALL;
+  pALNewInstr->m_Arg32 = interlocked_compare_member_ref;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+
+  // ldc.i4.1 : Load the constant 1 (int) to the stack
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_LDC_I4_1;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+
+  // ceq : Compare equality from two values from the stack
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_CEQ;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+
+  // ret : Return the value of the comparison
+  pALNewInstr = rewriter_already_loaded.NewILInstr();
+  pALNewInstr->m_opcode = CEE_RET;
+  rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
+  
+  hr = rewriter_already_loaded.Export();
+  if (FAILED(hr)) {
+    Warn(
+        "GenerateVoidILStartupMethod: Call to ILRewriter.Export() failed for "
+        "ModuleID=",
+        module_id);
+    return hr;
+  }
+
   // Define a method on the managed side that will PInvoke into the profiler method:
   // C++: void GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assemblySize, BYTE** pSymbolsArray, int* symbolsSize)
   // C#: static extern void GetAssemblyAndSymbolsBytes(out IntPtr assemblyPtr, out int assemblySize, out IntPtr symbolsPtr, out int symbolsSize)
@@ -1776,8 +1905,28 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   ILRewriter rewriter_void(this->info_, nullptr, module_id, *ret_method_token);
   rewriter_void.InitializeTiny();
   rewriter_void.SetTkLocalVarSig(locals_signature_token);
+
   ILInstr* pFirstInstr = rewriter_void.GetILList()->m_pNext;
   ILInstr* pNewInstr = NULL;
+
+  // Step 0) Check if the assembly was already loaded
+
+  // call bool IsAlreadyLoaded()
+  pNewInstr = rewriter_void.NewILInstr();
+  pNewInstr->m_opcode = CEE_CALL;
+  pNewInstr->m_Arg32 = alreadyLoadedMethodToken;
+  rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
+
+  // check if the return of the method call is true or false
+  pNewInstr = rewriter_void.NewILInstr();
+  pNewInstr->m_opcode = CEE_BRFALSE_S;
+  rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
+  ILInstr* pBranchFalseInstr = pNewInstr;
+  
+  // return if IsAlreadyLoaded is true
+  pNewInstr = rewriter_void.NewILInstr();
+  pNewInstr->m_opcode = CEE_RET;
+  rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
 
   // Step 1) Call void GetAssemblyAndSymbolsBytes(out IntPtr assemblyPtr, out int assemblySize, out IntPtr symbolsPtr, out int symbolsSize)
 
@@ -1786,6 +1935,9 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   pNewInstr->m_opcode = CEE_LDLOCA_S;
   pNewInstr->m_Arg32 = 0;
   rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
+
+  // Set the false branch target
+  pBranchFalseInstr->m_pTarget = pNewInstr;
 
   // ldloca.s 1 : Load the address of the "assemblySize" variable (locals index 1)
   pNewInstr = rewriter_void.NewILInstr();

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1468,7 +1468,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   }
 
   /////////////////////////////////////////////
-  // Define a new static field _isAssemblyLoaded on the new type type that has a int value.
+  // Define a new static int field _isAssemblyLoaded on the new type.
   BYTE field_signature[] = {
       IMAGE_CEE_CS_CALLCONV_FIELD,
       ELEMENT_TYPE_I4

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Datadog.Core.Tools;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class NoMultiLoaderTests : TestHelper
+    {
+        public NoMultiLoaderTests(ITestOutputHelper output)
+            : base("NoMultiLoader", output)
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        public void SingleLoaderTest()
+        {
+            string tmpFile = Path.GetTempFileName();
+            SetEnvironmentVariable("DD_TRACE_LOG_PATH", tmpFile);
+            using ProcessResult processResult = RunSampleAndWaitForExit(9696);
+            string[] logFileContent = File.ReadAllLines(tmpFile);
+            int numOfLoadersLoad = logFileContent.Count(line => line.Contains("Datadog.Trace.ClrProfiler.Managed.Loader loaded"));
+            Assert.Equal(1, numOfLoadersLoad);
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.NoMultiLoader/Program.cs
+++ b/test/test-applications/integrations/Samples.NoMultiLoader/Program.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Samples.NoMultiLoader
+{
+    class Program
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Main(string[] args)
+        {
+            int count = 2000;
+            while (count-- > 0)
+            {
+                Deps.DatabaseSample.CreateSqlConnection();
+            }
+            Console.WriteLine("Done.");
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.NoMultiLoader/Samples.NoMultiLoader.csproj
+++ b/test/test-applications/integrations/Samples.NoMultiLoader/Samples.NoMultiLoader.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Required to build multiple projects with the same Configuration|Platform -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\Samples.NoMultiLoader.Deps\Samples.NoMultiLoader.Deps.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/DatabaseSample.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/DatabaseSample.cs
@@ -1,0 +1,14 @@
+using System.Data.SqlClient;
+using System.Runtime.CompilerServices;
+
+namespace Samples.NoMultiLoader.Deps
+{
+    public class DatabaseSample
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void CreateSqlConnection()
+        {
+            _ = new SqlConnection();
+        }
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/Samples.NoMultiLoader.Deps.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/Samples.NoMultiLoader.Deps.csproj
@@ -6,17 +6,12 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   
-  <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">4.7.0</ApiVersion>
-  </PropertyGroup>
-
-
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Data" />
   </ItemGroup>
 
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
-    <PackageReference Include="System.Data.SqlClient" Version="$(ApiVersion)" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
 
 </Project>

--- a/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/Samples.NoMultiLoader.Deps.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/Samples.NoMultiLoader.Deps.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">4.7.0</ApiVersion>
+  </PropertyGroup>
+
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Data" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="System.Data.SqlClient" Version="$(ApiVersion)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds an Interlocked.CompareExchange to the loader IL code to ensure the loader is loaded only once.



@DataDog/apm-dotnet