### PR TITLE
Fix drive space issues related to sample projects

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -329,7 +329,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -444,7 +444,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
   - task: NuGetCommand@2
     displayName: nuget restore IIS samples

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -372,18 +372,11 @@ jobs:
     msiOutputDirectory: src/WindowsInstaller/bin/$(buildConfiguration)/$(buildPlatform)/en-us
 
   steps:
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: UseDotNet@2
     displayName: install dotnet core sdk 2.1
     inputs:
       packageType: sdk
       version: 2.1.x
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 3.0
@@ -391,17 +384,11 @@ jobs:
       packageType: sdk
       version: 3.0.x
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: UseDotNet@2
     displayName: install dotnet core sdk 3.1
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5
@@ -410,23 +397,14 @@ jobs:
       version: $(dotnetCoreSdk5Version)
       includePreviewVersions: true
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: NuGetToolInstaller@1
     displayName: install nuget
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   # this triggers a dependency chain that builds all the managed and native dlls
   - task: MSBuild@1
@@ -438,9 +416,6 @@ jobs:
       msbuildArguments: /t:msi /p:RunWixToolsOutOfProc=true /p:TracerHomeDirectory=$(publishOutput)
       maximumCpuCount: true
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: MSBuild@1
     displayName: Build .NET Framework projects (not SDK-based projects)
     inputs:
@@ -449,9 +424,6 @@ jobs:
       configuration: $(buildConfiguration)
       msbuildArguments: /t:BuildFrameworkReproductions
       maximumCpuCount: true
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build integration tests
@@ -465,9 +437,6 @@ jobs:
         !test/test-applications/regression/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: DotNetCoreCLI@2
     displayName: dotnet build samples
     inputs:
@@ -477,17 +446,11 @@ jobs:
         !test/test-applications/integrations/dependency-libs/**/*.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: NuGetCommand@2
     displayName: nuget restore IIS samples
     inputs:
       restoreSolution: test/test-applications/aspnet/samples-iis.sln
       verbosityRestore: Normal
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: MSBuild@1
     displayName: Publish IIS samples
@@ -497,17 +460,11 @@ jobs:
       msbuildArguments: '/p:DeployOnBuild=true /p:PublishProfile=FolderProfile.pubxml'
       maximumCpuCount: true
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: DockerCompose@0
     displayName: docker-compose build IIS containers
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: build --build-arg DOTNET_TRACER_MSI=$(msiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS.LoaderOptimizationRegKey
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: DockerCompose@0
     displayName: docker-compose start IIS containers
@@ -515,17 +472,11 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: up -d IntegrationTests.IIS.LoaderOptimizationRegKey
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - powershell: |
       [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
       $publish = New-Object System.EnterpriseServices.Internal.Publish
       Get-ChildItem $(publishOutput)/net45 -Filter *.dll | Foreach-Object { $publish.GacInstall($_.FullName) }
     displayName: Add net45 Datadog.Trace.ClrProfiler.Managed assets to the GAC
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test --filter LoadFromGAC=True
@@ -535,9 +486,6 @@ jobs:
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
       arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True&IIS!=True" -p:Platform=$(buildPlatform)
 
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
-
   - task: DotNetCoreCLI@2
     displayName: dotnet test IIS
     inputs:
@@ -545,9 +493,6 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
       arguments: --filter "(IIS=True)" -p:Platform=$(buildPlatform)
-
-  - pwsh: Get-PSDrive
-    displayName: HDD Info
 
   - task: DockerCompose@0
     displayName: docker-compose stop services

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -329,7 +329,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=false -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -475,7 +475,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=false -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
   - pwsh: Get-PSDrive
     displayName: HDD Info

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -329,7 +329,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=false -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -475,7 +475,7 @@ jobs:
       projects: |
         test/test-applications/integrations/**/*.csproj
         !test/test-applications/integrations/dependency-libs/**/*.csproj
-      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138
+      arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138 -p:ExcludeManagedProfiler=false -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
   - pwsh: Get-PSDrive
     displayName: HDD Info

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -372,11 +372,18 @@ jobs:
     msiOutputDirectory: src/WindowsInstaller/bin/$(buildConfiguration)/$(buildPlatform)/en-us
 
   steps:
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: UseDotNet@2
     displayName: install dotnet core sdk 2.1
     inputs:
       packageType: sdk
       version: 2.1.x
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 3.0
@@ -384,11 +391,17 @@ jobs:
       packageType: sdk
       version: 3.0.x
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: UseDotNet@2
     displayName: install dotnet core sdk 3.1
     inputs:
       packageType: sdk
       version: $(dotnetCoreSdkVersion)
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5
@@ -397,14 +410,23 @@ jobs:
       version: $(dotnetCoreSdk5Version)
       includePreviewVersions: true
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: NuGetToolInstaller@1
     displayName: install nuget
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:
       restoreSolution: Datadog.Trace.sln
       verbosityRestore: Normal
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   # this triggers a dependency chain that builds all the managed and native dlls
   - task: MSBuild@1
@@ -416,6 +438,9 @@ jobs:
       msbuildArguments: /t:msi /p:RunWixToolsOutOfProc=true /p:TracerHomeDirectory=$(publishOutput)
       maximumCpuCount: true
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: MSBuild@1
     displayName: Build .NET Framework projects (not SDK-based projects)
     inputs:
@@ -424,6 +449,9 @@ jobs:
       configuration: $(buildConfiguration)
       msbuildArguments: /t:BuildFrameworkReproductions
       maximumCpuCount: true
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: DotNetCoreCLI@2
     displayName: dotnet build integration tests
@@ -437,6 +465,9 @@ jobs:
         !test/test-applications/regression/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) /nowarn:netsdk1138
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: DotNetCoreCLI@2
     displayName: dotnet build samples
     inputs:
@@ -446,11 +477,17 @@ jobs:
         !test/test-applications/integrations/dependency-libs/**/*.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: NuGetCommand@2
     displayName: nuget restore IIS samples
     inputs:
       restoreSolution: test/test-applications/aspnet/samples-iis.sln
       verbosityRestore: Normal
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: MSBuild@1
     displayName: Publish IIS samples
@@ -460,11 +497,17 @@ jobs:
       msbuildArguments: '/p:DeployOnBuild=true /p:PublishProfile=FolderProfile.pubxml'
       maximumCpuCount: true
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: DockerCompose@0
     displayName: docker-compose build IIS containers
     inputs:
       containerregistrytype: Container Registry
       dockerComposeCommand: build --build-arg DOTNET_TRACER_MSI=$(msiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS.LoaderOptimizationRegKey
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: DockerCompose@0
     displayName: docker-compose start IIS containers
@@ -472,11 +515,17 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: up -d IntegrationTests.IIS.LoaderOptimizationRegKey
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - powershell: |
       [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
       $publish = New-Object System.EnterpriseServices.Internal.Publish
       Get-ChildItem $(publishOutput)/net45 -Filter *.dll | Foreach-Object { $publish.GacInstall($_.FullName) }
     displayName: Add net45 Datadog.Trace.ClrProfiler.Managed assets to the GAC
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test --filter LoadFromGAC=True
@@ -486,6 +535,9 @@ jobs:
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
       arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True&IIS!=True" -p:Platform=$(buildPlatform)
 
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
+
   - task: DotNetCoreCLI@2
     displayName: dotnet test IIS
     inputs:
@@ -493,6 +545,9 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
       arguments: --filter "(IIS=True)" -p:Platform=$(buildPlatform)
+
+  - pwsh: Get-PSDrive
+    displayName: HDD Info
 
   - task: DockerCompose@0
     displayName: docker-compose stop services

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -12,7 +12,11 @@
 
   <ItemGroup>
     <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <None Remove="xunit.runner.json" />
     <Content Include="..\..\integrations.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Link="profiler-lib\integrations.json" />
+    <Content Include="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
 
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
@@ -28,7 +32,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   
-  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild" >
+  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild">
     <ItemGroup>
       <!-- Subfolders of the output directory should each be a target framework -->
       <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -6,6 +6,8 @@
     <!--These should be consolidated in a file that can be shared for the tests and samples directories -->
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)'=='true' or '$(TestAllPackageVersions)'!='true'">$(DefineConstants);DEFAULT_SAMPLES</DefineConstants>
     <DefineConstants Condition="'$(PerformComprehensiveTesting)'=='true'">$(DefineConstants);COMPREHENSIVE_TESTS</DefineConstants>
+
+    <ManagedProfilerOutputDirectory Condition="'$(ManagedProfilerOutputDirectory)' == ''">$(MSBuildThisFileDirectory)\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(Configuration)</ManagedProfilerOutputDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,4 +27,14 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
+  
+  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild" >
+    <ItemGroup>
+      <!-- Subfolders of the output directory should each be a target framework -->
+      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />
+      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.pdb" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.pdb" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(ManagedProfilerFiles)" DestinationFolder="$(OutputPath)profiler-lib\%(RecursiveDir)" />
+  </Target>
 </Project>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/xunit.runner.json
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "shadowCopy": false
+}

--- a/test/test-applications/Directory.Build.props
+++ b/test/test-applications/Directory.Build.props
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild" 
-          Condition=" '$(ExcludeManagedProfiler)' != 'true' AND $(LoadManagedProfilerFromProfilerDirectory)' == 'true'">
+          Condition=" '$(ExcludeManagedProfiler)' != 'true' AND '$(LoadManagedProfilerFromProfilerDirectory)' == 'true'">
     <ItemGroup>
       <!-- Subfolders of the output directory should each be a target framework -->
       <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />

--- a/test/test-applications/Directory.Build.props
+++ b/test/test-applications/Directory.Build.props
@@ -37,7 +37,8 @@
              Link="profiler-lib\integrations.json" />
   </ItemGroup>
 
-  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild" Condition=" '$(LoadManagedProfilerFromProfilerDirectory)' == 'true'">
+  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild" 
+          Condition=" '$(ExcludeManagedProfiler)' != 'true' AND $(LoadManagedProfilerFromProfilerDirectory)' == 'true'">
     <ItemGroup>
       <!-- Subfolders of the output directory should each be a target framework -->
       <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />

--- a/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="GraphQL.StarWars" Version="1.0.0" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />

--- a/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -10,6 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="$(ApiVersion)" />
   </ItemGroup>
 

--- a/test/test-applications/integrations/Samples.RabbitMQ/Samples.RabbitMQ.csproj
+++ b/test/test-applications/integrations/Samples.RabbitMQ/Samples.RabbitMQ.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="$(ApiVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Previously the integration tests were copying the tracer home directory into the bin folder of every sample app to avoid file locking issues. However, this is only really an issue for local builds, and in CI it causes an extra ~170MB per app. Instead, use a single shared copy of the tracer (copied to the integration test output to make everything line up).

This is probably not the optimal way of doing things, but as long as it fixes the build, that's the important thing!