### PR TITLE
Fix CIApp tests environment variables overwrite.

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIEnvironmentVariableTests.cs
@@ -66,8 +66,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             }
         }
 
-        internal static void SetEnvironmentFromDictionary(IDictionary values)
+        internal void SetEnvironmentFromDictionary(IDictionary values)
         {
+            foreach (DictionaryEntry item in _originalEnvVars)
+            {
+                Environment.SetEnvironmentVariable(item.Key.ToString(), null);
+            }
+
             foreach (DictionaryEntry item in values)
             {
                 Environment.SetEnvironmentVariable(item.Key.ToString(), item.Value.ToString());
@@ -78,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             foreach (DictionaryEntry item in values)
             {
-                Environment.SetEnvironmentVariable(item.Key.ToString(), string.Empty);
+                Environment.SetEnvironmentVariable(item.Key.ToString(), null);
             }
 
             foreach (DictionaryEntry item in _originalEnvVars)

--- a/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
+++ b/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
@@ -127,6 +127,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed.Core\Datadog.Trace.ClrProfiler.Managed.Core.csproj">
+      <Project>{d95d5e26-f32a-481d-a15a-ef7b3b56d2e0}</Project>
+      <Name>Datadog.Trace.ClrProfiler.Managed.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
       <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
       <Name>Datadog.Trace.ClrProfiler.Managed</Name>


### PR DESCRIPTION
This PR fixes the CiAppEnvironmentVariableTests environment variable override that is currently failing in the CiApp specs repo.


@DataDog/apm-dotnet