### PR TITLE
Log content of http response on failure

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -206,7 +206,8 @@ namespace Datadog.Trace.Agent
                     {
                         try
                         {
-                            Log.Error("Failed to submit traces with status code {0} and message: {1}", response.StatusCode, await response.ReadAsStringAsync().ConfigureAwait(false));
+                            string responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                            Log.Error("Failed to submit traces with status code {0} and message: {1}", response.StatusCode, responseContent);
                         }
                         catch (Exception ex)
                         {

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Agent
                     if (isFinalTry)
                     {
                         // stop retrying
-                        Log.Error(exception, "An error occurred while sending {0} traces to the agent at {0}", traces.Length, _tracesEndpoint);
+                        Log.Error(exception, "An error occurred while sending {0} traces to the agent at {1}", traces.Length, _tracesEndpoint);
                         return false;
                     }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -93,18 +93,18 @@ namespace Datadog.Trace.Agent
 
                 bool success = false;
                 Exception exception = null;
+                bool isFinalTry = retryCount >= retryLimit;
 
                 try
                 {
-                    success = await SendTracesAsync(traces, request).ConfigureAwait(false);
+                    success = await SendTracesAsync(traces, request, isFinalTry).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)
                     {
-                        Log.Error(ex, "An error occurred while sending traces to the agent at {0}", _tracesEndpoint);
-                        Log.Error("Failed to send {0} traces to the DD agent", traces.Length);
+                        Log.Error(ex, "An error occurred while sending {0} traces to the agent at {0}", traces.Length, _tracesEndpoint);
                         return false;
                     }
 #endif
@@ -114,12 +114,10 @@ namespace Datadog.Trace.Agent
                 // Error handling block
                 if (!success)
                 {
-                    // Exit if we've hit our retry limit
-                    if (retryCount >= retryLimit)
+                    if (isFinalTry)
                     {
                         // stop retrying
-                        Log.Error(exception, "An error occurred while sending traces to the agent at {0}", _tracesEndpoint);
-                        Log.Error("Failed to send {0} traces to the DD agent", traces.Length);
+                        Log.Error(exception, "An error occurred while sending {0} traces to the agent at {0}", traces.Length, _tracesEndpoint);
                         return false;
                     }
 
@@ -173,7 +171,7 @@ namespace Datadog.Trace.Agent
 #endif
         }
 
-        private async Task<bool> SendTracesAsync(Span[][] traces, IApiRequest request)
+        private async Task<bool> SendTracesAsync(Span[][] traces, IApiRequest request, bool finalTry)
         {
             IApiResponse response = null;
 
@@ -204,6 +202,18 @@ namespace Datadog.Trace.Agent
                 // Attempt a retry if the status code is not SUCCESS
                 if (response.StatusCode < 200 || response.StatusCode >= 300)
                 {
+                    if (finalTry)
+                    {
+                        try
+                        {
+                            Log.Error("Failed to submit traces with status code {0} and message: {1}", response.StatusCode, await response.ReadAsStringAsync().ConfigureAwait(false));
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Unable to read response for failed request with status code {0}", response.StatusCode);
+                        }
+                    }
+
                     return false;
                 }
 

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Agent
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)
                     {
-                        Log.Error(ex, "An error occurred while sending {0} traces to the agent at {0}", traces.Length, _tracesEndpoint);
+                        Log.Error(ex, "An error occurred while sending {0} traces to the agent at {1}", traces.Length, _tracesEndpoint);
                         return false;
                     }
 #endif


### PR DESCRIPTION
Log the content of the http response when it is not a successful status code.
@DataDog/apm-dotnet

![image](https://user-images.githubusercontent.com/1801443/101917053-c539d680-3b95-11eb-8a40-3f47c8749b0e.png)
