### PR TITLE
Disable automatic logs injection during IIS PreStartInit phase - OLD

### DIFF
--- a/src/Datadog.Trace/IScopeManager.cs
+++ b/src/Datadog.Trace/IScopeManager.cs
@@ -7,6 +7,8 @@ namespace Datadog.Trace
     /// </summary>
     internal interface IScopeManager
     {
+        event EventHandler<SpanEventArgs> TraceStarted;
+
         event EventHandler<SpanEventArgs> SpanOpened;
 
         event EventHandler<SpanEventArgs> SpanActivated;

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Logging
 
         public void StackOnSpanOpened(object sender, SpanEventArgs spanEventArgs)
         {
-            SetSerilogCompatibleLogContext(_defaultServiceName, _version, _env, spanEventArgs.Span.TraceId, spanEventArgs.Span.SpanId);
+            SetSerilogCompatibleLogContext(spanEventArgs.Span.TraceId, spanEventArgs.Span.SpanId);
         }
 
         public void StackOnSpanClosed(object sender, SpanEventArgs spanEventArgs)
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Logging
         public void MapOnSpanActivated(object sender, SpanEventArgs spanEventArgs)
         {
             RemoveAllCorrelationIdentifierContexts();
-            SetLogContext(_defaultServiceName, _version, _env, spanEventArgs.Span.TraceId, spanEventArgs.Span.SpanId);
+            SetLogContext(spanEventArgs.Span.TraceId, spanEventArgs.Span.SpanId);
         }
 
         public void MapOnTraceEnded(object sender, SpanEventArgs spanEventArgs)
@@ -113,7 +113,7 @@ namespace Datadog.Trace.Logging
 
         private void SetDefaultValues()
         {
-            SetLogContext(_defaultServiceName, _version, _env, 0, 0);
+            SetLogContext(0, 0);
         }
 
         private void RemoveLastCorrelationIdentifierContext()
@@ -144,7 +144,7 @@ namespace Datadog.Trace.Logging
             }
         }
 
-        private void SetLogContext(string service, string version, string env, ulong traceId, ulong spanId)
+        private void SetLogContext(ulong traceId, ulong spanId)
         {
             if (!_safeToAddToMdc)
             {
@@ -156,13 +156,13 @@ namespace Datadog.Trace.Logging
                 // TODO: Debug logs
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.ServiceKey, service, destructure: false));
+                        CorrelationIdentifier.ServiceKey, _defaultServiceName, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.VersionKey, version, destructure: false));
+                        CorrelationIdentifier.VersionKey, _version, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.EnvKey, env, destructure: false));
+                        CorrelationIdentifier.EnvKey, _env, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
                         CorrelationIdentifier.TraceIdKey, traceId.ToString(), destructure: false));
@@ -177,7 +177,7 @@ namespace Datadog.Trace.Logging
             }
         }
 
-        private void SetSerilogCompatibleLogContext(string service, string version, string env, ulong traceId, ulong spanId)
+        private void SetSerilogCompatibleLogContext(ulong traceId, ulong spanId)
         {
             if (!_safeToAddToMdc)
             {
@@ -189,13 +189,13 @@ namespace Datadog.Trace.Logging
                 // TODO: Debug logs
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.SerilogServiceKey, service, destructure: false));
+                        CorrelationIdentifier.SerilogServiceKey, _defaultServiceName, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.SerilogVersionKey, version, destructure: false));
+                        CorrelationIdentifier.SerilogVersionKey, _version, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
-                        CorrelationIdentifier.SerilogEnvKey, env, destructure: false));
+                        CorrelationIdentifier.SerilogEnvKey, _env, destructure: false));
                 _contextDisposalStack.Push(
                     LogProvider.OpenMappedContext(
                         CorrelationIdentifier.SerilogTraceIdKey, traceId.ToString(), destructure: false));

--- a/src/Datadog.Trace/ScopeManagerBase.cs
+++ b/src/Datadog.Trace/ScopeManagerBase.cs
@@ -7,6 +7,8 @@ namespace Datadog.Trace
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(ScopeManagerBase));
 
+        public event EventHandler<SpanEventArgs> TraceStarted;
+
         public event EventHandler<SpanEventArgs> SpanOpened;
 
         public event EventHandler<SpanEventArgs> SpanActivated;
@@ -24,6 +26,11 @@ namespace Datadog.Trace
             var newParent = Active;
             var scope = new Scope(newParent, span, this, finishOnClose);
             var scopeOpenedArgs = new SpanEventArgs(span);
+
+            if (newParent == null)
+            {
+                TraceStarted?.Invoke(this, scopeOpenedArgs);
+            }
 
             SpanOpened?.Invoke(this, scopeOpenedArgs);
 


### PR DESCRIPTION
### Issue
This change fixes a crash that occurs under the following conditions:
1. .NET Framework application is hosted in IIS
2. Automatic logs injection is enabled
3. Application uses the log4net logging library
4. Automatic instrumentation is triggered during the IIS PreStartInit phase

### Context
In order to store ambient information for the logging context on .NET Framework, log4net uses `CallContext`. The first time a property is stored, a log4net dictionary type is created and permanently stored in the `CallContext`, even if the dictionary is later found to be empty. This creates an error condition: If this is stored into the `CallContext` during the IIS PreStartInit phase (which occurs in the application-specific AppDomain), then a crash will occur when the phase is finished and execution resumes in the IIS default AppDomain.

The proposed solution is to initialize a flag to true that indicates that the IIS PreStartInit phase is executing. Then, do the following:
1. When the logs injection is set up, check if the process name corresponds to IIS or IIS Express. If not, permanently set state to false.
2. At the start of each trace, get the stack trace. If the IIS PreStartInit code path is not in the stack trace, permanently set state to false.

### Benchmarks
Since this invokes `System.Diagnostics.StackTrace` which can be slow to invoke, I performed the following benchmarks. The `UseNewFeature=false` scenario shows the previous (and buggy) baseline behavior and `UseNewFeature=true` demonstrates the new behavior.

### Remaining Work

- Insert benchmarks results
- TODO add test scenario to our CI/CD

@DataDog/apm-dotnet