### PR TITLE
switch build image to shared image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,10 +3,7 @@ stages:
   - binary_build
   
 variables:
-  ## DBTODO this is the current branch of -buildimages.  Once the common
-  ## container is merged to master, then this needs to be updated with the
-  ## resulting tag prior to merging
-  DATADOG_AGENT_WINBUILDIMAGES: v3599352-d498c03
+  DATADOG_AGENT_WINBUILDIMAGES: v3651799-a21376a
     
 driver_build:
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,10 @@ stages:
   - binary_build
   
 variables:
-  DATADOG_AGENT_WINBUILDIMAGES: v3324313-6d0a8f4
+  ## DBTODO this is the current branch of -buildimages.  Once the common
+  ## container is merged to master, then this needs to be updated with the
+  ## resulting tag prior to merging
+  DATADOG_AGENT_WINBUILDIMAGES: v3599352-d498c03
     
 driver_build:
   only:


### PR DESCRIPTION
branch for testing shared builder for all platforms

Requires https://github.com/DataDog/datadog-agent-buildimages/pull/99; once merged, needs the
final update of the container tag

Fixes #

Changes (eventually) windows build container tag to single shared container for all build targets.




@DataDog/apm-dotnet