### PR TITLE
bump Service Fabric version to 1.23.0 to match Datadog.Trace

### DIFF
--- a/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
+++ b/src/Datadog.Trace.ServiceFabric/Datadog.Trace.ServiceFabric.csproj
@@ -9,7 +9,7 @@
     <PlatformTarget>x64</PlatformTarget>
 
     <!-- NuGet -->
-    <Version>1.20.0-alpha1</Version>
+    <Version>1.23.0-alpha1</Version>
     <Title>Datadog APM</Title>
     <Description>Service Remoting instrumentation for Datadog APM</Description>
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Datadog.Trace.ServiceFabric/Remoting.cs
+++ b/src/Datadog.Trace.ServiceFabric/Remoting.cs
@@ -18,8 +18,6 @@ namespace Datadog.Trace.ServiceFabric
 
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.ServiceRemoting));
 
-        // ILogger and DatadogLogging are internal to Datadog.Trade.dll, so we use NuGet package IgnoresAccessChecksToGenerator
-        // to generate [IgnoresAccessChecksToAttribute] and generate reference assemblies where they are public
         private static readonly Datadog.Trace.Logging.IDatadogLogger Log = Datadog.Trace.Logging.DatadogLogging.GetLoggerFor(typeof(Remoting));
 
         private static int _firstInitialization = 1;


### PR DESCRIPTION
- bump `Datadog.Trace.ServiceFabric` version to `1.23.0-alpha1` to match `Datadog.Trace`
- bonus: remove obsolete code comments