### PR TITLE
Add Site Extension Version to Trace Tags

### DIFF
--- a/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
+++ b/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
@@ -22,6 +22,12 @@ namespace Datadog.Trace.PlatformHelpers
         internal const string AzureAppServicesContextKey = "DD_AZURE_APP_SERVICES";
 
         /// <summary>
+        /// Configuration key which has the running version of the Azure Site Extension.
+        /// This is set within the applicationHost.xdt file.
+        /// </summary>
+        internal const string SiteExtensionVersionKey = "DD_AAS_DOTNET_EXTENSION_VERSION";
+
+        /// <summary>
         /// Example: 8c500027-5f00-400e-8f00-60000000000f+apm-dotnet-EastUSwebspace
         /// Format: {subscriptionId}+{planResourceGroup}-{hostedInRegion}
         /// </summary>
@@ -95,6 +101,7 @@ namespace Datadog.Trace.PlatformHelpers
                     SiteName = GetVariableIfExists(SiteNameKey, environmentVariables);
                     ResourceId = CompileResourceId();
 
+                    SiteExtensionVersion = GetVariableIfExists(SiteExtensionVersionKey, environmentVariables);
                     InstanceId = GetVariableIfExists(InstanceIdKey, environmentVariables);
                     InstanceName = GetVariableIfExists(InstanceNameKey, environmentVariables);
                     OperatingSystem = GetVariableIfExists(OperatingSystemKey, environmentVariables);
@@ -138,6 +145,8 @@ namespace Datadog.Trace.PlatformHelpers
         public bool IsRelevant { get; }
 
         public bool IsUnsafeToTrace { get; }
+
+        public string SiteExtensionVersion { get; }
 
         public string SiteType { get; }
 

--- a/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
+++ b/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
@@ -101,10 +101,10 @@ namespace Datadog.Trace.PlatformHelpers
                     SiteName = GetVariableIfExists(SiteNameKey, environmentVariables);
                     ResourceId = CompileResourceId();
 
-                    SiteExtensionVersion = GetVariableIfExists(SiteExtensionVersionKey, environmentVariables);
-                    InstanceId = GetVariableIfExists(InstanceIdKey, environmentVariables);
-                    InstanceName = GetVariableIfExists(InstanceNameKey, environmentVariables);
-                    OperatingSystem = GetVariableIfExists(OperatingSystemKey, environmentVariables);
+                    InstanceId = GetVariableIfExists(InstanceIdKey, environmentVariables) ?? "unknown";
+                    InstanceName = GetVariableIfExists(InstanceNameKey, environmentVariables) ?? "unknown";
+                    OperatingSystem = GetVariableIfExists(OperatingSystemKey, environmentVariables) ?? "unknown";
+                    SiteExtensionVersion = GetVariableIfExists(SiteExtensionVersionKey, environmentVariables) ?? "unknown";
 
                     // Functions
                     FunctionsWorkerRuntime =

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -232,6 +232,11 @@ namespace Datadog.Trace
         public const string AzureAppServicesSiteName = "aas.site.name";
 
         /// <summary>
+        /// The version of the extension installed where the traced application is running.
+        /// </summary>
+        public const string AzureAppServicesExtensionVersion = "aas.environment.extension_version";
+
+        /// <summary>
         /// The instance name in Azure where the traced application is running.
         /// </summary>
         public const string AzureAppServicesInstanceName = "aas.environment.instance_name";

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -150,6 +150,7 @@ namespace Datadog.Trace
                 span.SetTag(Tags.AzureAppServicesInstanceName, AzureAppServices.Metadata.InstanceName);
                 span.SetTag(Tags.AzureAppServicesOperatingSystem, AzureAppServices.Metadata.OperatingSystem);
                 span.SetTag(Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
+                span.SetTag(Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
             }
 
             // set the origin tag to the root span of each trace/subtrace


### PR DESCRIPTION
Variable introduced in last release for the site extension.
https://github.com/DataDog/datadog-aas-extension/pull/35/files#diff-c2bc7d4c393e7e89d79afe0b304c3f92e666995d6f3523e13da973a96b41a665R80

![image](https://user-images.githubusercontent.com/1801443/105220311-89dfdf80-5b25-11eb-8c62-c9955ea0ced1.png)


@DataDog/apm-dotnet