### PR TITLE
Fix a possible failure in MonitorGarbageCollections test

### DIFF
--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -45,6 +45,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             using var listener = new RuntimeEventListener(statsd.Object);
 
             statsd.ResetCalls();
+            mutex.Reset(); // In case a GC was triggered when creating the listener
 
             GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
 


### PR DESCRIPTION
If a GC is triggered before `ResetCalls`, the mutex would be signaled and we wouldn't wait for the new GC.