### PR TITLE
Fix ARM64 integration tests

### DIFF
--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -20,4 +20,4 @@ wait-for-it elasticsearch7_arm64:9200 -- \
 wait-for-it sqledge:1433 -- \
 wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
-dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results
+dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results --TestCaseFilter Category!=ArmUnsupported

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -20,4 +20,4 @@ wait-for-it elasticsearch7_arm64:9200 -- \
 wait-for-it sqledge:1433 -- \
 wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
-dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results --TestCaseFilter Category!=ArmUnsupported
+dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results --TestCaseFilter:Category!=ArmUnsupported

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/OrleansSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/OrleansSmokeTest.cs
@@ -14,6 +14,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [Fact]
         [Trait("Category", "Smoke")]
+        [Trait("Category", "ArmUnsupported")]
         public void NoExceptions()
         {
             CheckForSmoke(shouldDeserializeTraces: false);


### PR DESCRIPTION
Fixes the ARM64 integration test issue by skipping the Orleans smoke test and adds the ArmUnsupported test category.

@DataDog/apm-dotnet