### PR TITLE
Disable parallelization on runtime metrics tests

### DIFF
--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.RuntimeMetrics
 {
+    [CollectionDefinition(nameof(RuntimeMetricsWriterTests), DisableParallelization = true)]
     public class RuntimeMetricsWriterTests
     {
         [Fact]

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 namespace Datadog.Trace.Tests.RuntimeMetrics
 {
     [CollectionDefinition(nameof(RuntimeMetricsWriterTests), DisableParallelization = true)]
+    [Collection(nameof(RuntimeMetricsWriterTests))]
     public class RuntimeMetricsWriterTests
     {
         [Fact]


### PR DESCRIPTION
Since those tests listen to first-chance exceptions, they are likely to be impacted by other running tests.
