### PR TITLE
Disable automatic logs injection during IIS PreStartInit phase

### DIFF
--- a/build/docker/IIS/LoaderOptimizationRegKey.dockerfile
+++ b/build/docker/IIS/LoaderOptimizationRegKey.dockerfile
@@ -9,7 +9,7 @@ RUN Add-WindowsFeature NET-Framework-45-ASPNET; \
 ADD test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/bin/Release/Publish LoaderOptimizationRegKey
 
 # Set up IIS websites
-ARG ENABLE_32_BIT
+ARG ENABLE_32_BIT=false
 RUN Remove-WebSite -Name 'Default Web Site'; \
     New-Website -Name 'LoaderOptimizationRegKey' -Port 80 -PhysicalPath 'c:\LoaderOptimizationRegKey'
 RUN c:\Windows\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /enable32bitapponwin64:$env:ENABLE_32_BIT

--- a/build/docker/IIS/build.ps1
+++ b/build/docker/IIS/build.ps1
@@ -1,0 +1,44 @@
+$ProgressPreference = 'SilentlyContinue'
+
+$nuget_found = [bool] (Get-Command -ErrorAction Ignore -Type Application nuget)
+if (!$nuget_found)
+{
+    Write-Error 'nuget not found in $env:PATH. Exiting.' -ErrorAction Stop
+}
+
+$msbuild_found = [bool] (Get-Command -ErrorAction Ignore -Type Application msbuild)
+if (!$msbuild_found)
+{
+    Write-Error 'msbuild not found in $env:PATH. Exiting.' -ErrorAction Stop
+}
+
+$docker_compose_found = [bool] (Get-Command -ErrorAction Ignore -Type Application docker-compose)
+if (!$docker_compose_found)
+{
+    Write-Error 'docker-compose not found in $env:PATH. Exiting.' -ErrorAction Stop
+}
+
+$repo_root = Resolve-Path ../../..
+$trace_solution = Join-Path $repo_root Datadog.Trace.sln
+$trace_proj = Join-Path $repo_root Datadog.Trace.proj
+$solution = Join-Path $repo_root test/test-applications/aspnet/samples-iis.sln
+
+# Build IIS samples
+nuget restore $solution
+msbuild $solution /p:DeployOnBuild=true /p:PublishProfile=FolderProfile.pubxml
+
+# Build Datadog MSI's
+nuget restore $trace_solution
+msbuild $trace_proj /t:BuildCsharp /p:Configuration=Release
+
+msbuild $trace_proj /t:BuildCpp /p:"Configuration=Release;Platform=x64"
+msbuild $trace_proj /t:BuildCpp /p:"Configuration=Release;Platform=x86"
+
+msbuild $trace_proj /t:msi /p:"Configuration=Release;Platform=x64"
+msbuild $trace_proj /t:msi /p:"Configuration=Release;Platform=x86"
+
+# Build IIS container
+pushd $repo_root
+$relative_msi = "src/WindowsInstaller/bin/Release/x64/en-us/*.msi"
+docker-compose build --build-arg DOTNET_TRACER_MSI=$relative_msi IntegrationTests.IIS.LoaderOptimizationRegKey
+popd

--- a/build/docker/IIS/build.ps1
+++ b/build/docker/IIS/build.ps1
@@ -29,13 +29,7 @@ msbuild $solution /p:DeployOnBuild=true /p:PublishProfile=FolderProfile.pubxml
 
 # Build Datadog MSI's
 nuget restore $trace_solution
-msbuild $trace_proj /t:BuildCsharp /p:Configuration=Release
-
-msbuild $trace_proj /t:BuildCpp /p:"Configuration=Release;Platform=x64"
-msbuild $trace_proj /t:BuildCpp /p:"Configuration=Release;Platform=x86"
-
-msbuild $trace_proj /t:msi /p:"Configuration=Release;Platform=x64"
-msbuild $trace_proj /t:msi /p:"Configuration=Release;Platform=x86"
+msbuild $trace_proj /t:msi /p:"Configuration=Release;Platform=All"
 
 # Build IIS container
 pushd $repo_root

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2522,7 +2522,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
   LPCWSTR pre_init_start_str = L"Datadog_IISPreInitStart";
   auto pre_init_start_str_size = wcslen(pre_init_start_str);
 #else
-  char16_t load_helper_str[] =
+  char16_t pre_init_start_str[] =
       u"Datadog_IISPreInitStart";
   auto pre_init_start_str_size =
       std::char_traits<char16_t>::length(pre_init_start_str);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -88,6 +88,8 @@ class CorProfiler : public CorProfilerBase {
                              const mdToken function_token);
   HRESULT GenerateVoidILStartupMethod(const ModuleID module_id,
                            mdMethodDef* ret_method_token);
+  HRESULT AddIISPreStartInitFlags(const ModuleID module_id,
+                           const mdToken function_token);
 
   //
   // CallTarget Methods

--- a/src/Datadog.Trace/IScopeManager.cs
+++ b/src/Datadog.Trace/IScopeManager.cs
@@ -7,6 +7,8 @@ namespace Datadog.Trace
     /// </summary>
     internal interface IScopeManager
     {
+        event EventHandler<SpanEventArgs> TraceStarted;
+
         event EventHandler<SpanEventArgs> SpanOpened;
 
         event EventHandler<SpanEventArgs> SpanActivated;

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -290,7 +290,7 @@ namespace Datadog.Trace.Logging
 #pragma warning disable SA1204 // Static elements must appear before instance elements
         private static void RefreshIISPreAppState(ulong traceId)
         {
-            Debug.Assert(!_executingIISPreStartInit, $"{nameof(_executingIISPreStartInit)} should always be false when entering {nameof(RefreshIISPreAppState)}");
+            Debug.Assert(_executingIISPreStartInit, $"{nameof(_executingIISPreStartInit)} should always be true when entering {nameof(RefreshIISPreAppState)}");
 
             if (_performAppDomainFlagChecks)
             {

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -137,6 +137,11 @@ namespace Datadog.Trace.Logging
             {
                 RefreshIISPreAppState(traceId: spanEventArgs.Span.TraceId);
             }
+
+            if (!_executingIISPreStartInit)
+            {
+                _scopeManager.TraceStarted -= OnTraceStarted_RefreshIISState;
+            }
         }
 #endif
 

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Threading;
 using Datadog.Trace.Logging.LogProviders;
 using Datadog.Trace.Util;
 
@@ -72,6 +71,11 @@ namespace Datadog.Trace.Logging
                 {
                     Log.SafeLogError(ex, "Error obtaining the process name for quickly validating IIS PreStartInit condition.");
                 }
+            }
+
+            if (_executingIISPreStartInit)
+            {
+                Log.Warning("Automatic logs injection detected that IIS is still initializating. The {Source} will be checked at the start of each trace to only enable automatic logs injection when IIS is finished initializing.", _performAppDomainFlagChecks ? "AppDomain" : "System.Diagnostics.StackTrace");
             }
         }
 #endif

--- a/src/Datadog.Trace/ScopeManagerBase.cs
+++ b/src/Datadog.Trace/ScopeManagerBase.cs
@@ -7,6 +7,8 @@ namespace Datadog.Trace
     {
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(ScopeManagerBase));
 
+        public event EventHandler<SpanEventArgs> TraceStarted;
+
         public event EventHandler<SpanEventArgs> SpanOpened;
 
         public event EventHandler<SpanEventArgs> SpanActivated;
@@ -30,6 +32,11 @@ namespace Datadog.Trace
             var newParent = Active;
             var scope = new Scope(newParent, span, this, finishOnClose);
             var scopeOpenedArgs = new SpanEventArgs(span);
+
+            if (newParent == null)
+            {
+                TraceStarted?.Invoke(this, scopeOpenedArgs);
+            }
 
             SpanOpened?.Invoke(this, scopeOpenedArgs);
 

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/About.aspx.cs
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/About.aspx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -11,7 +11,7 @@ namespace Samples.AspNet472.LoaderOptimizationRegKey
     {
         protected void Page_Load(object sender, EventArgs e)
         {
-
+            Global.InitializeTrace("Samples.AspNet472.LoaderOptimizationRegKey.About.Page_Load");
         }
     }
 }

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Contact.aspx.cs
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Contact.aspx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -11,7 +11,7 @@ namespace Samples.AspNet472.LoaderOptimizationRegKey
     {
         protected void Page_Load(object sender, EventArgs e)
         {
-
+            Global.InitializeTrace("Samples.AspNet472.LoaderOptimizationRegKey.Contact.Page_Load");
         }
     }
 }

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Default.aspx.cs
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Default.aspx.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -11,7 +11,7 @@ namespace Samples.AspNet472.LoaderOptimizationRegKey
     {
         protected void Page_Load(object sender, EventArgs e)
         {
-
+            Global.InitializeTrace("Samples.AspNet472.LoaderOptimizationRegKey._Default.Page_Load");
         }
     }
 }

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Global.asax.cs
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Global.asax.cs
@@ -25,7 +25,7 @@ namespace Samples.AspNet472.LoaderOptimizationRegKey
 
         public static void InitializeTracePreStart()
         {
-            InitializeTrace("AutomaticLogInjectionInPreAppStart.MvcApplication.InitializeTracePreStart");
+            InitializeTrace("Samples.AspNet472.LoaderOptimizationRegKey.InitializeTracePreStart");
         }
 
         public static void InitializeTrace(string callingMethod)

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Global.asax.cs
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Global.asax.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Net;
 using System.Web;
 using System.Web.Optimization;
 using System.Web.Routing;
@@ -11,10 +13,47 @@ namespace Samples.AspNet472.LoaderOptimizationRegKey
 {
     public class Global : HttpApplication
     {
+        private static readonly log4net.ILog log = log4net.LogManager.GetLogger(typeof(Global));
+
         void Application_Start(object sender, EventArgs e)
         {
             // Code that runs on application startup
             RouteConfig.RegisterRoutes(RouteTable.Routes);
+
+            InitializeTrace("Executing from Application_Start");
+        }
+
+        public static void InitializeTracePreStart()
+        {
+            InitializeTrace("AutomaticLogInjectionInPreAppStart.MvcApplication.InitializeTracePreStart");
+        }
+
+        public static void InitializeTrace(string callingMethod)
+        {
+            log.Info(nameof(InitializeTrace) + " : Executing from " + callingMethod);
+
+            var request = WebRequest.Create("https://icanhazdadjoke.com/");
+            ((HttpWebRequest)request).Accept = "application/json;q=1";
+
+            using (var response = (HttpWebResponse)request.GetResponse())
+            using (var stream = response.GetResponseStream())
+            using (var reader = new StreamReader(stream))
+            {
+                string responseText = String.Empty;
+
+                try
+                {
+                    responseText = reader.ReadToEnd();
+                }
+                catch (Exception)
+                {
+                    responseText = "ENCOUNTERED AN ERROR WHEN READING RESPONSE.";
+                }
+                finally
+                {
+                    log.Info($"Response Text: {responseText}");
+                }
+            }
         }
     }
 }

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Properties/AssemblyInfo.cs
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -33,3 +33,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4net.config")]
+[assembly: System.Web.PreApplicationStartMethod(typeof(Samples.AspNet472.LoaderOptimizationRegKey.Global), nameof(Samples.AspNet472.LoaderOptimizationRegKey.Global.InitializeTracePreStart))]

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Samples.AspNet472.LoaderOptimizationRegKey.csproj
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Samples.AspNet472.LoaderOptimizationRegKey.csproj
@@ -44,6 +44,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
@@ -99,6 +102,9 @@
     <Content Include="Default.aspx" />
     <Content Include="favicon.ico" />
     <Content Include="Global.asax" />
+    <Content Include="log4net.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Properties\PublishProfiles\FolderProfile.pubxml" />
     <Content Include="Site.Master" />
     <Content Include="ViewSwitcher.ascx" />

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Web.config
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/Web.config
@@ -4,6 +4,9 @@
   https://go.microsoft.com/fwlink/?LinkId=169433
   -->
 <configuration>
+  <appSettings>
+    <add key="DD_LOGS_INJECTION" value="true"/>
+  </appSettings>
   <system.web>
     <customErrors mode="Off" />
     <compilation debug="true" targetFramework="4.7.2" />

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/log4net.config
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/log4net.config
@@ -1,0 +1,18 @@
+﻿<log4net>
+  <root>
+    <level value="ALL" />
+    <appender-ref ref="file" />
+  </root>
+  <appender name="file" type="log4net.Appender.RollingFileAppender">
+    <file value="myapp.log" />
+    <appendToFile value="true" />
+    <rollingStyle value="Size" />
+    <maxSizeRollBackups value="5" />
+    <maximumFileSize value="10MB" />
+    <staticLogFileName value="true" />
+    <layout type="log4net.Layout.PatternLayout">
+      <!-- <conversionPattern value="%date [%thread] %level %logger - %message%newline" /> -->
+      <conversionPattern value="%date [%thread] %level %logger {traceId=&quot;%property{dd.trace_id}&quot;, spanId=&quot;%property{dd.span_id}&quot;} - %message%newline" />
+    </layout>
+  </appender>
+</log4net>

--- a/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/packages.config
+++ b/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net472" />
+  <package id="log4net" version="2.0.8" targetFramework="net472" />
   <package id="Microsoft.AspNet.FriendlyUrls" version="1.0.2" targetFramework="net472" />
   <package id="Microsoft.AspNet.FriendlyUrls.Core" version="1.0.2" targetFramework="net472" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net472" />


### PR DESCRIPTION
Replaces #1139

### Issue
This change fixes a crash that occurs under the following conditions:
1. .NET Framework application is hosted in IIS
2. Automatic logs injection is enabled
3. Application uses the log4net logging library
4. Automatic instrumentation is triggered during the IIS PreStartInit phase

### Context
In order to store ambient information for the logging context on .NET Framework, log4net uses `CallContext`. The first time a property is stored, a log4net dictionary type is created and permanently stored in the `CallContext`, even if the dictionary is later found to be empty. This creates an error condition: If this is stored into the `CallContext` during the IIS PreStartInit phase (which occurs in the application-specific AppDomain), then a crash will occur when the phase is finished and execution resumes in the IIS default AppDomain.

### Solution
The solution is two-fold:

1. When automatic instrumentation is enabled, we already perform IL rewriting at the beginning of the IIS PreStartInit code path to load our managed code. Modify this code path to begin and end with a call to `AppDomain.SetData` to set a flag that indicates if the IIS PreStartInit phase is still running. This flag can be observed from elsewhere in the AppDomain and need not be on the same thread.
2. Register to a new `TraceStarted` event provided by the ScopeManager and register a callback to evaluate whether we're still running in this PreStartInit phase. It will either check for the AppDomain flag (if it was not-null) or it will fallback to checking the StackTrace (which is expensive). As soon as we detect false, we won't execute these checks again.

Optimizations to this strategy include never subscribing to the `TraceStarted` event if one of the following conditions is met at Tracer startup:
1. Automatic instrumentation is enabled and the IIS PreStartInit flag is already false
2. No automatic instrumentation is enabled and the process name is not `w3wp` or `iisexpress`

### Testing

1. Added automatic instrumentation + logs injection to IIS smoke test in CI/CD (project: `Samples.AspNet472.LoaderOptimizationRegKey`)
2. Tested locally with logs injection enabled and traces started in the IIS PreInitStart phase for both 1) IIS | IIS Express and 2) Automatic Instrumentation | Custom Instrumentation

### Benchmarks
Observations from the below numbers:
- The only performance penalty is when LogsInjectionEnabled=true and starting multiple traces inside the IIS PreStartInit phase of execution. Though, we expect this to be the rare case anyways.
- `AppDomain.SetData` / `AppDomain.GetData` check, which is used when automatic instrumentation is enabled, is at least 2x faster than the StackTrace walk. The StackTrace check is only needed when automatic instrumentation is not enabled, so this should be the rare case.

Code without the Tracer and scenario setup done in `[GlobalSetup]` before the iteration:
```
        [Benchmark]
        public int OpenTracesWithLogsInjectionEnabled()
        {
            int retVal = 0;

            for (int i = 0; i < NumberOfTraces; i++)
            {
                using (var scope = tracer.StartActive("iteration"))
                {
                    retVal++;
                }
            }

            return retVal;
        }
```

#### Scenario: LogsInjectionEnabled=false

|              State |     AutomaticInstr |     NumberOfTraces |           Mean |          Error |         StdDev |         Median |       Gen 0 |     Allocated |
|------------------- |------------------- |------------------- |---------------:|---------------:|---------------:|---------------:|------------:|--------------:|
|         **NotIIS** |          **False** |              **5** |   **4.203 μs** |  **0.0837 μs** |  **0.1941 μs** |   **4.209 μs** |  **0.6180** |   **2.86 KB** |
|         **NotIIS** |          **False** |             **10** |   **8.185 μs** |  **0.1601 μs** |  **0.2138 μs** |   **8.057 μs** |  **1.2360** |   **5.72 KB** |
|         **NotIIS** |          **False** |             **25** |  **20.413 μs** |  **0.2383 μs** |  **0.2113 μs** |  **20.355 μs** |  **3.0823** |   **14.3 KB** |
|         **NotIIS** |           **True** |              **5** |   **4.196 μs** |  **0.0834 μs** |  **0.1084 μs** |   **4.160 μs** |  **0.6180** |   **2.86 KB** |
|         **NotIIS** |           **True** |             **10** |   **8.190 μs** |  **0.0611 μs** |  **0.0477 μs** |   **8.194 μs** |  **1.2360** |   **5.72 KB** |
|         **NotIIS** |           **True** |             **25** |  **20.724 μs** |  **0.2628 μs** |  **0.2458 μs** |  **20.731 μs** |  **3.0823** |   **14.3 KB** |
|                    |                    |                    |                |                |                |                |             |               |
| **IISNotPreStart** |          **False** |              **5** |   **4.099 μs** |  **0.0754 μs** |  **0.0706 μs** |   **4.070 μs** |  **0.6180** |   **2.86 KB** |
| **IISNotPreStart** |          **False** |             **10** |   **8.343 μs** |  **0.0832 μs** |  **0.0778 μs** |   **8.351 μs** |  **1.2360** |   **5.72 KB** |
| **IISNotPreStart** |          **False** |             **25** |  **20.504 μs** |  **0.4028 μs** |  **0.4795 μs** |  **20.407 μs** |  **3.0823** |   **14.3 KB** |
| **IISNotPreStart** |           **True** |              **5** |   **4.198 μs** |  **0.0789 μs** |  **0.0844 μs** |   **4.232 μs** |  **0.6180** |   **2.86 KB** |
| **IISNotPreStart** |           **True** |             **10** |   **8.106 μs** |  **0.1070 μs** |  **0.0894 μs** |   **8.075 μs** |  **1.2360** |   **5.72 KB** |
| **IISNotPreStart** |           **True** |             **25** |  **20.479 μs** |  **0.4094 μs** |  **0.7383 μs** |  **20.158 μs** |  **3.0823** |   **14.3 KB** |
|                    |                    |                    |                |                |                |                |             |               |
|    **IISPreStart** |          **False** |              **5** |   **4.228 μs** |  **0.0805 μs** |  **0.1569 μs** |   **4.193 μs** |  **0.6180** |   **2.86 KB** |
|    **IISPreStart** |          **False** |             **10** |   **8.399 μs** |  **0.1649 μs** |  **0.3586 μs** |   **8.288 μs** |  **1.2360** |   **5.72 KB** |
|    **IISPreStart** |          **False** |             **25** |  **20.874 μs** |  **0.3948 μs** |  **0.4388 μs** |  **20.754 μs** |  **3.0823** |   **14.3 KB** |
|    **IISPreStart** |           **True** |              **5** |   **4.134 μs** |  **0.0815 μs** |  **0.1245 μs** |   **4.115 μs** |  **0.6180** |   **2.86 KB** |
|    **IISPreStart** |           **True** |             **10** |   **8.097 μs** |  **0.0651 μs** |  **0.0543 μs** |   **8.096 μs** |  **1.2360** |   **5.72 KB** |
|    **IISPreStart** |           **True** |             **25** |  **21.767 μs** |  **0.3984 μs** |  **0.3727 μs** |  **21.721 μs** |  **3.0823** |   **14.3 KB** |

#### Scenario: LogsInjectionEnabled=true

|              State |     AutomaticInstr |     NumberOfTraces |           Mean |          Error |         StdDev |         Median |       Gen 0 |     Allocated |
|------------------- |------------------- |------------------- |---------------:|---------------:|---------------:|---------------:|------------:|--------------:|
|         **NotIIS** |          **False** |              **5** |   **7.768 μs** |  **0.0961 μs** |  **0.0852 μs** |   **7.772 μs** |  **1.4343** |   **6.66 KB** |
|         **NotIIS** |          **False** |             **10** |  **15.735 μs** |  **0.2832 μs** |  **0.2365 μs** |  **15.757 μs** |  **2.8687** |  **13.32 KB** |
|         **NotIIS** |          **False** |             **25** |  **40.418 μs** |  **0.7801 μs** |  **1.4460 μs** |  **40.113 μs** |  **7.2021** |   **33.3 KB** |
|         **NotIIS** |           **True** |              **5** |   **8.021 μs** |  **0.1447 μs** |  **0.1283 μs** |   **8.003 μs** |  **1.4343** |   **6.66 KB** |
|         **NotIIS** |           **True** |             **10** |  **15.484 μs** |  **0.2796 μs** |  **0.2615 μs** |  **15.387 μs** |  **2.8687** |  **13.32 KB** |
|         **NotIIS** |           **True** |             **25** |  **39.060 μs** |  **0.7682 μs** |  **0.8220 μs** |  **38.811 μs** |  **7.2021** |   **33.3 KB** |
|                    |                    |                    |                |                |                |                |             |               |
| **IISNotPreStart** |          **False** |              **5** |   **7.911 μs** |  **0.1498 μs** |  **0.1784 μs** |   **7.895 μs** |  **1.4343** |   **6.66 KB** |
| **IISNotPreStart** |          **False** |             **10** |  **15.590 μs** |  **0.3103 μs** |  **0.3573 μs** |  **15.626 μs** |  **2.8687** |  **13.32 KB** |
| **IISNotPreStart** |          **False** |             **25** |  **38.816 μs** |  **0.5025 μs** |  **0.4454 μs** |  **38.716 μs** |  **7.2021** |   **33.3 KB** |
| **IISNotPreStart** |           **True** |              **5** |   **7.775 μs** |  **0.0994 μs** |  **0.0881 μs** |   **7.756 μs** |  **1.4343** |   **6.66 KB** |
| **IISNotPreStart** |           **True** |             **10** |  **16.035 μs** |  **0.3162 μs** |  **0.4634 μs** |  **15.901 μs** |  **2.8687** |  **13.32 KB** |
| **IISNotPreStart** |           **True** |             **25** |  **40.042 μs** |  **0.5196 μs** |  **0.4339 μs** |  **39.943 μs** |  **7.2021** |   **33.3 KB** |
|                    |                    |                    |                |                |                |                |             |               |
|    **IISPreStart** |          **False** |              **5** | **143.702 μs** |  **2.7051 μs** |  **2.5303 μs** | **143.335 μs** | **10.2539** |  **47.97 KB** |
|    **IISPreStart** |          **False** |             **10** | **289.001 μs** |  **5.3822 μs** |  **5.2860 μs** | **287.355 μs** | **20.5078** |  **95.91 KB** |
|    **IISPreStart** |          **False** |             **25** | **728.805 μs** | **12.5603 μs** | **12.8985 μs** | **726.538 μs** | **51.7578** | **239.88 KB** |
|    **IISPreStart** |           **True** |              **5** |  **62.554 μs** |  **0.9244 μs** |  **0.7719 μs** |  **62.470 μs** |  **2.4414** |  **11.69 KB** |
|    **IISPreStart** |           **True** |             **10** | **129.738 μs** |  **2.5527 μs** |  **3.0388 μs** | **130.842 μs** |  **4.8828** |  **23.38 KB** |
|    **IISPreStart** |           **True** |             **25** | **309.804 μs** |  **2.6852 μs** |  **2.0964 μs** | **310.451 μs** | **12.2070** |  **58.48 KB** |

@DataDog/apm-dotnet