### PR TITLE
Isolate StringBuilderCache

### DIFF
--- a/src/Datadog.Trace/Cache/StringBuilderCache.cs
+++ b/src/Datadog.Trace/Cache/StringBuilderCache.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Text;
+
+namespace Datadog.Trace.Cache
+{
+    /// <summary>
+    /// Provide a cached reusable instance of StringBuilder per thread.
+    /// </summary>
+    /// <remarks>
+    /// Based on https://source.dot.net/#System.Private.CoreLib/StringBuilderCache.cs,a6dbe82674916ac0
+    /// </remarks>
+    internal static class StringBuilderCache
+    {
+        internal const int MaxBuilderSize = 360;
+
+        [ThreadStatic]
+        private static StringBuilder _cachedInstance;
+
+        public static StringBuilder Acquire(int capacity)
+        {
+            if (capacity <= MaxBuilderSize)
+            {
+                StringBuilder sb = _cachedInstance;
+                if (sb != null)
+                {
+                    // Avoid StringBuilder block fragmentation by getting a new StringBuilder
+                    // when the requested size is larger than the current capacity
+                    if (capacity <= sb.Capacity)
+                    {
+                        _cachedInstance = null;
+                        sb.Clear();
+                        return sb;
+                    }
+                }
+            }
+
+            return new StringBuilder(capacity);
+        }
+
+        public static string GetStringAndRelease(StringBuilder sb)
+        {
+            string result = sb.ToString();
+            if (sb.Capacity <= MaxBuilderSize)
+            {
+                _cachedInstance = sb;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Datadog.Trace/Util/StringBuilderCache.cs
+++ b/src/Datadog.Trace/Util/StringBuilderCache.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Text;
 
-namespace Datadog.Trace.Cache
+namespace Datadog.Trace.Util
 {
     /// <summary>
     /// Provide a cached reusable instance of StringBuilder per thread.

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.CompilerServices;
-using Datadog.Trace.Cache;
 
 namespace Datadog.Trace.Util
 {

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
-using System.Text;
+using Datadog.Trace.Cache;
 
 namespace Datadog.Trace.Util
 {
@@ -134,51 +134,5 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool IsAGuid(ReadOnlySpan<char> segment, string format) => Guid.TryParseExact(segment, format, out _);
 #endif
-
-        /// <summary>
-        /// Provide a cached reusable instance of stringbuilder per thread.
-        /// </summary>
-        /// <remarks>
-        /// Based on https://source.dot.net/#System.Private.CoreLib/StringBuilderCache.cs,a6dbe82674916ac0
-        /// </remarks>
-        internal static class StringBuilderCache
-        {
-            internal const int MaxBuilderSize = 360;
-
-            [ThreadStatic]
-            private static StringBuilder _cachedInstance;
-
-            public static StringBuilder Acquire(int capacity)
-            {
-                if (capacity <= MaxBuilderSize)
-                {
-                    StringBuilder sb = _cachedInstance;
-                    if (sb != null)
-                    {
-                        // Avoid stringbuilder block fragmentation by getting a new StringBuilder
-                        // when the requested size is larger than the current capacity
-                        if (capacity <= sb.Capacity)
-                        {
-                            _cachedInstance = null;
-                            sb.Clear();
-                            return sb;
-                        }
-                    }
-                }
-
-                return new StringBuilder(capacity);
-            }
-
-            public static string GetStringAndRelease(StringBuilder sb)
-            {
-                string result = sb.ToString();
-                if (sb.Capacity <= MaxBuilderSize)
-                {
-                    _cachedInstance = sb;
-                }
-
-                return result;
-            }
-        }
     }
 }


### PR DESCRIPTION
Separate `StringBuilderCache` for use outside of `UriHelpers`


@DataDog/apm-dotnet