### PR TITLE
Ignore agent and port when in AAS (dogstatsd)

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -667,12 +667,17 @@ namespace Datadog.Trace
                 }
 
                 var statsd = new DogStatsdService();
-                statsd.Configure(new StatsdConfig
+                if (AzureAppServices.Metadata.IsRelevant)
                 {
-                    StatsdServerName = settings.AgentUri.DnsSafeHost,
-                    StatsdPort = port,
-                    ConstantTags = constantTags.ToArray()
-                });
+                    statsd.Configure(new StatsdConfig
+                    {
+                        ConstantTags = constantTags.ToArray()
+                    });
+                }
+                else
+                {
+                    statsd.Configure(new StatsdConfig { StatsdServerName = settings.AgentUri.DnsSafeHost, StatsdPort = port, ConstantTags = constantTags.ToArray() });
+                }
 
                 return statsd;
             }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -669,6 +669,8 @@ namespace Datadog.Trace
                 var statsd = new DogStatsdService();
                 if (AzureAppServices.Metadata.IsRelevant)
                 {
+                    // Environment variables set by the Azure App Service extension are used internally.
+                    // Setting the server name will force UDP, when we need named pipes.
                     statsd.Configure(new StatsdConfig
                     {
                         ConstantTags = constantTags.ToArray()

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -678,7 +678,12 @@ namespace Datadog.Trace
                 }
                 else
                 {
-                    statsd.Configure(new StatsdConfig { StatsdServerName = settings.AgentUri.DnsSafeHost, StatsdPort = port, ConstantTags = constantTags.ToArray() });
+                    statsd.Configure(new StatsdConfig
+                    {
+                        StatsdServerName = settings.AgentUri.DnsSafeHost,
+                        StatsdPort = port,
+                        ConstantTags = constantTags.ToArray()
+                    });
                 }
 
                 return statsd;


### PR DESCRIPTION
Make internal metrics AAS aware.

@DataDog/apm-dotnet