### PR TITLE
Make the diagnostic log fully fire-and-forget

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -161,7 +161,7 @@ namespace Datadog.Trace
             {
                 if (Settings.StartupDiagnosticLogEnabled)
                 {
-                    _ = WriteDiagnosticLog();
+                    _ = Task.Run(WriteDiagnosticLog);
                 }
 
                 if (Settings.RuntimeMetricsEnabled)


### PR DESCRIPTION
Avoids a case where it would lead to the HttpMessageHandler integration being called from the Tracer constructor, which in turns would call Tracer.Instance, creating a second instance of the tracer.
