### PR TITLE
Limit test parallelism to CPU count

### DIFF
--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -129,9 +129,9 @@ namespace Datadog.Trace.Tests.Sampling
         {
             var parallelism = test.NumberPerBurst;
 
-            if (parallelism > 10)
+            if (parallelism > Environment.ProcessorCount)
             {
-                parallelism = 10;
+                parallelism = Environment.ProcessorCount;
             }
 
             var limiter = new RateLimiter(maxTracesPerInterval: intervalLimit);


### PR DESCRIPTION
Test was running with 10 threads even though CI agent has 2 cores
