### PR TITLE
RabbitMQ CallTarget Integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1190,6 +1190,35 @@
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueBindIntegration",
           "action": "CallTargetModification"
         }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Framing.Impl.Model",
+          "method": "_Private_QueueDeclare",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueDeclareIntegration",
+          "action": "CallTargetModification"
+        }
       }
     ]
   },

--- a/integrations.json
+++ b/integrations.json
@@ -1169,6 +1169,36 @@
         "caller": {},
         "target": {
           "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Framing.Impl.Model",
+          "method": "_Private_ExchangeDeclare",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.String",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.ExchangeDeclareIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
           "type": "RabbitMQ.Client.Impl.ModelBase",
           "method": "QueueBind",
           "signature_types": [

--- a/integrations.json
+++ b/integrations.json
@@ -1170,6 +1170,33 @@
         "target": {
           "assembly": "RabbitMQ.Client",
           "type": "RabbitMQ.Client.Framing.Impl.Model",
+          "method": "_Private_BasicPublish",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.String",
+            "System.Boolean",
+            "RabbitMQ.Client.IBasicProperties",
+            "_"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicPublishIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Framing.Impl.Model",
           "method": "_Private_ExchangeDeclare",
           "signature_types": [
             "System.Void",

--- a/integrations.json
+++ b/integrations.json
@@ -399,6 +399,30 @@
       {
         "caller": {},
         "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Impl.ModelBase",
+          "method": "BasicGet",
+          "signature_types": [
+            "RabbitMQ.Client.BasicGetResult",
+            "System.String",
+            "System.Boolean"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicGetIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
           "assembly": "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter",
           "type": "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner",
           "method": "RunCleanup",

--- a/integrations.json
+++ b/integrations.json
@@ -1163,6 +1163,37 @@
     ]
   },
   {
+    "name": "RabbitMQ",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Impl.ModelBase",
+          "method": "QueueBind",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.String",
+            "System.String",
+            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueBindIntegration",
+          "action": "CallTargetModification"
+        }
+      }
+    ]
+  },
+  {
     "name": "OracleCommand",
     "method_replacements": [
       {

--- a/integrations.json
+++ b/integrations.json
@@ -399,30 +399,6 @@
       {
         "caller": {},
         "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Impl.ModelBase",
-          "method": "BasicGet",
-          "signature_types": [
-            "RabbitMQ.Client.BasicGetResult",
-            "System.String",
-            "System.Boolean"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicGetIntegration",
-          "action": "CallTargetModification"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
           "assembly": "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter",
           "type": "Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter.Execution.UnitTestRunner",
           "method": "RunCleanup",
@@ -1213,8 +1189,32 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicDeliverIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Impl.ModelBase",
+          "method": "BasicGet",
+          "signature_types": [
+            "RabbitMQ.Client.BasicGetResult",
+            "System.String",
+            "System.Boolean"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicGetIntegration",
           "action": "CallTargetModification"
         }
       },
@@ -1240,7 +1240,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicPublishIntegration",
           "action": "CallTargetModification"
         }
@@ -1270,7 +1270,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.ExchangeDeclareIntegration",
           "action": "CallTargetModification"
         }
@@ -1296,7 +1296,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueBindIntegration",
           "action": "CallTargetModification"
         }
@@ -1325,7 +1325,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueDeclareIntegration",
           "action": "CallTargetModification"
         }

--- a/integrations.json
+++ b/integrations.json
@@ -1169,6 +1169,35 @@
         "caller": {},
         "target": {
           "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Events.EventingBasicConsumer",
+          "method": "HandleBasicDeliver",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.UInt64",
+            "System.Boolean",
+            "System.String",
+            "System.String",
+            "RabbitMQ.Client.IBasicProperties",
+            "_"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.22.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicDeliverIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
           "type": "RabbitMQ.Client.Framing.Impl.Model",
           "method": "_Private_BasicPublish",
           "signature_types": [

--- a/integrations.json
+++ b/integrations.json
@@ -1163,176 +1163,6 @@
     ]
   },
   {
-    "name": "RabbitMQ",
-    "method_replacements": [
-      {
-        "caller": {},
-        "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Events.EventingBasicConsumer",
-          "method": "HandleBasicDeliver",
-          "signature_types": [
-            "System.Void",
-            "System.String",
-            "System.UInt64",
-            "System.Boolean",
-            "System.String",
-            "System.String",
-            "RabbitMQ.Client.IBasicProperties",
-            "_"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicDeliverIntegration",
-          "action": "CallTargetModification"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Impl.ModelBase",
-          "method": "BasicGet",
-          "signature_types": [
-            "RabbitMQ.Client.BasicGetResult",
-            "System.String",
-            "System.Boolean"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicGetIntegration",
-          "action": "CallTargetModification"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Framing.Impl.Model",
-          "method": "_Private_BasicPublish",
-          "signature_types": [
-            "System.Void",
-            "System.String",
-            "System.String",
-            "System.Boolean",
-            "RabbitMQ.Client.IBasicProperties",
-            "_"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicPublishIntegration",
-          "action": "CallTargetModification"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Framing.Impl.Model",
-          "method": "_Private_ExchangeDeclare",
-          "signature_types": [
-            "System.Void",
-            "System.String",
-            "System.String",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.ExchangeDeclareIntegration",
-          "action": "CallTargetModification"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Impl.ModelBase",
-          "method": "QueueBind",
-          "signature_types": [
-            "System.Void",
-            "System.String",
-            "System.String",
-            "System.String",
-            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueBindIntegration",
-          "action": "CallTargetModification"
-        }
-      },
-      {
-        "caller": {},
-        "target": {
-          "assembly": "RabbitMQ.Client",
-          "type": "RabbitMQ.Client.Framing.Impl.Model",
-          "method": "_Private_QueueDeclare",
-          "signature_types": [
-            "System.Void",
-            "System.String",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Boolean",
-            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
-          ],
-          "minimum_major": 3,
-          "minimum_minor": 6,
-          "minimum_patch": 9,
-          "maximum_major": 6,
-          "maximum_minor": 65535,
-          "maximum_patch": 65535
-        },
-        "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueDeclareIntegration",
-          "action": "CallTargetModification"
-        }
-      }
-    ]
-  },
-  {
     "name": "OracleCommand",
     "method_replacements": [
       {
@@ -1668,6 +1498,176 @@
         "wrapper": {
           "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteScalarIntegration",
+          "action": "CallTargetModification"
+        }
+      }
+    ]
+  },
+  {
+    "name": "RabbitMQ",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Events.EventingBasicConsumer",
+          "method": "HandleBasicDeliver",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.UInt64",
+            "System.Boolean",
+            "System.String",
+            "System.String",
+            "RabbitMQ.Client.IBasicProperties",
+            "_"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicDeliverIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Impl.ModelBase",
+          "method": "BasicGet",
+          "signature_types": [
+            "RabbitMQ.Client.BasicGetResult",
+            "System.String",
+            "System.Boolean"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicGetIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Framing.Impl.Model",
+          "method": "_Private_BasicPublish",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.String",
+            "System.Boolean",
+            "RabbitMQ.Client.IBasicProperties",
+            "_"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.BasicPublishIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Framing.Impl.Model",
+          "method": "_Private_ExchangeDeclare",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.String",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.ExchangeDeclareIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Impl.ModelBase",
+          "method": "QueueBind",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.String",
+            "System.String",
+            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueBindIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "RabbitMQ.Client",
+          "type": "RabbitMQ.Client.Framing.Impl.Model",
+          "method": "_Private_QueueDeclare",
+          "signature_types": [
+            "System.Void",
+            "System.String",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Boolean",
+            "System.Collections.Generic.IDictionary`2[System.String,System.Object]"
+          ],
+          "minimum_major": 3,
+          "minimum_minor": 6,
+          "minimum_patch": 9,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ.QueueDeclareIntegration",
           "action": "CallTargetModification"
         }
       }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -9,11 +9,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     /// RabbitMQ.Client BasicDeliver calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        Assembly = "RabbitMQ.Client",
-        Type = "RabbitMQ.Client.Events.EventingBasicConsumer",
-        Method = "HandleBasicDeliver",
+        AssemblyName = "RabbitMQ.Client",
+        TypeName = "RabbitMQ.Client.Events.EventingBasicConsumer",
+        MethodName = "HandleBasicDeliver",
         ReturnTypeName = ClrNames.Void,
-        ParametersTypesNames = new[] { ClrNames.String, ClrNames.UInt64, ClrNames.Bool, ClrNames.String, ClrNames.String, RabbitMQConstants.IBasicPropertiesTypeName, ClrNames.Ignore },
+        ParameterTypeNames = new[] { ClrNames.String, ClrNames.UInt64, ClrNames.Bool, ClrNames.String, ClrNames.String, RabbitMQConstants.IBasicPropertiesTypeName, ClrNames.Ignore },
         MinimumVersion = "3.6.9",
         MaximumVersion = "6.*.*",
         IntegrationName = RabbitMQConstants.IntegrationName)]

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// RabbitMQ.Client BasicDeliver calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Events.EventingBasicConsumer",
+        Method = "HandleBasicDeliver",
+        ReturnTypeName = ClrNames.Void,
+        ParametersTypesNames = new[] { ClrNames.String, ClrNames.UInt64, ClrNames.Bool, ClrNames.String, ClrNames.String, RabbitMQConstants.IBasicPropertiesTypeName, ClrNames.Ignore },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        IntegrationName = RabbitMQConstants.IntegrationName)]
+    public class BasicDeliverIntegration
+    {
+        private const string Command = "basic.deliver";
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicPublishIntegration));
+
+        private static Func<IDictionary<string, object>, string, IEnumerable<string>> headersGetter = ((carrier, key) =>
+        {
+            if (carrier.TryGetValue(key, out object value) && value is byte[] bytes)
+            {
+                return new[] { Encoding.UTF8.GetString(bytes) };
+            }
+            else
+            {
+                return Enumerable.Empty<string>();
+            }
+        });
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TBasicProperties">Type of the message properties</typeparam>
+        /// <typeparam name="TBody">Type of the message body</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="consumerTag">The original consumerTag argument</param>
+        /// <param name="deliveryTag">The original deliveryTag argument</param>
+        /// <param name="redelivered">The original redelivered argument</param>
+        /// <param name="exchange">Name of the exchange.</param>
+        /// <param name="routingKey">The routing key.</param>
+        /// <param name="basicProperties">The message properties.</param>
+        /// <param name="body">The message body.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, TBasicProperties basicProperties, TBody body)
+            where TBasicProperties : IBasicProperties
+            where TBody : IBody // ReadOnlyMemory<byte> body in 6.0.0
+        {
+            SpanContext propagatedContext = null;
+
+            // try to extract propagated context values from headers
+            if (basicProperties?.Headers != null)
+            {
+                try
+                {
+                    propagatedContext = SpanContextPropagator.Instance.Extract(basicProperties.Headers, headersGetter);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error extracting propagated headers.");
+                }
+            }
+
+            var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey);
+            if (tags != null)
+            {
+                tags.MessageSize = body?.Length.ToString() ?? "0";
+            }
+
+            return new CallTargetState(scope);
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -1,10 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -27,18 +27,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         private const string Command = "basic.deliver";
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicPublishIntegration));
 
-        private static Func<IDictionary<string, object>, string, IEnumerable<string>> headersGetter = ((carrier, key) =>
-        {
-            if (carrier.TryGetValue(key, out object value) && value is byte[] bytes)
-            {
-                return new[] { Encoding.UTF8.GetString(bytes) };
-            }
-            else
-            {
-                return Enumerable.Empty<string>();
-            }
-        });
-
         /// <summary>
         /// OnMethodBegin callback
         /// </summary>
@@ -65,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             {
                 try
                 {
-                    propagatedContext = SpanContextPropagator.Instance.Extract(basicProperties.Headers, headersGetter);
+                    propagatedContext = SpanContextPropagator.Instance.Extract(basicProperties.Headers, ContextPropagation.HeadersGetter);
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -1,5 +1,6 @@
 using System;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 
@@ -56,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey);
+            var scope = RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey);
             if (tags != null)
             {
                 tags.MessageSize = body?.Length.ToString() ?? "0";

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     public class BasicDeliverIntegration
     {
         private const string Command = "basic.deliver";
-        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicPublishIntegration));
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(BasicDeliverIntegration));
 
         /// <summary>
         /// OnMethodBegin callback

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            var scope = RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey);
+            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey);
             if (tags != null)
             {
                 tags.MessageSize = body?.Length.ToString() ?? "0";

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -1,10 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -29,18 +29,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicGetIntegration));
 
-        private static Func<IDictionary<string, object>, string, IEnumerable<string>> headersGetter = ((carrier, key) =>
-        {
-            if (carrier.TryGetValue(key, out object value) && value is byte[] bytes)
-            {
-                return new[] { Encoding.UTF8.GetString(bytes) };
-            }
-            else
-            {
-                return Enumerable.Empty<string>();
-            }
-        });
-
         /// <summary>
         /// OnMethodBegin callback
         /// </summary>
@@ -83,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 {
                     try
                     {
-                        propagatedContext = SpanContextPropagator.Instance.Extract(basicPropertiesHeaders, headersGetter);
+                        propagatedContext = SpanContextPropagator.Instance.Extract(basicPropertiesHeaders, ContextPropagation.HeadersGetter);
                     }
                     catch (Exception ex)
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -10,11 +10,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     /// RabbitMQ.Client BasicGet calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        Assembly = "RabbitMQ.Client",
-        Type = "RabbitMQ.Client.Impl.ModelBase",
-        Method = "BasicGet",
+        AssemblyName = "RabbitMQ.Client",
+        TypeName = "RabbitMQ.Client.Impl.ModelBase",
+        MethodName = "BasicGet",
         ReturnTypeName = "RabbitMQ.Client.BasicGetResult",
-        ParametersTypesNames = new[] { ClrNames.String, ClrNames.Bool },
+        ParameterTypeNames = new[] { ClrNames.String, ClrNames.Bool },
         MinimumVersion = "3.6.9",
         MaximumVersion = "6.*.*",
         IntegrationName = RabbitMQConstants.IntegrationName)]

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -101,17 +101,5 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
             return new CallTargetReturn<TResult>(basicGetResult);
         }
-
-        private readonly struct IntegrationState
-        {
-            public readonly Scope Scope;
-            public readonly RabbitMQTags Tags;
-
-            public IntegrationState(Scope scope, RabbitMQTags tags)
-            {
-                Scope = scope;
-                Tags = tags;
-            }
-        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     {
         private const string Command = "basic.get";
 
-        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicGetIntegration));
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(BasicGetIntegration));
 
         /// <summary>
         /// OnMethodBegin callback

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -1,5 +1,6 @@
 using System;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
@@ -75,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
+            using (var scope = RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
             {
                 if (scope != null)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            using (var scope = RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
+            using (var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
             {
                 if (scope != null)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string exchange, string routingKey, bool mandatory, TBasicProperties basicProperties, TBody body)
             where TBasicProperties : IBasicProperties, IDuckType
-            where TBody : IBody // byte[] body for versions < 6.0.0 // ReadOnlyMemory<byte> body for versions >= 6.0.0
+            where TBody : IBody // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
         {
             var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -11,11 +11,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     /// RabbitMQ.Client BasicPublish calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        Assembly = "RabbitMQ.Client",
-        Type = "RabbitMQ.Client.Framing.Impl.Model",
-        Method = "_Private_BasicPublish",
+        AssemblyName = "RabbitMQ.Client",
+        TypeName = "RabbitMQ.Client.Framing.Impl.Model",
+        MethodName = "_Private_BasicPublish",
         ReturnTypeName = ClrNames.Void,
-        ParametersTypesNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, RabbitMQConstants.IBasicPropertiesTypeName, ClrNames.Ignore },
+        ParameterTypeNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, RabbitMQConstants.IBasicPropertiesTypeName, ClrNames.Ignore },
         MinimumVersion = "3.6.9",
         MaximumVersion = "6.*.*",
         IntegrationName = RabbitMQConstants.IntegrationName)]

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string exchange, string routingKey, bool mandatory, TBasicProperties basicProperties, TBody body)
             where TBasicProperties : IBasicProperties, IDuckType
-            where TBody : IBody // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
+            where TBody : IBody, IDuckType // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
         {
             var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
 
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
                 if (tags != null)
                 {
-                    tags.MessageSize = body?.Length.ToString() ?? "0";
+                    tags.MessageSize = body.Instance != null ? body.Length.ToString() : "0";
                 }
 
                 if (basicProperties.Instance != null)

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -29,11 +29,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
         private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicPublishIntegration));
 
-        private static Action<IDictionary<string, object>, string, string> headersSetter = ((carrier, key, value) =>
-        {
-            carrier[key] = Encoding.UTF8.GetBytes(value);
-        });
-
         /// <summary>
         /// OnMethodBegin callback
         /// </summary>
@@ -77,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                         basicProperties.Headers = new Dictionary<string, object>();
                     }
 
-                    SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, headersSetter);
+                    SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, ContextPropagation.HeadersSetter);
                 }
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// RabbitMQ.Client BasicPublish calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Framing.Impl.Model",
+        Method = "_Private_BasicPublish",
+        ReturnTypeName = ClrNames.Void,
+        ParametersTypesNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, RabbitMQConstants.IBasicPropertiesTypeName, ClrNames.Ignore },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        IntegrationName = RabbitMQConstants.IntegrationName)]
+    public class BasicPublishIntegration
+    {
+        private const string Command = "basic.publish";
+
+        private static readonly string[] DeliveryModeStrings = { null, "1", "2" };
+
+        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicPublishIntegration));
+
+        private static Action<IDictionary<string, object>, string, string> headersSetter = ((carrier, key, value) =>
+        {
+            carrier[key] = Encoding.UTF8.GetBytes(value);
+        });
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TBasicProperties">Type of the message properties</typeparam>
+        /// <typeparam name="TBody">Type of the message body</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exchange">Name of the exchange.</param>
+        /// <param name="routingKey">The routing key.</param>
+        /// <param name="mandatory">The mandatory routing flag.</param>
+        /// <param name="basicProperties">The message properties.</param>
+        /// <param name="body">The message body.</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string exchange, string routingKey, bool mandatory, TBasicProperties basicProperties, TBody body)
+            where TBasicProperties : IBasicProperties, IDuckType
+            where TBody : IBody // byte[] body for versions < 6.0.0 // ReadOnlyMemory<byte> body for versions >= 6.0.0
+        {
+            var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
+
+            if (scope != null)
+            {
+                string exchangeDisplayName = string.IsNullOrEmpty(exchange) ? "<default>" : exchange;
+                string routingKeyDisplayName = string.IsNullOrEmpty(routingKey) ? "<all>" : routingKey.StartsWith("amq.gen-") ? "<generated>" : routingKey;
+                scope.Span.ResourceName = $"{Command} {exchangeDisplayName} -> {routingKeyDisplayName}";
+
+                if (tags != null)
+                {
+                    tags.MessageSize = body?.Length.ToString() ?? "0";
+                }
+
+                if (basicProperties != null)
+                {
+                    if (tags != null && basicProperties.IsDeliveryModePresent())
+                    {
+                        tags.DeliveryMode = DeliveryModeStrings[0x3 & basicProperties.DeliveryMode];
+                    }
+
+                    // add distributed tracing headers to the message
+                    if (basicProperties.Headers == null)
+                    {
+                        basicProperties.Headers = new Dictionary<string, object>();
+                    }
+
+                    SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, headersSetter);
+                }
+            }
+
+            return new CallTargetState(scope);
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using Datadog.Trace.ClrProfiler.CallTarget;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     tags.MessageSize = body?.Length.ToString() ?? "0";
                 }
 
-                if (basicProperties != null)
+                if (basicProperties.Instance != null)
                 {
                     if (tags != null && basicProperties.IsDeliveryModePresent())
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -25,8 +25,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
         private static readonly string[] DeliveryModeStrings = { null, "1", "2" };
 
-        private static readonly Vendors.Serilog.ILogger Log = DatadogLogging.GetLogger(typeof(BasicPublishIntegration));
-
         /// <summary>
         /// OnMethodBegin callback
         /// </summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             where TBasicProperties : IBasicProperties, IDuckType
             where TBody : IBody, IDuckType // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
         {
-            var scope = RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
+            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
 
             if (scope != null)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
@@ -42,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             where TBasicProperties : IBasicProperties, IDuckType
             where TBody : IBody, IDuckType // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
         {
-            var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
+            var scope = RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey);
 
             if (scope != null)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ContextPropagation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ContextPropagation.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ContextPropagation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ContextPropagation.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    internal static class ContextPropagation
+    {
+#pragma warning disable SA1401 // Fields must be private
+        public static Action<IDictionary<string, object>, string, string> HeadersSetter = (carrier, key, value) =>
+        {
+            carrier[key] = Encoding.UTF8.GetBytes(value);
+        };
+
+        public static Func<IDictionary<string, object>, string, IEnumerable<string>> HeadersGetter = ((carrier, key) =>
+        {
+            if (carrier.TryGetValue(key, out object value) && value is byte[] bytes)
+            {
+                return new[] { Encoding.UTF8.GetString(bytes) };
+            }
+            else
+            {
+                return Enumerable.Empty<string>();
+            }
+        });
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// RabbitMQ.Client ExchangeDeclare calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Framing.Impl.Model",
+        Method = "_Private_ExchangeDeclare",
+        ReturnTypeName = ClrNames.Void,
+        ParametersTypesNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, RabbitMQConstants.IDictionaryArgumentsTypeName },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        IntegrationName = RabbitMQConstants.IntegrationName)]
+    public class ExchangeDeclareIntegration
+    {
+        private const string Command = "exchange.declare";
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exchange">Name of the exchange.</param>
+        /// <param name="type">Type of the exchange.</param>
+        /// <param name="passive">The original passive setting</param>
+        /// <param name="durable">The original duable setting</param>
+        /// <param name="autoDelete">The original autoDelete setting</param>
+        /// <param name="internal">The original internal setting</param>
+        /// <param name="nowait">The original nowait setting</param>
+        /// <param name="arguments">The original arguments setting</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
+        {
+            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, exchange: exchange));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -8,11 +8,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     /// RabbitMQ.Client ExchangeDeclare calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        Assembly = "RabbitMQ.Client",
-        Type = "RabbitMQ.Client.Framing.Impl.Model",
-        Method = "_Private_ExchangeDeclare",
+        AssemblyName = "RabbitMQ.Client",
+        TypeName = "RabbitMQ.Client.Framing.Impl.Model",
+        MethodName = "_Private_ExchangeDeclare",
         ReturnTypeName = ClrNames.Void,
-        ParametersTypesNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, RabbitMQConstants.IDictionaryArgumentsTypeName },
+        ParameterTypeNames = new[] { ClrNames.String, ClrNames.String, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, RabbitMQConstants.IDictionaryArgumentsTypeName },
         MinimumVersion = "3.6.9",
         MaximumVersion = "6.*.*",
         IntegrationName = RabbitMQConstants.IntegrationName)]

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.Integrations;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
@@ -36,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange));
+            return new CallTargetState(RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="exchange">Name of the exchange.</param>
         /// <param name="type">Type of the exchange.</param>
         /// <param name="passive">The original passive setting</param>
-        /// <param name="durable">The original duable setting</param>
+        /// <param name="durable">The original durable setting</param>
         /// <param name="autoDelete">The original autoDelete setting</param>
         /// <param name="internal">The original internal setting</param>
         /// <param name="nowait">The original nowait setting</param>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, exchange: exchange));
+            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicGetResult.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicGetResult.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// BasicGetResult interface for ducktyping
+    /// </summary>
+    public interface IBasicGetResult
+    {
+        /// <summary>
+        /// Gets the message body of the result
+        /// </summary>
+        IBody Body { get; }
+
+        /// <summary>
+        /// Gets the message properties
+        /// </summary>
+        IBasicProperties BasicProperties { get; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicGetResult.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicGetResult.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
     /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// BasicProperties interface for ducktyping
+    /// </summary>
+    public interface IBasicProperties
+    {
+        /// <summary>
+        /// Gets or sets the headers of the message
+        /// </summary>
+        /// <returns>Message headers</returns>
+        IDictionary<string, object> Headers { get; set; }
+
+        /// <summary>
+        /// Gets the delivery mode of the message
+        /// </summary>
+        byte DeliveryMode { get; }
+
+        /// <summary>
+        /// Returns true if the DeliveryMode property is present
+        /// </summary>
+        /// <returns>true if the DeliveryMode property is present</returns>
+        bool IsDeliveryModePresent();
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBody.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBody.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// Body interface for ducktyping
+    /// </summary>
+    public interface IBody
+    {
+        /// <summary>
+        /// Gets the length of the message body
+        /// </summary>
+        int Length { get; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBody.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/IBody.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
     /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// RabbitMQ.Client QueueBind calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Impl.ModelBase",
+        Method = "QueueBind",
+        ReturnTypeName = ClrNames.Void,
+        ParametersTypesNames = new[] { ClrNames.String, ClrNames.String, ClrNames.String, RabbitMQConstants.IDictionaryArgumentsTypeName },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        IntegrationName = RabbitMQConstants.IntegrationName)]
+    public class QueueBindIntegration
+    {
+        private const string Command = "queue.bind";
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="queue">Name of the queue.</param>
+        /// <param name="exchange">The original exchange argument.</param>
+        /// <param name="routingKey">The original routingKey argument.</param>
+        /// <param name="arguments">The original arguments setting</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        {
+            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, queue: queue, exchange: exchange, routingKey: routingKey));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -8,11 +8,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     /// RabbitMQ.Client QueueBind calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        Assembly = "RabbitMQ.Client",
-        Type = "RabbitMQ.Client.Impl.ModelBase",
-        Method = "QueueBind",
+        AssemblyName = "RabbitMQ.Client",
+        TypeName = "RabbitMQ.Client.Impl.ModelBase",
+        MethodName = "QueueBind",
         ReturnTypeName = ClrNames.Void,
-        ParametersTypesNames = new[] { ClrNames.String, ClrNames.String, ClrNames.String, RabbitMQConstants.IDictionaryArgumentsTypeName },
+        ParameterTypeNames = new[] { ClrNames.String, ClrNames.String, ClrNames.String, RabbitMQConstants.IDictionaryArgumentsTypeName },
         MinimumVersion = "3.6.9",
         MaximumVersion = "6.*.*",
         IntegrationName = RabbitMQConstants.IntegrationName)]

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.Integrations;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey));
+            return new CallTargetState(RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, queue: queue, exchange: exchange, routingKey: routingKey));
+            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    /// <summary>
+    /// RabbitMQ.Client QueueDeclare calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        Assembly = "RabbitMQ.Client",
+        Type = "RabbitMQ.Client.Framing.Impl.Model",
+        Method = "_Private_QueueDeclare",
+        ReturnTypeName = ClrNames.Void,
+        ParametersTypesNames = new[] { ClrNames.String, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, RabbitMQConstants.IDictionaryArgumentsTypeName },
+        MinimumVersion = "3.6.9",
+        MaximumVersion = "6.*.*",
+        IntegrationName = RabbitMQConstants.IntegrationName)]
+    public class QueueDeclareIntegration
+    {
+        private const string Command = "queue.declare";
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="queue">Name of the queue.</param>
+        /// <param name="passive">The original passive setting</param>
+        /// <param name="durable">The original duable setting</param>
+        /// <param name="exclusive">The original exclusive settings</param>
+        /// <param name="autoDelete">The original autoDelete setting</param>
+        /// <param name="nowait">The original nowait setting</param>
+        /// <param name="arguments">The original arguments setting</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
+        {
+            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, queue: queue));
+        }
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            state.Scope.DisposeWithException(exception);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -8,11 +8,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     /// RabbitMQ.Client QueueDeclare calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        Assembly = "RabbitMQ.Client",
-        Type = "RabbitMQ.Client.Framing.Impl.Model",
-        Method = "_Private_QueueDeclare",
+        AssemblyName = "RabbitMQ.Client",
+        TypeName = "RabbitMQ.Client.Framing.Impl.Model",
+        MethodName = "_Private_QueueDeclare",
         ReturnTypeName = ClrNames.Void,
-        ParametersTypesNames = new[] { ClrNames.String, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, RabbitMQConstants.IDictionaryArgumentsTypeName },
+        ParameterTypeNames = new[] { ClrNames.String, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, ClrNames.Bool, RabbitMQConstants.IDictionaryArgumentsTypeName },
         MinimumVersion = "3.6.9",
         MaximumVersion = "6.*.*",
         IntegrationName = RabbitMQConstants.IntegrationName)]

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ClrProfiler.Integrations;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue));
+            return new CallTargetState(RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(RabbitMQIntegration.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
         {
-            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, queue: queue));
+            return new CallTargetState(ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
         /// <param name="queue">Name of the queue.</param>
         /// <param name="passive">The original passive setting</param>
-        /// <param name="durable">The original duable setting</param>
+        /// <param name="durable">The original durable setting</param>
         /// <param name="exclusive">The original exclusive settings</param>
         /// <param name="autoDelete">The original autoDelete setting</param>
         /// <param name="nowait">The original nowait setting</param>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/RabbitMQConstants.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/RabbitMQ/RabbitMQConstants.cs
@@ -1,0 +1,14 @@
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    internal static class RabbitMQConstants
+    {
+        internal const string IntegrationName = nameof(IntegrationIds.RabbitMQ);
+        internal const string IBasicPropertiesTypeName = "RabbitMQ.Client.IBasicProperties";
+        internal const string IDictionaryArgumentsTypeName = "System.Collections.Generic.IDictionary`2[System.String,System.Object]";
+        internal const string OperationName = "amqp.command";
+        internal const string ServiceName = "rabbitmq";
+        internal static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Datadog.Trace.ClrProfiler.CallTarget
@@ -10,6 +11,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         private readonly Scope _previousScope;
         private readonly Scope _scope;
         private readonly object _state;
+        private readonly DateTimeOffset? _startTime;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
@@ -20,6 +22,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _previousScope = null;
             _scope = scope;
             _state = null;
+            _startTime = null;
         }
 
         /// <summary>
@@ -32,6 +35,21 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _previousScope = null;
             _scope = scope;
             _state = state;
+            _startTime = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
+        /// </summary>
+        /// <param name="scope">Scope instance</param>
+        /// <param name="state">Object state instance</param>
+        /// <param name="startTime">The intended start time of the scope, intended for scopes created in the OnMethodEnd handler</param>
+        public CallTargetState(Scope scope, object state, DateTimeOffset? startTime)
+        {
+            _previousScope = null;
+            _scope = scope;
+            _state = state;
+            _startTime = startTime;
         }
 
         private CallTargetState(Scope previousScope, Scope scope, object state)
@@ -39,6 +57,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _previousScope = previousScope;
             _scope = scope;
             _state = state;
+            _startTime = null;
         }
 
         /// <summary>
@@ -52,6 +71,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         public object State => _state;
 
         internal Scope PreviousScope => _previousScope;
+
+        internal DateTimeOffset? StartTime => _startTime;
 
         /// <summary>
         /// Gets the default call target state (used by the native side to initialize the locals)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -132,7 +132,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                using (var scope = CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
+                using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
                     if (tags != null)
                     {
@@ -236,7 +236,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                using (var scope = CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
+                using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
                     if (tags != null && body != null && body.TryDuckCast<BodyStruct>(out var bodyStruct))
                     {
@@ -355,7 +355,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                using (var scope = CreateRabbitMQScope(Tracer.Instance, out tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
+                using (var scope = CreateScope(Tracer.Instance, out tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
                 {
                     if (scope != null)
                     {
@@ -438,7 +438,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
+            using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
             {
                 if (scope != null)
                 {
@@ -540,7 +540,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
+            using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
             {
                 if (scope != null)
                 {
@@ -655,7 +655,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateRabbitMQScope(Tracer.Instance, out _, command, SpanKinds.Client, exchange: exchange))
+            using (var scope = CreateScope(Tracer.Instance, out _, command, SpanKinds.Client, exchange: exchange))
             {
                 try
                 {
@@ -729,7 +729,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateRabbitMQScope(Tracer.Instance, out _, command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey))
+            using (var scope = CreateScope(Tracer.Instance, out _, command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey))
             {
                 try
                 {
@@ -807,7 +807,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateRabbitMQScope(Tracer.Instance, out _, command, SpanKinds.Client, queue: queue))
+            using (var scope = CreateScope(Tracer.Instance, out _, command, SpanKinds.Client, queue: queue))
             {
                 try
                 {
@@ -821,7 +821,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
         }
 
-        internal static Scope CreateRabbitMQScope(Tracer tracer, out RabbitMQTags tags, string command, string spanKind, ISpanContext parentContext = null, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
+        internal static Scope CreateScope(Tracer tracer, out RabbitMQTags tags, string command, string spanKind, ISpanContext parentContext = null, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
         {
             tags = null;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -132,7 +132,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
+                using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
                     if (tags != null)
                     {
@@ -236,7 +236,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
+                using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
                     if (tags != null && body != null && body.TryDuckCast<BodyStruct>(out var bodyStruct))
                     {
@@ -355,7 +355,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
-                using (var scope = CreateScope(Tracer.Instance, out tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
+                using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
                 {
                     if (scope != null)
                     {
@@ -438,7 +438,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
             {
                 if (scope != null)
                 {
@@ -540,7 +540,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out RabbitMQTags tags, command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey))
             {
                 if (scope != null)
                 {
@@ -655,7 +655,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(Tracer.Instance, out _, command, exchange: exchange))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, exchange: exchange))
             {
                 try
                 {
@@ -729,7 +729,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(Tracer.Instance, out _, command, queue: queue, exchange: exchange, routingKey: routingKey))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, queue: queue, exchange: exchange, routingKey: routingKey))
             {
                 try
                 {
@@ -807,7 +807,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = CreateScope(Tracer.Instance, out _, command, queue: queue))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, queue: queue))
             {
                 try
                 {
@@ -819,48 +819,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     throw;
                 }
             }
-        }
-
-        internal static Scope CreateScope(Tracer tracer, out RabbitMQTags tags, string command, ISpanContext parentContext = null, string spanKind = SpanKinds.Client, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
-        {
-            tags = null;
-
-            if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
-            {
-                // integration disabled, don't create a scope, skip this trace
-                return null;
-            }
-
-            Scope scope = null;
-
-            try
-            {
-                Span parent = tracer.ActiveScope?.Span;
-
-                tags = new RabbitMQTags(spanKind);
-                string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
-                scope = tracer.StartActiveWithTags(OperationName, parent: parentContext, tags: tags, serviceName: serviceName, startTime: startTime);
-                var span = scope.Span;
-
-                span.Type = SpanTypes.Queue;
-                span.ResourceName = command;
-                tags.Command = command;
-
-                tags.Queue = queue;
-                tags.Exchange = exchange;
-                tags.RoutingKey = routingKey;
-
-                tags.InstrumentationName = IntegrationName;
-                tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: false);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error creating or populating scope.");
-            }
-
-            // always returns the scope, even if it's null because we couldn't create it,
-            // or we couldn't populate it completely (some tags is better than no tags)
-            return scope;
         }
 
         /********************

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -655,7 +655,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, exchange: exchange))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, SpanKinds.Client, exchange: exchange))
             {
                 try
                 {
@@ -729,7 +729,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, queue: queue, exchange: exchange, routingKey: routingKey))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey))
             {
                 try
                 {
@@ -807,7 +807,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, queue: queue))
+            using (var scope = ScopeFactory.CreateRabbitMQScope(Tracer.Instance, out _, command, SpanKinds.Client, queue: queue))
             {
                 try
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Data;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
 using Datadog.Trace.ClrProfiler.Integrations.AdoNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
@@ -189,48 +188,6 @@ namespace Datadog.Trace.ClrProfiler
                 Log.Error(ex, "Error creating or populating scope.");
             }
 
-            return scope;
-        }
-
-        public static Scope CreateRabbitMQScope(Tracer tracer, out RabbitMQTags tags, string command, string spanKind, ISpanContext parentContext = null, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
-        {
-            tags = null;
-
-            if (!tracer.Settings.IsIntegrationEnabled(RabbitMQConstants.IntegrationId))
-            {
-                // integration disabled, don't create a scope, skip this trace
-                return null;
-            }
-
-            Scope scope = null;
-
-            try
-            {
-                Span parent = tracer.ActiveScope?.Span;
-
-                tags = new RabbitMQTags(spanKind);
-                string serviceName = tracer.Settings.GetServiceName(tracer, RabbitMQConstants.ServiceName);
-                scope = tracer.StartActiveWithTags(RabbitMQConstants.OperationName, parent: parentContext, tags: tags, serviceName: serviceName, startTime: startTime);
-                var span = scope.Span;
-
-                span.Type = SpanTypes.Queue;
-                span.ResourceName = command;
-                tags.Command = command;
-
-                tags.Queue = queue;
-                tags.Exchange = exchange;
-                tags.RoutingKey = routingKey;
-
-                tags.InstrumentationName = RabbitMQConstants.IntegrationName;
-                tags.SetAnalyticsSampleRate(RabbitMQConstants.IntegrationId, tracer.Settings, enabledWithGlobalSetting: false);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error creating or populating scope.");
-            }
-
-            // always returns the scope, even if it's null because we couldn't create it,
-            // or we couldn't populate it completely (some tags is better than no tags)
             return scope;
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.ClrProfiler
             return scope;
         }
 
-        public static Scope CreateRabbitMQScope(Tracer tracer, out RabbitMQTags tags, string command, ISpanContext parentContext = null, string spanKind = SpanKinds.Client, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
+        public static Scope CreateRabbitMQScope(Tracer tracer, out RabbitMQTags tags, string command, string spanKind, ISpanContext parentContext = null, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
         {
             tags = null;
 

--- a/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -23,6 +23,17 @@ namespace Samples.RabbitMQ
 
         public static void Main(string[] args)
         {
+            string prefix = "";
+            if (args.Length > 0)
+            {
+                prefix = args[0];
+            }
+
+            RunRabbitMQ(prefix);
+        }
+
+        private static void RunRabbitMQ(string prefix)
+        {
             PublishAndGet();
             PublishAndGetDefault();
 


### PR DESCRIPTION
This PR migrates the `RabbitMQ` integration to CallTarget instrumentation.

@DataDog/apm-dotnet