### PR TITLE
Exponential Backoff Named Pipe Check

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -92,11 +92,11 @@ namespace Datadog.Trace.Configuration
         public const string TracesPipeTimeoutMs = "DD_TRACE_PIPE_TIMEOUT_MS";
 
         /// <summary>
-        /// Configuration key for the name of the pipe where the Tracer can send metrics.
+        /// Configuration key for the named pipe that DogStatsD binds to.
         /// Default value is <c>null</c>.
         /// </summary>
         /// <seealso cref="TracerSettings.MetricsPipeName"/>
-        public const string MetricsPipeName = "DD_DOGSTATSD_WINDOWS_PIPE_NAME";
+        public const string MetricsPipeName = "DD_DOGSTATSD_PIPE_NAME";
 
         /// <summary>
         /// Sibling setting for <see cref="AgentPort"/>.

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace
 
                                         while (--attempts > 0)
                                         {
-                                            await Task.Delay((int)delay);
+                                            await Task.Delay((int)delay).ConfigureAwait(false);
 
                                             if (metadata.ProcessIsHealthy())
                                             {
@@ -208,7 +208,7 @@ namespace Datadog.Trace
                                             break;
                                         }
 
-                                        await Task.Delay(100);
+                                        await Task.Delay(100).ConfigureAwait(false);
                                         timeout -= 100;
                                     }
                                 }
@@ -224,12 +224,12 @@ namespace Datadog.Trace
                                 {
                                     metadata.SequentialFailures++;
                                     // Quicker retry in these cases
-                                    await Task.Delay(ExceptionRetryInterval);
+                                    await Task.Delay(ExceptionRetryInterval).ConfigureAwait(false);
                                 }
                                 else
                                 {
                                     // Delay for a reasonable amount of time before we check to see if the process is alive again.
-                                    await Task.Delay(KeepAliveInterval);
+                                    await Task.Delay(KeepAliveInterval).ConfigureAwait(false);
                                 }
                             }
                         }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace
                         {
                             if (metadata.SequentialFailures >= MaxFailures)
                             {
-                                Log.Error("Circuit breaker triggered for {Process}. Max retries reached ({ErrorCount}).", path, MaxFailures);
+                                Log.Error("Maximum retries ({ErrorCount}) reached starting {Process}.", path, MaxFailures);
                                 metadata.ProcessState = ProcessState.Faulted;
                                 return;
                             }
@@ -202,7 +202,7 @@ namespace Datadog.Trace
 
                                         if (metadata.Process == null || metadata.Process.HasExited)
                                         {
-                                            Log.Error("{Process} has failed to start.", path);
+                                            Log.Error("Failed to start {Process}.", path);
                                             metadata.ProcessState = ProcessState.Faulted;
                                             break;
                                         }
@@ -215,7 +215,7 @@ namespace Datadog.Trace
                             catch (Exception ex)
                             {
                                 metadata.ProcessState = ProcessState.Faulted;
-                                Log.Error(ex, "Exception when trying to start an instance of {Process}.", path);
+                                Log.Error(ex, "Failed to start {Process}.", path);
                             }
                             finally
                             {

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -173,8 +173,7 @@ namespace Datadog.Trace
 
                                     var startInfo = new ProcessStartInfo
                                     {
-                                        FileName = path,
-                                        UseShellExecute = false
+                                        FileName = path
                                     };
 
                                     if (!string.IsNullOrWhiteSpace(metadata.ProcessArguments))
@@ -183,17 +182,20 @@ namespace Datadog.Trace
                                     }
 
                                     metadata.Process = Process.Start(startInfo);
+                                    var timeout = 2000;
 
-                                    while (!metadata.NamedPipeIsBound())
+                                    while (!metadata.NamedPipeIsBound() && timeout > 0)
                                     {
-                                        Thread.Sleep(100);
-
                                         if (metadata.Process == null || metadata.Process.HasExited)
                                         {
                                             Log.Error("{Process} has failed to start.", path);
                                             metadata.SequentialFailures++;
                                             metadata.ProcessState = ProcessState.Faulted;
+                                            break;
                                         }
+
+                                        Thread.Sleep(100);
+                                        timeout -= 100;
                                     }
 
                                     Log.Debug("Successfully started {Process}.", path);

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -235,7 +235,6 @@ namespace Datadog.Trace
         internal class ProcessMetadata
         {
             private string _processPath;
-            private ProcessState _processState = ProcessState.NeverChecked;
 
             public string PipeName { get; set; }
 
@@ -252,17 +251,7 @@ namespace Datadog.Trace
 
             public int SequentialFailures { get; set; }
 
-            public ProcessState ProcessState
-            {
-                get => _processState;
-                set
-                {
-                    PreviousState = _processState;
-                    _processState = value;
-                }
-            }
-
-            public ProcessState PreviousState { get; private set; }
+            public ProcessState ProcessState { get; set; } = ProcessState.NeverChecked;
 
             public string ProcessPath
             {

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -203,7 +203,6 @@ namespace Datadog.Trace
                                         if (metadata.Process == null || metadata.Process.HasExited)
                                         {
                                             Log.Error("{Process} has failed to start.", path);
-                                            metadata.SequentialFailures++;
                                             metadata.ProcessState = ProcessState.Faulted;
                                             break;
                                         }

--- a/src/Datadog.Trace/TracingProcessManager.cs
+++ b/src/Datadog.Trace/TracingProcessManager.cs
@@ -119,6 +119,7 @@ namespace Datadog.Trace
                             {
                                 Log.Error("Circuit breaker triggered for {Process}. Max retries reached ({ErrorCount}).", path, MaxFailures);
                                 metadata.ProcessState = ProcessState.Faulted;
+                                return;
                             }
 
                             try
@@ -137,7 +138,7 @@ namespace Datadog.Trace
                                         // Assume healthy to start, but look for problems
                                         metadata.ProcessState = ProcessState.Healthy;
 
-                                        // Check on a delay to be sure we have the agent available
+                                        // Check on a delay to be sure we keep the process available after a shutdown
                                         var attempts = 7;
                                         var delay = 50d;
 
@@ -176,7 +177,8 @@ namespace Datadog.Trace
 
                                     var startInfo = new ProcessStartInfo
                                     {
-                                        FileName = path
+                                        FileName = path,
+                                        UseShellExecute = false // Force consistency in behavior between Framework and Core
                                     };
 
                                     if (!string.IsNullOrWhiteSpace(metadata.ProcessArguments))
@@ -234,7 +236,7 @@ namespace Datadog.Trace
                     }
                     finally
                     {
-                        Log.Debug("Keep alive is dropping for {Process}.", path);
+                        Log.Warning("Keep alive is dropping for {Process}.", path);
                         metadata.IsBeingManaged = false;
                     }
                 });


### PR DESCRIPTION
Reduce transient named pipe conflicts in AAS.
Reduces timespan where stats are sent into the abyss.


### netcore31
Tested cold startup.
Tested deployment over live app with concurrent requests which resulted in these logs for the trace agent as an example:
```
2021-01-29 17:15:56.721 +00:00 [INF] Using NamedPipeClientStreamFactory for trace transport, with pipe name datadogtrace-F243918E-6DAE-4F03-B0E3-2BAB4DB686B8 and timeout 100ms.
{ MachineName: ".", Process: "[27556 w3wp]", AppDomain: "[1 BareboneStats]", TracerVersion: "1.22.1.0" }
2021-01-29 17:15:57.031 +00:00 [INF] DATADOG TRACER CONFIGURATION - {"date":"2021-01-29T17:15:57.0224985+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.14393.0","version":"1.22.1.0","platform":"x86","lang":".NET Core","lang_version":"3.1.11","env":"dd-stats-debug-2","enabled":true,"service":"BareboneStats","agent_url":"http://127.0.0.1:8126/","debug":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":true,"disabled_integrations":[],"netstandard_enabled":false,"agent_reachable":true,"agent_error":""}
{ MachineName: ".", Process: "[27556 w3wp]", AppDomain: "[1 BareboneStats]", TracerVersion: "1.22.1.0" }
2021-01-29 17:16:00.402 +00:00 [INF] Recovering from previous C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_3\Agent\datadog-trace-agent.exe shutdown. Ready for start.
{ MachineName: ".", AppDomain: "[1 BareboneStats]", TracerVersion: "1.22.1.0" }
2021-01-29 17:16:00.409 +00:00 [INF] Attempting to start C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_3\Agent\datadog-trace-agent.exe.
{ MachineName: ".", AppDomain: "[1 BareboneStats]", TracerVersion: "1.22.1.0" }
2021-01-29 17:16:00.509 +00:00 [INF] Successfully started C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_3\Agent\datadog-trace-agent.exe.
{ MachineName: ".", AppDomain: "[1 BareboneStats]", TracerVersion: "1.22.1.0" }
```

### net472

Tested cold start.
Tested deploy over the top of framework app with concurrent requests.
Interestingly I have not hit the same code path in framework. Possibly it's a more clean cut over?
Either way, it works.
```
2021-01-29 19:01:26.804 +00:00 [INF] Attempting to start C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_4\Agent\datadog-trace-agent.exe.
{ MachineName: ".", AppDomain: "[2 /LM/W3SVC/1717539916/ROOT-1-132564204831634214]", TracerVersion: "1.22.1.0" }
2021-01-29 19:01:26.913 +00:00 [INF] Using NamedPipeClientStreamFactory for trace transport, with pipe name datadogtrace-10D77F83-F7C9-404F-ABC2-DF3B4389E212 and timeout 100ms.
{ MachineName: ".", Process: "[28092 w3wp]", AppDomain: "[2 /LM/W3SVC/1717539916/ROOT-1-132564204831634214]", TracerVersion: "1.22.1.0" }
2021-01-29 19:01:27.054 +00:00 [INF] DATADOG TRACER CONFIGURATION - {"date":"2021-01-29T19:01:27.0540606+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.14393.0","version":"1.22.1.0","platform":"x86","lang":".NET Framework","lang_version":"4.8","env":"aas-stats-debug-framework","enabled":true,"service":"dd-aas-stats-debug-framework","agent_url":"http://127.0.0.1:8126/","debug":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":true,"disabled_integrations":[],"netstandard_enabled":false,"agent_reachable":true,"agent_error":""}
{ MachineName: ".", Process: "[28092 w3wp]", AppDomain: "[2 /LM/W3SVC/1717539916/ROOT-1-132564204831634214]", TracerVersion: "1.22.1.0" }
2021-01-29 19:01:28.038 +00:00 [INF] Attempting to start C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_4\Agent\dogstatsd.exe.
{ MachineName: ".", AppDomain: "[2 /LM/W3SVC/1717539916/ROOT-1-132564204831634214]", TracerVersion: "1.22.1.0" }
2021-01-29 19:01:28.507 +00:00 [INF] Successfully started C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_4\Agent\datadog-trace-agent.exe.
{ MachineName: ".", AppDomain: "[2 /LM/W3SVC/1717539916/ROOT-1-132564204831634214]", TracerVersion: "1.22.1.0" }
2021-01-29 19:01:31.350 +00:00 [INF] Successfully started C:\home\SiteExtensions\Datadog.Development.AzureAppServices\v100_5_4\Agent\dogstatsd.exe.
{ MachineName: ".", AppDomain: "[2 /LM/W3SVC/1717539916/ROOT-1-132564204831634214]", TracerVersion: "1.22.1.0" }
```
@DataDog/apm-dotnet