### PR TITLE
Replace log messages using string.Format style with structured log style

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/CIEnvironmentValues.cs
+++ b/src/Datadog.Trace.Ci.Shared/CIEnvironmentValues.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Ci
             }
             catch (Exception ex)
             {
-                Logger.Warning(ex, "Error fixing branch name: {0}", Branch);
+                Logger.Warning(ex, "Error fixing branch name: {BranchName}", Branch);
             }
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -205,7 +205,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error instrumenting method {0}", "System.Web.Mvc.Async.IAsyncActionInvoker.BeginInvokeAction()");
+                Log.Error(ex, "Error instrumenting method {MethodName}", "System.Web.Mvc.Async.IAsyncActionInvoker.BeginInvokeAction()");
             }
 
             Func<object, object, object, object, object, object> instrumentedMethod;
@@ -288,7 +288,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error instrumenting method {0}", $"{AsyncActionInvokerTypeName}.EndInvokeAction()");
+                Log.Error(ex, "Error instrumenting method {MethodName}", $"{AsyncActionInvokerTypeName}.EndInvokeAction()");
             }
 
             Func<object, object, bool> instrumentedMethod;

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Agent
             var retryCount = 1;
             var sleepDuration = 100; // in milliseconds
 
-            Log.Debug("Sending {0} traces to the DD agent", traces.Length);
+            Log.Debug("Sending {Count} traces to the DD agent", traces.Length);
 
             while (true)
             {
@@ -53,7 +53,7 @@ namespace Datadog.Trace.Agent
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "An error occurred while generating http request to send traces to the agent at {0}", _apiRequestFactory.Info(_tracesEndpoint));
+                    Log.Error(ex, "An error occurred while generating http request to send traces to the agent at {AgentEndpoint}", _apiRequestFactory.Info(_tracesEndpoint));
                     return false;
                 }
 
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Agent
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)
                     {
-                        Log.Error(ex, "An error occurred while sending {0} traces to the agent at {1}", traces.Length, _apiRequestFactory.Info(_tracesEndpoint));
+                        Log.Error(ex, "An error occurred while sending {Count} traces to the agent at {AgentEndpoint}", traces.Length, _apiRequestFactory.Info(_tracesEndpoint));
                         return false;
                     }
 #endif
@@ -93,7 +93,7 @@ namespace Datadog.Trace.Agent
                     if (isFinalTry)
                     {
                         // stop retrying
-                        Log.Error(exception, "An error occurred while sending {0} traces to the agent at {1}", traces.Length, _apiRequestFactory.Info(_tracesEndpoint));
+                        Log.Error(exception, "An error occurred while sending {Count} traces to the agent at {AgentEndpoint}", traces.Length, _apiRequestFactory.Info(_tracesEndpoint));
                         return false;
                     }
 
@@ -114,7 +114,8 @@ namespace Datadog.Trace.Agent
 
                     if (isSocketException)
                     {
-                        Log.Debug(exception, "Unable to communicate with the trace agent at {0}", _apiRequestFactory.Info(_tracesEndpoint));
+                        // Somewhat expected, so just warn instead of error
+                        Log.Warning(exception, "Unable to communicate with the trace agent at {AgentEndpoint}", _apiRequestFactory.Info(_tracesEndpoint));
                     }
 
                     // Execute retry delay
@@ -125,7 +126,7 @@ namespace Datadog.Trace.Agent
                     continue;
                 }
 
-                Log.Debug("Successfully sent {0} traces to the DD agent", traces.Length);
+                Log.Debug("Successfully sent {Count} traces to the DD agent", traces.Length);
                 return true;
             }
         }
@@ -133,10 +134,10 @@ namespace Datadog.Trace.Agent
         private static IApiRequestFactory CreateRequestFactory()
         {
 #if NETCOREAPP
-            Log.Information("Using {0} for trace transport.", nameof(HttpClientRequestFactory));
+            Log.Information("Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
             return new HttpClientRequestFactory();
 #else
-            Log.Information("Using {0} for trace transport.", nameof(ApiWebRequestFactory));
+            Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
             return new ApiWebRequestFactory();
 #endif
         }
@@ -177,11 +178,11 @@ namespace Datadog.Trace.Agent
                         try
                         {
                             string responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                            Log.Error("Failed to submit traces with status code {0} and message: {1}", response.StatusCode, responseContent);
+                            Log.Error("Failed to submit traces with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, responseContent);
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, "Unable to read response for failed request with status code {0}", response.StatusCode);
+                            Log.Error(ex, "Unable to read response for failed request with status code {StatusCode}", response.StatusCode);
                         }
                     }
 
@@ -206,7 +207,7 @@ namespace Datadog.Trace.Agent
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, "Traces sent successfully to the Agent at {0}, but an error occurred deserializing the response.", _apiRequestFactory.Info(_tracesEndpoint));
+                    Log.Error(ex, "Traces sent successfully to the Agent at {AgentEndpoint}, but an error occurred deserializing the response.", _apiRequestFactory.Info(_tracesEndpoint));
                 }
             }
             finally

--- a/src/Datadog.Trace/Agent/TransportStrategy.cs
+++ b/src/Datadog.Trace/Agent/TransportStrategy.cs
@@ -20,10 +20,10 @@ namespace Datadog.Trace.Agent
             switch (strategy)
             {
                 case DatadogTcp:
-                    Log.Information("Using {0} for trace transport.", nameof(TcpStreamFactory));
+                    Log.Information("Using {FactoryType} for trace transport.", nameof(TcpStreamFactory));
                     return new HttpStreamRequestFactory(new TcpStreamFactory(settings.AgentUri.Host, settings.AgentUri.Port), new DatadogHttpClient());
                 case DatadogNamedPipes:
-                    Log.Information("Using {0} for trace transport, with pipe name {1} and timeout {2}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
+                    Log.Information("Using {FactoryType} for trace transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
                     return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), new DatadogHttpClient());
                 default:
                     // Defer decision to Api logic

--- a/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/JsonConfigurationSource.cs
@@ -137,7 +137,7 @@ namespace Datadog.Trace.Configuration
                 }
                 catch (Exception e)
                 {
-                    Log.Error(e, "Unable to parse configuration value for {0} as key-value pairs of strings.", key);
+                    Log.Error(e, "Unable to parse configuration value for {ConfigurationKey} as key-value pairs of strings.", key);
                     return null;
                 }
             }

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     if (Log.IsEnabled(LogEventLevel.Verbose))
                     {
                         Log.Verbose(
-                            "Subscriber '{0}' returned subscription for '{1}'",
+                            "Subscriber '{SubscriberType}' returned subscription for '{ListenerName}'",
                             subscriber.GetType().Name,
                             listener.Name);
                     }

--- a/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.DiagnosticListeners
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Event Exception: {0}", value.Key);
+                Log.Error(ex, "Event Exception: {EventName}", value.Key);
 #if DEBUG
                 // In debug mode we allow exceptions to be catch in the test suite
                 throw;

--- a/src/Datadog.Trace/HttpOverStreams/HttpMessage.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpMessage.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.HttpOverStreams
                 }
             }
 
-            Log.Warning("Assuming default UTF-8, Could not find an encoding for: {0}", contentType);
+            Log.Warning("Assuming default UTF-8, Could not find an encoding for: {ContentType}", contentType);
             return Utf8Encoding;
         }
     }

--- a/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
+++ b/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
@@ -184,19 +184,19 @@ namespace Datadog.Trace.PlatformHelpers
                 if (SubscriptionId == null)
                 {
                     success = false;
-                    Log.Warning("Could not successfully retrieve the subscription ID from variable: {0}", WebsiteOwnerNameKey);
+                    Log.Warning("Could not successfully retrieve the subscription ID from variable: {Variable}", WebsiteOwnerNameKey);
                 }
 
                 if (SiteName == null)
                 {
                     success = false;
-                    Log.Warning("Could not successfully retrieve the deployment ID from variable: {0}", SiteNameKey);
+                    Log.Warning("Could not successfully retrieve the deployment ID from variable: {Variable}", SiteNameKey);
                 }
 
                 if (ResourceGroup == null)
                 {
                     success = false;
-                    Log.Warning("Could not successfully retrieve the resource group name from variable: {0}", ResourceGroupKey);
+                    Log.Warning("Could not successfully retrieve the resource group name from variable: {Variable}", ResourceGroupKey);
                 }
 
                 if (success)

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -134,7 +134,7 @@ namespace Datadog.Trace.RuntimeMetrics
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Error while processing event {0} {1}", eventData.EventId, eventData.EventName);
+                Log.Warning(ex, "Error while processing event {EventId} {EventName}", eventData.EventId, eventData.EventName);
             }
         }
 
@@ -181,7 +181,7 @@ namespace Datadog.Trace.RuntimeMetrics
                 }
                 else
                 {
-                    Log.Debug<object>("EventCounter {0} has no Mean or Increment field", name);
+                    Log.Debug<object>("EventCounter {CounterName} has no Mean or Increment field", name);
                 }
             }
         }

--- a/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Sampling
                 _hasPoisonedRegex = true;
                 Log.Error(
                     timeoutEx,
-                    "Timeout when trying to match against {0} on {1}.",
+                    "Timeout when trying to match against {Value} on {Pattern}.",
                     input,
                     pattern);
             }

--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Sampling
                 return sampleRate;
             }
 
-            Log.Debug("Could not establish sample rate for trace {0}", span.TraceId);
+            Log.Debug("Could not establish sample rate for trace {TraceId}", span.TraceId);
 
             return 1;
         }
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Sampling
 
                     if (key == null)
                     {
-                        Log.Warning("Could not parse sample rate key {0}", pair.Key);
+                        Log.Warning("Could not parse sample rate key {SampleRateKey}", pair.Key);
                         continue;
                     }
 

--- a/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Sampling
 
         public float GetSamplingRate(Span span)
         {
-            Log.Debug("Using the global sampling rate: {0}", _globalRate);
+            Log.Debug("Using the global sampling rate: {Rate}", _globalRate);
             span.SetMetric(Metrics.SamplingRuleDecision, _globalRate);
             return _globalRate;
         }

--- a/src/Datadog.Trace/Sampling/RateLimiter.cs
+++ b/src/Datadog.Trace/Sampling/RateLimiter.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Sampling
 
                 if (count >= _maxTracesPerInterval)
                 {
-                    Log.Debug("Dropping trace id {0} with count of {1} for last {2}ms.", span.TraceId, count, _intervalMilliseconds);
+                    Log.Debug("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.TraceId, count, _intervalMilliseconds);
                     return false;
                 }
 

--- a/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Sampling
                         var sampleRate = rule.GetSamplingRate(span);
 
                         Log.Debug(
-                            "Matched on rule {0}. Applying rate of {1} to trace id {2}",
+                            "Matched on rule {RuleName}. Applying rate of {Rate} to trace id {TraceId}",
                             rule.RuleName,
                             sampleRate,
                             traceId);
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Sampling
                 }
             }
 
-            Log.Debug("No rules matched for trace {0}", traceId);
+            Log.Debug("No rules matched for trace {TraceId}", traceId);
 
             return SamplingPriority.AutoKeep;
         }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace
             StartTime = start ?? Context.TraceContext.UtcNow;
 
             Log.Debug(
-                "Span started: [s_id: {0}, p_id: {1}, t_id: {2}]",
+                "Span started: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
                 SpanId,
                 Context.ParentId,
                 TraceId);
@@ -197,7 +197,7 @@ namespace Datadog.Trace
                     }
                     else
                     {
-                        Log.Warning("Value {0} has incorrect format for tag {1}", value, Trace.Tags.Analytics);
+                        Log.Warning("Value {Value} has incorrect format for tag {TagName}", value, Trace.Tags.Analytics);
                     }
 
                     break;
@@ -223,7 +223,7 @@ namespace Datadog.Trace
                     }
                     else
                     {
-                        Log.Warning("Value {0} has incorrect format for tag {1}", value, Trace.Tags.Measured);
+                        Log.Warning("Value {Value} has incorrect format for tag {TagName}", value, Trace.Tags.Measured);
                     }
 
                     break;
@@ -339,7 +339,7 @@ namespace Datadog.Trace
                 if (IsLogLevelDebugEnabled)
                 {
                     Log.Debug(
-                        "Span closed: [s_id: {0}, p_id: {1}, t_id: {2}] for (Service: {3}, Resource: {4}, Operation: {5}, Tags: [{6}])",
+                        "Span closed: [s_id: {SpanId}, p_id: {ParentId}, t_id: {TraceId}] for (Service: {ServiceName}, Resource: {ResourceName}, Operation: {OperationName}, Tags: [{Tags}])",
                         SpanId,
                         Context.ParentId,
                         TraceId,

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -185,7 +185,7 @@ namespace Datadog.Trace
 
             if (hasValue)
             {
-                Log.Warning("Could not parse {0} headers: {1}", headerName, string.Join(",", headerValues));
+                Log.Warning("Could not parse {HeaderName} headers: {HeaderValues}", headerName, string.Join(",", headerValues));
             }
 
             return 0;
@@ -209,7 +209,7 @@ namespace Datadog.Trace
 
             if (hasValue)
             {
-                Log.Warning("Could not parse {0} headers: {1}", headerName, string.Join(",", headerValues));
+                Log.Warning("Could not parse {HeaderName} headers: {HeaderValues}", headerName, string.Join(",", headerValues));
             }
 
             return 0;
@@ -238,7 +238,7 @@ namespace Datadog.Trace
             if (hasValue)
             {
                 Log.Warning(
-                    "Could not parse {0} headers: {1}",
+                    "Could not parse {HeaderName} headers: {HeaderValues}",
                     headerName,
                     string.Join(",", headerValues));
             }
@@ -268,7 +268,7 @@ namespace Datadog.Trace
             if (hasValue)
             {
                 Log.Warning(
-                    "Could not parse {0} headers: {1}",
+                    "Could not parse {HeaderName} headers: {HeaderValues}",
                     headerName,
                     string.Join(",", headerValues));
             }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -114,7 +114,7 @@ namespace Datadog.Trace
 
                 if (globalRate < 0f || globalRate > 1f)
                 {
-                    Log.Warning("{0} configuration of {1} is out of range", ConfigurationKeys.GlobalSamplingRate, Settings.GlobalSamplingRate);
+                    Log.Warning("{ConfigurationKey} configuration of {ConfigurationValue} is out of range", ConfigurationKeys.GlobalSamplingRate, Settings.GlobalSamplingRate);
                 }
                 else
                 {
@@ -586,7 +586,7 @@ namespace Datadog.Trace
                     writer.WriteEndObject();
                 }
 
-                Log.Information("DATADOG TRACER CONFIGURATION - {0}", stringWriter.ToString());
+                Log.Information("DATADOG TRACER CONFIGURATION - {Configuration}", stringWriter.ToString());
             }
             catch (Exception ex)
             {
@@ -695,7 +695,7 @@ namespace Datadog.Trace
 
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            Log.Warning("Application threw an unhandled exception: {0}", e.ExceptionObject);
+            Log.Warning("Application threw an unhandled exception: {Exception}", e.ExceptionObject);
             RunShutdownTasks();
         }
 

--- a/src/Datadog.Trace/Util/EnvironmentHelpers.cs
+++ b/src/Datadog.Trace/Util/EnvironmentHelpers.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Util
             }
             catch (Exception ex)
             {
-                Logger.Warning(ex, "Error while reading environment variable {0}", key);
+                Logger.Warning(ex, "Error while reading environment variable {EnvironmentVariable}", key);
             }
 
             return defaultValue;

--- a/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -60,6 +60,20 @@ namespace Datadog.Trace.Tests.Logging
                 $"Found {_logEventSink.Events.Count} messages: \r\n{string.Join("\r\n", _logEventSink.Events.Select(l => l.RenderMessage()))}");
         }
 
+        [Fact]
+        public void MessageTemplates_ReplacesArgumentsCorrectly()
+        {
+            var value = 123;
+            _logger.Warning("Warning level message with argument '{MyArgument}'", value);
+
+            var log = Assert.Single(_logEventSink.Events);
+            var property = Assert.Single(log.Properties);
+
+            Assert.Equal("MyArgument", property.Key);
+            Assert.Equal("123", property.Value.ToString());
+            Assert.Equal("Warning level message with argument '123'", log.RenderMessage());
+        }
+
         private class CollectionSink : ILogEventSink
         {
             public List<LogEvent> Events { get; } = new List<LogEvent>();


### PR DESCRIPTION
Initial cleanup of log levels before implementing remainder of the logging RFC

Replaces string.Format() style log templates (`"{0},{1}"`) with named arguments (`"{Name},{Value}"`). Doesn't make much difference atm, as we're only writing to file, but is better practice, and will be better if we do structured logging down the line instead.

Extracted from https://github.com/DataDog/dd-trace-dotnet/pull/1150 as there concerns around following the RFC in that PR, and this change is independent

@DataDog/apm-dotnet