### PR TITLE
Collect metrics from aspnetcore eventcounters

### DIFF
--- a/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
@@ -28,5 +28,14 @@ namespace Datadog.Trace.RuntimeMetrics
         public const string CpuUserTime = "runtime.dotnet.cpu.user";
         public const string CpuSystemTime = "runtime.dotnet.cpu.system";
         public const string CpuPercentage = "runtime.dotnet.cpu.percent";
+
+        public const string CurrentRequests = "runtime.dotnet.aspnetcore.requests.current";
+        public const string FailedRequests = "runtime.dotnet.aspnetcore.requests.failed";
+        public const string TotalRequests = "runtime.dotnet.aspnetcore.requests.total";
+        public const string RequestQueueLength = "runtime.dotnet.aspnetcore.requests.queue_length";
+
+        public const string CurrentConnections = "runtime.dotnet.aspnetcore.connections.current";
+        public const string ConnectionQueueLength = "runtime.dotnet.aspnetcore.connections.queue_length";
+        public const string TotalConnections = "runtime.dotnet.aspnetcore.connections.total";
     }
 }

--- a/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/MetricsNames.cs
@@ -29,13 +29,13 @@ namespace Datadog.Trace.RuntimeMetrics
         public const string CpuSystemTime = "runtime.dotnet.cpu.system";
         public const string CpuPercentage = "runtime.dotnet.cpu.percent";
 
-        public const string CurrentRequests = "runtime.dotnet.aspnetcore.requests.current";
-        public const string FailedRequests = "runtime.dotnet.aspnetcore.requests.failed";
-        public const string TotalRequests = "runtime.dotnet.aspnetcore.requests.total";
-        public const string RequestQueueLength = "runtime.dotnet.aspnetcore.requests.queue_length";
+        public const string AspNetCoreCurrentRequests = "runtime.dotnet.aspnetcore.requests.current";
+        public const string AspNetCoreFailedRequests = "runtime.dotnet.aspnetcore.requests.failed";
+        public const string AspNetCoreTotalRequests = "runtime.dotnet.aspnetcore.requests.total";
+        public const string AspNetCoreRequestQueueLength = "runtime.dotnet.aspnetcore.requests.queue_length";
 
-        public const string CurrentConnections = "runtime.dotnet.aspnetcore.connections.current";
-        public const string ConnectionQueueLength = "runtime.dotnet.aspnetcore.connections.queue_length";
-        public const string TotalConnections = "runtime.dotnet.aspnetcore.connections.total";
+        public const string AspNetCoreCurrentConnections = "runtime.dotnet.aspnetcore.connections.current";
+        public const string AspNetCoreConnectionQueueLength = "runtime.dotnet.aspnetcore.connections.queue_length";
+        public const string AspNetCoreTotalConnections = "runtime.dotnet.aspnetcore.connections.total";
     }
 }

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -43,20 +43,20 @@ namespace Datadog.Trace.RuntimeMetrics
         {
             MetricsMapping = new Dictionary<string, string>
             {
-                ["current-requests"] = MetricsNames.CurrentRequests,
-                ["failed-requests"] = MetricsNames.FailedRequests,
-                ["total-requests"] = MetricsNames.TotalRequests,
-                ["request-queue-length"] = MetricsNames.RequestQueueLength,
-                ["current-connections"] = MetricsNames.CurrentConnections,
-                ["connection-queue-length"] = MetricsNames.ConnectionQueueLength,
-                ["total-connections"] = MetricsNames.TotalConnections
+                ["current-requests"] = MetricsNames.AspNetCoreCurrentRequests,
+                ["failed-requests"] = MetricsNames.AspNetCoreFailedRequests,
+                ["total-requests"] = MetricsNames.AspNetCoreTotalRequests,
+                ["request-queue-length"] = MetricsNames.AspNetCoreRequestQueueLength,
+                ["current-connections"] = MetricsNames.AspNetCoreCurrentConnections,
+                ["connection-queue-length"] = MetricsNames.AspNetCoreConnectionQueueLength,
+                ["total-connections"] = MetricsNames.AspNetCoreTotalConnections
             };
         }
 
-        public RuntimeEventListener(IDogStatsd statsd, int delay)
+        public RuntimeEventListener(IDogStatsd statsd, TimeSpan delay)
         {
             _statsd = statsd;
-            _delayInSeconds = (delay / 1000).ToString();
+            _delayInSeconds = ((int)delay.TotalSeconds).ToString();
 
             EventSourceCreated += (_, e) => EnableEventSource(e.EventSource);
         }

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.RuntimeMetrics
         {
         }
 
-        internal RuntimeMetricsWriter(IDogStatsd statsd, int delay, Func<IDogStatsd, IRuntimeMetricsListener> initializeListener)
+        internal RuntimeMetricsWriter(IDogStatsd statsd, int delay, Func<IDogStatsd, int, IRuntimeMetricsListener> initializeListener)
         {
             _delay = delay;
             _statsd = statsd;
@@ -63,7 +63,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
             try
             {
-                _listener = initializeListener(statsd);
+                _listener = initializeListener(statsd, delay);
             }
             catch (Exception ex)
             {
@@ -134,10 +134,10 @@ namespace Datadog.Trace.RuntimeMetrics
             }
         }
 
-        private static IRuntimeMetricsListener InitializeListener(IDogStatsd statsd)
+        private static IRuntimeMetricsListener InitializeListener(IDogStatsd statsd, int delay)
         {
 #if NETCOREAPP
-            return new RuntimeEventListener(statsd);
+            return new RuntimeEventListener(statsd, delay);
 #elif NETFRAMEWORK
             return new PerformanceCountersListener(statsd);
 #else

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -193,7 +193,7 @@ namespace Datadog.Trace
 
                 if (Settings.RuntimeMetricsEnabled)
                 {
-                    _runtimeMetricsWriter = new RuntimeMetricsWriter(Statsd ?? CreateDogStatsdClient(Settings, DefaultServiceName, Settings.DogStatsdPort), 10000);
+                    _runtimeMetricsWriter = new RuntimeMetricsWriter(Statsd ?? CreateDogStatsdClient(Settings, DefaultServiceName, Settings.DogStatsdPort), TimeSpan.FromSeconds(10));
                 }
             }
         }

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -1,11 +1,8 @@
 #if NETCOREAPP3_1 || NET5_0
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
+using System.Diagnostics.Tracing;
 using System.Threading;
-using System.Threading.Tasks;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Vendors.StatsdClient;
 using Moq;
@@ -20,7 +17,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         {
             var statsd = new Mock<IDogStatsd>();
 
-            using var listener = new RuntimeEventListener(statsd.Object);
+            using var listener = new RuntimeEventListener(statsd.Object, 10000);
 
             listener.Refresh();
 
@@ -42,7 +39,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Setup(s => s.Timer(MetricsNames.GcPauseTime, It.IsAny<double>(), It.IsAny<double>(), null))
                 .Callback(() => mutex.Set());
 
-            using var listener = new RuntimeEventListener(statsd.Object);
+            using var listener = new RuntimeEventListener(statsd.Object, 10000);
 
             statsd.ResetCalls();
 
@@ -63,6 +60,52 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Verify(s => s.Timer(MetricsNames.GcPauseTime, It.IsAny<double>(), It.IsAny<double>(), null), Times.AtLeastOnce);
             statsd.Verify(s => s.Gauge(MetricsNames.GcMemoryLoad, It.IsAny<uint>(), It.IsAny<double>(), null), Times.AtLeastOnce);
             statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, 1, It.IsAny<double>(), compactingGcTags), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public void PushEventCounters()
+        {
+            // Pretending we're aspnetcore
+            var eventSource = new EventSource("Microsoft.AspNetCore.Hosting");
+
+            var mutex = new ManualResetEventSlim();
+
+            Func<double> callback = () =>
+            {
+                mutex.Set();
+                return 0.0;
+            };
+
+            var counters = new List<DiagnosticCounter>
+            {
+                new PollingCounter("current-requests", eventSource, () => 1.0),
+                new PollingCounter("failed-requests", eventSource, () => 2.0),
+                new PollingCounter("total-requests", eventSource, () => 4.0),
+                new PollingCounter("request-queue-length", eventSource, () => 8.0),
+                new PollingCounter("connection-queue-length", eventSource, () => 16.0),
+                new PollingCounter("total-connections", eventSource, () => 32.0),
+
+                // This counter sets the mutex, so it needs to be created last
+                new PollingCounter("Dummy", eventSource, callback)
+            };
+
+            var statsd = new Mock<IDogStatsd>();
+            using var listener = new RuntimeEventListener(statsd.Object, 1000);
+
+            // Wait for the counters to be refreshed
+            mutex.Wait();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.CurrentRequests, 1.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.FailedRequests, 2.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.TotalRequests, 4.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.RequestQueueLength, 8.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.ConnectionQueueLength, 16.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.TotalConnections, 32.0, 1, null), Times.AtLeastOnce);
+
+            foreach (var counter in counters)
+            {
+                counter.Dispose();
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         {
             var statsd = new Mock<IDogStatsd>();
 
-            using var listener = new RuntimeEventListener(statsd.Object, 10000);
+            using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(10));
 
             listener.Refresh();
 
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Setup(s => s.Timer(MetricsNames.GcPauseTime, It.IsAny<double>(), It.IsAny<double>(), null))
                 .Callback(() => mutex.Set());
 
-            using var listener = new RuntimeEventListener(statsd.Object, 10000);
+            using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(10));
 
             statsd.ResetCalls();
 
@@ -90,17 +90,17 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             };
 
             var statsd = new Mock<IDogStatsd>();
-            using var listener = new RuntimeEventListener(statsd.Object, 1000);
+            using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(1));
 
             // Wait for the counters to be refreshed
             mutex.Wait();
 
-            statsd.Verify(s => s.Gauge(MetricsNames.CurrentRequests, 1.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.FailedRequests, 2.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.TotalRequests, 4.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.RequestQueueLength, 8.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.ConnectionQueueLength, 16.0, 1, null), Times.AtLeastOnce);
-            statsd.Verify(s => s.Gauge(MetricsNames.TotalConnections, 32.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreCurrentRequests, 1.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreFailedRequests, 2.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreTotalRequests, 4.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreRequestQueueLength, 8.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreConnectionQueueLength, 16.0, 1, null), Times.AtLeastOnce);
+            statsd.Verify(s => s.Gauge(MetricsNames.AspNetCoreTotalConnections, 32.0, 1, null), Times.AtLeastOnce);
 
             foreach (var counter in counters)
             {

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             listener.Setup(l => l.Refresh())
                 .Callback(() => mutex.Set());
 
-            using (new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), 10, _ => listener.Object))
+            using (new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), 10, (_, d) => listener.Object))
             {
                 Assert.True(mutex.Wait(10000), "Method Refresh() wasn't called on the listener");
             }
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         [Fact]
         public void ShouldSwallowFactoryExceptions()
         {
-            Func<IDogStatsd, IRuntimeMetricsListener> factory = _ => throw new InvalidOperationException("This exception should be caught");
+            Func<IDogStatsd, int, IRuntimeMetricsListener> factory = (_, d) => throw new InvalidOperationException("This exception should be caught");
 
             var writer = new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), 10, factory);
             writer.Dispose();
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         {
             var statsd = new Mock<IDogStatsd>();
 
-            using (var writer = new RuntimeMetricsWriter(statsd.Object, Timeout.Infinite, _ => Mock.Of<IRuntimeMetricsListener>()))
+            using (var writer = new RuntimeMetricsWriter(statsd.Object, Timeout.Infinite, (_, d) => Mock.Of<IRuntimeMetricsListener>()))
             {
                 for (int i = 0; i < 10; i++)
                 {
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             var statsd = new Mock<IDogStatsd>();
             var runtimeListener = new Mock<IRuntimeMetricsListener>();
 
-            var writer = new RuntimeMetricsWriter(statsd.Object, Timeout.Infinite, _ => runtimeListener.Object);
+            var writer = new RuntimeMetricsWriter(statsd.Object, Timeout.Infinite, (_, d) => runtimeListener.Object);
             writer.Dispose();
 
             runtimeListener.Verify(l => l.Dispose(), Times.Once);

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             listener.Setup(l => l.Refresh())
                 .Callback(() => mutex.Set());
 
-            using (new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), 10, (_, d) => listener.Object))
+            using (new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), TimeSpan.FromMilliseconds(10), (_, d) => listener.Object))
             {
                 Assert.True(mutex.Wait(10000), "Method Refresh() wasn't called on the listener");
             }
@@ -30,9 +30,9 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         [Fact]
         public void ShouldSwallowFactoryExceptions()
         {
-            Func<IDogStatsd, int, IRuntimeMetricsListener> factory = (_, d) => throw new InvalidOperationException("This exception should be caught");
+            Func<IDogStatsd, TimeSpan, IRuntimeMetricsListener> factory = (_, d) => throw new InvalidOperationException("This exception should be caught");
 
-            var writer = new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), 10, factory);
+            var writer = new RuntimeMetricsWriter(Mock.Of<IDogStatsd>(), TimeSpan.FromMilliseconds(10), factory);
             writer.Dispose();
         }
 
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         {
             var statsd = new Mock<IDogStatsd>();
 
-            using (var writer = new RuntimeMetricsWriter(statsd.Object, Timeout.Infinite, (_, d) => Mock.Of<IRuntimeMetricsListener>()))
+            using (var writer = new RuntimeMetricsWriter(statsd.Object, TimeSpan.FromMilliseconds(Timeout.Infinite), (_, d) => Mock.Of<IRuntimeMetricsListener>()))
             {
                 for (int i = 0; i < 10; i++)
                 {
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             var statsd = new Mock<IDogStatsd>();
             var runtimeListener = new Mock<IRuntimeMetricsListener>();
 
-            var writer = new RuntimeMetricsWriter(statsd.Object, Timeout.Infinite, (_, d) => runtimeListener.Object);
+            var writer = new RuntimeMetricsWriter(statsd.Object, TimeSpan.FromMilliseconds(Timeout.Infinite), (_, d) => runtimeListener.Object);
             writer.Dispose();
 
             runtimeListener.Verify(l => l.Dispose(), Times.Once);


### PR DESCRIPTION
Note: `Microsoft-AspNetCore-Server-Kestrel` provider is only available on .NET 5