### PR TITLE
Properly drain stdout/stderr in integration tests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -96,7 +96,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
             {
-                var parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
+                var parameters = string.Empty;
+
+                if (testCase.TestMethodArguments != null)
+                {
+                    parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
+                }
+
                 var test = $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}({parameters})";
 
                 _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"Starting execution of {test}"));

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -95,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
             {
-                var parameters = string.Join(", ", testCase.TestMethodArguments);
+                var parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
                 var test = $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}({parameters})";
 
                 _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"Starting execution of {test}"));

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Datadog.Trace.ClrProfiler.IntegrationTests.CustomTestFramework", "Datadog.Trace.ClrProfiler.IntegrationTests")]
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class CustomTestFramework : XunitTestFramework
+    {
+        public CustomTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            return new CustomExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+        }
+
+        private class CustomExecutor : XunitTestFrameworkExecutor
+        {
+            public CustomExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+                : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+            {
+            }
+
+            protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+            {
+                using (var assemblyRunner = new CustomAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+                {
+                    await assemblyRunner.RunAsync();
+                }
+            }
+        }
+
+        private class CustomAssemblyRunner : XunitTestAssemblyRunner
+        {
+            public CustomAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+                : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+            {
+            }
+
+            protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
+            {
+                return new CustomTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource).RunAsync();
+            }
+        }
+
+        private class CustomTestCollectionRunner : XunitTestCollectionRunner
+        {
+            private readonly IMessageSink _diagnosticMessageSink;
+
+            public CustomTestCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+                : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+            {
+                _diagnosticMessageSink = diagnosticMessageSink;
+            }
+
+            protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+            {
+                return new CustomTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, CollectionFixtureMappings)
+                   .RunAsync();
+            }
+        }
+
+        private class CustomTestClassRunner : XunitTestClassRunner
+        {
+            public CustomTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings)
+                : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+            {
+            }
+
+            protected override async Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, object[] constructorArguments)
+            {
+                var test = $"{testMethod.TestClass.Class.Name}.{testMethod.Method.Name}";
+
+                DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Starting execution of {test}"));
+
+                try
+                {
+                    return await base.RunTestMethodAsync(testMethod, method, testCases, constructorArguments);
+                }
+                finally
+                {
+                    DiagnosticMessageSink.OnMessage(new DiagnosticMessage($"Finished execution of {test}"));
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ProcessHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/ProcessHelper.cs
@@ -30,7 +30,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public bool Drain(int timeout = Timeout.Infinite)
         {
-            return _outputMutex.Wait(timeout / 2) && _errorMutex.Wait(timeout / 2);
+            if (timeout != Timeout.Infinite)
+            {
+                timeout /= 2;
+            }
+
+            return _outputMutex.Wait(timeout) && _errorMutex.Wait(timeout);
         }
 
         public void Dispose()

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -78,15 +78,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             var process = StartSample(traceAgentPort, arguments, packageVersion, aspNetCorePort: 5000, statsdPort: statsdPort, framework: framework);
 
-            var standardOutput = process.StandardOutput.ReadToEnd();
-            var standardError = process.StandardError.ReadToEnd();
+            using var helper = new ProcessHelper(process);
+
             process.WaitForExit();
+            helper.Drain();
             var exitCode = process.ExitCode;
+
+            var standardOutput = helper.StandardOutput;
 
             if (!string.IsNullOrWhiteSpace(standardOutput))
             {
                 Output.WriteLine($"StandardOutput:{Environment.NewLine}{standardOutput}");
             }
+
+            var standardError = helper.ErrorOutput;
 
             if (!string.IsNullOrWhiteSpace(standardError))
             {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessHelper.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    /// <summary>
+    /// Drains the standard and error output of a process
+    /// </summary>
+    internal class ProcessHelper : IDisposable
+    {
+        private readonly ManualResetEventSlim _errorMutex = new();
+        private readonly ManualResetEventSlim _outputMutex = new();
+        private readonly StringBuilder _outputBuffer = new();
+        private readonly StringBuilder _errorBuffer = new();
+
+        public ProcessHelper(Process process)
+        {
+            process.OutputDataReceived += (_, e) => DrainOutput(e, _outputBuffer, _outputMutex);
+            process.ErrorDataReceived += (_, e) => DrainOutput(e, _errorBuffer, _errorMutex);
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+        }
+
+        public string StandardOutput => _outputBuffer.ToString();
+
+        public string ErrorOutput => _errorBuffer.ToString();
+
+        public bool Drain(int timeout = Timeout.Infinite)
+        {
+            return _outputMutex.Wait(timeout / 2) && _errorMutex.Wait(timeout / 2);
+        }
+
+        public void Dispose()
+        {
+            _errorMutex.Dispose();
+            _outputMutex.Dispose();
+        }
+
+        private static void DrainOutput(DataReceivedEventArgs e, StringBuilder buffer, ManualResetEventSlim mutex)
+        {
+            if (e.Data == null)
+            {
+                mutex.Set();
+            }
+            else
+            {
+                buffer.AppendLine(e.Data);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/xunit.runner.json
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/xunit.runner.json
@@ -1,3 +1,5 @@
 ﻿{
-  "shadowCopy": false
+  "shadowCopy": false,
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
 }


### PR DESCRIPTION
Previous code was using `.ReadToEnd()` to drain the output. It meant that stderr was only drained when stdout was closed (= when the process exited) which could lead to deadlock situations.