### PR TITLE
Fix xUnit instrumentation bug

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/AsyncTool.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/AsyncTool.cs
@@ -119,7 +119,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 TResult result = default;
                 try
                 {
-                    result = await previousTask.ConfigureAwait(false);
+                    result = await previousTask;
                 }
                 catch (Exception ex)
                 {
@@ -140,15 +140,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 TResult result = default;
                 try
                 {
-                    result = await previousTask.ConfigureAwait(false);
+                    result = await previousTask;
                 }
                 catch (Exception ex)
                 {
-                    await continuation(result, ex, state).ConfigureAwait(false);
+                    await continuation(result, ex, state);
                     throw;
                 }
 
-                return (TResult)await continuation(result, null, state).ConfigureAwait(false);
+                return (TResult)await continuation(result, null, state);
             }
         }
 
@@ -175,7 +175,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
             {
                 try
                 {
-                    await previousTask.ConfigureAwait(false);
+                    await previousTask;
                 }
                 catch (Exception ex)
                 {
@@ -200,15 +200,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
             {
                 try
                 {
-                    await previousTask.ConfigureAwait(false);
+                    await previousTask;
                 }
                 catch (Exception ex)
                 {
-                    await continuation(null, ex, state).ConfigureAwait(false);
+                    await continuation(null, ex, state);
                     throw;
                 }
 
-                await continuation(null, null, state).ConfigureAwait(false);
+                await continuation(null, null, state);
             }
         }
     }


### PR DESCRIPTION
This `PR` handles some weird errors (missing span tags) with some async tests using the xUnit instrumentation.

After a research the behavior is caused by the AsyncTool continuations skipping the [custom synchronization context setted](https://github.com/xunit/xunit/blob/6bc9543856f17cd69ec96e63307529edec2c60cd/src/xunit.v3.core/Sdk/AsyncTestSyncContext.cs) by the xUnit testing framework.

By removing `ConfigureAwait(false)` the weird behavior disappear.

@DataDog/apm-dotnet