### PR TITLE
Fix WinHttpHandlerIntegration

### DIFF
--- a/build/docker/dotnet.alpine.core21.dockerfile
+++ b/build/docker/dotnet.alpine.core21.dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1-alpine3.9
 
-RUN apk update && apk upgrade && apk add --no-cache --update bash
+RUN apk update && apk upgrade && apk add --no-cache --update bash curl
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.alpine.core30.dockerfile
+++ b/build/docker/dotnet.alpine.core30.dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine3.10
 
-RUN apk update && apk upgrade && apk add --no-cache --update bash
+RUN apk update && apk upgrade && apk add --no-cache --update bash curl
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.alpine.core31.dockerfile
+++ b/build/docker/dotnet.alpine.core31.dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine3.10
 
-RUN apk update && apk upgrade && apk add --no-cache --update bash
+RUN apk update && apk upgrade && apk add --no-cache --update bash curl
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it

--- a/integrations.json
+++ b/integrations.json
@@ -5,7 +5,7 @@
       {
         "caller": {},
         "target": {
-          "assembly": "System.Net.Http",
+          "assembly": "System.Net.Http.WinHttpHandler",
           "type": "System.Net.Http.WinHttpHandler",
           "method": "SendAsync",
           "signature_types": [
@@ -4024,7 +4024,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.21.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetRequestStream",
           "signature": "00 04 1C 1C 08 08 0A",
@@ -4048,7 +4048,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.21.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.WebRequestIntegration",
           "method": "GetRequestStream",
           "signature": "00 04 1C 1C 08 08 0A",

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -39,15 +39,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
         public static CallTargetState OnMethodBegin<TTarget, TRequest>(TTarget instance, TRequest requestMessage, CancellationToken cancellationToken)
             where TRequest : IHttpRequestMessage
         {
-            Log.Warning("WinHttpHandler started");
             if (IsTracingEnabled(requestMessage.Headers))
             {
-                Log.Warning("WinHttpHandler enabled");
                 Scope scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
-                    Log.Warning("WinHttpHandler scope created");
-
                     tags.HttpClientHandlerType = instance.GetType().FullName;
 
                     // add distributed tracing headers to the HTTP request

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -25,7 +25,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
         private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
         private static readonly IntegrationInfo WinHttpHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.WinHttpHandler));
-        private static readonly Vendors.Serilog.ILogger Log = Datadog.Trace.Logging.DatadogLogging.GetLogger(typeof(WinHttpHandlerIntegration));
 
         /// <summary>
         /// OnMethodBegin callback

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
     /// System.Net.Http.WinHttpHandler calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        AssemblyName = "System.Net.Http",
+        AssemblyName = "System.Net.Http.WinHttpHandler",
         TypeName = "System.Net.Http.WinHttpHandler",
         MethodName = "SendAsync",
         ReturnTypeName = ClrNames.HttpResponseMessageTask,
@@ -25,6 +25,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
         private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
         private static readonly IntegrationInfo WinHttpHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.WinHttpHandler));
+        private static readonly Vendors.Serilog.ILogger Log = Datadog.Trace.Logging.DatadogLogging.GetLogger(typeof(WinHttpHandlerIntegration));
 
         /// <summary>
         /// OnMethodBegin callback
@@ -38,11 +39,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
         public static CallTargetState OnMethodBegin<TTarget, TRequest>(TTarget instance, TRequest requestMessage, CancellationToken cancellationToken)
             where TRequest : IHttpRequestMessage
         {
+            Log.Warning("WinHttpHandler started");
             if (IsTracingEnabled(requestMessage.Headers))
             {
+                Log.Warning("WinHttpHandler enabled");
                 Scope scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
                 if (scope != null)
                 {
+                    Log.Warning("WinHttpHandler scope created");
+
                     tags.HttpClientHandlerType = instance.GetType().FullName;
 
                     // add distributed tracing headers to the HTTP request

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -9,7 +9,7 @@ using Datadog.Trace.Tagging;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.WinHttpHandler
 {
     /// <summary>
-    /// System.Net.Http.SocketsHttpHandler calltarget instrumentation
+    /// System.Net.Http.WinHttpHandler calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
         AssemblyName = "System.Net.Http",

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Datadog.Core.Tools;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
@@ -14,22 +17,43 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public HttpMessageHandlerTests(ITestOutputHelper output)
             : base("HttpMessageHandler", output)
         {
-            SetEnvironmentVariable("DD_HttpSocketsHandler_ENABLED", "true");
             SetEnvironmentVariable("DD_HTTP_CLIENT_ERROR_STATUSES", "400-499, 502,-343,11-53, 500-500-200");
             SetServiceVersion("1.0.0");
         }
 
+        internal static IEnumerable<InliningOptions> InliningOptionsValues =>
+            new List<InliningOptions>
+            {
+                new InliningOptions(enableCallTarget: false, enableInlining: false),
+                new InliningOptions(enableCallTarget: true, enableInlining: false),
+                new InliningOptions(enableCallTarget: true, enableInlining: true),
+            };
+
+        internal static IEnumerable<InstrumentationOptions> InstrumentationOptionsValues =>
+            new List<InstrumentationOptions>
+            {
+                new InstrumentationOptions(instrumentSocketHandler: false, instrumentWinHttpHandler: false),
+                new InstrumentationOptions(instrumentSocketHandler: false, instrumentWinHttpHandler: true),
+                new InstrumentationOptions(instrumentSocketHandler: true, instrumentWinHttpHandler: false),
+                new InstrumentationOptions(instrumentSocketHandler: true, instrumentWinHttpHandler: true),
+            };
+
+        public static IEnumerable<object[]> IntegrationConfig() =>
+            from inliningOptions in InliningOptionsValues
+            from instrumentationOptions in InstrumentationOptionsValues
+            from socketHandlerEnabled in new[] { true, false }
+            select new object[] { inliningOptions, instrumentationOptions, socketHandlerEnabled };
+
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void SubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [MemberData(nameof(IntegrationConfig))]
+        public void HttpClient_SubmitsTraces(InliningOptions inlining, InstrumentationOptions instrumentation, bool enableSocketsHandler)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            ConfigureInstrumentation(inlining, instrumentation, enableSocketsHandler);
 
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 36 : 32;
+            var expectedSpanCount = CalculateExpectedAsyncSpans(instrumentation, inlining.EnableCallTarget);
+
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "Samples.HttpMessageHandler-http-client";
 
@@ -73,12 +97,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void TracingDisabled_DoesNotSubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [MemberData(nameof(IntegrationConfig))]
+        public void TracingDisabled_DoesNotSubmitsTraces(InliningOptions inlining, InstrumentationOptions instrumentation, bool enableSocketsHandler)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            ConfigureInstrumentation(inlining, instrumentation, enableSocketsHandler);
 
             const string expectedOperationName = "http.request";
 
@@ -101,6 +123,87 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Null(parentSpanId);
                 Assert.Equal("false", tracingEnabled);
             }
+        }
+
+        private static int CalculateExpectedAsyncSpans(InstrumentationOptions instrumentation, bool enableCallTarget)
+        {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+            // net4x doesn't have patch
+            var spansPerHttpClient = EnvironmentHelper.IsCoreClr() ? 35 : 31;
+
+            var expectedSpanCount = spansPerHttpClient * 2; // default HttpClient and CustomHttpClientHandler
+
+#if !NET452
+            // WinHttpHandler instrumentation is off by default, and only available on Windows
+            if (enableCallTarget && isWindows && (instrumentation.InstrumentWinHttpHandler ?? false))
+            {
+                expectedSpanCount += spansPerHttpClient;
+            }
+#endif
+
+            // SocketsHttpHandler instrumentation is on by default
+            if (EnvironmentHelper.IsCoreClr() && (instrumentation.InstrumentSocketHandler ?? true))
+            {
+                expectedSpanCount += spansPerHttpClient;
+            }
+
+            return expectedSpanCount;
+        }
+
+        private void ConfigureInstrumentation(InliningOptions inlining, InstrumentationOptions instrumentation, bool enableSocketsHandler)
+        {
+            SetCallTargetSettings(inlining.EnableCallTarget, inlining.EnableInlining);
+
+            // Should HttpClient try to use HttpSocketsHandler
+            SetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER", enableSocketsHandler ? "1" : "0");
+
+            // Enable specific integrations, or use defaults
+            if (instrumentation.InstrumentSocketHandler.HasValue)
+            {
+                SetEnvironmentVariable("DD_HttpSocketsHandler_ENABLED", instrumentation.InstrumentSocketHandler.Value ? "true" : "false");
+            }
+
+            if (instrumentation.InstrumentWinHttpHandler.HasValue)
+            {
+                SetEnvironmentVariable("DD_WinHttpHandler_ENABLED", instrumentation.InstrumentWinHttpHandler.Value ? "true" : "false");
+            }
+        }
+
+        public class InliningOptions
+        {
+            internal InliningOptions(
+                bool enableCallTarget,
+                bool enableInlining)
+            {
+                EnableCallTarget = enableCallTarget;
+                EnableInlining = enableInlining;
+            }
+
+            internal bool EnableCallTarget { get; }
+
+            internal bool EnableInlining { get; }
+
+            public override string ToString() =>
+                $"EnableCallTarget={EnableCallTarget},EnableInlining={EnableInlining}";
+        }
+
+        public class InstrumentationOptions
+        {
+            internal InstrumentationOptions(
+                bool? instrumentSocketHandler,
+                bool? instrumentWinHttpHandler)
+            {
+                InstrumentSocketHandler = instrumentSocketHandler;
+                InstrumentWinHttpHandler = instrumentWinHttpHandler;
+            }
+
+            internal bool? InstrumentSocketHandler { get; }
+
+            internal bool? InstrumentWinHttpHandler { get; }
+
+            public override string ToString() =>
+                $"InstrumentSocketHandler={InstrumentSocketHandler},InstrumentWinHttpHandler={InstrumentWinHttpHandler}";
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -20,7 +20,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void RenamesService()
         {
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 70 : 26; // .NET Framework automatic instrumentation doesn't cover Async / TaskAsync operations
+            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 71 : 27; // .NET Framework automatic instrumentation doesn't cover Async / TaskAsync operations
+
+            var ignoreAsync = EnvironmentHelper.IsCoreClr() ? string.Empty : "IgnoreAsync ";
+
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "my-custom-client";
 
@@ -31,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"{ignoreAsync}Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -5,6 +5,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [CollectionDefinition(nameof(WebRequestTests), DisableParallelization = true)]
     public class ServiceMappingTests : TestHelper
     {
         public ServiceMappingTests(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -10,6 +10,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [CollectionDefinition(nameof(WebRequestTests), DisableParallelization = true)]
     public class WebRequestTests : TestHelper
     {
         public WebRequestTests(ITestOutputHelper output)

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -2,6 +2,8 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -33,8 +35,43 @@ namespace Samples.HttpMessageHandler
 
                 // send http requests using HttpClient
                 Console.WriteLine();
-                Console.WriteLine("Sending request with HttpClient.");
-                await RequestHelpers.SendHttpClientRequestsAsync(tracingDisabled, Url, RequestContent);
+                Console.WriteLine("Sending async request with default HttpClient.");
+                using (var client = new HttpClient())
+                {
+                    await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                }
+
+                // send async http requests using HttpClient with CustomHandler
+                Console.WriteLine();
+                Console.WriteLine("Sending async request with HttpClient(CustomHandler).");
+                using (var client = new HttpClient(new CustomHandler()))
+                {
+                    await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                }
+
+#if !NET452
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    // send async http requests using HttpClient with raw WinHttpHandler
+                    Console.WriteLine();
+                    Console.WriteLine("Sending async request with HttpClient(WinHttpHandler).");
+                    using (var client = new HttpClient(new WinHttpHandler()))
+                    {
+                        await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    }
+                }
+#endif
+
+#if NETCOREAPP
+                // send async http requests using HttpClient with raw SocketsHttpHandler
+                Console.WriteLine();
+                Console.WriteLine("Sending async request with HttpClient(SocketsHttpHandler).");
+                using (var client = new HttpClient(new SocketsHttpHandler()))
+                {
+                    await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                }
+#endif
+
 
                 Console.WriteLine();
                 Console.WriteLine("Stopping HTTP listener.");

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Properties/launchSettings.json
@@ -13,8 +13,7 @@
 
           "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
           "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
-          "DD_VERSION": "1.0.0",
-          "DD_HttpSocketsHandler_ENABLED": "true"
+          "DD_VERSION": "1.0.0"
         },
         "nativeDebugging": true
       }

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -146,16 +146,16 @@ namespace Samples.HttpMessageHandler
                     using (Tracer.Instance.StartActive("SendAsync"))
                     {
                         await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url));
-                        Console.WriteLine("Received response for client.PostAsync(HttpRequestMessage)");
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage)");
 
                         await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
                         Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, CancellationToken)");
 
                         await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead);
-                        Console.WriteLine("Received response for client.PostAsync(HttpRequestMessage, HttpCompletionOption)");
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption)");
 
                         await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                        Console.WriteLine("Received response for client.PostAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
                     }
 
                     using (Tracer.Instance.StartActive("ErrorSpanBelow"))

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -13,170 +13,153 @@ namespace Samples.HttpMessageHandler
     {
         private static readonly Encoding Utf8 = Encoding.UTF8;
 
-        public static async Task SendHttpClientRequestsAsync(bool tracingDisabled, string url, string requestContent)
+        public static async Task SendHttpClientRequestsAsync(HttpClient client, bool tracingDisabled, string url, string requestContent)
         {
             // Insert a call to the Tracer.Instance to include an AssemblyRef to Datadog.Trace assembly in the final executable
             Console.WriteLine($"[HttpClient] sending requests to {url}");
 
-            using (var client = new HttpClient())
+            if (tracingDisabled)
             {
-                if (tracingDisabled)
+                client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+            }
+
+            using (Tracer.Instance.StartActive("HttpClientRequestAsync"))
+            {
+                using (Tracer.Instance.StartActive("DeleteAsync"))
                 {
-                    client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                    await client.DeleteAsync(url);
+                    Console.WriteLine("Received response for client.DeleteAsync(String)");
+
+                    await client.DeleteAsync(new Uri(url));
+                    Console.WriteLine("Received response for client.DeleteAsync(Uri)");
+
+                    await client.DeleteAsync(url, CancellationToken.None);
+                    Console.WriteLine("Received response for client.DeleteAsync(String, CancellationToken)");
+
+                    await client.DeleteAsync(new Uri(url), CancellationToken.None);
+                    Console.WriteLine("Received response for client.DeleteAsync(Uri, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("HttpClientRequestAsync"))
+                using (Tracer.Instance.StartActive("GetAsync"))
                 {
-                    using (Tracer.Instance.StartActive("DeleteAsync"))
-                    {
-                        await client.DeleteAsync(url);
-                        Console.WriteLine("Received response for client.DeleteAsync(String)");
+                    await client.GetAsync(url);
+                    Console.WriteLine("Received response for client.GetAsync(String)");
 
-                        await client.DeleteAsync(new Uri(url));
-                        Console.WriteLine("Received response for client.DeleteAsync(Uri)");
+                    await client.GetAsync(new Uri(url));
+                    Console.WriteLine("Received response for client.GetAsync(Uri)");
 
-                        await client.DeleteAsync(url, CancellationToken.None);
-                        Console.WriteLine("Received response for client.DeleteAsync(String, CancellationToken)");
+                    await client.GetAsync(url, CancellationToken.None);
+                    Console.WriteLine("Received response for client.GetAsync(String, CancellationToken)");
 
-                        await client.DeleteAsync(new Uri(url), CancellationToken.None);
-                        Console.WriteLine("Received response for client.DeleteAsync(Uri, CancellationToken)");
-                    }
+                    await client.GetAsync(new Uri(url), CancellationToken.None);
+                    Console.WriteLine("Received response for client.GetAsync(Uri, CancellationToken)");
 
-                    using (Tracer.Instance.StartActive("GetAsync"))
-                    {
-                        await client.GetAsync(url);
-                        Console.WriteLine("Received response for client.GetAsync(String)");
+                    await client.GetAsync(url, HttpCompletionOption.ResponseContentRead);
+                    Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption)");
 
-                        await client.GetAsync(new Uri(url));
-                        Console.WriteLine("Received response for client.GetAsync(Uri)");
+                    await client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead);
+                    Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption)");
 
-                        await client.GetAsync(url, CancellationToken.None);
-                        Console.WriteLine("Received response for client.GetAsync(String, CancellationToken)");
+                    await client.GetAsync(url, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+                    Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption, CancellationToken)");
 
-                        await client.GetAsync(new Uri(url), CancellationToken.None);
-                        Console.WriteLine("Received response for client.GetAsync(Uri, CancellationToken)");
+                    await client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+                    Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption, CancellationToken)");
+                }
 
-                        await client.GetAsync(url, HttpCompletionOption.ResponseContentRead);
-                        Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption)");
+                using (Tracer.Instance.StartActive("GetByteArrayAsync"))
+                {
+                    await client.GetByteArrayAsync(url);
+                    Console.WriteLine("Received response for client.GetByteArrayAsync(String)");
 
-                        await client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead);
-                        Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption)");
+                    await client.GetByteArrayAsync(new Uri(url));
+                    Console.WriteLine("Received response for client.GetByteArrayAsync(Uri)");
+                }
 
-                        await client.GetAsync(url, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                        Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption, CancellationToken)");
+                using (Tracer.Instance.StartActive("GetStreamAsync"))
+                {
+                    using Stream stream1 = await client.GetStreamAsync(url);
+                    Console.WriteLine("Received response for client.GetStreamAsync(String)");
 
-                        await client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                        Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption, CancellationToken)");
-                    }
+                    using Stream stream2 = await client.GetStreamAsync(new Uri(url));
+                    Console.WriteLine("Received response for client.GetStreamAsync(Uri)");
+                }
 
-                    using (Tracer.Instance.StartActive("GetByteArrayAsync"))
-                    {
-                        await client.GetByteArrayAsync(url);
-                        Console.WriteLine("Received response for client.GetByteArrayAsync(String)");
+                using (Tracer.Instance.StartActive("GetStringAsync"))
+                {
+                    await client.GetStringAsync(url);
+                    Console.WriteLine("Received response for client.GetStringAsync(String)");
 
-                        await client.GetByteArrayAsync(new Uri(url));
-                        Console.WriteLine("Received response for client.GetByteArrayAsync(Uri)");
-                    }
-
-                    using (Tracer.Instance.StartActive("GetStreamAsync"))
-                    {
-                        using Stream stream1 = await client.GetStreamAsync(url);
-                        Console.WriteLine("Received response for client.GetStreamAsync(String)");
-
-                        using Stream stream2 = await client.GetStreamAsync(new Uri(url));
-                        Console.WriteLine("Received response for client.GetStreamAsync(Uri)");
-                    }
-
-                    using (Tracer.Instance.StartActive("GetStringAsync"))
-                    {
-                        await client.GetStringAsync(url);
-                        Console.WriteLine("Received response for client.GetStringAsync(String)");
-
-                        await client.GetStringAsync(new Uri(url));
-                        Console.WriteLine("Received response for client.GetStringAsync(Uri)");
-                    }
+                    await client.GetStringAsync(new Uri(url));
+                    Console.WriteLine("Received response for client.GetStringAsync(Uri)");
+                }
 
 #if NETCOREAPP
-                    using (Tracer.Instance.StartActive("PatchAsync"))
-                    {
-                        await client.PatchAsync(url, new StringContent(requestContent, Utf8));
-                        Console.WriteLine("Received response for client.PatchAsync(String, HttpContent)");
+                using (Tracer.Instance.StartActive("PatchAsync"))
+                {
+                    await client.PatchAsync(url, new StringContent(requestContent, Utf8));
+                    Console.WriteLine("Received response for client.PatchAsync(String, HttpContent)");
 
-                        await client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8));
-                        Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent)");
+                    await client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8));
+                    Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent)");
 
-                        await client.PatchAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
-                        Console.WriteLine("Received response for client.PatchAsync(String, HttpContent, CancellationToken)");
+                    await client.PatchAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
+                    Console.WriteLine("Received response for client.PatchAsync(String, HttpContent, CancellationToken)");
 
-                        await client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
-                        Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent, CancellationToken)");
-                    }
+                    await client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
+                    Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent, CancellationToken)");
+                }
 
 #endif
-                    using (Tracer.Instance.StartActive("PostAsync"))
-                    {
-                        await client.PostAsync(url, new StringContent(requestContent, Utf8));
-                        Console.WriteLine("Received response for client.PostAsync(String, HttpContent)");
-
-                        await client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8));
-                        Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent)");
-
-                        await client.PostAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
-                        Console.WriteLine("Received response for client.PostAsync(String, HttpContent, CancellationToken)");
-
-                        await client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
-                        Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent, CancellationToken)");
-                    }
-
-                    using (Tracer.Instance.StartActive("PutAsync"))
-                    {
-                        await client.PutAsync(url, new StringContent(requestContent, Utf8));
-                        Console.WriteLine("Received response for client.PutAsync(String, HttpContent)");
-
-                        await client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8));
-                        Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent)");
-
-                        await client.PutAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
-                        Console.WriteLine("Received response for client.PutAsync(String, HttpContent, CancellationToken)");
-
-                        await client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
-                        Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent, CancellationToken)");
-                    }
-
-                    using (Tracer.Instance.StartActive("SendAsync"))
-                    {
-                        await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url));
-                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage)");
-
-                        await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
-                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, CancellationToken)");
-
-                        await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead);
-                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption)");
-
-                        await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
-                    }
-
-                    using (Tracer.Instance.StartActive("ErrorSpanBelow"))
-                    {
-                        await client.GetAsync($"{url}HttpErrorCode");
-                        Console.WriteLine("Received response for client.GetAsync Error Span");
-                    }
-                }
-            }
-            
-            using (var clientWithCustomHandler = new HttpClient(new CustomHandler()))
-            {
-                if (tracingDisabled)
+                using (Tracer.Instance.StartActive("PostAsync"))
                 {
-                    clientWithCustomHandler.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                    await client.PostAsync(url, new StringContent(requestContent, Utf8));
+                    Console.WriteLine("Received response for client.PostAsync(String, HttpContent)");
+
+                    await client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8));
+                    Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent)");
+
+                    await client.PostAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
+                    Console.WriteLine("Received response for client.PostAsync(String, HttpContent, CancellationToken)");
+
+                    await client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
+                    Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent, CancellationToken)");
                 }
 
-                using (Tracer.Instance.StartActive("CustomHandler"))
+                using (Tracer.Instance.StartActive("PutAsync"))
                 {
-                    await clientWithCustomHandler.GetAsync(url);
-                    Console.WriteLine("Received response for clientWithCustomHandler.GetAsync");
+                    await client.PutAsync(url, new StringContent(requestContent, Utf8));
+                    Console.WriteLine("Received response for client.PutAsync(String, HttpContent)");
+
+                    await client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8));
+                    Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent)");
+
+                    await client.PutAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
+                    Console.WriteLine("Received response for client.PutAsync(String, HttpContent, CancellationToken)");
+
+                    await client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
+                    Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent, CancellationToken)");
+                }
+
+                using (Tracer.Instance.StartActive("SendAsync"))
+                {
+                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url));
+                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage)");
+
+                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
+                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, CancellationToken)");
+
+                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead);
+                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption)");
+
+                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
+                }
+
+                using (Tracer.Instance.StartActive("ErrorSpanBelow"))
+                {
+                    await client.GetAsync($"{url}HttpErrorCode");
+                    Console.WriteLine("Received response for client.GetAsync Error Span");
                 }
             }
         }

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
@@ -10,6 +10,10 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net45')) ">
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="5.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR fixes the CallTarget `WinHttpHandlerIntegration` and adds extra integration tests

The current `HttpMessageHandler` previously only tested two scenarios:

* `HttpClient` tracing with the default configuration (using `new HttpClient()`)
* A custom `HttpClientHandler`

However, the `HttpClient` stack can be quite complicated. For example, the following scenarios were not previously tested:

* `HttpClient` with [the `DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER`  switch](https://docs.microsoft.com/dotnet/api/system.net.http.socketshttphandler) disabled and calling `new HttpClient()`
* `SocketsHttpHandler` without the `HttpClientHandler`, i.e. calling `new HttpClient(new SocketsHttpHandler())`
* `WinHttpHandler` without the `HttpClientHandler`, i.e. calling `new HttpClient(new WinHttpHandler())`
* `CurlHandler` (not instrumented or tested)

This PR expands the testing matrix to cover these additional scenarios.

We currently have CallSite instrumentation for `SocketsHttpHandler` and `HttpClientHandler`, and CallTarget instrumentation for both these and the `WinHttpHandler`. 

> It is worth noting that both  `SocketsHttpHandler` and `WinHttpHandler` CallTarget instrumentation [are currently disabled by default](https://github.com/DataDog/dd-trace-dotnet/blob/a32ebc2604aef5be79c7c4840b7d3bc962146063/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/WinHttpHandler/WinHttpHandlerIntegration.cs#L97), so if a user uses `new HttpClient(new WinHttpHandler())` they will **not** be instrumented by default. ~~Is that intentional?~~ As mentioned by @tonyredondo , yes it is, but we should potentially consider enabling them by default for CallTarget

As part of this testing, discovered that the `WinHttpHandler` CallTarget tracing was not working, as it's referencing the wrong assembly. This PR fixes that. 

@DataDog/apm-dotnet