### PR TITLE
Suppress warning NETSDK1138

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
     inputs:
       command: build
       projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-      arguments: --configuration $(buildConfiguration)
+      arguments: --configuration $(buildConfiguration) /nowarn:netsdk1138
 
   - task: DotNetCoreCLI@2
     displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed 2.0
@@ -136,7 +136,7 @@ jobs:
     inputs:
       command: build
       projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-      arguments: --configuration $(buildConfiguration)
+      arguments: --configuration $(buildConfiguration) /nowarn:netsdk1138
 
   - task: DotNetCoreCLI@2
     displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed 2.0
@@ -313,7 +313,7 @@ jobs:
         !test/test-applications/regression/**/ExpenseItDemo*.csproj
         !test/test-applications/regression/**/EntityFramework6x*.csproj
         !test/test-applications/regression/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput)
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build samples
@@ -322,7 +322,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -428,7 +428,7 @@ jobs:
         !test/test-applications/regression/**/ExpenseItDemo*.csproj
         !test/test-applications/regression/**/EntityFramework6x*.csproj
         !test/test-applications/regression/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput)
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build samples
@@ -437,7 +437,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138
 
   - task: NuGetCommand@2
     displayName: nuget restore IIS samples

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -81,7 +81,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
-      arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
+      arguments: /nowarn:netsdk1138 -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj
@@ -122,6 +122,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
         sample-libs/**/Samples.ExampleLibrary*.csproj
@@ -172,6 +173,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
   
@@ -214,6 +216,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
   
@@ -270,6 +273,7 @@ jobs:
     inputs:
       command: build
       configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
       projects: |
         src/**/*.csproj
         test/**/*.Tests.csproj


### PR DESCRIPTION
This warning is about using versions of the framework that are not supported anymore.

