### PR TITLE
Remove Restriction for Pipe Request Content-Length

### DIFF
--- a/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -9,6 +9,14 @@ namespace Datadog.Trace.Agent.Transports
 {
     internal class HttpStreamRequest : IApiRequest
     {
+        /// <summary>
+        /// This value is greater than any reasonable response we would receive from the agent.
+        /// It is smaller than the internal default of 81920
+        /// https://source.dot.net/#System.Private.CoreLib/Stream.cs,122
+        /// It is a multiple of 4096.
+        /// </summary>
+        private const int ResponseReadBufferSize = 12_228;
+
         private readonly Uri _uri;
         private readonly DatadogHttpClient _client;
         private readonly IStreamFactory _streamFactory;
@@ -44,7 +52,7 @@ namespace Datadog.Trace.Agent.Transports
 
                 // buffer the entire contents for now
                 var responseContentStream = new MemoryStream();
-                await response.Content.CopyToAsync(responseContentStream, DatadogHttpValues.MaximumResponseBufferSize).ConfigureAwait(false);
+                await response.Content.CopyToAsync(responseContentStream, ResponseReadBufferSize).ConfigureAwait(false);
                 responseContentStream.Position = 0;
 
                 var contentLength = response.ContentLength;

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -8,6 +8,12 @@ namespace Datadog.Trace.HttpOverStreams
 {
     internal class DatadogHttpClient
     {
+        /// <summary>
+        /// Typical headers sent to the agent are small.
+        /// Allow enough room for future expansion of headers.
+        /// </summary>
+        private const int MaxRequestHeadersBufferSize = 4096;
+
         private const string ContentLengthHeaderKey = "Content-Length";
 
         private static readonly Vendors.Serilog.ILogger Logger = DatadogLogging.For<DatadogHttpClient>();
@@ -21,7 +27,7 @@ namespace Datadog.Trace.HttpOverStreams
         private async Task SendRequestAsync(HttpRequest request, Stream requestStream)
         {
             // Headers are always ASCII per the HTTP spec
-            using (var writer = new StreamWriter(requestStream, Encoding.ASCII, bufferSize: -1, leaveOpen: true))
+            using (var writer = new StreamWriter(requestStream, Encoding.ASCII, bufferSize: MaxRequestHeadersBufferSize, leaveOpen: true))
             {
                 await DatadogHttpHeaderHelper.WriteLeadingHeaders(request, writer).ConfigureAwait(false);
 

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.HttpOverStreams
                 await DatadogHttpHeaderHelper.WriteEndOfHeaders(writer).ConfigureAwait(false);
             }
 
-            await request.Content.CopyToAsync(requestStream, DatadogHttpValues.MaximumRequestBufferSize).ConfigureAwait(false);
+            await request.Content.CopyToAsync(requestStream, DatadogHttpValues.DefaultMaximumRequestBufferSize).ConfigureAwait(false);
             Logger.Debug("Datadog HTTP: Flushing stream.");
             await requestStream.FlushAsync().ConfigureAwait(false);
         }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
@@ -7,15 +7,18 @@ namespace Datadog.Trace.HttpOverStreams
         /// <summary>
         /// Some sane limit for responses from the agent.
         /// Most responses will be a few hundred or less.
+        /// Oversized to account for future expansion or errors.
         /// </summary>
-        public const int MaximumResponseBufferSize = 5120;
+        public const int MaximumResponseBufferSize = 10_240;
 
         /// <summary>
-        /// Some sane limit for requests to the agent.
+        /// Some limit for requests to the agent.
         /// Maximum throughput for one request is 50kb.
         /// This number is based on local testing.
+        /// However, failing before the send means that behavior is changed and logs are different, so this is slightly oversized.
+        /// This value will only be used if the Content-Length is not specified, which is never in the case of the current named pipes implementation.
         /// </summary>
-        public const int MaximumRequestBufferSize = 51_200;
+        public const int DefaultMaximumRequestBufferSize = 52_431_485;
 
         public const char CarriageReturn = '\r';
         public static readonly string NewLine = Environment.NewLine;

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
@@ -4,22 +4,6 @@ namespace Datadog.Trace.HttpOverStreams
 {
     internal static class DatadogHttpValues
     {
-        /// <summary>
-        /// Some sane limit for responses from the agent.
-        /// Most responses will be a few hundred or less.
-        /// Oversized to account for future expansion or errors.
-        /// </summary>
-        public const int MaximumResponseBufferSize = 10_240;
-
-        /// <summary>
-        /// Some limit for requests to the agent.
-        /// Maximum throughput for one request is 50kb.
-        /// This number is based on local testing.
-        /// However, failing before the send means that behavior is changed and logs are different, so this is slightly oversized.
-        /// This value will only be used if the Content-Length is not specified, which is never in the case of the current named pipes implementation.
-        /// </summary>
-        public const int DefaultMaximumRequestBufferSize = 52_431_485;
-
         public const char CarriageReturn = '\r';
         public static readonly string NewLine = Environment.NewLine;
         public static readonly int CrLfLength = NewLine.Length;

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -16,21 +15,14 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
 
         public long? Length { get; }
 
-        public Task CopyToAsync(Stream destination, int maxBufferSize)
+        public Task CopyToAsync(Stream destination, int? bufferSize)
         {
-            var maxLengthToRead = maxBufferSize;
-
-            if (Length != null)
+            if (bufferSize == null)
             {
-                if (Length > int.MaxValue)
-                {
-                    throw new Exception($"Content length is above integer maximum, this is unexpected and requests cannot be sent.");
-                }
-
-                maxLengthToRead = (int)Length;
+                return Stream.CopyToAsync(destination);
             }
 
-            return Stream.CopyToAsync(destination, maxLengthToRead);
+            return Stream.CopyToAsync(destination, bufferSize.Value);
         }
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -21,9 +22,9 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
 
             if (Length != null)
             {
-                if (Length > maxBufferSize)
+                if (Length > int.MaxValue)
                 {
-                    throw new DatadogHttpRequestException($"Content length ({Length}) is above bounds of expected size ({maxBufferSize}), terminating request.");
+                    throw new Exception($"Content length is above integer maximum, this is unexpected and requests cannot be sent.");
                 }
 
                 maxLengthToRead = (int)Length;

--- a/src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
@@ -7,6 +7,6 @@ namespace Datadog.Trace.HttpOverStreams
     {
         long? Length { get; }
 
-        Task CopyToAsync(Stream destination, int maxBufferSize);
+        Task CopyToAsync(Stream destination, int? bufferSize);
     }
 }

--- a/test/test-applications/regression/AspNetMvcCorePerformance/Program.cs
+++ b/test/test-applications/regression/AspNetMvcCorePerformance/Program.cs
@@ -88,6 +88,12 @@ namespace AspNetMvcCorePerformance
                 {
                     Thread.Sleep(1000);
                 }
+
+                foreach (var exceptionGroup in exceptionBag.GroupBy(e => e.Message))
+                {
+                    Console.WriteLine($"Exceptions ({exceptionGroup.Count()}) Found: {exceptionGroup.Key}");
+                    Console.WriteLine(exceptionGroup.First());
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Remove the restriction on content-length for trace payload, because it causes requests to be partially written and fails larger requests that would otherwise succeed.
Match the default http client behavior, allowing the agent to return a payload too large response.

@DataDog/apm-dotnet