### PR TITLE
Fix memory leak by adding missing delete[] instructions.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -95,6 +95,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         typeRef, GetTypeFromHandleMethodName.data(), signature,
         sizeof(signature), &getTypeFromHandleToken);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper getTypeFromHandleToken could not be defined.");
       return hr;
@@ -202,6 +203,7 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens() {
         callTargetStateTypeRef,
         managed_profiler_calltarget_statetype_getdefault_name.data(), signature,
         signatureLength, &callTargetStateTypeGetDefault);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper callTargetStateTypeGetDefault could not be defined.");
       return hr;
@@ -288,6 +290,7 @@ mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(
 
   hr = module_metadata->metadata_emit->GetTokenFromTypeSpec(
       signature, signatureLength, &returnValueTypeSpec);
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating return value type spec");
     return mdTypeSpecNil;
@@ -334,6 +337,7 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnVoidDefaultMemberRef() {
         callTargetReturnVoidTypeRef,
         managed_profiler_calltarget_returntype_getdefault_name.data(),
         signature, signatureLength, &callTargetReturnVoidTypeGetDefault);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper callTargetReturnVoidTypeGetDefault could not be defined.");
       return mdMemberRefNil;
@@ -382,6 +386,7 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnValueDefaultMemberRef(
       callTargetReturnTypeSpec,
       managed_profiler_calltarget_returntype_getdefault_name.data(), signature,
       signatureLength, &callTargetReturnTypeGetDefault);
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Wrapper callTargetReturnTypeGetDefault could not be defined.");
     return mdMemberRefNil;
@@ -417,6 +422,7 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(
         callTargetTypeRef,
         managed_profiler_calltarget_getdefaultvalue_name.data(), signature,
         signatureLength, &getDefaultMemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper getDefaultMemberRef could not be defined.");
       return hr;
@@ -443,7 +449,7 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       getDefaultMemberRef, signature, signatureLength, &getDefaultMethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating getDefaultMethodSpec.");
     return mdMethodSpecNil;
@@ -625,6 +631,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(
   mdToken newLocalVarSig;
   hr = module_metadata->metadata_emit->GetTokenFromSig(
       newSignatureBuffer, newSignatureSize, &newLocalVarSig);
+  delete[] newSignatureBuffer;
   if (FAILED(hr)) {
     Warn("Error creating new locals var signature.");
     return hr;
@@ -732,6 +739,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithoutArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP0MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP0MemberRef could not be defined.");
       return hr;
@@ -771,7 +779,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithoutArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP0MemberRef, signature, signatureLength, &beginP0MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -819,6 +827,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP1MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP1MemberRef could not be defined.");
       return hr;
@@ -866,7 +875,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP1MemberRef, signature, signatureLength, &beginP1MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -917,6 +926,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP2MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP2MemberRef could not be defined.");
       return hr;
@@ -970,7 +980,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP2MemberRef, signature, signatureLength, &beginP2MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -1025,6 +1035,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP3MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP3MemberRef could not be defined.");
       return hr;
@@ -1085,7 +1096,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP3MemberRef, signature, signatureLength, &beginP3MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -1143,6 +1154,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP4MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP4MemberRef could not be defined.");
       return hr;
@@ -1209,7 +1221,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP4MemberRef, signature, signatureLength, &beginP4MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -1271,6 +1283,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP5MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP5MemberRef could not be defined.");
       return hr;
@@ -1344,7 +1357,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP5MemberRef, signature, signatureLength, &beginP5MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -1409,6 +1422,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginP6MemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginP6MemberRef could not be defined.");
       return hr;
@@ -1488,7 +1502,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArguments(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginP6MemberRef, signature, signatureLength, &beginP6MethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -1534,6 +1548,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(),
         signature, signatureLength, &beginArrayMemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper beginArrayMemberRef could not be defined.");
       return hr;
@@ -1573,7 +1588,7 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       beginArrayMemberRef, signature, signatureLength, &beginArrayMethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating begin method spec.");
     return hr;
@@ -1633,6 +1648,7 @@ HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_endmethod_name.data(),
         signature, signatureLength, &endVoidMemberRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper endVoidMemberRef could not be defined.");
       return hr;
@@ -1672,7 +1688,7 @@ HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       endVoidMemberRef, signature, signatureLength, &endVoidMethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating end void method method spec.");
     return hr;
@@ -1744,6 +1760,7 @@ HRESULT CallTargetTokens::WriteEndReturnMemberRef(
   hr = module_metadata->metadata_emit->DefineMemberRef(
       callTargetTypeRef, managed_profiler_calltarget_endmethod_name.data(),
       signature, signatureLength, &endMethodMemberRef);
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Wrapper endMethodMemberRef could not be defined.");
     return hr;
@@ -1793,7 +1810,7 @@ HRESULT CallTargetTokens::WriteEndReturnMemberRef(
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       endMethodMemberRef, signature, signatureLength, &endMethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating end method member spec.");
     return hr;
@@ -1834,6 +1851,7 @@ HRESULT CallTargetTokens::WriteLogException(void* rewriterWrapperPtr,
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetTypeRef, managed_profiler_calltarget_logexception_name.data(),
         signature, signatureLength, &logExceptionRef);
+    delete[] signature;
     if (FAILED(hr)) {
       Warn("Wrapper logExceptionRef could not be defined.");
       return hr;
@@ -1873,7 +1891,7 @@ HRESULT CallTargetTokens::WriteLogException(void* rewriterWrapperPtr,
 
   hr = module_metadata->metadata_emit->DefineMethodSpec(
       logExceptionRef, signature, signatureLength, &logExceptionMethodSpec);
-
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Error creating log exception method spec.");
     return hr;
@@ -1909,6 +1927,7 @@ HRESULT CallTargetTokens::WriteCallTargetReturnGetReturnValue(
       callTargetReturnTypeSpec,
       managed_profiler_calltarget_returntype_getreturnvalue_name.data(),
       signature, signatureLength, &callTargetReturnGetValueMemberRef);
+  delete[] signature;
   if (FAILED(hr)) {
     Warn("Wrapper callTargetReturnGetValueMemberRef could not be defined.");
     return mdMemberRefNil;


### PR DESCRIPTION
This PR adds the missing `delete[]` instructions when creating the new signatures for CallTarget modifications, removing the current memory leak (not a crashing one because that signatures are created only in the rewriting process).


@DataDog/apm-dotnet