### PR TITLE
Packages pipeline fix

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -79,7 +79,7 @@ stages:
 
   - job: linux_packages
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-20.04
     variables:
       tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 
@@ -192,7 +192,7 @@ stages:
   - job: s3_upload
 
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-20.04
 
     steps:
     - download: current

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -79,7 +79,7 @@ stages:
 
   - job: linux_packages
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-18.04
     variables:
       tracerHome: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -235,7 +235,7 @@ stages:
         cat $INDEX_FILE
       displayName: Write index.txt
 
-    - script: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing awscli
+    - script: sudo apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing awscli
       displayName: Install AWS CLI
 
     - script: aws configure set aws_access_key_id $SECRET

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -235,7 +235,7 @@ stages:
         cat $INDEX_FILE
       displayName: Write index.txt
 
-    - script: sudo apt-get install -y awscli
+    - script: sudo apt-get install -y --fix-missing awscli
       displayName: Install AWS CLI
 
     - script: aws configure set aws_access_key_id $SECRET

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -235,7 +235,7 @@ stages:
         cat $INDEX_FILE
       displayName: Write index.txt
 
-    - script: sudo apt-get install -y --fix-missing awscli
+    - script: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing awscli
       displayName: Install AWS CLI
 
     - script: aws configure set aws_access_key_id $SECRET

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -192,7 +192,7 @@ stages:
   - job: s3_upload
 
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-18.04
 
     steps:
     - download: current
@@ -235,7 +235,7 @@ stages:
         cat $INDEX_FILE
       displayName: Write index.txt
 
-    - script: sudo apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing awscli
+    - script: sudo apt-get install -y --fix-missing awscli
       displayName: Install AWS CLI
 
     - script: aws configure set aws_access_key_id $SECRET

--- a/build/docker/package.dockerfile
+++ b/build/docker/package.dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
     rpm \
     ruby \
     ruby-dev \
-    rubygems
+    rubygems \
+    git
 
 RUN gem install --no-ri --no-rdoc fpm

--- a/build/docker/package.dockerfile
+++ b/build/docker/package.dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
+RUN apt-get update && apt-get install -y --fix-missing \
     build-essential \
     rpm \
     ruby \

--- a/build/docker/package.dockerfile
+++ b/build/docker/package.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y --fix-missing \
     build-essential \

--- a/build/docker/package.dockerfile
+++ b/build/docker/package.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y --fix-missing \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --fix-missing \
     build-essential \
     rpm \
     ruby \

--- a/build/docker/package.dockerfile
+++ b/build/docker/package.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --fix-missing \
     build-essential \
     rpm \
     ruby \

--- a/build/docker/package.dockerfile
+++ b/build/docker/package.dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --fix-missing \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
     build-essential \
     rpm \
     ruby \


### PR DESCRIPTION
This PR adds fixes the packages pipeline by adding the git to the apt-get command.

Previous error:

```
sh: 1: git: not found (Git::GitExecuteError)
```

@DataDog/apm-dotnet