### PR TITLE
Patch .NET 5.0 SDK to work around NuGet cert issue

### DIFF
--- a/build/docker/dotnet.arm64.core50.dockerfile
+++ b/build/docker/dotnet.arm64.core50.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
 
 ADD https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh /bin/wait-for-it
 RUN chmod +x /bin/wait-for-it

--- a/build/docker/dotnet.arm64.dockerfile
+++ b/build/docker/dotnet.arm64.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
 
 # Install aspnetcore-runtime-3.1.10
 RUN wget https://download.visualstudio.microsoft.com/download/pr/936a9563-1dad-4c4b-b366-c7fcc3e28215/a1edcaf4c35bce760d07e3f1f3d0b9cf/aspnetcore-runtime-3.1.10-linux-arm64.tar.gz && \

--- a/build/docker/dotnet.dockerfile
+++ b/build/docker/dotnet.dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim
 
 # Instructions to install .NET Core runtimes from
 # https://docs.microsoft.com/en-us/dotnet/core/install/linux-package-manager-debian10


### PR DESCRIPTION
As described in https://github.com/NuGet/Announcements/issues/49 and https://github.com/NuGet/Home/issues/10491

@DataDog/apm-dotnet