### PR TITLE
Remove the Analyzed Span flag on Benchmarks instrumentation

### DIFF
--- a/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -52,7 +52,6 @@ namespace Datadog.Trace.BenchmarkDotNet
                     Span span = tracer.StartSpan("benchmarkdotnet.test", startTime: startTime);
                     double durationNanoseconds = 0;
 
-                    span.SetMetric(Tags.Analytics, 1.0d);
                     span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                     span.Type = SpanTypes.Test;
                     span.ResourceName = $"{report.BenchmarkCase.Descriptor.Type.FullName}.{report.BenchmarkCase.Descriptor.WorkloadMethod.Name}";


### PR DESCRIPTION
This PR removes:
```csharp
span.SetMetric(Tags.Analytics, 1.0d);
```

from the Benchmark test spans.

@DataDog/apm-dotnet