### PR TITLE
Add VB tests for SQL server

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -404,6 +404,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.RuntimeMetrics", "t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LargePayload", "test\test-applications\regression\LargePayload\LargePayload.csproj", "{D20E8A18-DF59-46D3-A894-A448F7593237}"
 EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Samples.SqlServer.Vb", "test\test-applications\integrations\dependency-libs\Samples.SqlServer.Vb\Samples.SqlServer.Vb.vbproj", "{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1486,6 +1488,18 @@ Global
 		{D20E8A18-DF59-46D3-A894-A448F7593237}.Release|x64.Build.0 = Release|x64
 		{D20E8A18-DF59-46D3-A894-A448F7593237}.Release|x86.ActiveCfg = Release|x86
 		{D20E8A18-DF59-46D3-A894-A448F7593237}.Release|x86.Build.0 = Release|x86
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|x64.Build.0 = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Debug|x86.Build.0 = Debug|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x64.ActiveCfg = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x64.Build.0 = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x86.ActiveCfg = Release|Any CPU
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1602,6 +1616,7 @@ Global
 		{C1210E08-58E5-44D4-BE6F-634C3FC5E410} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{600953C4-BD8F-4A4B-A275-6D6F9EF48342} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{D20E8A18-DF59-46D3-A894-A448F7593237} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
+		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -428,7 +428,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             int mdToken,
             long moduleVersionPtr)
         {
-            return ExecuteNonQuery(command, opCode, mdToken, moduleVersionPtr, SystemSqlDataReaderTypeName);
+            var result = ExecuteNonQuery(command, opCode, mdToken, moduleVersionPtr, SystemSqlDataReaderTypeName);
+            return result;
         }
 
         /// <summary>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -1,4 +1,3 @@
-using System.Data.SqlClient;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
@@ -29,11 +28,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
             // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET452
-            var expectedSpanCount = 49; // 7 queries * 7 groups
+            var expectedSpanCount = 56; // 7 queries * 8 groups
 #elif NET461
-            var expectedSpanCount = 77; // 7 queries * 11 groups
+            var expectedSpanCount = 84; // 7 queries * 12 groups
 #else
-            var expectedSpanCount = 81; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
+            var expectedSpanCount = 88; // 7 queries * 12 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             const string dbType = "sql-server";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -1,3 +1,4 @@
+using System.Data.SqlClient;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
@@ -28,11 +29,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
             // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET452
-            var expectedSpanCount = 56; // 7 queries * 8 groups
+            var expectedSpanCount = 70; // 7 queries * 10 groups
 #elif NET461
-            var expectedSpanCount = 84; // 7 queries * 12 groups
+            var expectedSpanCount = 98; // 7 queries * 14 groups
 #else
-            var expectedSpanCount = 88; // 7 queries * 12 groups + 4 spans from generic wrapper on .NET Core
+            var expectedSpanCount = 102; // 7 queries * 14 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             const string dbType = "sql-server";

--- a/test/test-applications/integrations/Samples.SqlServer/Program.cs
+++ b/test/test-applications/integrations/Samples.SqlServer/Program.cs
@@ -3,6 +3,7 @@ using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using Samples.DatabaseHelper;
+using Samples.SqlServer.Vb;
 
 namespace Samples.SqlServer
 {
@@ -12,11 +13,13 @@ namespace Samples.SqlServer
         {
             var commandFactory = new DbCommandFactory($"[System-Data-SqlClient-Test-{Guid.NewGuid():N}]");
             var commandExecutor = new SqlCommandExecutor();
+            var commandExecutorVb = new SqlCommandExecutorVb();
             var cts = new CancellationTokenSource();
 
             using (var connection = OpenConnection())
             {
                 await RelationalDatabaseTestHarness.RunAllAsync<SqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
+                await RelationalDatabaseTestHarness.RunSingleAsync(connection, commandFactory, commandExecutorVb, cts.Token);
             }
 
             // allow time to flush

--- a/test/test-applications/integrations/Samples.SqlServer/Samples.SqlServer.csproj
+++ b/test/test-applications/integrations/Samples.SqlServer/Samples.SqlServer.csproj
@@ -23,6 +23,7 @@
 
     <!-- this referenced project only targets netstandard2.0 -->
     <ProjectReference Condition="'$(TargetFramework)' != 'net452'" Include="..\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj" />
+    <ProjectReference Include="..\dependency-libs\Samples.SqlServer.Vb\Samples.SqlServer.Vb.vbproj" />
   </ItemGroup>
 
 </Project>

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -63,6 +63,26 @@ namespace Samples.DatabaseHelper
             }
         }
 
+        public static async Task RunSingleAsync(
+            IDbConnection connection,
+            DbCommandFactory commandFactory,
+            IDbCommandExecutor providerSpecificCommandExecutor,
+            CancellationToken cancellationToken)
+        {
+            var executors = new List<IDbCommandExecutor>
+                            {
+                                providerSpecificCommandExecutor
+                            };
+
+            using (var root = Tracer.Instance.StartActive("root"))
+            {
+                foreach (var executor in executors)
+                {
+                    await RunAsync(connection, commandFactory, executor, cancellationToken);
+                }
+            }
+        }
+
         /// <summary>
         /// Helper method that runs ADO.NET test suite for the specified <see cref="IDbCommandExecutor"/>
         /// in addition to other built-in implementations.

--- a/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/Samples.SqlServer.Vb.vbproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/Samples.SqlServer.Vb.vbproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+
+    <ApiVersion Condition="'$(ApiVersion)' == ''">4.7.0</ApiVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Data" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="System.Data.SqlClient" Version="$(ApiVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
+
+  </ItemGroup>
+
+</Project>

--- a/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/Samples.SqlServer.Vb.vbproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/Samples.SqlServer.Vb.vbproj
@@ -4,7 +4,7 @@
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
 
-    <ApiVersion Condition="'$(ApiVersion)' == ''">4.7.0</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">4.1.0</ApiVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/SqlCommandExecutorVb.vb
+++ b/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/SqlCommandExecutorVb.vb
@@ -1,0 +1,59 @@
+Imports System.Data
+Imports System.Data.SqlClient
+Imports System.Threading
+Imports Samples.DatabaseHelper
+
+Public Class SqlCommandExecutorVb
+    Inherits DbCommandExecutor(Of SqlCommand)
+
+    Public Overrides ReadOnly Property CommandTypeName As String = "SqlCommandVb"
+    Public Overrides ReadOnly Property SupportsAsyncMethods As Boolean = True
+
+    Public Overrides Sub ExecuteNonQuery(command As SqlCommand)
+        command.ExecuteNonQuery()
+    End Sub
+
+    Public Overrides Function ExecuteNonQueryAsync(command As SqlCommand) As Task
+        Return command.ExecuteNonQueryAsync()
+    End Function
+
+    Public Overrides Function ExecuteNonQueryAsync(command As SqlCommand, cancellationToken As CancellationToken) As Task
+        Return command.ExecuteNonQueryAsync(cancellationToken)
+    End Function
+
+    Public Overrides Sub ExecuteScalar(command As SqlCommand)
+        command.ExecuteScalar()
+    End Sub
+
+    Public Overrides Function ExecuteScalarAsync(command As SqlCommand) As Task
+        Return command.ExecuteScalarAsync()
+    End Function
+
+    Public Overrides Function ExecuteScalarAsync(command As SqlCommand, cancellationToken As CancellationToken) As Task
+        Return command.ExecuteScalarAsync(cancellationToken)
+    End Function
+
+    Public Overrides Sub ExecuteReader(command As SqlCommand)
+        command.ExecuteReader()
+    End Sub
+
+    Public Overrides Sub ExecuteReader(command As SqlCommand, behavior As CommandBehavior)
+        command.ExecuteReader(behavior)
+    End Sub
+
+    Public Overrides Function ExecuteReaderAsync(command As SqlCommand) As Task
+        Return command.ExecuteReaderAsync()
+    End Function
+
+    Public Overrides Function ExecuteReaderAsync(command As SqlCommand, behavior As CommandBehavior) As Task
+        Return command.ExecuteReaderAsync(behavior)
+    End Function
+
+    Public Overrides Function ExecuteReaderAsync(command As SqlCommand, cancellationToken As CancellationToken) As Task
+        Return command.ExecuteReaderAsync(cancellationToken)
+    End Function
+
+    Public Overrides Function ExecuteReaderAsync(command As SqlCommand, behavior As CommandBehavior, cancellationToken As CancellationToken) As Task
+        Return command.ExecuteReaderAsync(behavior, cancellationToken)
+    End Function
+End Class

--- a/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/SqlCommandExecutorVb.vb
+++ b/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/SqlCommandExecutorVb.vb
@@ -34,26 +34,32 @@ Public Class SqlCommandExecutorVb
     End Function
 
     Public Overrides Sub ExecuteReader(command As SqlCommand)
-        command.ExecuteReader()
+        Using command.ExecuteReader()
+        End Using
     End Sub
 
     Public Overrides Sub ExecuteReader(command As SqlCommand, behavior As CommandBehavior)
-        command.ExecuteReader(behavior)
+        Using command.ExecuteReader(behavior)
+        End Using
     End Sub
 
-    Public Overrides Function ExecuteReaderAsync(command As SqlCommand) As Task
-        Return command.ExecuteReaderAsync()
+    Public Overrides Async Function ExecuteReaderAsync(command As SqlCommand) As Task
+        Using Await command.ExecuteReaderAsync()
+        End Using
     End Function
 
-    Public Overrides Function ExecuteReaderAsync(command As SqlCommand, behavior As CommandBehavior) As Task
-        Return command.ExecuteReaderAsync(behavior)
+    Public Overrides Async Function ExecuteReaderAsync(command As SqlCommand, behavior As CommandBehavior) As Task
+        Using Await command.ExecuteReaderAsync(behavior)
+        End Using
     End Function
 
-    Public Overrides Function ExecuteReaderAsync(command As SqlCommand, cancellationToken As CancellationToken) As Task
-        Return command.ExecuteReaderAsync(cancellationToken)
+    Public Overrides Async Function ExecuteReaderAsync(command As SqlCommand, cancellationToken As CancellationToken) As Task
+        Using Await command.ExecuteReaderAsync(cancellationToken)
+        End Using
     End Function
 
-    Public Overrides Function ExecuteReaderAsync(command As SqlCommand, behavior As CommandBehavior, cancellationToken As CancellationToken) As Task
-        Return command.ExecuteReaderAsync(behavior, cancellationToken)
+    Public Overrides Async Function ExecuteReaderAsync(command As SqlCommand, behavior As CommandBehavior, cancellationToken As CancellationToken) As Task
+        Using Await command.ExecuteReaderAsync(behavior, cancellationToken)
+        End Using
     End Function
 End Class


### PR DESCRIPTION
Virtual calls are compiled differently in VB and C#. This causes SqlCommandIntegrations to be invoked in VB where DbCommandIntegrations would have been invoked in C#.

First running the tests on the commit before https://github.com/DataDog/dd-trace-dotnet/commit/d40130e291273208789784e40d6dc91094dcbf35 to confirm it crashes. Then I will rebase on master.