### PR TITLE
MySql CallTarget integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -77,6 +77,352 @@
     ]
   },
   {
+    "name": "MySqlCommand",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteNonQueryAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Int32>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteNonQueryAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySql.Data",
+          "type": "MySql.Data.MySqlClient.MySqlCommand",
+          "method": "ExecuteNonQuery",
+          "signature_types": [
+            "System.Int32"
+          ],
+          "minimum_major": 8,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 8,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteNonQueryIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteNonQuery",
+          "signature_types": [
+            "System.Int32"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteNonQueryIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<MySqlConnector.MySqlDataReader>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<MySqlConnector.MySqlDataReader>",
+            "System.Data.CommandBehavior",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderAsyncWithBehaviorIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteDbDataReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>",
+            "System.Data.CommandBehavior",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderAsyncWithBehaviorIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySql.Data",
+          "type": "MySql.Data.MySqlClient.MySqlCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "MySql.Data.MySqlClient.MySqlDataReader"
+          ],
+          "minimum_major": 8,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 8,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "MySqlConnector.MySqlDataReader"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySql.Data",
+          "type": "MySql.Data.MySqlClient.MySqlCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "MySql.Data.MySqlClient.MySqlDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 8,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 8,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySql.Data",
+          "type": "MySql.Data.MySqlClient.MySqlCommand",
+          "method": "ExecuteDbDataReader",
+          "signature_types": [
+            "System.Data.Common.DbDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 8,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 8,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteReader",
+          "signature_types": [
+            "MySqlConnector.MySqlDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteDbDataReader",
+          "signature_types": [
+            "System.Data.Common.DbDataReader",
+            "System.Data.CommandBehavior"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteScalarAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Object>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteScalarAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySql.Data",
+          "type": "MySql.Data.MySqlClient.MySqlCommand",
+          "method": "ExecuteScalar",
+          "signature_types": [
+            "System.Object"
+          ],
+          "minimum_major": 8,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 8,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteScalarIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "MySqlConnector",
+          "type": "MySqlConnector.MySqlCommand",
+          "method": "ExecuteScalar",
+          "signature_types": [
+            "System.Object"
+          ],
+          "minimum_major": 1,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 1,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteScalarIntegration",
+          "action": "CallTargetModification"
+        }
+      }
+    ]
+  },
+  {
     "name": "NUnit",
     "method_replacements": [
       {

--- a/integrations.json
+++ b/integrations.json
@@ -97,7 +97,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteNonQueryAsyncIntegration",
           "action": "CallTargetModification"
         }
@@ -119,7 +119,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteNonQueryIntegration",
           "action": "CallTargetModification"
         }
@@ -141,7 +141,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteNonQueryIntegration",
           "action": "CallTargetModification"
         }
@@ -164,7 +164,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderAsyncIntegration",
           "action": "CallTargetModification"
         }
@@ -188,7 +188,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderAsyncWithBehaviorIntegration",
           "action": "CallTargetModification"
         }
@@ -212,7 +212,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderAsyncWithBehaviorIntegration",
           "action": "CallTargetModification"
         }
@@ -234,7 +234,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderIntegration",
           "action": "CallTargetModification"
         }
@@ -256,7 +256,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderIntegration",
           "action": "CallTargetModification"
         }
@@ -279,7 +279,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
           "action": "CallTargetModification"
         }
@@ -302,7 +302,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
           "action": "CallTargetModification"
         }
@@ -325,7 +325,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
           "action": "CallTargetModification"
         }
@@ -348,7 +348,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteReaderWithBehaviorIntegration",
           "action": "CallTargetModification"
         }
@@ -371,7 +371,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteScalarAsyncIntegration",
           "action": "CallTargetModification"
         }
@@ -393,7 +393,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteScalarIntegration",
           "action": "CallTargetModification"
         }
@@ -415,7 +415,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql.MySqlCommandExecuteScalarIntegration",
           "action": "CallTargetModification"
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlClientConstants.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlClientConstants.cs
@@ -1,0 +1,51 @@
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    internal static class MySqlClientConstants
+    {
+        public const string SqlCommandIntegrationName = "MySqlCommand";
+
+        public static class MySqlData
+        {
+            public const string AssemblyName = "MySql.Data";
+            public const string SqlCommandType = "MySql.Data.MySqlClient.MySqlCommand";
+            public const string MinimumVersion = "8.0.0";
+            public const string MaximumVersion = "8.*.*";
+            public const string SqlDataReaderType = "MySql.Data.MySqlClient.MySqlDataReader";
+            public const string SqlDataReaderTaskType = "System.Threading.Tasks.Task`1<MySql.Data.MySqlClient.MySqlDataReader>";
+
+            public class InstrumentSqlCommandAttribute : Datadog.Trace.ClrProfiler.InstrumentMethodAttribute
+            {
+                public InstrumentSqlCommandAttribute()
+                {
+                    Assembly = MySqlClientConstants.MySqlData.AssemblyName;
+                    Type = MySqlClientConstants.MySqlData.SqlCommandType;
+                    MinimumVersion = MySqlClientConstants.MySqlData.MinimumVersion;
+                    MaximumVersion = MySqlClientConstants.MySqlData.MaximumVersion;
+                    IntegrationName = MySqlClientConstants.SqlCommandIntegrationName;
+                }
+            }
+        }
+
+        public static class MySqlConnector
+        {
+            public const string AssemblyName = "MySqlConnector";
+            public const string SqlCommandType = "MySqlConnector.MySqlCommand";
+            public const string MinimumVersion = "1.0.0";
+            public const string MaximumVersion = "1.*.*";
+            public const string SqlDataReaderType = "MySqlConnector.MySqlDataReader";
+            public const string SqlDataReaderTaskType = "System.Threading.Tasks.Task`1<MySqlConnector.MySqlDataReader>";
+
+            public class InstrumentSqlCommandAttribute : Datadog.Trace.ClrProfiler.InstrumentMethodAttribute
+            {
+                public InstrumentSqlCommandAttribute()
+                {
+                    Assembly = MySqlClientConstants.MySqlConnector.AssemblyName;
+                    Type = MySqlClientConstants.MySqlConnector.SqlCommandType;
+                    MinimumVersion = MySqlClientConstants.MySqlConnector.MinimumVersion;
+                    MaximumVersion = MySqlClientConstants.MySqlConnector.MaximumVersion;
+                    IntegrationName = MySqlClientConstants.SqlCommandIntegrationName;
+                }
+            }
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteNonQueryAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteNonQueryAsyncIntegration.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// Task[int] MySqlConnector.MySqlCommand.ExecuteNonQueryAsync(CancellationToken)
+    /// </summary>
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteNonQueryAsync,
+        ReturnTypeName = "System.Threading.Tasks.Task`1<System.Int32>",
+        ParametersTypesNames = new[] { ClrNames.CancellationToken })]
+    public class MySqlCommandExecuteNonQueryAsyncIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="cancellationToken">CancellationToken value</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnAsyncMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value, in an async scenario will be T of Task of T</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Return value instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return returnValue;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteNonQueryIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteNonQueryIntegration.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Data.Common;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// int MySql.Data.MySqlClient.MySqlCommand.ExecuteNonQuery()
+    /// int MySqlConnector.MySqlCommand.ExecuteNonQuery()
+    /// </summary>
+    [MySqlClientConstants.MySqlData.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteNonQuery,
+        ReturnTypeName = ClrNames.Int32)]
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteNonQuery,
+        ReturnTypeName = ClrNames.Int32)]
+    public class MySqlCommandExecuteNonQueryIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Task of HttpResponse message instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return new CallTargetReturn<TReturn>(returnValue);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderAsyncIntegration.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// Task[MySqlDataReader] MySqlConnector.MySqlCommand.ExecuteReaderAsync(CancellationToken)
+    /// </summary>
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteReaderAsync,
+        ReturnTypeName = MySqlClientConstants.MySqlConnector.SqlDataReaderTaskType,
+        ParametersTypesNames = new[] { ClrNames.CancellationToken })]
+    public class MySqlCommandExecuteReaderAsyncIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="cancellationToken">CancellationToken value</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnAsyncMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value, in an async scenario will be T of Task of T</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Return value instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return returnValue;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderAsyncWithBehaviorIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderAsyncWithBehaviorIntegration.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// Task[MySqlDataReader] MySqlConnector.MySqlCommand.ExecuteReaderAsync(CommandBehavior, CancellationToken)
+    /// Task[DbDataReader] MySqlConnector.MySqlCommand.ExecuteDbDataReaderAsync(CommandBehavior, CancellationToken)
+    /// </summary>
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteReaderAsync,
+        ReturnTypeName = MySqlClientConstants.MySqlConnector.SqlDataReaderTaskType,
+        ParametersTypesNames = new[] { AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken })]
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteDbDataReaderAsync,
+        ReturnTypeName = AdoNetConstants.TypeNames.DbDataReaderTaskType,
+        ParametersTypesNames = new[] { AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken })]
+    public class MySqlCommandExecuteReaderAsyncWithBehaviorIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TBehavior">Command Behavior type</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="commandBehavior">Command behavior</param>
+        /// <param name="cancellationToken">CancellationToken value</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior, CancellationToken cancellationToken)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnAsyncMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value, in an async scenario will be T of Task of T</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Return value instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return returnValue;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderIntegration.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Data.Common;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// MySqlDataReader MySql.Data.MySqlClient.MySqlCommand.ExecuteReader()
+    /// MySqlDataReader MySqlConnector.MySqlCommand.ExecuteReader()
+    /// </summary>
+    [MySqlClientConstants.MySqlData.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteReader,
+        ReturnTypeName = MySqlClientConstants.MySqlData.SqlDataReaderType)]
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteReader,
+        ReturnTypeName = MySqlClientConstants.MySqlConnector.SqlDataReaderType)]
+    public class MySqlCommandExecuteReaderIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Task of HttpResponse message instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return new CallTargetReturn<TReturn>(returnValue);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderWithBehaviorIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteReaderWithBehaviorIntegration.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Data.Common;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// MySqlDataReader MySql.Data.MySqlClient.MySqlCommand.ExecuteReader(CommandBehavior)
+    /// DbDataReader MySql.Data.MySqlClient.MySqlCommand.ExecuteDbDataReader(CommandBehavior)
+    /// MySqlDataReader MySqlConnector.MySqlCommand.ExecuteReader(CommandBehavior)
+    /// DbDataReader MySqlConnector.MySqlCommand.ExecuteDbDataReader(CommandBehavior)
+    /// </summary>
+    [MySqlClientConstants.MySqlData.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteReader,
+        ReturnTypeName = MySqlClientConstants.MySqlData.SqlDataReaderType,
+        ParametersTypesNames = new[] { AdoNetConstants.TypeNames.CommandBehavior })]
+    [MySqlClientConstants.MySqlData.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteDbDataReader,
+        ReturnTypeName = AdoNetConstants.TypeNames.DbDataReaderType,
+        ParametersTypesNames = new[] { AdoNetConstants.TypeNames.CommandBehavior })]
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteReader,
+        ReturnTypeName = MySqlClientConstants.MySqlConnector.SqlDataReaderType,
+        ParametersTypesNames = new[] { AdoNetConstants.TypeNames.CommandBehavior })]
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteDbDataReader,
+        ReturnTypeName = AdoNetConstants.TypeNames.DbDataReaderType,
+        ParametersTypesNames = new[] { AdoNetConstants.TypeNames.CommandBehavior })]
+    public class MySqlCommandExecuteReaderWithBehaviorIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TBehavior">Command Behavior type</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="commandBehavior">Command behavior</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Task of HttpResponse message instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return new CallTargetReturn<TReturn>(returnValue);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteScalarAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteScalarAsyncIntegration.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// Task[object] MySqlConnector.MySqlCommand.ExecuteScalarAsync(CancellationToken)
+    /// </summary>
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteScalarAsync,
+        ReturnTypeName = "System.Threading.Tasks.Task`1<System.Object>",
+        ParametersTypesNames = new[] { ClrNames.CancellationToken })]
+    public class MySqlCommandExecuteScalarAsyncIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="cancellationToken">CancellationToken value</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnAsyncMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value, in an async scenario will be T of Task of T</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Return value instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return returnValue;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteScalarIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/MySql/MySqlCommandExecuteScalarIntegration.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Data.Common;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
+{
+    /// <summary>
+    /// CallTarget instrumentation for:
+    /// object MySql.Data.MySqlClient.MySqlCommand.ExecuteScalar()
+    /// object MySqlConnector.MySqlCommand.ExecuteScalar()
+    /// </summary>
+    [MySqlClientConstants.MySqlData.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteScalar,
+        ReturnTypeName = ClrNames.Object)]
+    [MySqlClientConstants.MySqlConnector.InstrumentSqlCommand(
+        Method = AdoNetConstants.MethodNames.ExecuteScalar,
+        ReturnTypeName = ClrNames.Object)]
+    public class MySqlCommandExecuteScalarIntegration
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+        {
+            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as DbCommand));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Task of HttpResponse message instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return new CallTargetReturn<TReturn>(returnValue);
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -33,6 +33,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
 #endif
 
+            if (enableCallTarget)
+            {
+#if NET452
+                expectedSpanCount = 62;
+#else
+                expectedSpanCount = 97;
+#endif
+            }
+
             const string dbType = "mysql";
             const string expectedOperationName = dbType + ".query";
             const string expectedServiceName = "Samples.MySql-" + dbType;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -15,10 +15,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             SetServiceVersion("1.0.0");
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesWithNetStandard()
+        public void SubmitsTracesWithNetStandard(bool enableCallTarget, bool enableInlining)
         {
+            SetCallTargetSettings(enableCallTarget, enableInlining);
+
             // Note: The automatic instrumentation currently bails out on the generic wrappers.
             // Once this is implemented, this will add another 1 group for the direct assembly reference
             // and another 1 group for the netstandard assembly reference
@@ -56,10 +61,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             }
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
         [Trait("Category", "EndToEnd")]
-        public void SpansDisabledByAdoNetExcludedTypes()
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
         {
+            SetCallTargetSettings(enableCallTarget, enableInlining);
+
             var totalSpanCount = 21;
 
             const string dbType = "mysql";


### PR DESCRIPTION
This PR adds the MySql CallTarget integration for both `Mysql.Data` and `MySqlConnector` libraries based on ADO.NET interface.

@DataDog/apm-dotnet