### PR TITLE
Increase number of iterations for sampler tests

### DIFF
--- a/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(new CustomSamplingRule(0.5f, "Allow_nothing", ".*", ".*"));
             RunSamplerTest(
                 sampler,
-                10_000, // Higher number for lower variance
+                50_000, // Higher number for lower variance
                 0.5f,
                 0.05f);
         }
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             RunSamplerTest(
                 sampler,
-                10_000, // Higher number for lower variance
+                50_000, // Higher number for lower variance
                 FallbackRate,
                 0.05f);
         }


### PR DESCRIPTION
With seed 771467036 and 10k iterations, the test fails with a difference of 5.6%
