### PR TITLE
Shutdown logger before profiler shutdown.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -593,8 +593,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown() {
   std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
   Warn("Exiting.");
-  Logger::Instance()->Flush();
   is_attached_.store(false);
+  Logger::Shutdown();
   return S_OK;
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -28,6 +28,7 @@ class Logger : public Singleton<Logger> {
   void Error(const std::string& str);
   void Critical(const std::string& str);
   void Flush();
+  static void Shutdown() { spdlog::shutdown(); }
 };
 
 template <typename Arg>


### PR DESCRIPTION
Due https://github.com/gabime/spdlog/issues/1533

We need to make sure we shutdown spdlog before profiler shutdown.



@DataDog/apm-dotnet