### PR TITLE
Add configuration for customising span service names

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNetCommon.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             string method = requestData.GetProperty("Method").GetValueOrDefault()?.ToString();
             var url = requestData.GetProperty("Uri").GetValueOrDefault()?.ToString();
 
-            var serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -234,7 +234,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             Tracer tracer = Tracer.Instance;
             string source = document.GetProperty<string>("OriginalQuery")
                                     .GetValueOrDefault();
-            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -461,7 +461,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             Tracer tracer = Tracer.Instance;
-            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
 
             Scope scope = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -826,7 +826,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 Span parent = tracer.ActiveScope?.Span;
 
                 tags = new RabbitMQTags(spanKind);
-                scope = tracer.StartActiveWithTags(OperationName, parent: parentContext, tags: tags, serviceName: $"{tracer.DefaultServiceName}-{ServiceName}", startTime: startTime);
+                string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
+                scope = tracer.StartActiveWithTags(OperationName, parent: parentContext, tags: tags, serviceName: serviceName, startTime: startTime);
                 var span = scope.Span;
 
                 span.Type = SpanTypes.Queue;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -826,7 +826,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 Span parent = tracer.ActiveScope?.Span;
 
                 tags = new RabbitMQTags(spanKind);
-                scope = tracer.StartActiveWithTags(OperationName, parent: parentContext, tags: tags, serviceName: $"{tracer.DefaultServiceName}-{IntegrationName}", startTime: startTime);
+                scope = tracer.StartActiveWithTags(OperationName, parent: parentContext, tags: tags, serviceName: $"{tracer.DefaultServiceName}-{ServiceName}", startTime: startTime);
                 var span = scope.Span;
 
                 span.Type = SpanTypes.Queue;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RedisHelper.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 return null;
             }
 
-            string serviceName = $"{tracer.DefaultServiceName}-{ServiceName}";
+            string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
             Scope scope = null;
 
             try

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -58,7 +58,9 @@ namespace Datadog.Trace.ClrProfiler
                 string httpUrl = requestUri != null ? UriHelpers.CleanUri(requestUri, removeScheme: false, tryRemoveIds: false) : null;
 
                 tags = new HttpTags();
-                scope = tracer.StartActiveWithTags(OperationName, tags: tags, serviceName: $"{tracer.DefaultServiceName}-{ServiceName}");
+
+                string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
+                scope = tracer.StartActiveWithTags(OperationName, tags: tags, serviceName: serviceName);
                 var span = scope.Span;
 
                 span.Type = SpanTypes.Http;
@@ -120,7 +122,7 @@ namespace Datadog.Trace.ClrProfiler
                     return null;
                 }
 
-                string serviceName = $"{tracer.DefaultServiceName}-{dbType}";
+                string serviceName = tracer.Settings.GetServiceName(tracer, dbType);
                 string operationName = $"{dbType}.query";
 
                 var tags = new SqlTags();

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -134,6 +134,12 @@ namespace Datadog.Trace.Configuration
         public const string HeaderTags = "DD_TRACE_HEADER_TAGS";
 
         /// <summary>
+        /// Configuration key for a map of services to rename.
+        /// </summary>
+        /// <seealso cref="TracerSettings.ServiceNameMappings"/>
+        public const string ServiceNameMappings = "DD_TRACE_SERVICE_MAPPING";
+
+        /// <summary>
         /// Configuration key for setting the size of the trace buffer
         /// </summary>
         public const string QueueSize = "DD_TRACE_QUEUE_SIZE";

--- a/src/Datadog.Trace/Configuration/ServiceNames.cs
+++ b/src/Datadog.Trace/Configuration/ServiceNames.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Trace.Configuration
+{
+    internal class ServiceNames
+    {
+        private readonly object _lock = new object();
+        private Dictionary<string, string> _mappings = null;
+
+        public ServiceNames(IDictionary<string, string> mappings)
+        {
+            if (mappings is null)
+            {
+                throw new ArgumentNullException(nameof(mappings));
+            }
+
+            if (mappings.Count > 0)
+            {
+                _mappings = new Dictionary<string, string>(mappings);
+            }
+        }
+
+        public string GetServiceName(string applicationName, string key)
+        {
+            if (_mappings is not null && _mappings.TryGetValue(key, out var name))
+            {
+                return name;
+            }
+            else
+            {
+                return $"{applicationName}-{key}";
+            }
+        }
+
+        public void SetServiceNameMapping(string originalName, string newName)
+        {
+            lock (_lock)
+            {
+                var others = _mappings;
+                others = others is null
+                    ? new Dictionary<string, string>()
+                    : new Dictionary<string, string>(others);
+                others[originalName] = newName;
+                _mappings = others;
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace/Configuration/ServiceNames.cs
+++ b/src/Datadog.Trace/Configuration/ServiceNames.cs
@@ -10,12 +10,7 @@ namespace Datadog.Trace.Configuration
 
         public ServiceNames(IDictionary<string, string> mappings)
         {
-            if (mappings is null)
-            {
-                throw new ArgumentNullException(nameof(mappings));
-            }
-
-            if (mappings.Count > 0)
+            if (mappings?.Count > 0)
             {
                 _mappings = new Dictionary<string, string>(mappings);
             }

--- a/src/Datadog.Trace/Configuration/ServiceNames.cs
+++ b/src/Datadog.Trace/Configuration/ServiceNames.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Datadog.Trace.Configuration
 {
@@ -28,16 +28,11 @@ namespace Datadog.Trace.Configuration
             }
         }
 
-        public void SetServiceNameMapping(string originalName, string newName)
+        public void SetServiceNameMappings(IEnumerable<KeyValuePair<string, string>> mappings)
         {
             lock (_lock)
             {
-                var others = _mappings;
-                others = others is null
-                    ? new Dictionary<string, string>()
-                    : new Dictionary<string, string>(others);
-                others[originalName] = newName;
-                _mappings = others;
+                _mappings = mappings.ToDictionary(x => x.Key, x => x.Value);
             }
         }
     }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -130,7 +130,7 @@ namespace Datadog.Trace.Configuration
                          new ConcurrentDictionary<string, string>();
 
             // Filter out tags with empty keys or empty values, and trim whitespace
-            GlobalTags = GlobalTags.Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value))
+            GlobalTags = GlobalTags.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                                    .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
             HeaderTags = source?.GetDictionary(ConfigurationKeys.HeaderTags) ??
@@ -138,11 +138,11 @@ namespace Datadog.Trace.Configuration
                          new ConcurrentDictionary<string, string>();
 
             // Filter out tags with empty keys or empty values, and trim whitespace
-            HeaderTags = HeaderTags.Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value))
+            HeaderTags = HeaderTags.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                                    .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
             var serviceNameMappings = source?.GetDictionary(ConfigurationKeys.ServiceNameMappings)
-                                      ?.Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value))
+                                      ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
                                       ?.ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
             ServiceNameMappings = new ServiceNames(serviceNameMappings);

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -532,9 +532,15 @@ namespace Datadog.Trace.Configuration
 
         internal string GetServiceName(Tracer tracer, string serviceName)
         {
-            return ServiceNameMappings.TryGetValue(serviceName, out string mappedServiceName)
-                ? mappedServiceName
-                : $"{tracer.DefaultServiceName}-{serviceName}";
+            if (ServiceNameMappings.Count > 0
+                && ServiceNameMappings.TryGetValue(serviceName, out string mappedServiceName))
+            {
+                return mappedServiceName;
+            }
+            else
+            {
+                return $"{tracer.DefaultServiceName}-{serviceName}";
+            }
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -417,13 +417,13 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <summary>
-        /// Sets a mapping to use as the service name within a <see cref="Span"/>
+        /// Sets the mappings to use for service names within a <see cref="Span"/>
         /// </summary>
-        /// <param name="originalName">The original name of the service, for example <code>sql-server</code> or <code>graphql</code> </param>
-        /// <param name="newName">The new name to use for the service</param>
-        public void SetServiceNameMapping(string originalName, string newName)
+        /// <param name="mappings">Mappings to use from original service name (e.g. <code>sql-server</code> or <code>graphql</code>)
+        /// as the <see cref="KeyValuePair{TKey, TValue}.Key"/>) to replacement service names as <see cref="KeyValuePair{TKey, TValue}.Value"/>).</param>
+        public void SetServiceNameMappings(IEnumerable<KeyValuePair<string, string>> mappings)
         {
-            ServiceNameMappings.SetServiceNameMapping(originalName, newName);
+            ServiceNameMappings.SetServiceNameMappings(mappings);
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -141,13 +141,9 @@ namespace Datadog.Trace.Configuration
             HeaderTags = HeaderTags.Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value))
                                    .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
-            var serviceNameMappings = source?.GetDictionary(ConfigurationKeys.ServiceNameMappings) ??
-                         // default value (empty)
-                         new ConcurrentDictionary<string, string>();
-
-            // Filter out mappings with empty keys or empty values, and trim whitespace
-            serviceNameMappings = serviceNameMappings.Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value))
-                                   .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
+            var serviceNameMappings = source?.GetDictionary(ConfigurationKeys.ServiceNameMappings)
+                                      ?.Where(kvp => !string.IsNullOrEmpty(kvp.Key) && !string.IsNullOrEmpty(kvp.Value))
+                                      ?.ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim());
 
             ServiceNameMappings = new ServiceNames(serviceNameMappings);
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+using System.Linq;
+using Datadog.Core.Tools;
+using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [CollectionDefinition(nameof(ServiceMappingTests), DisableParallelization = true)]
+    public class ServiceMappingTests : TestHelper
+    {
+        public ServiceMappingTests(ITestOutputHelper output)
+            : base("HttpMessageHandler", output)
+        {
+            SetEnvironmentVariable("DD_HttpSocketsHandler_ENABLED", "true");
+            SetEnvironmentVariable("DD_TRACE_SERVICE_MAPPING", "some-trace:not-used,http-client:my-custom-client");
+            SetServiceVersion("1.0.0");
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void RenamesService(bool enableCallTarget, bool enableInlining)
+        {
+            SetCallTargetSettings(enableCallTarget, enableInlining);
+
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 36 : 32;
+            const string expectedOperationName = "http.request";
+            const string expectedServiceName = "my-custom-client";
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            int httpPort = TcpPortProvider.GetOpenPort();
+
+            Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"Port={httpPort}"))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
+
+                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                Assert.Equal(expectedSpanCount, spans.Count);
+
+                foreach (var span in spans)
+                {
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(SpanTypes.Http, span.Type);
+                    Assert.Equal("HttpMessageHandler", span.Tags[Tags.InstrumentationName]);
+                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
@@ -59,6 +59,18 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Fact]
+        public void CanPassNullToConstructor()
+        {
+            var serviceName = "elasticsearch";
+            var expected = $"{ApplicationName}-{serviceName}";
+            var serviceNames = new ServiceNames(null);
+
+            var actual = serviceNames.GetServiceName(ApplicationName, serviceName);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
         public void CanAddMappingsLater()
         {
             var serviceName = "elasticsearch";

--- a/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
@@ -76,11 +76,30 @@ namespace Datadog.Trace.Tests.Configuration
             var serviceName = "elasticsearch";
             var expected = "custom-name";
             var serviceNames = new ServiceNames(new Dictionary<string, string>());
-            serviceNames.SetServiceNameMapping(serviceName, expected);
+            serviceNames.SetServiceNameMappings(new Dictionary<string, string> { { serviceName, expected } });
 
             var actual = serviceNames.GetServiceName(ApplicationName, serviceName);
 
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ReplacesExistingMappings()
+        {
+            var serviceNames = new ServiceNames(new Dictionary<string, string>
+            {
+                { "sql-server", "custom-db" },
+                { "elasticsearch", "original-service" },
+            });
+            serviceNames.SetServiceNameMappings(new Dictionary<string, string> { { "elasticsearch", "custom-name" } });
+
+            var mongodbActual = serviceNames.GetServiceName(ApplicationName, "mongodb");
+            var elasticActual = serviceNames.GetServiceName(ApplicationName, "elasticsearch");
+            var sqlActual = serviceNames.GetServiceName(ApplicationName, "sql-server");
+
+            Assert.Equal($"{ApplicationName}-mongodb", mongodbActual);
+            Assert.Equal("custom-name", elasticActual);
+            Assert.Equal($"{ApplicationName}-sql-server", sqlActual);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Configuration;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class ServiceNameTests
+    {
+        private const string ApplicationName = "MyApplication";
+        private readonly ServiceNames _serviceNames;
+
+        public ServiceNameTests()
+        {
+            _serviceNames = new ServiceNames(new Dictionary<string, string>
+            {
+                { "sql-server", "custom-db" },
+                { "http-client", "some-service" },
+                { "mongodb", "my-mongo" },
+            });
+        }
+
+        [Theory]
+        [InlineData("sql-server", "custom-db")]
+        [InlineData("http-client", "some-service")]
+        [InlineData("mongodb", "my-mongo")]
+        public void RetrievesMappedServiceNames(string serviceName, string expected)
+        {
+            var actual = _serviceNames.GetServiceName(ApplicationName, serviceName);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("elasticsearch")]
+        [InlineData("postgres")]
+        [InlineData("custom-service")]
+        public void RetrievesUnmappedServiceNames(string serviceName)
+        {
+            var expected = $"{ApplicationName}-{serviceName}";
+
+            var actual = _serviceNames.GetServiceName(ApplicationName, serviceName);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("elasticsearch")]
+        [InlineData("postgres")]
+        [InlineData("custom-service")]
+        public void DoesNotRequireAnyMappings(string serviceName)
+        {
+            var serviceNames = new ServiceNames(new Dictionary<string, string>());
+            var expected = $"{ApplicationName}-{serviceName}";
+
+            var actual = serviceNames.GetServiceName(ApplicationName, serviceName);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void CanAddMappingsLater()
+        {
+            var serviceName = "elasticsearch";
+            var expected = "custom-name";
+            var serviceNames = new ServiceNames(new Dictionary<string, string>());
+            serviceNames.SetServiceNameMapping(serviceName, expected);
+
+            var actual = serviceNames.GetServiceName(ApplicationName, serviceName);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
Added configuration for customising how service names are recorded in traces using the `DD_TRACE_SERVICE_MAPPING` environment variable (similar to existing Java implementation).

For most integrations, we use the integration name as the key, and replace with the custom service name. For SQL integrations, we use the database type as the key. For example if `DD_TRACE_SERVICE_MAPPING` is set to `sql-server:custom-value`, then the service name in the span will be changed from `my-application-sql-server` to `custom-value`.

Note that we currently record all outgoing  `HttpClient` requests as `http-client`, we don't split based on hostname.

@DataDog/apm-dotnet