### PR TITLE
Build and Test ARM64 automatic instrumentation in CI

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -500,3 +500,100 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: down
     condition: succeededOrFailed()
+
+- job: build_linux_profiler_arm64
+  pool: Arm64
+  workspace:
+    clean: all
+
+  steps:
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build Datadog.Trace.ClrProfiler.Managed.Loader
+    inputs:
+      command: build
+      projects: src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+      arguments: --configuration $(buildConfiguration) /nowarn:netsdk1138
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed 2.0
+    inputs:
+      command: publish
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
+      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+      arguments: --configuration $(buildConfiguration) --framework netstandard2.0 --output $(publishOutput)/netstandard2.0
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet publish Datadog.Trace.ClrProfiler.Managed 3.1
+    inputs:
+      command: publish
+      publishWebProjects: false
+      modifyOutputPath: false
+      zipAfterPublish: false
+      projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+      arguments: --configuration $(buildConfiguration) --framework netcoreapp3.1 --output $(publishOutput)/netcoreapp3.1
+
+  - task: DockerCompose@0
+    displayName: docker-compose run Profiler
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run Profiler
+
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
+    artifact: linux-tracer-home_arm
+
+- job: Linux_arm64
+  timeoutInMinutes: 120
+  pool: Arm64
+  workspace:
+    clean: all
+
+  dependsOn: build_linux_profiler_arm64
+  condition: succeeded()
+  strategy:
+    matrix:
+      netcoreapp3_1:
+        publishTargetFramework: netcoreapp3.1
+      net5_0:
+        publishTargetFramework: net5.0
+
+  variables:
+    TestAllPackageVersions: true
+
+  steps:
+  - download: current
+    artifact: linux-tracer-home_arm
+
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: $(Pipeline.Workspace)/linux-tracer-home_arm
+      targetFolder: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/arm64
+
+  - task: DockerCompose@0
+    displayName: docker-compose run build.arm64
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) build.arm64
+
+  - task: DockerCompose@0
+    displayName: docker-compose run IntegrationTests.ARM64.Core31
+    condition: eq(variables['publishTargetFramework'], 'netcoreapp3.1')
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core31
+
+  - task: DockerCompose@0
+    displayName: docker-compose run IntegrationTests.ARM64.Core50
+    condition: eq(variables['publishTargetFramework'], 'net5.0')
+    inputs:
+      containerregistrytype: Container Registry
+      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core50
+
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
+      testResultsFormat: VSTest
+      testResultsFiles: test/**/*.trx
+    condition: succeededOrFailed()

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -545,7 +545,6 @@ jobs:
     artifact: linux-tracer-home_arm
 
 - job: Linux_arm64
-  timeoutInMinutes: 120
   pool: Arm64
   workspace:
     clean: all

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -552,12 +552,6 @@ jobs:
 
   dependsOn: build_linux_profiler_arm64
   condition: succeeded()
-  strategy:
-    matrix:
-      netcoreapp3_1:
-        publishTargetFramework: netcoreapp3.1
-      net5_0:
-        publishTargetFramework: net5.0
 
   variables:
     TestAllPackageVersions: true
@@ -575,18 +569,10 @@ jobs:
     displayName: docker-compose run build.arm64
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) build.arm64
-
-  - task: DockerCompose@0
-    displayName: docker-compose run IntegrationTests.ARM64.Core31
-    condition: eq(variables['publishTargetFramework'], 'netcoreapp3.1')
-    inputs:
-      containerregistrytype: Container Registry
-      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core31
+      dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=net5.0 build.arm64
 
   - task: DockerCompose@0
     displayName: docker-compose run IntegrationTests.ARM64.Core50
-    condition: eq(variables['publishTargetFramework'], 'net5.0')
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core50

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -99,7 +99,33 @@ jobs:
     env:
       DD_SERVICE_NAME: dd-tracer-dotnet
 
-- job: macos_managed
+- job: managed_linux_arm64
+  pool: Arm64
+  workspace:
+    clean: all
+
+  steps:
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
+      projects: |
+        src/**/*.csproj
+        test/**/*.Tests.csproj
+        benchmarks/**/*.csproj
+        !src/Datadog.Trace.Tools.Runner/*.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      configuration: $(buildConfiguration)
+      projects: test/**/*.Tests.csproj
+
+- job: managed_macos
   pool:
     vmImage: macOS-10.15
 
@@ -147,6 +173,7 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
+
 
 - job: windows_profiler
   strategy:

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -99,6 +99,55 @@ jobs:
     env:
       DD_SERVICE_NAME: dd-tracer-dotnet
 
+- job: macos_managed
+  pool:
+    vmImage: macOS-10.15
+
+  steps:
+
+  - task: UseDotNet@2
+    displayName: install dotnet core runtime 2.1
+    inputs:
+      packageType: runtime
+      version: 2.1.x
+
+  - task: UseDotNet@2
+    displayName: install dotnet core runtime 3.0
+    inputs:
+      packageType: runtime
+      version: 3.0.x
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 3.1
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdkVersion)
+
+  - task: UseDotNet@2
+    displayName: install dotnet core sdk 5.0
+    inputs:
+      packageType: sdk
+      version: $(dotnetCoreSdk5Version)
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
+      projects: |
+        src/**/*.csproj
+        test/**/*.Tests.csproj
+        benchmarks/**/*.csproj
+        !src/Datadog.Trace.Tools.Runner/*.csproj
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet test
+    inputs:
+      command: test
+      configuration: $(buildConfiguration)
+      projects: test/**/*.Tests.csproj
+
 - job: windows_profiler
   strategy:
     matrix:
@@ -200,6 +249,28 @@ jobs:
       make
     displayName: build_profiler
 
+- job: linux_profiler_arm64
+  pool: Arm64
+  workspace:
+    clean: all
+
+  steps:
+
+  - task: DotNetCoreCLI@2
+    displayName: dotnet build
+    inputs:
+      command: build
+      configuration: $(buildConfiguration)
+      arguments: /nowarn:netsdk1138
+      projects: |
+        src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+  
+  - script: |
+      cd ./src/Datadog.Trace.ClrProfiler.Native
+      CXX=clang++ CC=clang cmake .
+      make
+    displayName: build_profiler
+
 - job: macos_profiler
   pool:
     vmImage: macOS-10.15
@@ -231,52 +302,3 @@ jobs:
       cmake .
       make
     displayName: build_profiler
-
-- job: macos_managed
-  pool:
-    vmImage: macOS-10.15
-
-  steps:
-
-  - task: UseDotNet@2
-    displayName: install dotnet core runtime 2.1
-    inputs:
-      packageType: runtime
-      version: 2.1.x
-
-  - task: UseDotNet@2
-    displayName: install dotnet core runtime 3.0
-    inputs:
-      packageType: runtime
-      version: 3.0.x
-
-  - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
-    inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
-
-  - task: UseDotNet@2
-    displayName: install dotnet core sdk 5.0
-    inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdk5Version)
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet build
-    inputs:
-      command: build
-      configuration: $(buildConfiguration)
-      arguments: /nowarn:netsdk1138
-      projects: |
-        src/**/*.csproj
-        test/**/*.Tests.csproj
-        benchmarks/**/*.csproj
-        !src/Datadog.Trace.Tools.Runner/*.csproj
-
-  - task: DotNetCoreCLI@2
-    displayName: dotnet test
-    inputs:
-      command: test
-      configuration: $(buildConfiguration)
-      projects: test/**/*.Tests.csproj

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euxo pipefail
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
+
+mkdir -p /var/log/datadog/dotnet
+touch /var/log/datadog/dotnet/dotnet-tracer-native.log
+tail -f /var/log/datadog/dotnet/dotnet-tracer-native.log | awk '
+  /info/ {print "\033[32m" $0 "\033[39m"}
+  /warn/ {print "\033[31m" $0 "\033[39m"}
+' &
+
+dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
+
+dotnet vstest test/Datadog.Trace.OpenTracing.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.OpenTracing.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.OpenTracing.IntegrationTests/results
+
+wait-for-it servicestackredis:6379 -- \
+wait-for-it stackexchangeredis:6379 -- \
+wait-for-it elasticsearch7_arm64:9200 -- \
+wait-for-it sqledge:1433 -- \
+wait-for-it mongo:27017 -- \
+wait-for-it postgres:5432 -- \
+dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euxo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+cd "$DIR/../.."
+
+PUBLISH_OUTPUT="$( pwd )/src/bin/managed-publish"
+mkdir -p "$PUBLISH_OUTPUT/netstandard2.0"
+mkdir -p "$PUBLISH_OUTPUT/netcoreapp3.1"
+
+dotnet build -c $buildConfiguration src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+
+for proj in Datadog.Trace Datadog.Trace.OpenTracing ; do
+    dotnet publish -f netstandard2.0 -c $buildConfiguration src/$proj/$proj.csproj
+    dotnet publish -f netcoreapp3.1 -c $buildConfiguration src/$proj/$proj.csproj
+done
+
+dotnet publish -f netstandard2.0 -c $buildConfiguration src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj -o "$PUBLISH_OUTPUT/netstandard2.0"
+dotnet publish -f netcoreapp3.1 -c $buildConfiguration src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj -o "$PUBLISH_OUTPUT/netcoreapp3.1"
+
+# Only build Samples.AspNetCoreMvc31 for netcoreapp3.1
+if [ "$publishTargetFramework" == "netcoreapp3.1" ]
+then
+    dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
+fi
+
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader ; do
+    dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
+done
+
+for sample in DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject NetCoreAssemblyLoadFailureOlderNuGet ; do
+    dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/regression/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
+done
+
+dotnet msbuild Datadog.Trace.proj -t:RestoreAndBuildSamplesForPackageVersions -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT" -p:TargetFramework=$publishTargetFramework
+
+for proj in Datadog.Trace.IntegrationTests Datadog.Trace.OpenTracing.IntegrationTests Datadog.Trace.ClrProfiler.IntegrationTests ; do
+    dotnet publish -f $publishTargetFramework -c $buildConfiguration test/$proj/$proj.csproj
+done

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -25,7 +25,7 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -25,7 +25,7 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/build/docker/dotnet.arm64.core31.dockerfile
+++ b/build/docker/dotnet.arm64.core31.dockerfile
@@ -1,4 +1,0 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-
-ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
-RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.arm64.core31.dockerfile
+++ b/build/docker/dotnet.arm64.core31.dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
+RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.arm64.core50.dockerfile
+++ b/build/docker/dotnet.arm64.core50.dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
+RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.arm64.dockerfile
+++ b/build/docker/dotnet.arm64.dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0
+
+# Install aspnetcore-runtime-3.1.10
+RUN wget https://download.visualstudio.microsoft.com/download/pr/936a9563-1dad-4c4b-b366-c7fcc3e28215/a1edcaf4c35bce760d07e3f1f3d0b9cf/aspnetcore-runtime-3.1.10-linux-arm64.tar.gz && \
+    tar zxf aspnetcore-runtime-3.1.10-linux-arm64.tar.gz -C "/usr/share/dotnet"
+
+# Install aspnetcore-runtime-5.0.1
+RUN wget https://download.visualstudio.microsoft.com/download/pr/e12f9b23-cb47-4718-9903-8a000f85a442/d1a6a6c75cc832ad8187f5bce0d6234a/aspnetcore-runtime-5.0.1-linux-arm64.tar.gz && \
+    tar zxf aspnetcore-runtime-5.0.1-linux-arm64.tar.gz -C "/usr/share/dotnet"
+
+ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
+RUN chmod +x /bin/wait-for-it 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -447,37 +447,6 @@ services:
     - mysql
     - rabbitmq
 
-  IntegrationTests.ARM64.Core31:
-    build:
-      context: ./
-      dockerfile: ./build/docker/dotnet.arm64.core31.dockerfile
-    image: datadog-dotnet-arm64-core31
-    command: /project/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
-    volumes:
-    - ./:/project
-    environment:
-    - MONGO_HOST=mongo
-    - SERVICESTACK_REDIS_HOST=servicestackredis:6379
-    - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
-    - ELASTICSEARCH6_HOST=elasticsearch7_arm64:9200
-    - ELASTICSEARCH5_HOST=elasticsearch7_arm64:9200
-    - SQLSERVER_CONNECTION_STRING=Server=sqledge;User=sa;Password=Strong!Passw0rd
-    - POSTGRES_HOST=postgres
-    - MYSQL_HOST=mysql
-    - MYSQL_PORT=3306
-    - RABBITMQ_HOST=rabbitmq
-    - buildConfiguration=${buildConfiguration}
-    - publishTargetFramework=netcoreapp3.1
-    depends_on:
-    - servicestackredis
-    - stackexchangeredis
-    - elasticsearch7_arm64
-    - sqledge
-    - mongo
-    - postgres
-    - mysql
-    - rabbitmq
-
   IntegrationTests.ARM64.Core50:
     build:
       context: ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,14 @@ services:
     environment:
     - discovery.type=single-node
 
+  elasticsearch7_arm64:
+    image: elasticsearch:7.10.1
+    ports:
+    - "127.0.0.1:9200:9200"
+    - "127.0.0.1:9300:9300"
+    environment:
+    - discovery.type=single-node
+
   postgres:
     image: postgres:10.5-alpine
     environment:
@@ -68,6 +76,14 @@ services:
     - ACCEPT_EULA=Y
     - SA_PASSWORD=Strong!Passw0rd
 
+  sqledge:
+    image: mcr.microsoft.com/azure-sql-edge:latest
+    ports:
+    - "127.0.0.1:1433:1433"
+    environment:
+    - ACCEPT_EULA=Y
+    - SA_PASSWORD=Strong!Passw0rd
+
   wcfservice:
     image: mcr.microsoft.com/dotnet/framework/wcf:4.8
     ports:
@@ -82,6 +98,18 @@ services:
     - buildConfiguration=${buildConfiguration}
     - publishTargetFramework=${publishTargetFramework}
     command: /project/build/docker/build.sh
+    volumes:
+    - ./:/project
+
+  build.arm64:
+    build:
+      context: ./
+      dockerfile: ./build/docker/dotnet.arm64.dockerfile
+    image: datadog-dotnet
+    environment:
+    - buildConfiguration=${buildConfiguration}
+    - publishTargetFramework=${publishTargetFramework}
+    command: /project/build/docker/build.arm64.sh
     volumes:
     - ./:/project
 
@@ -418,3 +446,61 @@ services:
     - postgres
     - mysql
     - rabbitmq
+
+  IntegrationTests.ARM64.Core31:
+    build:
+      context: ./
+      dockerfile: ./build/docker/dotnet.arm64.core31.dockerfile
+    image: datadog-dotnet-arm64-core31
+    command: /project/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+    volumes:
+    - ./:/project
+    environment:
+    - MONGO_HOST=mongo
+    - SERVICESTACK_REDIS_HOST=servicestackredis:6379
+    - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
+    - ELASTICSEARCH6_HOST=elasticsearch7_arm64:9200
+    - ELASTICSEARCH5_HOST=elasticsearch7_arm64:9200
+    - SQLSERVER_CONNECTION_STRING=Server=sqledge;User=sa;Password=Strong!Passw0rd
+    - POSTGRES_HOST=postgres
+    - MYSQL_HOST=mysql
+    - MYSQL_PORT=3306
+    - buildConfiguration=${buildConfiguration}
+    - publishTargetFramework=netcoreapp3.1
+    depends_on:
+    - servicestackredis
+    - stackexchangeredis
+    - elasticsearch7_arm64
+    - sqledge
+    - mongo
+    - postgres
+    - mysql
+
+  IntegrationTests.ARM64.Core50:
+    build:
+      context: ./
+      dockerfile: ./build/docker/dotnet.arm64.core50.dockerfile
+    image: datadog-dotnet-arm64-core50
+    command: /project/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+    volumes:
+    - ./:/project
+    environment:
+    - MONGO_HOST=mongo
+    - SERVICESTACK_REDIS_HOST=servicestackredis:6379
+    - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
+    - ELASTICSEARCH6_HOST=elasticsearch7_arm64:9200
+    - ELASTICSEARCH5_HOST=elasticsearch7_arm64:9200
+    - SQLSERVER_CONNECTION_STRING=Server=sqledge;User=sa;Password=Strong!Passw0rd
+    - POSTGRES_HOST=postgres
+    - MYSQL_HOST=mysql
+    - MYSQL_PORT=3306
+    - buildConfiguration=${buildConfiguration}
+    - publishTargetFramework=net5.0
+    depends_on:
+    - servicestackredis
+    - stackexchangeredis
+    - elasticsearch7_arm64
+    - sqledge
+    - mongo
+    - postgres
+    - mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -465,6 +465,7 @@ services:
     - POSTGRES_HOST=postgres
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
+    - RABBITMQ_HOST=rabbitmq
     - buildConfiguration=${buildConfiguration}
     - publishTargetFramework=netcoreapp3.1
     depends_on:
@@ -475,6 +476,7 @@ services:
     - mongo
     - postgres
     - mysql
+    - rabbitmq
 
   IntegrationTests.ARM64.Core50:
     build:
@@ -494,6 +496,7 @@ services:
     - POSTGRES_HOST=postgres
     - MYSQL_HOST=mysql
     - MYSQL_PORT=3306
+    - RABBITMQ_HOST=rabbitmq
     - buildConfiguration=${buildConfiguration}
     - publishTargetFramework=net5.0
     depends_on:
@@ -504,3 +507,4 @@ services:
     - mongo
     - postgres
     - mysql
+    - rabbitmq


### PR DESCRIPTION
This PR adds ARM64 support in both `unit-tests` and `integration-tests` pipeline.

@DataDog/apm-dotnet