### PR TITLE
Add Area tag to ASP.NET integration

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -99,6 +99,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     resourceName = $"{httpMethod} {cleanUri.ToLowerInvariant()}";
                 }
 
+                string areaName = (routeValues?.GetValueOrDefault("area") as string)?.ToLowerInvariant();
                 string controllerName = (routeValues?.GetValueOrDefault("controller") as string)?.ToLowerInvariant();
                 string actionName = (routeValues?.GetValueOrDefault("action") as string)?.ToLowerInvariant();
 
@@ -134,6 +135,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 // Fail safe to catch templates in routing values
                 resourceName =
                     resourceName
+                       .Replace("{area}", areaName)
                        .Replace("{controller}", controllerName)
                        .Replace("{action}", actionName);
 
@@ -146,6 +148,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     tagsFromHeaders);
 
                 tags.AspNetRoute = route?.Url;
+                tags.AspNetArea = areaName;
                 tags.AspNetController = controllerName;
                 tags.AspNetAction = actionName;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -281,6 +281,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 string controller = string.Empty;
                 string action = string.Empty;
+                string area = string.Empty;
                 try
                 {
                     var routeValues = controllerContext.GetProperty<object>("RouteData").GetProperty<IDictionary<string, object>>("Values").GetValueOrDefault();
@@ -288,6 +289,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     {
                         controller = (routeValues.GetValueOrDefault("controller") as string)?.ToLowerInvariant();
                         action = (routeValues.GetValueOrDefault("action") as string)?.ToLowerInvariant();
+                        area = (routeValues.GetValueOrDefault("area") as string)?.ToLowerInvariant();
                     }
                 }
                 catch
@@ -297,6 +299,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 // Fail safe to catch templates in routing values
                 resourceName =
                     resourceName
+                       .Replace("{area}", area)
                        .Replace("{controller}", controller)
                        .Replace("{action}", action);
 
@@ -310,6 +313,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 tags.AspNetAction = action;
                 tags.AspNetController = controller;
+                tags.AspNetArea = area;
                 tags.AspNetRoute = route;
             }
             catch (Exception ex)

--- a/src/Datadog.Trace/Tagging/AspNetTags.cs
+++ b/src/Datadog.Trace/Tagging/AspNetTags.cs
@@ -7,6 +7,7 @@ namespace Datadog.Trace.Tagging
         private static readonly IProperty<string>[] AspNetTagsProperties =
             WebTagsProperties.Concat(
                 new Property<AspNetTags, string>(Trace.Tags.AspNetRoute, t => t.AspNetRoute, (t, v) => t.AspNetRoute = v),
+                new Property<AspNetTags, string>(Trace.Tags.AspNetArea, t => t.AspNetArea, (t, v) => t.AspNetArea = v),
                 new Property<AspNetTags, string>(Trace.Tags.AspNetController, t => t.AspNetController, (t, v) => t.AspNetController = v),
                 new Property<AspNetTags, string>(Trace.Tags.AspNetAction, t => t.AspNetAction, (t, v) => t.AspNetAction = v));
 
@@ -15,6 +16,8 @@ namespace Datadog.Trace.Tagging
         public string AspNetController { get; set; }
 
         public string AspNetAction { get; set; }
+
+        public string AspNetArea { get; set; }
 
         protected override IProperty<string>[] GetAdditionalTags() => AspNetTagsProperties;
     }

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -110,6 +110,11 @@ namespace Datadog.Trace
         public const string AspNetAction = "aspnet.action";
 
         /// <summary>
+        /// The MVC or Web API area name.
+        /// </summary>
+        public const string AspNetArea = "aspnet.area";
+
+        /// <summary>
         /// The hostname of a outgoing server connection.
         /// </summary>
         public const string OutHost = "out.host";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -1,5 +1,6 @@
 #if NET461
 
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -21,23 +22,30 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _iisFixture.TryStartIis(this);
         }
 
+        public static TheoryData<string, string, HttpStatusCode, bool, string, string, Dictionary<string, string>> Data =>
+            new TheoryData<string, string, HttpStatusCode, bool, string, string, Dictionary<string, string>>
+            {
+                { "/DataDog/DogHouse/Woof", "GET /datadog/doghouse/woof", HttpStatusCode.OK, false, null, null, DatadogAreaTags() },
+                { "/Home/Index", "GET /home/index", HttpStatusCode.OK, false, null, null, HomeIndexTags() },
+                { "/delay/0", "GET /delay/{seconds}", HttpStatusCode.OK, false, null, null, DelayTags() },
+                { "/delay-async/0", "GET /delay-async/{seconds}", HttpStatusCode.OK, false, null, null, DelayAsyncTags() },
+                { "/badrequest", "GET /badrequest", HttpStatusCode.InternalServerError, true, null, null, BadRequestTags() },
+                { "/statuscode/201", "GET /statuscode/{value}", HttpStatusCode.Created, false, null, null, StatusCodeTags() },
+                { "/statuscode/503", "GET /statuscode/{value}", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.", StatusCodeTags() }
+            };
+
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [InlineData("/Home/Index", "GET", "/home/index", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/delay/0", "GET", "/delay/{seconds}", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/delay-async/0", "GET", "/delay-async/{seconds}", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/badrequest", "GET", "/badrequest", HttpStatusCode.InternalServerError, true, null, null)]
-        [InlineData("/statuscode/201", "GET", "/statuscode/{value}", HttpStatusCode.Created, false, null, null)]
-        [InlineData("/statuscode/503", "GET", "/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.")]
+        [MemberData(nameof(Data))]
         public async Task SubmitsTraces(
             string path,
-            string expectedVerb,
-            string expectedResourceSuffix,
+            string expectedResourceName,
             HttpStatusCode expectedStatusCode,
             bool isError,
             string expectedErrorType,
-            string expectedErrorMessage)
+            string expectedErrorMessage,
+            Dictionary<string, string> expectedTags)
         {
             await AssertWebServerSpan(
                 path,
@@ -49,9 +57,61 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 expectedErrorMessage,
                 "web",
                 "aspnet-mvc.request",
-                $"{expectedVerb} {expectedResourceSuffix}",
-                "1.0.0");
+                expectedResourceName,
+                "1.0.0",
+                expectedTags);
         }
+
+        private static Dictionary<string, string> DatadogAreaTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "Datadog/{controller}/{action}/{id}" },
+                { Tags.AspNetController, "doghouse" },
+                { Tags.AspNetAction, "woof" },
+                { Tags.AspNetArea, "datadog" }
+            };
+
+        private static string DefaultRoute() => "{controller}/{action}/{id}";
+
+        private static Dictionary<string, string> HomeIndexTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, DefaultRoute() },
+                { Tags.AspNetController, "home" },
+                { Tags.AspNetAction, "index" }
+            };
+
+        private static Dictionary<string, string> DelayTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "delay/{seconds}" },
+                { Tags.AspNetController, "home" },
+                { Tags.AspNetAction, "delay" }
+            };
+
+        private static Dictionary<string, string> BadRequestTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, DefaultRoute() },
+                { Tags.AspNetController, "home" },
+                { Tags.AspNetAction, "badrequest" }
+            };
+
+        private static Dictionary<string, string> DelayAsyncTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "delay-async/{seconds}" },
+                { Tags.AspNetController, "home" },
+                { Tags.AspNetAction, "delayasync" }
+            };
+
+        private static Dictionary<string, string> StatusCodeTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, DefaultRoute() },
+                { Tags.AspNetController, "home" },
+                { Tags.AspNetAction, "statuscode" }
+            };
     }
 }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -1,5 +1,6 @@
 #if NET461
 
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Xunit;
@@ -21,16 +22,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _iisFixture.TryStartIis(this);
         }
 
+        public static TheoryData<string, string, HttpStatusCode, bool, string, string, Dictionary<string, string>> Data =>
+            new TheoryData<string, string, HttpStatusCode, bool, string, string, Dictionary<string, string>>
+            {
+                { "/api/environment", "GET api/environment", HttpStatusCode.OK, false, null, null, EnvironmentTags() },
+                { "/api/delay/0", "GET api/delay/{seconds}", HttpStatusCode.OK, false, null, null, DelayTags() },
+                { "/api/delay-async/0", "GET api/delay-async/{seconds}", HttpStatusCode.OK, false, null, null, DelayAsyncTags() },
+                { "/api/transient-failure/true", "GET api/transient-failure/{value}", HttpStatusCode.OK, false, null, null, TransientFailureTags() },
+                { "/api/transient-failure/false", "GET api/transient-failure/{value}", HttpStatusCode.InternalServerError, true, null, null, TransientFailureTags() },
+                { "/api/statuscode/201", "GET api/statuscode/{value}", HttpStatusCode.Created, false, null, null, StatusCodeTags() },
+                { "/api/statuscode/503", "GET api/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.", StatusCodeTags() },
+            };
+
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
-        [InlineData("/api/environment", "GET api/environment", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/api/delay/0", "GET api/delay/{seconds}", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/api/delay-async/0", "GET api/delay-async/{seconds}", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/api/transient-failure/true", "GET api/transient-failure/{value}", HttpStatusCode.OK, false, null, null)]
-        [InlineData("/api/transient-failure/false", "GET api/transient-failure/{value}", HttpStatusCode.InternalServerError, true, null, null)]
-        [InlineData("/api/statuscode/201", "GET api/statuscode/{value}", HttpStatusCode.Created, false, null, null)]
-        [InlineData("/api/statuscode/503", "GET api/statuscode/{value}", HttpStatusCode.ServiceUnavailable, true, null, "The HTTP response has status code 503.")]
+        [MemberData(nameof(Data))]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,
@@ -52,6 +59,46 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 expectedResourceName,
                 "1.0.0");
         }
+
+        private static Dictionary<string, string> EnvironmentTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "api/environment" },
+                { Tags.AspNetController, "api" },
+                { Tags.AspNetAction, "environment" },
+            };
+
+        private static Dictionary<string, string> TransientFailureTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "api/transient-failure/{value}" },
+                { Tags.AspNetController, "api" },
+                { Tags.AspNetAction, "transientfailure" }
+            };
+
+        private static Dictionary<string, string> DelayTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "api/delay/{seconds}" },
+                { Tags.AspNetController, "api" },
+                { Tags.AspNetAction, "delay" }
+            };
+
+        private static Dictionary<string, string> DelayAsyncTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "api/delay-async/{seconds}" },
+                { Tags.AspNetController, "api" },
+                { Tags.AspNetAction, "delayasync" }
+            };
+
+        private static Dictionary<string, string> StatusCodeTags() =>
+            new Dictionary<string, string>
+            {
+                { Tags.AspNetRoute, "api/statuscode/{value}" },
+                { Tags.AspNetController, "api" },
+                { Tags.AspNetAction, "statuscode" }
+            };
     }
 }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -246,7 +246,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             string expectedSpanType,
             string expectedOperationName,
             string expectedResourceName,
-            string expectedServiceVersion)
+            string expectedServiceVersion,
+            IDictionary<string, string> expectedTags = null)
         {
             IImmutableList<MockTracerAgent.Span> spans;
 
@@ -283,6 +284,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // other tags
             Assert.Equal(SpanKinds.Server, span.Tags.GetValueOrDefault(Tags.SpanKind));
             Assert.Equal(expectedServiceVersion, span.Tags.GetValueOrDefault(Tags.Version));
+
+            if (expectedTags is not null)
+            {
+                foreach (var expectedTag in expectedTags)
+                {
+                    Assert.Equal(expectedTag.Value, span.Tags.GetValueOrDefault(expectedTag.Key));
+                }
+            }
         }
 
         internal class TupleList<T1, T2> : List<Tuple<T1, T2>>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/App_Start/RouteConfig.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/App_Start/RouteConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
@@ -16,7 +16,8 @@ namespace Samples.AspNetMvc4
             routes.MapRoute(
                 name: "Default",
                 url: "{controller}/{action}/{id}",
-                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional }
+                defaults: new { controller = "Home", action = "Index", id = UrlParameter.Optional },
+                namespaces: new [] { "Samples.AspNetMvc4.Controllers" }
             );
         }
     }

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/AdminAreaRegistration.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/AdminAreaRegistration.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Samples.AspNetMvc4.Areas.Admin
+{
+    public class AdminAreaRegistration : AreaRegistration
+    {
+        public override string AreaName => "Admin";
+
+        public override void RegisterArea(AreaRegistrationContext context)
+        {
+            context.MapRoute(
+                "AdminArea_default",
+                "Admin/{controller}/{action}/{id}",
+                new { area = "admin", controller = "Home", action = "Index", id = UrlParameter.Optional }
+            );
+        }
+    }
+}

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/Controllers/HomeController.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/Controllers/HomeController.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace Samples.AspNetMvc4.Areas.Admin.Controllers
+{
+    public class HomeController : Controller
+    {
+        public ActionResult Index()
+        {
+            var values = new Dictionary<string, string>
+            {
+                {"Area", GetRouteValueOrDefault("area") },
+                {"Controller", GetRouteValueOrDefault("controller") },
+                {"Action", GetRouteValueOrDefault("action") },
+            };
+
+            return View(values);
+        }
+
+        private string GetRouteValueOrDefault(string key)
+        {
+            return RouteData.Values.TryGetValue(key, out var value)
+                       ? value.ToString()
+                       : default;
+        }
+    }
+}

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/Views/Home/Index.cshtml
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/Views/Home/Index.cshtml
@@ -1,0 +1,22 @@
+﻿@model Dictionary<string, string> 
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>Admin Home page</title>
+</head>
+<body>
+    <h1>Admin Home page</h1>
+    <ul>
+        @foreach (var pair in Model)
+        {
+            <li>@pair.Key = @pair.Value</li>
+        }
+    </ul>
+</body>
+</html>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/Views/Web.config
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Areas/Admin/Views/Web.config
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0"?>
+
+<configuration>
+  <configSections>
+    <sectionGroup name="system.web.webPages.razor" type="System.Web.WebPages.Razor.Configuration.RazorWebSectionGroup, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35">
+      <section name="host" type="System.Web.WebPages.Razor.Configuration.HostSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+      <section name="pages" type="System.Web.WebPages.Razor.Configuration.RazorPagesSection, System.Web.WebPages.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" requirePermission="false" />
+    </sectionGroup>
+  </configSections>
+
+  <system.web.webPages.razor>
+    <host factoryType="System.Web.Mvc.MvcWebRazorHostFactory, System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+    <pages pageBaseType="System.Web.Mvc.WebViewPage">
+      <namespaces>
+        <add namespace="System.Web.Mvc" />
+        <add namespace="System.Web.Mvc.Ajax" />
+        <add namespace="System.Web.Mvc.Html" />
+        <add namespace="System.Web.Optimization"/>
+        <add namespace="System.Web.Routing" />
+        <add namespace="Samples.AspNetMvc4" />
+      </namespaces>
+    </pages>
+  </system.web.webPages.razor>
+
+  <appSettings>
+    <add key="webpages:Enabled" value="false" />
+  </appSettings>
+
+  <system.webServer>
+    <handlers>
+      <remove name="BlockViewHandler"/>
+      <add name="BlockViewHandler" path="*" verb="*" preCondition="integratedMode" type="System.Web.HttpNotFoundHandler" />
+    </handlers>
+  </system.webServer>
+
+  <system.web>
+    <compilation>
+      <assemblies>
+        <add assembly="System.Web.Mvc, Version=4.0.0.1, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
+      </assemblies>
+    </compilation>
+  </system.web>
+</configuration>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Controllers/HomeController.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Controllers/HomeController.cs
@@ -49,5 +49,11 @@ namespace Samples.AspNetMvc4.Controllers
         {
             throw new Exception("Oops, it broke.");
         }
+
+        public ActionResult Identifier(int id)
+        {
+            ViewBag.Message = "Identifier set to " + id;
+            return View("About");
+        }
     }
 }

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Samples.AspNetMvc4.csproj
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Samples.AspNetMvc4.csproj
@@ -120,6 +120,8 @@
     <Compile Include="App_Start\BundleConfig.cs" />
     <Compile Include="App_Start\FilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Areas\Admin\AdminAreaRegistration.cs" />
+    <Compile Include="Areas\Admin\Controllers\HomeController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
@@ -146,6 +148,10 @@
     <Content Include="Content\bootstrap.css.map" />
     <Content Include="Content\bootstrap-theme.min.css.map" />
     <Content Include="Content\bootstrap-theme.css.map" />
+    <Content Include="Areas\Admin\Views\Home\Index.cshtml" />
+    <Content Include="Areas\Admin\Views\Web.config">
+      <SubType>Designer</SubType>
+    </Content>
     <None Include="Scripts\jquery-3.3.1.intellisense.js" />
     <Content Include="Scripts\bootstrap.js" />
     <Content Include="Scripts\bootstrap.min.js" />

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Views/Shared/_Layout.cshtml
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Views/Shared/_Layout.cshtml
@@ -24,6 +24,7 @@
                     <li>@Html.ActionLink("About", "About", "Home")</li>
                     <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
                     <li>@Html.ActionLink("Bad Request", "BadRequest", "Home")</li>
+                    <li>@Html.ActionLink("Admin Area", "Index", "Home", new { Area = "Admin" }, new { })</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Attempts to parse Area from the route values and adds as a tag on the MVC span in ASP.NET integration

Expand integration tests to confirm tags are added correctly

@DataDog/apm-dotnet