### PR TITLE
Fix off-by-one error in sampling logic

### DIFF
--- a/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace.Sampling
 
         private SamplingPriority GetSamplingPriority(Span span, float rate, bool agentSampling)
         {
-            var sample = ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
+            var sample = ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) < (rate * TracerConstants.MaxTraceId);
             var priority = SamplingPriority.AutoReject;
 
             if (sample && (agentSampling || _limiter.Allowed(span)))

--- a/src/Datadog.Trace/Util/SpanIdGenerator.cs
+++ b/src/Datadog.Trace/Util/SpanIdGenerator.cs
@@ -55,9 +55,14 @@ namespace Datadog.Trace.Util
 
                 return idGenerator;
             }
+
+            internal set
+            {
+                _threadInstance = value;
+            }
         }
 
-        public ulong CreateNew()
+        public virtual ulong CreateNew()
         {
             long high = _random.Next(int.MinValue, int.MaxValue);
             long low = _random.Next(int.MinValue, int.MaxValue);


### PR DESCRIPTION
A span with an id of 0 would be accepted even if sampling rate is 0.