### PR TITLE
Fix some diagnostic warnings in tests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -194,7 +194,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        public class InliningOptions
+        public class InliningOptions : IXunitSerializable
         {
             internal InliningOptions(
                 bool enableCallTarget,
@@ -204,15 +204,27 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 EnableInlining = enableInlining;
             }
 
-            internal bool EnableCallTarget { get; }
+            internal bool EnableCallTarget { get; private set; }
 
-            internal bool EnableInlining { get; }
+            internal bool EnableInlining { get; private set; }
+
+            public void Deserialize(IXunitSerializationInfo info)
+            {
+                EnableCallTarget = info.GetValue<bool>(nameof(EnableCallTarget));
+                EnableInlining = info.GetValue<bool>(nameof(EnableInlining));
+            }
+
+            public void Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue(nameof(EnableCallTarget), EnableCallTarget);
+                info.AddValue(nameof(EnableInlining), EnableInlining);
+            }
 
             public override string ToString() =>
                 $"EnableCallTarget={EnableCallTarget},EnableInlining={EnableInlining}";
         }
 
-        public class InstrumentationOptions
+        public class InstrumentationOptions : IXunitSerializable
         {
             internal InstrumentationOptions(
                 bool? instrumentSocketHandler,
@@ -222,9 +234,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 InstrumentWinHttpHandler = instrumentWinHttpHandler;
             }
 
-            internal bool? InstrumentSocketHandler { get; }
+            internal bool? InstrumentSocketHandler { get; private set; }
 
-            internal bool? InstrumentWinHttpHandler { get; }
+            internal bool? InstrumentWinHttpHandler { get; private set; }
+
+            public void Deserialize(IXunitSerializationInfo info)
+            {
+                InstrumentSocketHandler = info.GetValue<bool?>(nameof(InstrumentSocketHandler));
+                InstrumentWinHttpHandler = info.GetValue<bool?>(nameof(InstrumentWinHttpHandler));
+            }
+
+            public void Serialize(IXunitSerializationInfo info)
+            {
+                info.AddValue(nameof(InstrumentSocketHandler), InstrumentSocketHandler);
+                info.AddValue(nameof(InstrumentWinHttpHandler), InstrumentWinHttpHandler);
+            }
 
             public override string ToString() =>
                 $"InstrumentSocketHandler={InstrumentSocketHandler},InstrumentWinHttpHandler={InstrumentWinHttpHandler}";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -5,7 +5,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    [CollectionDefinition(nameof(WebRequestTests), DisableParallelization = true)]
+    [Collection(nameof(WebRequestTests))]
     public class ServiceMappingTests : TestHelper
     {
         public ServiceMappingTests(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [CollectionDefinition(nameof(WebRequestTests), DisableParallelization = true)]
+    [Collection(nameof(WebRequestTests))]
     public class WebRequestTests : TestHelper
     {
         public WebRequestTests(ITestOutputHelper output)


### PR DESCRIPTION
Fixes some warnings found by @kevingosse  when enabling `diagnosticMessages` for xUnit.

@DataDog/apm-dotnet