### PR TITLE
Removing warnings from the clang-tidy utility.

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -242,7 +242,7 @@ jobs:
     condition: succeededOrFailed()
 
 - job: Windows
-  timeoutInMinutes: 80
+  timeoutInMinutes: 100
   strategy:
     matrix:
       x64:
@@ -357,7 +357,7 @@ jobs:
     condition: succeededOrFailed()
     
 - job: Windows_IIS
-  timeoutInMinutes: 80
+  timeoutInMinutes: 100
   strategy:
     matrix:
       x64:

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -178,7 +178,7 @@ endif()
 # Sets compiler options
 add_compile_options(-std=c++11 -fPIC -fms-extensions)
 add_compile_options(-DPAL_STDCPP_COMPAT -DPLATFORM_UNIX -DUNICODE)
-add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined)
+add_compile_options(-Wno-invalid-noreturn -Wno-macro-redefined -Wno-c++17-extensions)
 if (ISMACOS)
     add_compile_options(-stdlib=libc++ -DMACOS -Wno-pragma-pack)
 elseif(ISLINUX)

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -426,7 +426,7 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(
   // *** Create de MethodSpec using the FunctionMethodArgument
 
   // Gets the Return type signature
-  PCCOR_SIGNATURE methodArgumentSignature = NULL;
+  PCCOR_SIGNATURE methodArgumentSignature = nullptr;
   ULONG methodArgumentSignatureSize;
   methodArgumentSignatureSize =
       methodArgument->GetSignature(methodArgumentSignature);
@@ -476,7 +476,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(
 
   ModuleMetadata* module_metadata = GetMetadata();
 
-  PCCOR_SIGNATURE originalSignature = NULL;
+  PCCOR_SIGNATURE originalSignature = nullptr;
   ULONG originalSignatureSize = 0;
   mdToken localVarSig = reWriter->GetTkLocalVarSig();
 
@@ -512,12 +512,12 @@ HRESULT CallTargetTokens::ModifyLocalSig(
   auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
 
   // Gets the Return type signature
-  PCCOR_SIGNATURE returnSignatureType = NULL;
+  PCCOR_SIGNATURE returnSignatureType = nullptr;
   ULONG returnSignatureTypeSize = 0;
 
   // Gets the CallTargetReturn<T> mdTypeSpec
   mdToken callTargetReturn = mdTokenNil;
-  PCCOR_SIGNATURE callTargetReturnSignature = NULL;
+  PCCOR_SIGNATURE callTargetReturnSignature = nullptr;
   ULONG callTargetReturnSignatureSize;
   unsigned callTargetReturnBuffer;
   ULONG callTargetReturnSize;
@@ -591,7 +591,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(
   // Add new locals
 
   // Return value local
-  if (returnSignatureType != NULL) {
+  if (returnSignatureType != nullptr) {
     memcpy(&newSignatureBuffer[newSignatureOffset], returnSignatureType,
            returnSignatureTypeSize);
     newSignatureOffset += returnSignatureTypeSize;
@@ -604,7 +604,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(
   newSignatureOffset += exTypeRefSize;
 
   // CallTarget Return value
-  if (callTargetReturnSignature != NULL) {
+  if (callTargetReturnSignature != nullptr) {
     memcpy(&newSignatureBuffer[newSignatureOffset], callTargetReturnSignature,
            callTargetReturnSignatureSize);
     newSignatureOffset += callTargetReturnSignatureSize;
@@ -634,7 +634,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(
   *callTargetStateToken = callTargetStateTypeRef;
   *exceptionToken = exTypeRef;
   *callTargetReturnToken = callTargetReturn;
-  if (returnSignatureType != NULL) {
+  if (returnSignatureType != nullptr) {
     *returnValueIndex = newLocalsCount - 4;
   } else {
     *returnValueIndex = static_cast<ULONG>(ULONG_MAX);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -147,7 +147,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
           return this->CallTarget_RewriterCallback(mod, method);
       });
   } else {
-      rejit_handler = NULL;
+      rejit_handler = nullptr;
   }
 
   // load all available integrations from JSON files
@@ -1453,7 +1453,7 @@ const std::string indent_values[] = {
     std::string(2 * 10, ' '),
 };
 
-std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
+std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewriter,
                                     const FunctionInfo& caller, ModuleMetadata* module_metadata) {
   std::stringstream orig_sstream;
   orig_sstream << title;
@@ -1468,7 +1468,7 @@ std::string CorProfiler::GetILCodes(std::string title, ILRewriter* rewriter,
   const auto ehPtr = rewriter->GetEHPointer();
   int indent = 1;
 
-  PCCOR_SIGNATURE originalSignature = NULL;
+  PCCOR_SIGNATURE originalSignature = nullptr;
   ULONG originalSignatureSize = 0;
   mdToken localVarSig = rewriter->GetTkLocalVarSig();
 
@@ -2414,13 +2414,13 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
   *symbolsSize = pdb_end - pdb_start;
   *pSymbolsArray = (BYTE*)pdb_start;
 #else
-    const auto imgCount = _dyld_image_count();
+    const unsigned int imgCount = _dyld_image_count();
 
     for(auto i = 0; i < imgCount; i++) {
-        const auto name = std::string(_dyld_get_image_name(i));
+        const std::string name = std::string(_dyld_get_image_name(i));
 
         if (name.rfind("Datadog.Trace.ClrProfiler.Native.dylib") != std::string::npos) {
-            const auto header = (const struct mach_header_64 *) _dyld_get_image_header(i);
+            const mach_header_64* header = (const struct mach_header_64 *) _dyld_get_image_header(i);
 
             unsigned long dllSize;
             const auto dllData = getsectiondata(header, "binary", "dll", &dllSize);
@@ -2435,7 +2435,6 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
         }
     }
 #endif
-  return;
 }
 
 
@@ -2488,12 +2487,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef
 /// <param name="module_metadata">Module metadata for the module</param>
 /// <param name="filtered_integrations">Filtered vector of integrations to be applied</param>
 /// <returns>Number of ReJIT requests made</returns>
-size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleMetadata* module_metadata, std::vector<IntegrationMethod> filtered_integrations) {
+size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleMetadata* module_metadata, const std::vector<IntegrationMethod> &filtered_integrations) {
   auto metadata_import = module_metadata->metadata_import;
   std::vector<ModuleID> vtModules;
   std::vector<mdMethodDef> vtMethodDefs;
 
-  for (IntegrationMethod integration : filtered_integrations) {
+  for (const IntegrationMethod& integration : filtered_integrations) {
 
     // If the integration is not for the current assembly we skip.
     if (integration.replacement.target_method.assembly.name != module_metadata->assemblyName) {
@@ -2601,7 +2600,7 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
   }
 
   // Request the ReJIT for all integrations found in the module.
-  if (vtMethodDefs.size() > 0) {
+  if (!vtMethodDefs.empty()) {
     Info("Requesting ReJIT for ", vtMethodDefs.size(), " methods.");
     this->info_->RequestReJIT((ULONG)vtMethodDefs.size(), vtModules.data(), vtMethodDefs.data());
   }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -30,7 +30,7 @@ class CorProfiler : public CorProfilerBase {
 
   bool instrument_domain_neutral_assemblies = false;
   bool corlib_module_loaded = false;
-  AppDomainID corlib_app_domain_id;
+  AppDomainID corlib_app_domain_id = 0;
   bool managed_profiler_loaded_domain_neutral = false;
   std::unordered_set<AppDomainID> managed_profiler_loaded_app_domains;
   std::unordered_set<AppDomainID> first_jit_compilation_app_domains;
@@ -40,7 +40,7 @@ class CorProfiler : public CorProfilerBase {
   //
   // CallTarget Members
   //
-  RejitHandler* rejit_handler;
+  RejitHandler* rejit_handler = nullptr;
 
   // Cor assembly properties
   AssemblyProperty corAssemblyProperty{};
@@ -77,7 +77,7 @@ class CorProfiler : public CorProfilerBase {
                                          const FunctionInfo& caller,
                                          const std::vector<MethodReplacement> method_replacements);
   bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
-  std::string GetILCodes(std::string title, ILRewriter* rewriter,
+  std::string GetILCodes(const std::string& title, ILRewriter* rewriter,
                          const FunctionInfo& caller,
                          ModuleMetadata* module_metadata);
   //
@@ -94,7 +94,7 @@ class CorProfiler : public CorProfilerBase {
   //
   size_t CallTarget_RequestRejitForModule(
     ModuleID module_id, ModuleMetadata* module_metadata,
-    std::vector<IntegrationMethod> filtered_integrations);
+    const std::vector<IntegrationMethod>& filtered_integrations);
   HRESULT CallTarget_RewriterCallback(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler);
 
  public:

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -132,7 +132,7 @@ HRESULT RejitHandler::NotifyReJITParameters(
     return S_FALSE;
   }
 
-  if (moduleHandler->GetModuleId() == NULL) {
+  if (moduleHandler->GetModuleId() == 0) {
     Warn(
         "NotifyReJITCompilationStarted: ModuleID is missing for "
         "MethodDef: ",

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
@@ -32,6 +32,8 @@ class RejitHandlerModuleMethod {
     this->methodDef = methodDef;
     this->pFunctionControl = nullptr;
     this->module = module;
+    this->functionInfo = nullptr;
+    this->methodReplacement = nullptr;
   }
   inline mdMethodDef GetMethodDef() { return this->methodDef; }
   inline ICorProfilerFunctionControl* GetFunctionControl() {


### PR DESCRIPTION
This PR addresses some of the recommendations made from the clang-tidy utility.

@DataDog/apm-dotnet