### PR TITLE
Allow users to add "_dd.measured" metric to spans

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -202,15 +202,24 @@ namespace Datadog.Trace
 
                     break;
                 case Trace.Tags.Measured:
-                    if (value?.ToBoolean() == true || string.IsNullOrEmpty(value))
+                    if (string.IsNullOrEmpty(value))
                     {
-                        // Set metric to true by passing the value of 1
-                        SetMetric(Trace.Tags.Measured, 1);
+                        // Remove metric if value is null
+                        SetMetric(Trace.Tags.Measured, null);
+                        return this;
                     }
-                    else if (value?.ToBoolean() == false)
+
+                    bool? measured = value.ToBoolean();
+
+                    if (measured == true)
                     {
-                        // Set metric to false by passing the value of 0
-                        SetMetric(Trace.Tags.Measured, 0);
+                        // Set metric to true by passing the value of 1.0
+                        SetMetric(Trace.Tags.Measured, 1.0);
+                    }
+                    else if (measured == false)
+                    {
+                        // Set metric to false by passing the value of 0.0
+                        SetMetric(Trace.Tags.Measured, 0.0);
                     }
                     else
                     {

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -201,6 +201,23 @@ namespace Datadog.Trace
                     }
 
                     break;
+                case Trace.Tags.Measured:
+                    if (value?.ToBoolean() == true || string.IsNullOrEmpty(value))
+                    {
+                        // Set metric to true by passing the value of 1
+                        SetMetric(Trace.Tags.Measured, 1);
+                    }
+                    else if (value?.ToBoolean() == false)
+                    {
+                        // Set metric to false by passing the value of 0
+                        SetMetric(Trace.Tags.Measured, 0);
+                    }
+                    else
+                    {
+                        Log.Warning("Value {0} has incorrect format for tag {1}", value, Trace.Tags.Measured);
+                    }
+
+                    break;
                 default:
                     Tags.SetTag(key, value);
                     break;

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -211,6 +211,11 @@ namespace Datadog.Trace
         /// </summary>
         public const string Origin = "_dd.origin";
 
+        /// <summary>
+        /// Configures the measured metric for a span.
+        /// </summary>
+        public const string Measured = "_dd.measured";
+
         internal const string ElasticsearchAction = "elasticsearch.action";
 
         internal const string ElasticsearchMethod = "elasticsearch.method";


### PR DESCRIPTION
What does this PR do?
---------------------
Adds logic to add create metrics for spans that have "_dd.measure" tag.

Who will it impact?
-------------------
Users that wish to create metrics for their custom spans.

Motivation
----------
Internal Tracking: 
https://datadoghq.atlassian.net/browse/DOTNET-77 
https://docs.google.com/document/d/1qQeI47ddNNKBlmdxwj5dofmK6d1XHC68cSIKiJirpZM/edit#heading=h.dswo7zb7vsj1

@DataDog/apm-dotnet