### PR TITLE
Fix CIApp integrations by removing the Analyzed span tag

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -220,7 +220,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                         Span span = scope.Span;
 
                         span.Type = SpanTypes.Test;
-                        span.SetMetric(Tags.Analytics, 1.0d);
                         span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                         span.ResourceName = $"{testSuite}.{testName}";
                         span.SetTag(TestTags.Suite, testSuite);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -415,7 +415,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 Span span = scope.Span;
 
                 span.Type = SpanTypes.Test;
-                span.SetMetric(Tags.Analytics, 1.0d);
                 span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                 span.ResourceName = $"{testSuite}.{testName}";
                 span.SetTag(TestTags.Suite, testSuite);


### PR DESCRIPTION
This PR fixes an issue with CIApp that prevent indexing the test spans.

The issue appears since the CIApp backend changed to use new tracks were the Analyzed flag is not supported.


@DataDog/apm-dotnet