### PR TITLE
Fix AspNetCoreDiagnosticObserver bug

### DIFF
--- a/.azure-pipelines/setup_tracer.ps1
+++ b/.azure-pipelines/setup_tracer.ps1
@@ -46,6 +46,9 @@ else
     echo "Extracting linux.tar.gz"
     tar -xvzf linux.tar.gz -C ./release
     Remove-Item linux.tar.gz
+    # Ensure the profiler can write the native log profiler
+    sudo mkdir -p /var/log/datadog/dotnet
+    sudo chmod -R 777 /var/log/datadog/dotnet
     
     if ([string]::IsNullOrEmpty($dd_tracer_workingfolder)) {
         $dd_tracer_home = "$(pwd)/release"

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -81,7 +81,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
-      arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
+      #arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -40,17 +40,17 @@ jobs:
     vmImage: $(imageName)
 
   # Enable the Datadog Agent service for this job
-  services:
-    dd_agent: dd_agent
+  #services:
+  #  dd_agent: dd_agent
 
   steps:
 
   # Install the tracer latest stable release to attach the profiler to the build and test steps.
   # The script exposes the required environment variables to the following steps
-  - task: PowerShell@2
-    displayName: Install profiler latest release
-    inputs:
-      filePath: ./.azure-pipelines/setup_tracer.ps1
+  #- task: PowerShell@2
+  #  displayName: Install profiler latest release
+  #  inputs:
+  #    filePath: ./.azure-pipelines/setup_tracer.ps1
 
   - task: UseDotNet@2
     displayName: install dotnet core runtime 2.1
@@ -81,7 +81,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
-      #arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
+      arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -40,17 +40,17 @@ jobs:
     vmImage: $(imageName)
 
   # Enable the Datadog Agent service for this job
-  #services:
-  #  dd_agent: dd_agent
+  services:
+    dd_agent: dd_agent
 
   steps:
 
   # Install the tracer latest stable release to attach the profiler to the build and test steps.
   # The script exposes the required environment variables to the following steps
-  #- task: PowerShell@2
-  #  displayName: Install profiler latest release
-  #  inputs:
-  #    filePath: ./.azure-pipelines/setup_tracer.ps1
+  - task: PowerShell@2
+    displayName: Install profiler latest release
+    inputs:
+      filePath: ./.azure-pipelines/setup_tracer.ps1
 
   - task: UseDotNet@2
     displayName: install dotnet core runtime 2.1
@@ -81,7 +81,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
-      #arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
+      arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj

--- a/src/Datadog.Trace.DuckTyping/DuckAttribute.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 
 namespace Datadog.Trace.DuckTyping
 {
@@ -25,6 +26,11 @@ namespace Datadog.Trace.DuckTyping
     public class DuckAttribute : Attribute
     {
         /// <summary>
+        /// Default BindingFlags
+        /// </summary>
+        public const BindingFlags DefaultFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
+
+        /// <summary>
         /// Gets or sets the underlying type member name
         /// </summary>
         public string Name { get; set; }
@@ -33,6 +39,11 @@ namespace Datadog.Trace.DuckTyping
         /// Gets or sets duck kind
         /// </summary>
         public DuckKind Kind { get; set; } = DuckKind.Property;
+
+        /// <summary>
+        /// Gets or sets the binding flags
+        /// </summary>
+        public BindingFlags BindingFlags { get; set; } = DefaultFlags;
 
         /// <summary>
         /// Gets or sets the generic parameter type names definition for a generic method call (required when calling generic methods and instance type is non public)

--- a/src/Datadog.Trace.DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Methods.cs
@@ -453,7 +453,7 @@ namespace Datadog.Trace.DuckTyping
             if (proxyMethodDuckAttribute.ParameterTypeNames != null)
             {
                 Type[] parameterTypes = proxyMethodDuckAttribute.ParameterTypeNames.Select(pName => Type.GetType(pName, true)).ToArray();
-                targetMethod = targetType.GetMethod(proxyMethodDuckAttribute.Name, DefaultFlags, null, parameterTypes, null);
+                targetMethod = targetType.GetMethod(proxyMethodDuckAttribute.Name, proxyMethodDuckAttribute.BindingFlags, null, parameterTypes, null);
                 if (targetMethod is null)
                 {
                     DuckTypeTargetMethodNotFoundException.Throw(proxyMethod);
@@ -465,7 +465,7 @@ namespace Datadog.Trace.DuckTyping
             // If the duck attribute doesn't specify the parameters to use, we do the best effor to find a target method without any ambiguity.
 
             // First we try with the current proxy parameter types
-            targetMethod = targetType.GetMethod(proxyMethodDuckAttribute.Name, DefaultFlags, null, proxyMethodParametersTypes, null);
+            targetMethod = targetType.GetMethod(proxyMethodDuckAttribute.Name, proxyMethodDuckAttribute.BindingFlags, null, proxyMethodParametersTypes, null);
             if (targetMethod != null)
             {
                 return targetMethod;
@@ -475,7 +475,7 @@ namespace Datadog.Trace.DuckTyping
             // Also this can happen if the proxy parameters type uses a base object (ex: System.Object) instead the type.
             // In this case we try to find a method that we can match, in case of ambiguity (> 1 method found) we throw an exception.
 
-            MethodInfo[] allTargetMethods = targetType.GetMethods(DefaultFlags);
+            MethodInfo[] allTargetMethods = targetType.GetMethods(DuckAttribute.DefaultFlags);
             foreach (MethodInfo candidateMethod in allTargetMethods)
             {
                 // We omit target methods with different names.

--- a/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.Statics.cs
@@ -21,8 +21,6 @@ namespace Datadog.Trace.DuckTyping
         /// </summary>
         public static readonly MethodInfo EnumToObjectMethodInfo = typeof(Enum).GetMethod(nameof(Enum.ToObject), new[] { typeof(Type), typeof(object) });
 
-        private const BindingFlags DefaultFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy;
-
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly object _locker = new object();
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/Datadog.Trace.DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace.DuckTyping/DuckType.cs
@@ -273,7 +273,7 @@ namespace Datadog.Trace.DuckTyping
                         PropertyInfo targetProperty = null;
                         try
                         {
-                            targetProperty = targetType.GetProperty(duckAttribute.Name, DefaultFlags);
+                            targetProperty = targetType.GetProperty(duckAttribute.Name, duckAttribute.BindingFlags);
                         }
                         catch
                         {
@@ -320,7 +320,7 @@ namespace Datadog.Trace.DuckTyping
                         break;
 
                     case DuckKind.Field:
-                        FieldInfo targetField = targetType.GetField(duckAttribute.Name, DefaultFlags);
+                        FieldInfo targetField = targetType.GetField(duckAttribute.Name, duckAttribute.BindingFlags);
                         if (targetField is null)
                         {
                             break;
@@ -389,7 +389,7 @@ namespace Datadog.Trace.DuckTyping
                 switch (duckAttribute.Kind)
                 {
                     case DuckKind.Property:
-                        PropertyInfo targetProperty = targetType.GetProperty(duckAttribute.Name, DefaultFlags);
+                        PropertyInfo targetProperty = targetType.GetProperty(duckAttribute.Name, duckAttribute.BindingFlags);
                         if (targetProperty is null)
                         {
                             break;
@@ -406,7 +406,7 @@ namespace Datadog.Trace.DuckTyping
                         break;
 
                     case DuckKind.Field:
-                        FieldInfo targetField = targetType.GetField(duckAttribute.Name, DefaultFlags);
+                        FieldInfo targetField = targetType.GetField(duckAttribute.Name, duckAttribute.BindingFlags);
                         if (targetField is null)
                         {
                             break;

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -310,9 +310,15 @@ namespace Datadog.Trace.DiagnosticListeners
                 HttpRequest request = typedArg.HttpContext.Request;
 
                 string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
-                string controllerName = actionDescriptor.RouteValues["controller"];
-                string actionName = actionDescriptor.RouteValues["action"];
-                string routeTemplate = actionDescriptor.AttributeRouteInfo?.Template ?? $"{controllerName}/{actionName}";
+                string routeTemplate = actionDescriptor.AttributeRouteInfo?.Template;
+                if (routeTemplate is null)
+                {
+                    string controllerName = actionDescriptor.RouteValues["controller"];
+                    string actionName = actionDescriptor.RouteValues["action"];
+
+                    routeTemplate = $"{controllerName}/{actionName}";
+                }
+
                 string resourceName = $"{httpMethod} {routeTemplate}";
 
                 // override the parent's resource name with the MVC route template
@@ -378,8 +384,10 @@ namespace Datadog.Trace.DiagnosticListeners
         [DuckCopy]
         public struct BeforeActionStruct
         {
+            [Duck(Name = "httpContext")]
             public HttpContext HttpContext;
 
+            [Duck(Name = "actionDescriptor")]
             public ActionDescriptor ActionDescriptor;
         }
 

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
@@ -366,28 +367,31 @@ namespace Datadog.Trace.DiagnosticListeners
         [DuckCopy]
         public struct HttpRequestInStartStruct
         {
+            [Duck(BindingFlags = DuckAttribute.DefaultFlags | BindingFlags.IgnoreCase)]
             public HttpContext HttpContext;
         }
 
         [DuckCopy]
         public struct HttpRequestInStopStruct
         {
+            [Duck(BindingFlags = DuckAttribute.DefaultFlags | BindingFlags.IgnoreCase)]
             public HttpContext HttpContext;
         }
 
         [DuckCopy]
         public struct UnhandledExceptionStruct
         {
+            [Duck(BindingFlags = DuckAttribute.DefaultFlags | BindingFlags.IgnoreCase)]
             public Exception Exception;
         }
 
         [DuckCopy]
         public struct BeforeActionStruct
         {
-            [Duck(Name = "httpContext")]
+            [Duck(BindingFlags = DuckAttribute.DefaultFlags | BindingFlags.IgnoreCase)]
             public HttpContext HttpContext;
 
-            [Duck(Name = "actionDescriptor")]
+            [Duck(BindingFlags = DuckAttribute.DefaultFlags | BindingFlags.IgnoreCase)]
             public ActionDescriptor ActionDescriptor;
         }
 

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
@@ -41,6 +41,10 @@ namespace Datadog.Trace.DiagnosticListeners
 
         void IObserver<KeyValuePair<string, object>>.OnNext(KeyValuePair<string, object> value)
         {
+#if DEBUG
+            // In debug mode we allow exceptions to be catch in the test suite
+            OnNext(value.Key, value.Value);
+#else
             try
             {
                 OnNext(value.Key, value.Value);
@@ -49,6 +53,7 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 Log.Error(ex, "Event Exception: {0}", value.Key);
             }
+#endif
         }
 
         protected virtual bool IsEventEnabled(string eventName)

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
@@ -41,10 +41,6 @@ namespace Datadog.Trace.DiagnosticListeners
 
         void IObserver<KeyValuePair<string, object>>.OnNext(KeyValuePair<string, object> value)
         {
-#if DEBUG
-            // In debug mode we allow exceptions to be catch in the test suite
-            OnNext(value.Key, value.Value);
-#else
             try
             {
                 OnNext(value.Key, value.Value);
@@ -52,8 +48,11 @@ namespace Datadog.Trace.DiagnosticListeners
             catch (Exception ex)
             {
                 Log.Error(ex, "Event Exception: {0}", value.Key);
-            }
+#if DEBUG
+                // In debug mode we allow exceptions to be catch in the test suite
+                throw;
 #endif
+            }
         }
 
         protected virtual bool IsEventEnabled(string eventName)

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -24,5 +24,7 @@
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -42,6 +42,11 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
                 diagnosticManager.Start();
                 DiagnosticManager.Instance = diagnosticManager;
                 retValue = await client.GetStringAsync("/Home");
+                try
+                {
+                    await client.GetStringAsync("/Home/error");
+                }
+                catch { }
                 DiagnosticManager.Instance = null;
             }
 
@@ -144,6 +149,11 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         {
             await Task.Yield();
             return "Hello world";
+        }
+
+        public void Error()
+        {
+            throw new Exception();
         }
     }
 }

--- a/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -34,10 +34,17 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
 
             var testServer = new TestServer(builder);
             var client = testServer.CreateClient();
+            var observers = new List<DiagnosticObserver> { new AspNetCoreDiagnosticObserver() };
+            string retValue = null;
 
-            Datadog.Trace.ClrProfiler.Instrumentation.Initialize();
+            using (var diagnosticManager = new DiagnosticManager(observers))
+            {
+                diagnosticManager.Start();
+                DiagnosticManager.Instance = diagnosticManager;
+                retValue = await client.GetStringAsync("/Home");
+                DiagnosticManager.Instance = null;
+            }
 
-            string retValue = await client.GetStringAsync("/Home");
             return retValue;
         }
 

--- a/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -1,19 +1,46 @@
 #if !NETFRAMEWORK
 using System;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Sampling;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Datadog.Trace.Tests.DiagnosticListeners
 {
+    [CollectionDefinition(nameof(AspNetCoreDiagnosticObserverTests), DisableParallelization = true)]
+    [TracerRestorer]
     public class AspNetCoreDiagnosticObserverTests
     {
+        [Fact]
+        public async Task<string> CompleteDiagnosticObserverTest()
+        {
+            Tracer.Instance = GetTracer();
+
+            var builder = new WebHostBuilder()
+                .UseStartup<Startup>();
+
+            var testServer = new TestServer(builder);
+            var client = testServer.CreateClient();
+
+            Datadog.Trace.ClrProfiler.Instrumentation.Initialize();
+
+            string retValue = await client.GetStringAsync("/Home");
+            return retValue;
+        }
+
         [Fact]
         public void HttpRequestIn_PopulateSpan()
         {
@@ -66,6 +93,50 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             httpContext.Request.Method = "GET";
 
             return httpContext;
+        }
+
+        private class Startup
+        {
+            public void ConfigureServices(IServiceCollection services)
+            {
+                services.AddMvc();
+            }
+
+            public void Configure(IApplicationBuilder builder)
+            {
+                builder.UseMvcWithDefaultRoute();
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+        private class TracerRestorerAttribute : BeforeAfterTestAttribute
+        {
+            private Tracer _tracer;
+
+            public override void Before(MethodInfo methodUnderTest)
+            {
+                _tracer = Tracer.Instance;
+                base.Before(methodUnderTest);
+            }
+
+            public override void After(MethodInfo methodUnderTest)
+            {
+                Tracer.Instance = _tracer;
+                base.After(methodUnderTest);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Simple controller used for the aspnetcore test
+    /// </summary>
+#pragma warning disable SA1402 // File may only contain a single class
+    public class HomeController : Controller
+    {
+        public async Task<string> Index()
+        {
+            await Task.Yield();
+            return "Hello world";
         }
     }
 }


### PR DESCRIPTION
- Fix AspNetCoreDiagnosticObserver bug.
- Adds a CompleteDiagnosticObserverTest based in the benchmark test logic.
- Adds support for BindingFlags in the DuckTyping library.
- Adds IgnoreCase binding flags to the AspNetCoreDiagnosticObserver

@DataDog/apm-dotnet