### PR TITLE
Reenable dogfooding by removing the breaking change

### DIFF
--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -47,16 +47,10 @@ jobs:
 
   # Install the tracer latest stable release to attach the profiler to the build and test steps.
   # The script exposes the required environment variables to the following steps
-
-  # PR: https://github.com/DataDog/dd-trace-dotnet/pull/1092
-  # Introduces a breaking change in the xUnit Integration causing instrumentation failure when
-  # using previous releases of the tracer. We have to disable the dogfooding until we release
-  # a new version of the tracer that includes the changes in the PR.
-  
-  #- task: PowerShell@2
-  #  displayName: Install profiler latest release
-  #  inputs:
-  #    filePath: ./.azure-pipelines/setup_tracer.ps1
+  - task: PowerShell@2
+    displayName: Install profiler latest release
+    inputs:
+      filePath: ./.azure-pipelines/setup_tracer.ps1
 
   - task: UseDotNet@2
     displayName: install dotnet core runtime 2.1

--- a/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace
             get { return _instance ?? (_instance = Create()); }
         }
 
-        private static FrameworkDescription Create()
+        public static FrameworkDescription Create()
         {
             var frameworkName = "unknown";
             var frameworkVersion = "unknown";

--- a/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace
             get { return _instance ?? (_instance = Create()); }
         }
 
-        private static FrameworkDescription Create()
+        public static FrameworkDescription Create()
         {
             var osArchitecture = "unknown";
             var processArchitecture = "unknown";


### PR DESCRIPTION
- ReEnable the dogfooding in unit-tests pipeline.
- Revert the visibility for FrameworkDescription.Create() method, removing the breaking change when the old integration dll is loaded.


@DataDog/apm-dotnet