### PR TITLE
Scope restore on CallTarget async integrations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/HttpClientHandler/HttpClientHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/HttpClientHandler/HttpClientHandlerIntegration.cs
@@ -38,11 +38,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
             where TRequest : IHttpRequestMessage
         {
             Scope scope = null;
-            HttpTags tags = null;
 
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out tags);
+                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
@@ -52,35 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
                 }
             }
 
-            return new CallTargetState(new IntegrationState(scope, tags));
-        }
-
-        /// <summary>
-        /// OnMethodEnd callback
-        /// </summary>
-        /// <typeparam name="TTarget">Type of the target</typeparam>
-        /// <typeparam name="TReturn">Type of the return value</typeparam>
-        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
-        /// <param name="returnValue">Task of HttpResponse message instance</param>
-        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
-        /// <param name="state">Calltarget state value</param>
-        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-        {
-            IntegrationState integrationState = (IntegrationState)state.State;
-            if (integrationState.Scope != null)
-            {
-                // Before returning the control flow we need to restore the parent Scope setted by ScopeFactory.CreateOutboundHttpScope
-                // This doesn't affect to OnAsyncMethodEnd async continuation, an ExecutionContext is captured
-                // by the inner await.
-                IScopeManager scopeManager = ((IDatadogTracer)Tracer.Instance).ScopeManager;
-                if (scopeManager.Active == integrationState.Scope)
-                {
-                    scopeManager.Close(integrationState.Scope);
-                }
-            }
-
-            return new CallTargetReturn<TReturn>(returnValue);
+            return new CallTargetState(scope);
         }
 
         /// <summary>
@@ -96,24 +67,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
         public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, CallTargetState state)
             where TResponse : IHttpResponseMessage
         {
-            IntegrationState integrationState = (IntegrationState)state.State;
-            if (integrationState.Scope is null)
+            Scope scope = state.Scope;
+
+            if (scope is null)
             {
                 return responseMessage;
             }
 
             try
             {
-                integrationState.Scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+                scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
 
                 if (exception != null)
                 {
-                    integrationState.Scope.Span.SetException(exception);
+                    scope.Span.SetException(exception);
                 }
             }
             finally
             {
-                integrationState.Scope.Dispose();
+                scope.Dispose();
             }
 
             return responseMessage;
@@ -144,18 +116,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
             }
 
             return true;
-        }
-
-        private readonly struct IntegrationState
-        {
-            public readonly Scope Scope;
-            public readonly HttpTags Tags;
-
-            public IntegrationState(Scope scope, HttpTags tags)
-            {
-                Scope = scope;
-                Tags = tags;
-            }
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/HttpClientHandler/HttpClientHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/HttpClientHandler/HttpClientHandlerIntegration.cs
@@ -37,21 +37,21 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.HttpClientHandler
         public static CallTargetState OnMethodBegin<TTarget, TRequest>(TTarget instance, TRequest requestMessage, CancellationToken cancellationToken)
             where TRequest : IHttpRequestMessage
         {
-            Scope scope = null;
-
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
+                Scope scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
 
                     // add distributed tracing headers to the HTTP request
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(requestMessage.Headers));
+
+                    return new CallTargetState(scope);
                 }
             }
 
-            return new CallTargetState(scope);
+            return CallTargetState.GetDefault();
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/NUnit/NUnitSkipCommandExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/NUnit/NUnitSkipCommandExecuteIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.NUnit
         /// <returns>Return value of the method</returns>
         public static CallTargetReturn<TResult> OnMethodEnd<TTarget, TResult>(TTarget instance, TResult returnValue, Exception exception, CallTargetState state)
         {
-            Scope scope = (Scope)state.State;
+            Scope scope = state.Scope;
             if (scope != null)
             {
                 NUnitIntegration.FinishScope(scope, exception);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/NUnit/NUnitTestMethodCommandExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/NUnit/NUnitTestMethodCommandExecuteIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.NUnit
         /// <returns>Return value of the method</returns>
         public static CallTargetReturn<TResult> OnMethodEnd<TTarget, TResult>(TTarget instance, TResult returnValue, Exception exception, CallTargetState state)
         {
-            Scope scope = (Scope)state.State;
+            Scope scope = state.Scope;
             if (scope != null)
             {
                 NUnitIntegration.FinishScope(scope, exception);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
@@ -39,11 +39,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
             where TRequest : IHttpRequestMessage
         {
             Scope scope = null;
-            HttpTags tags = null;
 
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out tags);
+                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
@@ -53,35 +52,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
                 }
             }
 
-            return new CallTargetState(new IntegrationState(scope, tags));
-        }
-
-        /// <summary>
-        /// OnMethodEnd callback
-        /// </summary>
-        /// <typeparam name="TTarget">Type of the target</typeparam>
-        /// <typeparam name="TReturn">Type of the return value</typeparam>
-        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
-        /// <param name="returnValue">Task of HttpResponse message instance</param>
-        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
-        /// <param name="state">Calltarget state value</param>
-        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-        {
-            IntegrationState integrationState = (IntegrationState)state.State;
-            if (integrationState.Scope != null)
-            {
-                // Before returning the control flow we need to restore the parent Scope setted by ScopeFactory.CreateOutboundHttpScope
-                // This doesn't affect to OnAsyncMethodEnd async continuation, an ExecutionContext is captured
-                // by the inner await.
-                IScopeManager scopeManager = ((IDatadogTracer)Tracer.Instance).ScopeManager;
-                if (scopeManager.Active == integrationState.Scope)
-                {
-                    scopeManager.Close(integrationState.Scope);
-                }
-            }
-
-            return new CallTargetReturn<TReturn>(returnValue);
+            return new CallTargetState(scope);
         }
 
         /// <summary>
@@ -97,24 +68,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
         public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, CallTargetState state)
             where TResponse : IHttpResponseMessage
         {
-            IntegrationState integrationState = (IntegrationState)state.State;
-            if (integrationState.Scope is null)
+            Scope scope = state.Scope;
+
+            if (scope is null)
             {
                 return responseMessage;
             }
 
             try
             {
-                integrationState.Scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+                scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
 
                 if (exception != null)
                 {
-                    integrationState.Scope.Span.SetException(exception);
+                    scope.Span.SetException(exception);
                 }
             }
             finally
             {
-                integrationState.Scope.Dispose();
+                scope.Dispose();
             }
 
             return responseMessage;
@@ -150,18 +122,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
             }
 
             return true;
-        }
-
-        private readonly struct IntegrationState
-        {
-            public readonly Scope Scope;
-            public readonly HttpTags Tags;
-
-            public IntegrationState(Scope scope, HttpTags tags)
-            {
-                Scope = scope;
-                Tags = tags;
-            }
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
@@ -38,21 +38,21 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.SocketsHttpHandler
         public static CallTargetState OnMethodBegin<TTarget, TRequest>(TTarget instance, TRequest requestMessage, CancellationToken cancellationToken)
             where TRequest : IHttpRequestMessage
         {
-            Scope scope = null;
-
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
+                Scope scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
 
                     // add distributed tracing headers to the HTTP request
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(requestMessage.Headers));
+
+                    return new CallTargetState(scope);
                 }
             }
 
-            return new CallTargetState(scope);
+            return CallTargetState.GetDefault();
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -39,11 +39,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
             where TRequest : IHttpRequestMessage
         {
             Scope scope = null;
-            HttpTags tags = null;
 
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out tags);
+                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
@@ -53,35 +52,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
                 }
             }
 
-            return new CallTargetState(new IntegrationState(scope, tags));
-        }
-
-        /// <summary>
-        /// OnMethodEnd callback
-        /// </summary>
-        /// <typeparam name="TTarget">Type of the target</typeparam>
-        /// <typeparam name="TReturn">Type of the return value</typeparam>
-        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
-        /// <param name="returnValue">Task of HttpResponse message instance</param>
-        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
-        /// <param name="state">Calltarget state value</param>
-        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-        {
-            IntegrationState integrationState = (IntegrationState)state.State;
-            if (integrationState.Scope != null)
-            {
-                // Before returning the control flow we need to restore the parent Scope setted by ScopeFactory.CreateOutboundHttpScope
-                // This doesn't affect to OnAsyncMethodEnd async continuation, an ExecutionContext is captured
-                // by the inner await.
-                IScopeManager scopeManager = ((IDatadogTracer)Tracer.Instance).ScopeManager;
-                if (scopeManager.Active == integrationState.Scope)
-                {
-                    scopeManager.Close(integrationState.Scope);
-                }
-            }
-
-            return new CallTargetReturn<TReturn>(returnValue);
+            return new CallTargetState(scope);
         }
 
         /// <summary>
@@ -97,24 +68,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
         public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, CallTargetState state)
             where TResponse : IHttpResponseMessage
         {
-            IntegrationState integrationState = (IntegrationState)state.State;
-            if (integrationState.Scope is null)
+            Scope scope = state.Scope;
+
+            if (scope is null)
             {
                 return responseMessage;
             }
 
             try
             {
-                integrationState.Scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+                scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
 
                 if (exception != null)
                 {
-                    integrationState.Scope.Span.SetException(exception);
+                    scope.Span.SetException(exception);
                 }
             }
             finally
             {
-                integrationState.Scope.Dispose();
+                scope.Dispose();
             }
 
             return responseMessage;
@@ -150,18 +122,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
             }
 
             return true;
-        }
-
-        private readonly struct IntegrationState
-        {
-            public readonly Scope Scope;
-            public readonly HttpTags Tags;
-
-            public IntegrationState(Scope scope, HttpTags tags)
-            {
-                Scope = scope;
-                Tags = tags;
-            }
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -38,21 +38,21 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
         public static CallTargetState OnMethodBegin<TTarget, TRequest>(TTarget instance, TRequest requestMessage, CancellationToken cancellationToken)
             where TRequest : IHttpRequestMessage
         {
-            Scope scope = null;
-
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
+                Scope scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
                     tags.HttpClientHandlerType = instance.GetType().FullName;
 
                     // add distributed tracing headers to the HTTP request
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(requestMessage.Headers));
+
+                    return new CallTargetState(scope);
                 }
             }
 
-            return new CallTargetState(scope);
+            return CallTargetState.GetDefault();
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
@@ -47,34 +47,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.XUnit
         }
 
         /// <summary>
-        /// OnMethodEnd callback
-        /// </summary>
-        /// <typeparam name="TTarget">Type of the target</typeparam>
-        /// <typeparam name="TReturn">Type of the return value</typeparam>
-        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
-        /// <param name="returnValue">Task of HttpResponse message instance</param>
-        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
-        /// <param name="state">Calltarget state value</param>
-        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
-        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-        {
-            Scope scope = (Scope)state.State;
-            if (scope != null)
-            {
-                // Before returning the control flow we need to restore the parent Scope setted by ScopeFactory.CreateOutboundHttpScope
-                // This doesn't affect to OnAsyncMethodEnd async continuation, an ExecutionContext is captured
-                // by the inner await.
-                IScopeManager scopeManager = ((IDatadogTracer)Tracer.Instance).ScopeManager;
-                if (scopeManager.Active == scope)
-                {
-                    scopeManager.Close(scope);
-                }
-            }
-
-            return new CallTargetReturn<TReturn>(returnValue);
-        }
-
-        /// <summary>
         /// OnAsyncMethodEnd callback
         /// </summary>
         /// <typeparam name="TTarget">Type of the target</typeparam>
@@ -85,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.XUnit
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static decimal OnAsyncMethodEnd<TTarget>(TTarget instance, decimal returnValue, Exception exception, CallTargetState state)
         {
-            Scope scope = (Scope)state.State;
+            Scope scope = state.Scope;
             if (scope != null)
             {
                 TestInvokerStruct invokerInstance = instance.As<TestInvokerStruct>();

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
     /// </summary>
     public readonly struct CallTargetState
     {
-        private readonly Scope _oldScope;
+        private readonly Scope _previousScope;
         private readonly Scope _scope;
         private readonly object _state;
 
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="scope">Scope instance</param>
         public CallTargetState(Scope scope)
         {
-            _oldScope = null;
+            _previousScope = null;
             _scope = scope;
             _state = null;
         }
@@ -29,14 +29,14 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="state">Object state instance</param>
         public CallTargetState(Scope scope, object state)
         {
-            _oldScope = null;
+            _previousScope = null;
             _scope = scope;
             _state = state;
         }
 
-        private CallTargetState(Scope oldScope, Scope scope, object state)
+        private CallTargetState(Scope previousScope, Scope scope, object state)
         {
-            _oldScope = oldScope;
+            _previousScope = previousScope;
             _scope = scope;
             _state = state;
         }
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// </summary>
         public object State => _state;
 
-        internal Scope OldScope => _oldScope;
+        internal Scope PreviousScope => _previousScope;
 
         /// <summary>
         /// Gets the default call target state (used by the native side to initialize the locals)
@@ -69,12 +69,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <returns>String value</returns>
         public override string ToString()
         {
-            return $"{typeof(CallTargetState).FullName}({_oldScope}, {_scope}, {_state})";
+            return $"{typeof(CallTargetState).FullName}({_previousScope}, {_scope}, {_state})";
         }
 
-        internal static CallTargetState WithPreviousScope(Scope oldScope, CallTargetState state)
+        internal static CallTargetState WithPreviousScope(Scope previousScope, CallTargetState state)
         {
-            return new CallTargetState(oldScope, state._scope, state._state);
+            return new CallTargetState(previousScope, state._scope, state._state);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
@@ -7,21 +7,51 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
     /// </summary>
     public readonly struct CallTargetState
     {
+        private readonly Scope _oldScope;
+        private readonly Scope _scope;
         private readonly object _state;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
         /// </summary>
-        /// <param name="state">Object state instance</param>
-        public CallTargetState(object state)
+        /// <param name="scope">Scope instance</param>
+        public CallTargetState(Scope scope)
         {
+            _oldScope = null;
+            _scope = scope;
+            _state = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
+        /// </summary>
+        /// <param name="scope">Scope instance</param>
+        /// <param name="state">Object state instance</param>
+        public CallTargetState(Scope scope, object state)
+        {
+            _oldScope = null;
+            _scope = scope;
             _state = state;
         }
+
+        private CallTargetState(Scope oldScope, Scope scope, object state)
+        {
+            _oldScope = oldScope;
+            _scope = scope;
+            _state = state;
+        }
+
+        /// <summary>
+        /// Gets the CallTarget BeginMethod scope
+        /// </summary>
+        public Scope Scope => _scope;
 
         /// <summary>
         /// Gets the CallTarget BeginMethod state
         /// </summary>
         public object State => _state;
+
+        internal Scope OldScope => _oldScope;
 
         /// <summary>
         /// Gets the default call target state (used by the native side to initialize the locals)
@@ -39,7 +69,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <returns>String value</returns>
         public override string ToString()
         {
-            return $"{typeof(CallTargetState).FullName}({_state})";
+            return $"{typeof(CallTargetState).FullName}({_oldScope}, {_scope}, {_state})";
+        }
+
+        internal static CallTargetState WithPreviousScope(Scope oldScope, CallTargetState state)
+        {
+            return new CallTargetState(oldScope, state._scope, state._state);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance)
-            => _invokeDelegate(instance);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1)
-            => _invokeDelegate(instance, arg1);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2)
-            => _invokeDelegate(instance, arg1, arg2);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3)
-            => _invokeDelegate(instance, arg1, arg2, arg3);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
-            => _invokeDelegate(instance, arg1, arg2, arg3, arg4);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
-            => _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -36,6 +36,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
-            => _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -35,6 +35,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, object[] arguments)
-            => _invokeDelegate(instance, arguments);
+        {
+            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arguments));
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/EndMethodHandler.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/EndMethodHandler.cs
@@ -35,6 +35,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetReturn Invoke(TTarget instance, Exception exception, CallTargetState state)
-            => _invokeDelegate(instance, exception, state);
+        {
+            return _invokeDelegate(instance, exception, state);
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -74,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 // This is used to mimic the ExecutionContext copy from the StateMachine
                 if (((IDatadogTracer)Tracer.Instance).ScopeManager is IScopeRawAccess rawAccess)
                 {
-                    rawAccess.Active = state.OldScope;
+                    rawAccess.Active = state.PreviousScope;
                 }
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -69,6 +69,13 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             if (_continuationGenerator != null)
             {
                 returnValue = _continuationGenerator.SetContinuation(instance, returnValue, exception, state);
+
+                // Restore previous scope if there is a continuation
+                // This is used to mimic the ExecutionContext copy from the StateMachine
+                if (((IDatadogTracer)Tracer.Instance).ScopeManager is IScopeRawAccess rawAccess)
+                {
+                    rawAccess.Active = state.OldScope;
+                }
             }
 
             if (_invokeDelegate != null)

--- a/src/Datadog.Trace/IScopeRawAccess.cs
+++ b/src/Datadog.Trace/IScopeRawAccess.cs
@@ -1,0 +1,10 @@
+namespace Datadog.Trace
+{
+    /// <summary>
+    /// Interface for scope getter and setter access
+    /// </summary>
+    internal interface IScopeRawAccess
+    {
+        Scope Active { get; set; }
+    }
+}

--- a/src/Datadog.Trace/ScopeManagerBase.cs
+++ b/src/Datadog.Trace/ScopeManagerBase.cs
@@ -3,7 +3,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace
 {
-    internal abstract class ScopeManagerBase : IScopeManager
+    internal abstract class ScopeManagerBase : IScopeManager, IScopeRawAccess
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(ScopeManagerBase));
 
@@ -18,6 +18,12 @@ namespace Datadog.Trace
         public event EventHandler<SpanEventArgs> TraceEnded;
 
         public abstract Scope Active { get; protected set; }
+
+        Scope IScopeRawAccess.Active
+        {
+            get => Active;
+            set => Active = value;
+        }
 
         public Scope Activate(Span span, bool finishOnClose)
         {


### PR DESCRIPTION
This PR removes the required OnEndMethod workaround on async integrations to restore the current Scope before returning the control flow.

Now this is done automatically by the CallTarget mechanism when a continuation is set.

Using the new method simplify the integrations.

@DataDog/apm-dotnet