### PR TITLE
Add new configuration setting DD_TRACE_EXCLUDE_SERVICES to exclude spans with user-specified service names

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
@@ -27,6 +27,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return null;
             }
 
+            var serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            if (!tracer.Settings.IsServiceEnabled(serviceName))
+            {
+                // service disabled, don't create a scope, skip this trace
+                return null;
+            }
+
             string requestName = pipeline.GetProperty("RequestParameters")
                                          .GetValueOrDefault()
                                         ?.GetType()
@@ -38,8 +45,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
             string method = requestData.GetProperty("Method").GetValueOrDefault()?.ToString();
             var url = requestData.GetProperty("Uri").GetValueOrDefault()?.ToString();
-
-            var serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(wireProtocol, connection))
+            using (var scope = CreateScope(Tracer.Instance, wireProtocol, connection))
             {
                 try
                 {
@@ -154,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(wireProtocol, connection))
+            using (var scope = CreateScope(Tracer.Instance, wireProtocol, connection))
             {
                 try
                 {
@@ -331,7 +331,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CancellationToken cancellationToken,
             Func<object, object, CancellationToken, object> originalMethod)
         {
-            using (var scope = CreateScope(wireProtocol, connection))
+            using (var scope = CreateScope(Tracer.Instance, wireProtocol, connection))
             {
                 try
                 {
@@ -358,7 +358,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CancellationToken cancellationToken,
             Func<object, object, CancellationToken, object> originalMethod)
         {
-            using (var scope = CreateScope(wireProtocol, connection))
+            using (var scope = CreateScope(Tracer.Instance, wireProtocol, connection))
             {
                 try
                 {
@@ -374,9 +374,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
         }
 
-        private static Scope CreateScope(object wireProtocol, object connection)
+        internal static Scope CreateScope(Tracer tracer, object wireProtocol, object connection)
         {
-            Tracer tracer = Tracer.Instance;
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // integration disabled, don't create a scope, skip this trace

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -376,9 +376,17 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static Scope CreateScope(object wireProtocol, object connection)
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            Tracer tracer = Tracer.Instance;
+            if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // integration disabled, don't create a scope, skip this trace
+                return null;
+            }
+
+            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            if (!tracer.Settings.IsServiceEnabled(serviceName))
+            {
+                // service disabled, don't create a scope, skip this trace
                 return null;
             }
 
@@ -459,9 +467,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 Log.Warning(ex, "Unable to access IWireProtocol.Command properties.");
             }
-
-            Tracer tracer = Tracer.Instance;
-            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -14,13 +14,19 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         internal static Scope CreateScope(Tracer tracer, IntegrationInfo integrationId, string host, string port, string rawCommand)
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(integrationId))
+            if (!tracer.Settings.IsIntegrationEnabled(integrationId))
             {
                 // integration disabled, don't create a scope, skip this trace
                 return null;
             }
 
             string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            if (!tracer.Settings.IsServiceEnabled(serviceName))
+            {
+                // service disabled, don't create a scope, skip this trace
+                return null;
+            }
+
             Scope scope = null;
 
             try

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -55,6 +55,14 @@ namespace Datadog.Trace.Configuration
         public const string DisabledIntegrations = "DD_DISABLED_INTEGRATIONS";
 
         /// <summary>
+        /// Configuration key for a list of services to disable.
+        /// Default is empty (all service names are enabled).
+        /// Supports multiple values separated with semi-colons.
+        /// </summary>
+        /// <seealso cref="TracerSettings.ExcludedServiceNames"/>
+        public const string ExcludeServices = "DD_TRACE_EXCLUDE_SERVICES";
+
+        /// <summary>
         /// Configuration key for the Agent host where the Tracer can send traces.
         /// Overridden by <see cref="AgentUri"/> if present.
         /// Default value is "localhost".

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -54,6 +54,11 @@ namespace Datadog.Trace.Configuration
 
             DisabledIntegrationNames = new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase);
 
+            var excludedServiceNames = source?.GetString(ConfigurationKeys.ExcludeServices)
+                                             ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
+                                       Enumerable.Empty<string>();
+            ExcludedServiceNames = new HashSet<string>(excludedServiceNames, StringComparer.OrdinalIgnoreCase);
+
             Integrations = new IntegrationSettingsCollection(source);
 
             var agentHost = source?.GetString(ConfigurationKeys.AgentHost) ??
@@ -176,6 +181,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
         public HashSet<string> DisabledIntegrationNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the names of excluded service names.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.ExcludeServices"/>
+        public HashSet<string> ExcludedServiceNames { get; set; }
 
         /// <summary>
         /// Gets or sets the Uri where the Tracer can connect to the Agent.
@@ -330,6 +341,11 @@ namespace Datadog.Trace.Configuration
             }
 
             return false;
+        }
+
+        internal bool IsServiceEnabled(string serviceName)
+        {
+            return TraceEnabled && !ExcludedServiceNames.Contains(serviceName);
         }
 
         internal double? GetIntegrationAnalyticsSampleRate(IntegrationInfo integration, bool enabledWithGlobalSetting)

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Npgsql" Version="4.0.10" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
   </ItemGroup>
@@ -11,5 +15,7 @@
 
   <ItemGroup Condition="  !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
+
 </Project>

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationMethodTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationMethodTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.Integrations;
+using Datadog.Trace.Configuration;
+using Npgsql;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class IntegrationMethodTests
+    {
+        private const string TestServiceName = "test-service";
+
+        public static Func<TracerSettings, object> CreateFunc(Func<TracerSettings, object> settingGetter)
+        {
+            return settingGetter;
+        }
+
+        public static IEnumerable<object[]> GetDisabledByServiceNameTestData()
+        {
+            yield return new object[] { (int)IntegrationIds.ElasticsearchNet5, "elasticsearch", (Func<Tracer, int, Scope>)ElasticSearchCreateScope };
+            yield return new object[] { (int)IntegrationIds.ElasticsearchNet, "elasticsearch", (Func<Tracer, int, Scope>)ElasticSearchCreateScope };
+            yield return new object[] { (int)IntegrationIds.MongoDb, "mongodb", (Func<Tracer, int, Scope>)MongoDbCreateScope };
+            yield return new object[] { (int)IntegrationIds.ServiceStackRedis, "redis", (Func<Tracer, int, Scope>)RedisCreateScope };
+            yield return new object[] { (int)IntegrationIds.StackExchangeRedis, "redis", (Func<Tracer, int, Scope>)RedisCreateScope };
+            yield return new object[] { (int)IntegrationIds.HttpMessageHandler, "http-client", (Func<Tracer, int, Scope>)HttpRequestCreateScope };
+            yield return new object[] { (int)IntegrationIds.WebRequest, "http-client", (Func<Tracer, int, Scope>)HttpRequestCreateScope };
+            yield return new object[] { (int)IntegrationIds.AdoNet, "sql-server", (Func<Tracer, int, Scope>)SqlCommandCreateScope };
+            yield return new object[] { (int)IntegrationIds.AdoNet, "postgres", (Func<Tracer, int, Scope>)PostgresCreateScope };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDisabledByServiceNameTestData))]
+        public void ClientSpans_DisabledByServiceName(int integration, string serviceNameSuffix, Func<Tracer, int, Scope> createScopeFunc)
+        {
+            // Set up tracer
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.ServiceName, TestServiceName },
+                { ConfigurationKeys.ExcludeServices, $"{TestServiceName}-{serviceNameSuffix}" }
+            };
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var tracerSettings = new TracerSettings(source);
+            var tracer = new Tracer(tracerSettings);
+
+            // Create scope
+            var scope = createScopeFunc(tracer, integration);
+
+            Assert.Null(scope);
+        }
+
+        private static Scope ElasticSearchCreateScope(Tracer tracer, int integration) => ElasticsearchNetCommon.CreateScope(tracer, new IntegrationInfo(integration), null, null);
+
+        private static Scope HttpRequestCreateScope(Tracer tracer, int integration) => ScopeFactory.CreateOutboundHttpScope(tracer, "GET", new Uri("http://www.contoso.com"), new IntegrationInfo(integration), out _);
+
+        private static Scope MongoDbCreateScope(Tracer tracer, int integration) => MongoDbIntegration.CreateScope(tracer, null, null);
+
+        private static Scope RedisCreateScope(Tracer tracer, int integration) => RedisHelper.CreateScope(tracer, new IntegrationInfo(integration), null, null, null);
+
+        private static Scope SqlCommandCreateScope(Tracer tracer, int integration) => ScopeFactory.CreateDbCommandScope(tracer, new SqlCommand());
+
+        private static Scope PostgresCreateScope(Tracer tracer, int integration) => ScopeFactory.CreateDbCommandScope(tracer, new NpgsqlCommand());
+    }
+}

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -49,6 +49,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
+            yield return new object[] { CreateFunc(s => s.ExcludedServiceNames.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
             yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
@@ -74,6 +75,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { "DD_SERVICE_NAME", "web-service", CreateFunc(s => s.ServiceName), "web-service" };
 
             yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
+            yield return new object[] { ConfigurationKeys.ExcludeServices, "service-http-client;service-mysql", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
 
             yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags), TagsK1V1K2V2 };
             yield return new object[] { ConfigurationKeys.GlobalTags, "keyonly:,nocolon,:,:valueonly,k2:v2", CreateFunc(s => s.GlobalTags), TagsK2V2 };


### PR DESCRIPTION
Current configuration settings allow us to exclude entire integrations from creating spans, but we are currently missing a fine-grained feature to exclude certain spans from being generated. Specifically, we have customer cases where this functionality would help decrease the size of traces. This PR adds a `DD_TRACE_EXCLUDE_SERVICES` setting that will filter out spans with user-specified service names, and since it is only a configuration setting the implementation can be flexible in the future. This setting is currently checked and enforced only for 1) automatic instrumentation and 2) client (outbound) calls.

Changes proposed in this pull request:
- Add `DD_TRACE_EXCLUDE_SERVICES` configuration setting
- Add unit tests for `DD_TRACE_EXCLUDE_SERVICES` in `Datadog.Trace.ClrProfiler.Managed.Tests` project
- Add integration test for `DD_TRACE_EXCLUDE_SERVICES` in `HttpMessageHandlerTests` of the `Datadog.Trace.ClrProfiler.IntegrationTests` project

@DataDog/apm-dotnet