### PR TITLE
Attempt to fix integration-tests build failure "Cannot open Datadog.Trace.dll | Datadog.Trace.AspNet.dll"

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -417,6 +417,7 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
+  # Useless comment to trigger CI
   - task: DotNetCoreCLI@2
     displayName: dotnet build
     inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -284,6 +284,7 @@ jobs:
       arguments: /nowarn:netsdk1138
       projects: |
         src/**/*.csproj
+        !src/Datadog.Trace.Tools.Runner/*.csproj
 
   - task: NuGetCommand@2
     displayName: nuget restore
@@ -416,6 +417,7 @@ jobs:
       arguments: /nowarn:netsdk1138
       projects: |
         src/**/*.csproj
+        !src/Datadog.Trace.Tools.Runner/*.csproj
 
   - task: NuGetCommand@2
     displayName: nuget restore

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -6,7 +6,6 @@ trigger:
     exclude:
       - docs/*
       - .github/*
-
 pr:	
   branches:	
     include:	

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -6,15 +6,6 @@ trigger:
     exclude:
       - docs/*
       - .github/*
-pr:
-  branches:
-    include:
-      - master
-      - release/*
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
 
 pool:
   vmImage: ubuntu-18.04

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -408,7 +408,6 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
-  # Useless comment to trigger CI
   - task: DotNetCoreCLI@2
     displayName: dotnet build
     inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -7,6 +7,16 @@ trigger:
       - docs/*
       - .github/*
 
+pr:	
+  branches:	
+    include:	
+      - master	
+      - release/*	
+  paths:	
+    exclude:	
+      - docs/*	
+      - .github/*
+
 pool:
   vmImage: ubuntu-18.04
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -291,7 +291,30 @@ jobs:
       restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
 
-  # this triggers a dependency chain that builds all the managed and native dlls
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
+      projects: |
+        src/**/*.csproj
+
+  - task: NuGetCommand@2
+    displayName: nuget restore
+    inputs:
+      restoreSolution: Datadog.Trace.Native.sln
+      verbosityRestore: Normal
+
+  - task: MSBuild@1
+    displayName: msbuild
+    inputs:
+      solution: Datadog.Trace.proj
+      platform: $(buildPlatform)
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:BuildCpp
+      maximumCpuCount: true
+
   - task: MSBuild@1
     displayName: msbuild tracer-home
     inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -289,7 +289,7 @@ jobs:
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
-      restoreSolution: Datadog.Trace.Native.sln
+      restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
 
   - task: MSBuild@1
@@ -422,7 +422,7 @@ jobs:
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
-      restoreSolution: Datadog.Trace.Native.sln
+      restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
 
   - task: MSBuild@1

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -285,12 +285,6 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
-  - task: NuGetCommand@2
-    displayName: nuget restore
-    inputs:
-      restoreSolution: Datadog.Trace.sln
-      verbosityRestore: Normal
-
   - task: DotNetCoreCLI@2
     displayName: dotnet build
     inputs:
@@ -423,13 +417,30 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
+      projects: |
+        src/**/*.csproj
+
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
-      restoreSolution: Datadog.Trace.sln
+      restoreSolution: Datadog.Trace.Native.sln
       verbosityRestore: Normal
 
-  # this triggers a dependency chain that builds all the managed and native dlls
+  - task: MSBuild@1
+    displayName: msbuild
+    inputs:
+      solution: Datadog.Trace.proj
+      platform: $(buildPlatform)
+      configuration: $(buildConfiguration)
+      msbuildArguments: /t:BuildCpp
+      maximumCpuCount: true
+
   - task: MSBuild@1
     displayName: msbuild tracer-home
     inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -6,14 +6,14 @@ trigger:
     exclude:
       - docs/*
       - .github/*
-pr:	
-  branches:	
-    include:	
-      - master	
-      - release/*	
-  paths:	
-    exclude:	
-      - docs/*	
+pr:
+  branches:
+    include:
+      - master
+      - release/*
+  paths:
+    exclude:
+      - docs/*
       - .github/*
 
 pool:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -276,31 +276,13 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      configuration: $(buildConfiguration)
-      arguments: /nowarn:netsdk1138
-      projects: |
-        src/**/*.csproj
-        !src/Datadog.Trace.Tools.Runner/*.csproj
-
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
 
-  - task: MSBuild@1
-    displayName: msbuild
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp
-      maximumCpuCount: true
-
+  # this triggers a dependency chain that builds all the managed and native dlls
   - task: MSBuild@1
     displayName: msbuild tracer-home
     inputs:
@@ -409,31 +391,13 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      configuration: $(buildConfiguration)
-      arguments: /nowarn:netsdk1138
-      projects: |
-        src/**/*.csproj
-        !src/Datadog.Trace.Tools.Runner/*.csproj
-
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
 
-  - task: MSBuild@1
-    displayName: msbuild
-    inputs:
-      solution: Datadog.Trace.proj
-      platform: $(buildPlatform)
-      configuration: $(buildConfiguration)
-      msbuildArguments: /t:BuildCpp
-      maximumCpuCount: true
-
+  # this triggers a dependency chain that builds all the managed and native dlls
   - task: MSBuild@1
     displayName: msbuild tracer-home
     inputs:

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -130,7 +130,7 @@
       </ManagedProfilerPublishProject>
     </ItemGroup>
 
-    <MSBuild Targets="Publish" Projects="@(ManagedProfilerPublishProject)" BuildInParallel="$(BuildInParallel)">
+    <MSBuild Targets="Publish" Projects="@(ManagedProfilerPublishProject)" BuildInParallel="false">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>
@@ -154,7 +154,7 @@
       </BuildLoggerPublishProject>
     </ItemGroup>
 
-    <MSBuild Targets="Publish" Projects="@(BuildLoggerPublishProject)" BuildInParallel="$(BuildInParallel)">
+    <MSBuild Targets="Publish" Projects="@(BuildLoggerPublishProject)" BuildInParallel="false">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>


### PR DESCRIPTION
Set `BuildInParallel=false` for the offending build step that is causing the following build errors:
- `Cannot open 'D:\a\1\s\src\Datadog.Trace.AspNet\obj\Debug\net45\Datadog.Trace.dll'`
- `Cannot open 'D:\a\1\s\src\Datadog.Trace.AspNet\obj\Debug\net45\Datadog.Trace.AspNet.dll'`

@DataDog/apm-dotnet