### PR TITLE
Added configuration for span errors based on http status codes

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -160,7 +160,7 @@ namespace Datadog.Trace.AspNet
                 if (sender is HttpApplication app &&
                     app.Context.Items[_httpContextScopeKey] is Scope scope)
                 {
-                    scope.Span.SetHttpServerStatusCode(app.Context.Response.StatusCode);
+                    scope.Span.SetHttpStatusCode(app.Context.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
             }

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -160,7 +160,7 @@ namespace Datadog.Trace.AspNet
                 if (sender is HttpApplication app &&
                     app.Context.Items[_httpContextScopeKey] is Scope scope)
                 {
-                    scope.Span.SetServerStatusCode(app.Context.Response.StatusCode);
+                    scope.Span.SetHttpServerStatusCode(app.Context.Response.StatusCode);
                     scope.Dispose();
                 }
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/HttpClientHandler/HttpClientHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/HttpClientHandler/HttpClientHandlerIntegration.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
@@ -103,14 +104,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
 
             try
             {
-                if (exception is null)
-                {
-                    if (integrationState.Tags != null)
-                    {
-                        integrationState.Tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString(responseMessage.StatusCode);
-                    }
-                }
-                else
+                integrationState.Scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+
+                if (exception != null)
                 {
                     integrationState.Scope.Span.SetException(exception);
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
@@ -104,14 +105,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
 
             try
             {
-                if (exception is null)
-                {
-                    if (integrationState.Tags != null)
-                    {
-                        integrationState.Tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString(responseMessage.StatusCode);
-                    }
-                }
-                else
+                integrationState.Scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+
+                if (exception != null)
                 {
                     integrationState.Scope.Span.SetException(exception);
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
@@ -104,14 +105,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
 
             try
             {
-                if (exception is null)
-                {
-                    if (integrationState.Tags != null)
-                    {
-                        integrationState.Tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString(responseMessage.StatusCode);
-                    }
-                }
-                else
+                integrationState.Scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+
+                if (exception != null)
                 {
                     integrationState.Scope.Span.SetException(exception);
                 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -324,7 +324,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 if (scope != null)
                 {
-                    scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
+                    scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
 
@@ -355,7 +355,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
+            scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -324,7 +324,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 if (scope != null)
                 {
-                    scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
+                    scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
                     scope.Dispose();
                 }
 
@@ -355,7 +355,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
+            scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
             scope.Span.Finish(finishTime);
             scope.Dispose();
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -162,7 +162,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     UpdateSpan(controllerContext, scope.Span, tags, Enumerable.Empty<KeyValuePair<string, string>>());
 
                     var statusCode = responseMessage.GetProperty("StatusCode");
-                    scope.Span.SetServerStatusCode((int)statusCode.Value);
+                    scope.Span.SetHttpServerStatusCode((int)statusCode.Value);
                     scope.Dispose();
                 }
 
@@ -320,7 +320,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(System.Web.HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
+            scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
             scope.Span.Finish(finishTime);
             scope.Dispose();
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -162,7 +162,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     UpdateSpan(controllerContext, scope.Span, tags, Enumerable.Empty<KeyValuePair<string, string>>());
 
                     var statusCode = responseMessage.GetProperty("StatusCode");
-                    scope.Span.SetHttpServerStatusCode((int)statusCode.Value);
+                    scope.Span.SetHttpStatusCode((int)statusCode.Value, isServer: true);
                     scope.Dispose();
                 }
 
@@ -320,7 +320,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(System.Web.HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
+            scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -7,6 +7,7 @@ using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
@@ -272,7 +273,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null)
                     {
-                        tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString(statusCode);
+                        scope.Span.SetClientStatusCode(statusCode);
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -273,7 +273,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null)
                     {
-                        scope.Span.SetClientStatusCode(statusCode);
+                        scope.Span.SetHttpClientStatusCode(statusCode);
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -10,7 +10,6 @@ using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -273,7 +272,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null)
                     {
-                        scope.Span.SetHttpClientStatusCode(statusCode);
+                        scope.Span.SetHttpStatusCode(statusCode, isServer: false);
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -5,7 +5,6 @@ using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations
 {
@@ -97,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        scope.Span.SetHttpClientStatusCode((int)webResponse.StatusCode);
+                        scope.Span.SetHttpStatusCode((int)webResponse.StatusCode, isServer: false);
                     }
 
                     return response;
@@ -182,7 +181,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        scope.Span.SetHttpClientStatusCode((int)webResponse.StatusCode);
+                        scope.Span.SetHttpStatusCode((int)webResponse.StatusCode, isServer: false);
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString((int)webResponse.StatusCode);
+                        scope.Span.SetClientStatusCode((int)webResponse.StatusCode);
                     }
 
                     return response;
@@ -182,7 +182,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        tags.HttpStatusCode = HttpTags.ConvertStatusCodeToString((int)webResponse.StatusCode);
+                        scope.Span.SetClientStatusCode((int)webResponse.StatusCode);
                     }
 
                     return response;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        scope.Span.SetClientStatusCode((int)webResponse.StatusCode);
+                        scope.Span.SetHttpClientStatusCode((int)webResponse.StatusCode);
                     }
 
                     return response;
@@ -182,7 +182,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (scope != null && response is HttpWebResponse webResponse)
                     {
-                        scope.Span.SetClientStatusCode((int)webResponse.StatusCode);
+                        scope.Span.SetHttpClientStatusCode((int)webResponse.StatusCode);
                     }
 
                     return response;

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -245,6 +245,18 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
 
         /// <summary>
+        /// Configuration key for the application's servers http statuses to set spans as errors by.
+        /// </summary>
+        /// <seealso cref="TracerSettings.HttpServerErrorStatuses"/>
+        public const string HttpServerErrors = "DD_HTTP_SERVER_ERROR_STATUSES";
+
+        /// <summary>
+        /// Configuration key for the application's client http statuses to set spans as errors by.
+        /// </summary>
+        /// <seealso cref="TracerSettings.HttpClientErrorStatuses"/>
+        public const string HttpClientErrors = "DD_HTTP_CLIENT_ERROR_STATUSES";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -245,16 +245,16 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
 
         /// <summary>
-        /// Configuration key for the application's servers http statuses to set spans as errors by.
+        /// Configuration key for the application's server http statuses to set spans as errors by.
         /// </summary>
-        /// <seealso cref="TracerSettings.HttpServerErrorStatuses"/>
-        public const string HttpServerErrors = "DD_HTTP_SERVER_ERROR_STATUSES";
+        /// <seealso cref="TracerSettings.HttpServerErrorCodes"/>
+        public const string HttpServerErrorCodes = "DD_HTTP_SERVER_ERROR_STATUSES";
 
         /// <summary>
         /// Configuration key for the application's client http statuses to set spans as errors by.
         /// </summary>
-        /// <seealso cref="TracerSettings.HttpClientErrorStatuses"/>
-        public const string HttpClientErrors = "DD_HTTP_CLIENT_ERROR_STATUSES";
+        /// <seealso cref="TracerSettings.HttpClientErrorCodes"/>
+        public const string HttpClientErrorCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
 
         /// <summary>
         /// String format patterns used to match integration-specific configuration keys.

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -247,14 +247,14 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for the application's server http statuses to set spans as errors by.
         /// </summary>
-        /// <seealso cref="TracerSettings.HttpServerErrorCodes"/>
-        public const string HttpServerErrorStatuses = "DD_HTTP_SERVER_ERROR_STATUSES";
+        /// <seealso cref="TracerSettings.HttpServerErrorStatusCodes"/>
+        public const string HttpServerErrorStatusCodes = "DD_HTTP_SERVER_ERROR_STATUSES";
 
         /// <summary>
         /// Configuration key for the application's client http statuses to set spans as errors by.
         /// </summary>
-        /// <seealso cref="TracerSettings.HttpClientErrorCodes"/>
-        public const string HttpClientErrorStatuses = "DD_HTTP_CLIENT_ERROR_STATUSES";
+        /// <seealso cref="TracerSettings.HttpClientErrorStatusCodes"/>
+        public const string HttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
 
         /// <summary>
         /// String format patterns used to match integration-specific configuration keys.

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -248,13 +248,13 @@ namespace Datadog.Trace.Configuration
         /// Configuration key for the application's server http statuses to set spans as errors by.
         /// </summary>
         /// <seealso cref="TracerSettings.HttpServerErrorCodes"/>
-        public const string HttpServerErrorCodes = "DD_HTTP_SERVER_ERROR_STATUSES";
+        public const string HttpServerErrorStatuses = "DD_HTTP_SERVER_ERROR_STATUSES";
 
         /// <summary>
         /// Configuration key for the application's client http statuses to set spans as errors by.
         /// </summary>
         /// <seealso cref="TracerSettings.HttpClientErrorCodes"/>
-        public const string HttpClientErrorCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
+        public const string HttpClientErrorStatuses = "DD_HTTP_CLIENT_ERROR_STATUSES";
 
         /// <summary>
         /// String format patterns used to match integration-specific configuration keys.

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -312,13 +312,13 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets the HTTP status code that should be marked as errors for server integrations.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.HttpServerErrorStatusCodes"/>
-        public bool[] HttpServerErrorStatusCodes { get; set; }
+        internal bool[] HttpServerErrorStatusCodes { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP status code that should be marked as errors for client integrations.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
-        public bool[] HttpClientErrorStatusCodes { get; set; }
+        internal bool[] HttpClientErrorStatusCodes { get; set; }
 
         /// <summary>
         /// Gets a value indicating the size of the trace buffer
@@ -344,6 +344,26 @@ namespace Datadog.Trace.Configuration
         public static CompositeConfigurationSource CreateDefaultConfigurationSource()
         {
             return GlobalSettings.CreateDefaultConfigurationSource();
+        }
+
+        /// <summary>
+        /// Sets the HTTP status code that should be marked as errors for client integrations.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
+        /// <param name="statusCodes">Status codes that should be marked as errors</param>
+        public void SetHttpClientErrorStatusCodes(IEnumerable<int> statusCodes)
+        {
+            HttpClientErrorStatusCodes = ParseHttpCodesToArray(string.Join(",", statusCodes));
+        }
+
+        /// <summary>
+        /// Sets the HTTP status code that should be marked as errors for server integrations.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpServerErrorStatusCodes"/>
+        /// <param name="statusCodes">Status codes that should be marked as errors</param>
+        public void SetHttpServerErrorStatusCodes(IEnumerable<int> statusCodes)
+        {
+            HttpServerErrorStatusCodes = ParseHttpCodesToArray(string.Join(",", statusCodes));
         }
 
         /// <summary>
@@ -410,6 +430,14 @@ namespace Datadog.Trace.Configuration
         {
             bool[] httpErrorCodesArray = new bool[600];
 
+            void TrySetValue(int index)
+            {
+                if (index >= 0 && index < httpErrorCodesArray.Length)
+                {
+                    httpErrorCodesArray[index] = true;
+                }
+            }
+
             string[] configurationsArray = httpStatusErrorCodes.Replace(" ", string.Empty).Split(',');
 
             foreach (string statusConfiguration in configurationsArray)
@@ -425,7 +453,7 @@ namespace Datadog.Trace.Configuration
                 // If statusConfiguration equals a single value i.e. `401` parse the value and save to the array
                 else if (int.TryParse(statusConfiguration, out startStatus))
                 {
-                    httpErrorCodesArray[startStatus] = true;
+                    TrySetValue(startStatus);
                 }
                 else
                 {
@@ -442,7 +470,7 @@ namespace Datadog.Trace.Configuration
 
                     for (int statusCode = startStatus; statusCode <= endStatus; statusCode++)
                     {
-                        httpErrorCodesArray[statusCode] = true;
+                        TrySetValue(statusCode);
                     }
                 }
             }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -151,12 +151,12 @@ namespace Datadog.Trace.Configuration
             var httpServerErrorCodes = source?.GetString(ConfigurationKeys.HttpServerErrorCodes) ??
                                            // Default value
                                            "500-599";
-            HttpServerErrorCodes = MapStatusToList(httpServerErrorCodes);
+            HttpServerErrorCodes = ParseHttpCodesToDictionary(httpServerErrorCodes);
 
             var httpClientErrorCodes = source?.GetString(ConfigurationKeys.HttpClientErrorCodes) ??
                                         // Default value
                                         "400-499";
-            HttpClientErrorCodes = MapStatusToList(httpClientErrorCodes);
+            HttpClientErrorCodes = ParseHttpCodesToDictionary(httpClientErrorCodes);
 
             TraceQueueSize = source?.GetInt32(ConfigurationKeys.QueueSize)
                         ?? 1000;
@@ -388,7 +388,7 @@ namespace Datadog.Trace.Configuration
             return value == "1" || value == "true";
         }
 
-        internal IDictionary<int, bool> MapStatusToList(string httpStatusErrorCodes)
+        internal IDictionary<int, bool> ParseHttpCodesToDictionary(string httpStatusErrorCodes)
         {
             string[] configurationsArray = string.Concat(httpStatusErrorCodes.Where(c => !char.IsWhiteSpace(c))).Split(',');
 

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -354,6 +354,23 @@ namespace Datadog.Trace.Configuration
             Integrations.SetDisabledIntegrations(DisabledIntegrationNames);
         }
 
+        internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
+        {
+            var source = serverStatusCode ? HttpServerErrorStatusCodes : HttpClientErrorStatusCodes;
+
+            if (source == null)
+            {
+                return false;
+            }
+
+            if (statusCode >= source.Length)
+            {
+                return false;
+            }
+
+            return source[statusCode];
+        }
+
         internal bool IsIntegrationEnabled(IntegrationInfo integration, bool defaultValue = true)
         {
             if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -147,6 +147,16 @@ namespace Datadog.Trace.Configuration
                                           // default value
                                           true;
 
+            var httpServerErrorsStatuses = source?.GetString(ConfigurationKeys.HttpServerErrors) ??
+                                           // Default value
+                                           "500-599";
+            HttpServerErrorStatuses = MapStatusToList(httpServerErrorsStatuses);
+
+            var httpClientErrorStatuses = source?.GetString(ConfigurationKeys.HttpClientErrors) ??
+                                        // Default value
+                                        "400-499";
+            HttpClientErrorStatuses = MapStatusToList(httpClientErrorStatuses);
+
             TraceQueueSize = source?.GetInt32(ConfigurationKeys.QueueSize)
                         ?? 1000;
         }
@@ -297,6 +307,17 @@ namespace Datadog.Trace.Configuration
         public bool StartupDiagnosticLogEnabled { get; set; }
 
         /// <summary>
+        /// Gets or sets the HTTP status code that should be marked as errors for server integrations.        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpServerErrors"/>
+        public IDictionary<int, bool> HttpServerErrorStatuses { get; set; }
+
+        /// <summary>
+        /// Gets or sets the HTTP status code that should be marked as errors for client integrations.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpClientErrors"/>
+        public IDictionary<int, bool> HttpClientErrorStatuses { get; set; }
+
+        /// <summary>
         /// Gets a value indicating the size of the trace buffer
         /// </summary>
         internal int TraceQueueSize { get; }
@@ -363,6 +384,47 @@ namespace Datadog.Trace.Configuration
             var value = EnvironmentHelpers.GetEnvironmentVariable("DD_TRACE_NETSTANDARD_ENABLED", string.Empty);
 
             return value == "1" || value == "true";
+        }
+
+        internal IDictionary<int, bool> MapStatusToList(string httpStatusErrors)
+        {
+            string[] configurationsArray = string.Concat(httpStatusErrors.Where(c => !char.IsWhiteSpace(c))).Split(',');
+
+            IDictionary<int, bool> httpStatusesDictionary = new Dictionary<int, bool>();
+
+            foreach (string statusConfiguration in configurationsArray)
+            {
+                int parsedStatus;
+
+                if (int.TryParse(statusConfiguration, out parsedStatus))
+                {
+                    httpStatusesDictionary[parsedStatus] = true;
+                }
+                else if (statusConfiguration.Split('-').Length > 1)
+                {
+                    var statusRange = statusConfiguration.Split('-').Select(int.Parse).ToArray();
+                    parsedStatus = statusRange[0];
+
+                    if (statusRange[1] < statusRange[0])
+                    {
+                        parsedStatus = statusRange[1];
+                        statusRange[1] = statusRange[0];
+                        statusRange[0] = parsedStatus;
+                    }
+
+                    while (parsedStatus < statusRange[1] + 1)
+                    {
+                        httpStatusesDictionary[parsedStatus] = true;
+                        parsedStatus++;
+                    }
+                }
+                else
+                {
+                    Log.Warning("Wrong format '{0}' for DD_HTTP_SERVER/CLIENT_ERROR_STATUSES configuration.", statusConfiguration);
+                }
+            }
+
+            return httpStatusesDictionary;
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -148,12 +148,12 @@ namespace Datadog.Trace.Configuration
                                           // default value
                                           true;
 
-            var httpServerErrorCodes = source?.GetString(ConfigurationKeys.HttpServerErrorCodes) ??
+            var httpServerErrorCodes = source?.GetString(ConfigurationKeys.HttpServerErrorStatuses) ??
                                            // Default value
                                            "500-599";
             HttpServerErrorCodes = ParseHttpCodesToDictionary(httpServerErrorCodes);
 
-            var httpClientErrorCodes = source?.GetString(ConfigurationKeys.HttpClientErrorCodes) ??
+            var httpClientErrorCodes = source?.GetString(ConfigurationKeys.HttpClientErrorStatuses) ??
                                         // Default value
                                         "400-499";
             HttpClientErrorCodes = ParseHttpCodesToDictionary(httpClientErrorCodes);
@@ -310,13 +310,13 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets or sets the HTTP status code that should be marked as errors for server integrations.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.HttpServerErrorCodes"/>
+        /// <seealso cref="ConfigurationKeys.HttpServerErrorStatuses"/>
         public IDictionary<int, bool> HttpServerErrorCodes { get; set; }
 
         /// <summary>
         /// Gets or sets the HTTP status code that should be marked as errors for client integrations.
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.HttpClientErrorCodes"/>
+        /// <seealso cref="ConfigurationKeys.HttpClientErrorStatuses"/>
         public IDictionary<int, bool> HttpClientErrorCodes { get; set; }
 
         /// <summary>
@@ -390,9 +390,10 @@ namespace Datadog.Trace.Configuration
 
         internal IDictionary<int, bool> ParseHttpCodesToDictionary(string httpStatusErrorCodes)
         {
-            string[] configurationsArray = string.Concat(httpStatusErrorCodes.Where(c => !char.IsWhiteSpace(c))).Split(',');
-
             IDictionary<int, bool> httpErrorCodesDictionary = new Dictionary<int, bool>();
+
+            string[] configurationsArray = httpStatusErrorCodes.Split();
+            configurationsArray = string.Join(string.Empty, configurationsArray).Split(',');
 
             foreach (string statusConfiguration in configurationsArray)
             {
@@ -408,17 +409,19 @@ namespace Datadog.Trace.Configuration
                 }
                 else
                 {
-                    var statusRange = statusConfiguration.Split('-').Select(int.Parse).ToArray();
-                    parsedStatus = statusRange[0];
+                    var stringStatusCodeRange = statusConfiguration.Split('-');
+                    int[] intStatusCodeRange = { int.Parse(stringStatusCodeRange[0]), int.Parse(stringStatusCodeRange[1]) };
 
-                    if (statusRange[1] < statusRange[0])
+                    parsedStatus = intStatusCodeRange[0];
+
+                    if (intStatusCodeRange[1] < intStatusCodeRange[0])
                     {
-                        parsedStatus = statusRange[1];
-                        statusRange[1] = statusRange[0];
-                        statusRange[0] = parsedStatus;
+                        parsedStatus = intStatusCodeRange[1];
+                        intStatusCodeRange[1] = intStatusCodeRange[0];
+                        intStatusCodeRange[0] = parsedStatus;
                     }
 
-                    while (parsedStatus < statusRange[1] + 1)
+                    while (parsedStatus <= intStatusCodeRange[1])
                     {
                         httpErrorCodesDictionary[parsedStatus] = true;
                         parsedStatus++;

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -343,7 +343,7 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 HttpContext httpContext = arg.As<HttpRequestInStopStruct>().HttpContext;
 
-                scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
+                scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                 scope.Dispose();
             }
         }

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -343,7 +343,7 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 HttpContext httpContext = arg.As<HttpRequestInStopStruct>().HttpContext;
 
-                scope.Span.SetServerStatusCode(httpContext.Response.StatusCode);
+                scope.Span.SetHttpServerStatusCode(httpContext.Response.StatusCode);
                 scope.Dispose();
             }
         }

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -67,13 +67,13 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static void SetServerStatusCode(this Span span, int statusCode)
+        internal static void SetHttpServerStatusCode(this Span span, int statusCode)
         {
             string statusCodeString = HttpTags.ConvertStatusCodeToString(statusCode);
             span.SetTag(Tags.HttpStatusCode, statusCodeString);
 
             // Check the customers SERVER http statuses that should be marked as errors
-            if (Tracer.Instance.Settings.HttpServerErrorStatuses.TryGetValue(statusCode, out _))
+            if (Tracer.Instance.Settings.HttpServerErrorCodes.TryGetValue(statusCode, out _))
             {
                 span.Error = true;
 
@@ -85,13 +85,13 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static void SetClientStatusCode(this Span span, int statusCode)
+        internal static void SetHttpClientStatusCode(this Span span, int statusCode)
         {
             string statusCodeString = HttpTags.ConvertStatusCodeToString(statusCode);
             span.SetTag(Tags.HttpStatusCode, statusCodeString);
 
             // Check the customers CLIENT http statuses that should be marked as errors
-            if (Tracer.Instance.Settings.HttpClientErrorStatuses.TryGetValue(statusCode, out _))
+            if (Tracer.Instance.Settings.HttpClientErrorCodes.TryGetValue(statusCode, out _))
             {
                 span.Error = true;
 

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ExtensionMethods
             span.SetTag(Tags.HttpStatusCode, statusCodeString);
 
             // Check the customers SERVER http statuses that should be marked as errors
-            if (Tracer.Instance.Settings.HttpServerErrorCodes.TryGetValue(statusCode, out _))
+            if (Tracer.Instance.Settings.HttpServerErrorStatusCodes[statusCode])
             {
                 span.Error = true;
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ExtensionMethods
             span.SetTag(Tags.HttpStatusCode, statusCodeString);
 
             // Check the customers CLIENT http statuses that should be marked as errors
-            if (Tracer.Instance.Settings.HttpClientErrorCodes.TryGetValue(statusCode, out _))
+            if (Tracer.Instance.Settings.HttpClientErrorStatusCodes[statusCode])
             {
                 span.Error = true;
 

--- a/src/Datadog.Trace/Tagging/HttpTags.cs
+++ b/src/Datadog.Trace/Tagging/HttpTags.cs
@@ -2,7 +2,7 @@ using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Tagging
 {
-    internal class HttpTags : InstrumentationTags
+    internal class HttpTags : InstrumentationTags, IHasStatusCode
     {
         protected static readonly IProperty<string>[] HttpTagsProperties =
             InstrumentationTagsProperties.Concat(
@@ -25,46 +25,6 @@ namespace Datadog.Trace.Tagging
         public string HttpClientHandlerType { get; set; }
 
         public string HttpStatusCode { get; set; }
-
-        public static string ConvertStatusCodeToString(int statusCode)
-        {
-            if (statusCode == 200)
-            {
-                return "200";
-            }
-
-            if (statusCode == 302)
-            {
-                return "302";
-            }
-
-            if (statusCode == 401)
-            {
-                return "401";
-            }
-
-            if (statusCode == 403)
-            {
-                return "403";
-            }
-
-            if (statusCode == 404)
-            {
-                return "404";
-            }
-
-            if (statusCode == 500)
-            {
-                return "500";
-            }
-
-            if (statusCode == 503)
-            {
-                return "503";
-            }
-
-            return statusCode.ToString();
-        }
 
         protected override IProperty<string>[] GetAdditionalTags() => HttpTagsProperties;
     }

--- a/src/Datadog.Trace/Tagging/IHasStatusCode.cs
+++ b/src/Datadog.Trace/Tagging/IHasStatusCode.cs
@@ -1,0 +1,7 @@
+namespace Datadog.Trace.Tagging
+{
+    internal interface IHasStatusCode
+    {
+        string HttpStatusCode { get; set; }
+    }
+}

--- a/src/Datadog.Trace/Tagging/WebTags.cs
+++ b/src/Datadog.Trace/Tagging/WebTags.cs
@@ -2,11 +2,11 @@ using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Tagging
 {
-    internal class WebTags : InstrumentationTags
+    internal class WebTags : InstrumentationTags, IHasStatusCode
     {
         protected static readonly IProperty<string>[] WebTagsProperties =
             InstrumentationTagsProperties.Concat(
-                new Property<WebTags, string>(Trace.Tags.HttpStatusCode, t => t.StatusCode, (t, v) => t.StatusCode = v),
+                new Property<WebTags, string>(Trace.Tags.HttpStatusCode, t => t.HttpStatusCode, (t, v) => t.HttpStatusCode = v),
                 new Property<WebTags, string>(Trace.Tags.HttpMethod, t => t.HttpMethod, (t, v) => t.HttpMethod = v),
                 new Property<WebTags, string>(Trace.Tags.HttpRequestHeadersHost, t => t.HttpRequestHeadersHost, (t, v) => t.HttpRequestHeadersHost = v),
                 new Property<WebTags, string>(Trace.Tags.HttpUrl, t => t.HttpUrl, (t, v) => t.HttpUrl = v),
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Tagging
 
         public string Language => TracerConstants.Language;
 
-        public string StatusCode { get; set; }
+        public string HttpStatusCode { get; set; }
 
         protected override IProperty<string>[] GetAdditionalTags() => WebTagsProperties;
     }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             HttpClient = new HttpClient();
             HttpClient.DefaultRequestHeaders.Add(HeaderName1, HeaderValue1);
             SetEnvironmentVariable(ConfigurationKeys.HeaderTags, $"{HeaderName1Upper}:{HeaderTagName1}");
-            SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorCodes, "400-403, 500-501-234, s342, 500");
+            SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatuses, "400-403, 500-501-234, s342, 500");
 
             SetServiceVersion(ServiceVersion);
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             HttpClient = new HttpClient();
             HttpClient.DefaultRequestHeaders.Add(HeaderName1, HeaderValue1);
             SetEnvironmentVariable(ConfigurationKeys.HeaderTags, $"{HeaderName1Upper}:{HeaderTagName1}");
-            SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatuses, "400-403, 500-501-234, s342, 500");
+            SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-501-234, s342, 500");
 
             SetServiceVersion(ServiceVersion);
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             HttpClient = new HttpClient();
             HttpClient.DefaultRequestHeaders.Add(HeaderName1, HeaderValue1);
             SetEnvironmentVariable(ConfigurationKeys.HeaderTags, $"{HeaderName1Upper}:{HeaderTagName1}");
+            SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorCodes, "400-403, 500-501-234, s342, 500");
 
             SetServiceVersion(ServiceVersion);
 
@@ -90,6 +91,31 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                     var errorMessage = SpanExpectation.GetTag(span, Tags.ErrorMsg);
 
                     if (errorMessage != "This was a bad request.")
+                    {
+                        failures.Add($"Expected specific error message within {span.Resource}. Found \"{errorMessage}\"");
+                    }
+
+                    return failures;
+                });
+
+            CreateTopLevelExpectation(
+                url: "/status-code/402",
+                httpMethod: "GET",
+                httpStatus: "402",
+                resourceUrl: "status-code/{statusCode}",
+                serviceVersion: ServiceVersion,
+                additionalCheck: span =>
+                {
+                    var failures = new List<string>();
+
+                    if (span.Error == 0)
+                    {
+                        failures.Add($"Expected Error flag set within {span.Resource}");
+                    }
+
+                    var errorMessage = SpanExpectation.GetTag(span, Tags.ErrorMsg);
+
+                    if (errorMessage != "The HTTP response has status code 402.")
                     {
                         failures.Add($"Expected specific error message within {span.Resource}. Found \"{errorMessage}\"");
                     }

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -96,5 +96,17 @@ namespace Datadog.Trace.Tests
 
             Assert.Equal(expected, tracerSettings.AgentUri.ToString());
         }
+
+        [Theory]
+        [InlineData("404 -401, 419,344_ 23-302, 201,_5633-55", "401,402,403,404,419,201")]
+        [InlineData("-33, 500-503,113#53,500-502-200,456_2, 590-590", "500,501,502,503,590")]
+        public void ParseHttpCodesReturnsExpectedKeys(string original, string expected)
+        {
+            var tracerSettings = new TracerSettings();
+
+            string joinedDictionaryKeys = string.Join(",", tracerSettings.ParseHttpCodesToDictionary(original).Keys);
+
+            Assert.Equal(expected, joinedDictionaryKeys);
+        }
     }
 }

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.Agent;
@@ -100,17 +102,53 @@ namespace Datadog.Trace.Tests
         [Theory]
         [InlineData("404 -401, 419,344_ 23-302, 201,_5633-55, 409-411", "401,402,403,404,419,201,409,410,411")]
         [InlineData("-33, 500-503,113#53,500-502-200,456_2, 590-590", "500,501,502,503,590")]
+        [InlineData("800", "")]
+        [InlineData("599-605,700-800", "599")]
         public void ParseHttpCodes(string original, string expected)
         {
             var tracerSettings = new TracerSettings();
 
             bool[] errorStatusCodesArray = tracerSettings.ParseHttpCodesToArray(original);
-            string[] expectedKeysArray = expected.Split(',');
+            string[] expectedKeysArray = expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var value in expectedKeysArray)
             {
                 Assert.True(errorStatusCodesArray[int.Parse(value)]);
             }
+        }
+
+        [Fact]
+        public void SetClientHttpCodes()
+        {
+            SetAndValidateStatusCodes((s, c) => s.SetHttpClientErrorStatusCodes(c), s => s.HttpClientErrorStatusCodes);
+        }
+
+        [Fact]
+        public void SetServerHttpCodes()
+        {
+            SetAndValidateStatusCodes((s, c) => s.SetHttpServerErrorStatusCodes(c), s => s.HttpServerErrorStatusCodes);
+        }
+
+        private void SetAndValidateStatusCodes(Action<TracerSettings, IEnumerable<int>> setStatusCodes, Func<TracerSettings, bool[]> getStatusCodes)
+        {
+            var settings = new TracerSettings();
+            var statusCodes = new Queue<int>(new[] { 100, 201, 503 });
+
+            setStatusCodes(settings, statusCodes);
+
+            var result = getStatusCodes(settings);
+
+            for (int i = 0; i < 600; i++)
+            {
+                if (result[i])
+                {
+                    var code = statusCodes.Dequeue();
+
+                    Assert.Equal(code, i);
+                }
+            }
+
+            Assert.Empty(statusCodes);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -98,15 +98,19 @@ namespace Datadog.Trace.Tests
         }
 
         [Theory]
-        [InlineData("404 -401, 419,344_ 23-302, 201,_5633-55", "401,402,403,404,419,201")]
+        [InlineData("404 -401, 419,344_ 23-302, 201,_5633-55, 409-411", "401,402,403,404,419,201,409,410,411")]
         [InlineData("-33, 500-503,113#53,500-502-200,456_2, 590-590", "500,501,502,503,590")]
-        public void ParseHttpCodesReturnsExpectedKeys(string original, string expected)
+        public void ParseHttpCodes(string original, string expected)
         {
             var tracerSettings = new TracerSettings();
 
-            string joinedDictionaryKeys = string.Join(",", tracerSettings.ParseHttpCodesToDictionary(original).Keys);
+            bool[] errorStatusCodesArray = tracerSettings.ParseHttpCodesToArray(original);
+            string[] expectedKeysArray = expected.Split(',');
 
-            Assert.Equal(expected, joinedDictionaryKeys);
+            foreach (var value in expectedKeysArray)
+            {
+                Assert.True(errorStatusCodesArray[int.Parse(value)]);
+            }
         }
     }
 }

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -110,6 +110,10 @@ namespace Samples.HttpMessageHandler
                     byte[] responseBytes = Utf8.GetBytes(ResponseContent);
                     context.Response.ContentEncoding = Utf8;
                     context.Response.ContentLength64 = responseBytes.Length;
+                    if (context.Request.RawUrl == "/Samples.HttpMessageHandler/HttpErrorCode")
+                    {
+                        context.Response.StatusCode = 502;
+                    }
                     context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
 
                     // we must close the response

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Properties/launchSettings.json
@@ -14,8 +14,7 @@
           "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
           "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
           "DD_VERSION": "1.0.0",
-
-          "DD_HttpSocketsHandler_ENABLED": "true",
+          "DD_HttpSocketsHandler_ENABLED": "true"
         },
         "nativeDebugging": true
       }

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -157,6 +157,12 @@ namespace Samples.HttpMessageHandler
                         await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
                         Console.WriteLine("Received response for client.PostAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                     }
+
+                    using (Tracer.Instance.StartActive("ErrorSpanBelow"))
+                    {
+                        await client.GetAsync($"{url}HttpErrorCode");
+                        Console.WriteLine("Received response for client.GetAsync Error Span");
+                    }
                 }
             }
             


### PR DESCRIPTION
Recreated from https://github.com/DataDog/dd-trace-dotnet/pull/1080

**What does this PR do?**
By default will mark client spans with error if status code between 400 and 499 and also provides the option to mark spans errors depending on the custom customers status code configurations, the same behavior applies for server spans but using 500-599 by default.

**Who will it impact?**
Users that wish to have control over which spans should be mark as error depending their selected status codes.