### PR TITLE
Verbose Assert Message - DogStatsD Tests

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -262,6 +262,11 @@ namespace Datadog.Trace.TestHelpers
 
             [Key("metrics")]
             public Dictionary<string, double> Metrics { get; set; }
+
+            public override string ToString()
+            {
+                return $"TraceId={TraceId}, SpanId={SpanId}, Service={Service}, Name={Name}, Resource={Resource}, Type={Type}";
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Tests
             var statsd = new Mock<IDogStatsd>();
             var spans = SendSpan(tracerMetricsEnabled: false, statsd.Object);
 
-            Assert.True(spans.Count == 2, AssertionFailureMessage(1, spans));
+            Assert.True(spans.Count == 1, AssertionFailureMessage(1, spans));
 
             // no methods should be called on the IStatsd
             statsd.VerifyNoOtherCalls();

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
@@ -27,7 +28,7 @@ namespace Datadog.Trace.Tests
             var statsd = new Mock<IDogStatsd>();
             var spans = SendSpan(tracerMetricsEnabled: false, statsd.Object);
 
-            Assert.True(spans.Count == 1, "Expected one span");
+            Assert.True(spans.Count == 2, AssertionFailureMessage(1, spans));
 
             // no methods should be called on the IStatsd
             statsd.VerifyNoOtherCalls();
@@ -46,7 +47,7 @@ namespace Datadog.Trace.Tests
 
             var spans = SendSpan(tracerMetricsEnabled: true, statsd.Object);
 
-            Assert.True(spans.Count == 1, "Expected one span");
+            Assert.True(spans.Count == 1, AssertionFailureMessage(1, spans));
 
             // for a single trace, these methods are called once with a value of "1"
             statsd.Verify(
@@ -131,6 +132,11 @@ namespace Datadog.Trace.Tests
             }
 
             return spans;
+        }
+
+        private static string AssertionFailureMessage(int expected, IImmutableList<MockTracerAgent.Span> spans)
+        {
+            return $"Expected {expected} span, received {spans.Count}: {Environment.NewLine}{string.Join(Environment.NewLine, spans.Select(s => s.ToString()))}";
         }
     }
 }


### PR DESCRIPTION
Better message for assert failure:
![image](https://user-images.githubusercontent.com/1801443/102811714-cb993100-4393-11eb-8892-434973f73ede.png)
versus the original:
![image](https://user-images.githubusercontent.com/1801443/102811759-e370b500-4393-11eb-93a6-672e77a4e1eb.png)


@DataDog/apm-dotnet