### PR TITLE
Standardise log levels

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Agent
 
             if (!success)
             {
-                Log.Debug("Trace buffer is full. Dropping a trace from the buffer.");
+                Log.Warning("Trace buffer is full. Dropping a trace from the buffer.");
             }
 
             if (_statsd != null)

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Configuration
 
             if (enabled)
             {
-                DatadogLogging.SetLogLevel(LogEventLevel.Verbose);
+                DatadogLogging.SetLogLevel(LogEventLevel.Debug);
             }
             else
             {

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             if (_allListenersSubscription == null)
             {
-                Log.Verbose("Starting DiagnosticListener.AllListeners subscription");
+                Log.Debug("Starting DiagnosticListener.AllListeners subscription");
                 _allListenersSubscription = DiagnosticListener.AllListeners.Subscribe(this);
             }
         }
@@ -55,9 +55,9 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 if (subscription != null)
                 {
-                    if (Log.IsEnabled(LogEventLevel.Verbose))
+                    if (Log.IsEnabled(LogEventLevel.Debug))
                     {
-                        Log.Verbose(
+                        Log.Debug(
                             "Subscriber '{SubscriberType}' returned subscription for '{ListenerName}'",
                             subscriber.GetType().Name,
                             listener.Name);
@@ -72,9 +72,9 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             if (_allListenersSubscription != null)
             {
-                if (Log.IsEnabled(LogEventLevel.Verbose))
+                if (Log.IsEnabled(LogEventLevel.Debug))
                 {
-                    Log.Verbose("Stopping DiagnosticListener.AllListeners subscription");
+                    Log.Debug("Stopping DiagnosticListener.AllListeners subscription");
                 }
 
                 _allListenersSubscription.Dispose();

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Logging
             {
                 if (GlobalSettings.Source.DebugEnabled)
                 {
-                    LoggingLevelSwitch.MinimumLevel = LogEventLevel.Verbose;
+                    LoggingLevelSwitch.MinimumLevel = LogEventLevel.Debug;
                 }
 
                 var maxLogSizeVar = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.MaxLogFileSize);
@@ -133,7 +133,7 @@ namespace Datadog.Trace.Logging
 
         internal static void UseDefaultLevel()
         {
-            SetLogLevel(LogEventLevel.Information);
+            SetLogLevel(DefaultLogLevel);
         }
 
         private static string GetLogDirectory()

--- a/src/Datadog.Trace/RuntimeMetrics/PerformanceCounterWrapper.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/PerformanceCounterWrapper.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.RuntimeMetrics
             }
             catch (Exception ex)
             {
-                Log.Information(ex, "Error while renewing counter");
+                Log.Warning(ex, "Error while renewing counter");
             }
         }
     }

--- a/src/Datadog.Trace/Sampling/RateLimiter.cs
+++ b/src/Datadog.Trace/Sampling/RateLimiter.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Sampling
 
                 if (count >= _maxTracesPerInterval)
                 {
-                    Log.Debug("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.TraceId, count, _intervalMilliseconds);
+                    Log.Warning("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.TraceId, count, _intervalMilliseconds);
                     return false;
                 }
 

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -128,7 +128,7 @@ namespace Datadog.Trace
         {
             if (IsFinished)
             {
-                Log.Debug("SetTag should not be called after the span was closed");
+                Log.Warning("SetTag should not be called after the span was closed");
                 return this;
             }
 


### PR DESCRIPTION
Initial cleanup of log levels before implementing remainder of [the logging RFC](https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/tracer-logging/rfc.md#rate-limits)

- Use only the allowed levels: `Debug`, `Warning`, `Error`
- Update default/minimum log level accordingly
- Update some log levels based on [suggestions in RFC](https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/tracer-logging/rfc.md#log-levels).
- Replace `string.Format()` style log templates (`"{0},{1}"`) with named arguments (`"{Name},{Value}"`). Doesn't make much difference atm, as we're only writing to file, but is better practice, and will be better if we do structured logging down the line instead.

In a follow up PR I'll encapsulate the `ILogger` to restrict to using only the allowed levels, and add rate limiting, as defined in the RFC

@DataDog/apm-dotnet