### PR TITLE
Fix logging tests

### DIFF
--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -80,6 +80,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public static void Reload()
         {
+            DatadogLogging.Reset();
             Source = FromDefaultSources();
         }
 

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -13,7 +13,8 @@ namespace Datadog.Trace.Logging
 {
     internal static class DatadogLogging
     {
-        internal static readonly LoggingLevelSwitch LoggingLevelSwitch = new LoggingLevelSwitch(LogEventLevel.Information);
+        internal static readonly LoggingLevelSwitch LoggingLevelSwitch = new LoggingLevelSwitch(DefaultLogLevel);
+        private const LogEventLevel DefaultLogLevel = LogEventLevel.Information;
         private static readonly long? MaxLogFileSize = 10 * 1024 * 1024;
         private static readonly ILogger SharedLogger = null;
 
@@ -118,6 +119,11 @@ namespace Datadog.Trace.Logging
                     // ignore
                 }
             }
+        }
+
+        internal static void Reset()
+        {
+            LoggingLevelSwitch.MinimumLevel = DefaultLogLevel;
         }
 
         internal static void SetLogLevel(LogEventLevel logLevel)

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -7,6 +7,8 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.Configuration
 {
+    [CollectionDefinition(nameof(ConfigurationSourceTests), DisableParallelization = true)]
+    [Collection(nameof(ConfigurationSourceTests))]
     public class ConfigurationSourceTests
     {
         private static readonly Dictionary<string, string> TagsK1V1K2V2 = new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" } };

--- a/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.Logging
 {
+    [CollectionDefinition(nameof(Datadog.Trace.Tests.Logging), DisableParallelization = true)]
     [Collection(nameof(Datadog.Trace.Tests.Logging))]
     public class DatadogLoggingTests : IDisposable
     {


### PR DESCRIPTION
- Both DatadogLoggingTests and ConfigurationSourceTests impact the global logging level, so disable parallelization on those
- `GlobalSettings.Reload()` was not actually resetting the log level