### PR TITLE
Fixes the flaky mutex destroyed while busy error in integration tests. 

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -574,13 +574,20 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown() {
   std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
   Warn("Exiting.");
+  Logger::Instance()->Flush();
   is_attached_ = false;
   return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerDetachSucceeded() {
+  CorProfilerBase::ProfilerDetachSucceeded();
+
+  // keep this lock until we are done using the module,
+  // to prevent it from unloading while in use
+  std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
+
   Warn("Detaching profiler.");
-  Logger::Shutdown();
+  Logger::Instance()->Flush();
   return S_OK;
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -28,7 +28,6 @@ class Logger : public Singleton<Logger> {
   void Error(const std::string& str);
   void Critical(const std::string& str);
   void Flush();
-  static void Shutdown() { spdlog::shutdown(); }
 };
 
 template <typename Arg>


### PR DESCRIPTION
Fixes a `mutex` disposal flaky problem detected in: https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=38387&view=logs&j=4fbced83-508e-5fe0-c978-5c71ec0fc506&t=61d34ef4-724f-5c76-d290-a97c2fe9549e

@DataDog/apm-dotnet