### PR TITLE
Fixes GetILCodes crash

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1355,7 +1355,7 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
         if (SUCCEEDED(hr)) {
           orig_sstream << "  | ";
           orig_sstream << "\"";
-          orig_sstream << ToString(WSTRING(szString).substr(0, szStringLength));
+          orig_sstream << ToString(WSTRING(szString, szStringLength));
           orig_sstream << "\"";
         }
       }


### PR DESCRIPTION
Fixes GetILCodes crash when the original string does not have the \0 char.


@DataDog/apm-dotnet