### PR TITLE
Update README with current links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,8 +112,8 @@ docker-compose run IntegrationTests
 
 Datadog APM
 - [Datadog APM](https://docs.datadoghq.com/tracing/)
-- [Datadog APM - Tracing .NET Applications](https://docs.datadoghq.com/tracing/setup/dotnet/)
-- [Datadog APM - Advanced Usage](https://docs.datadoghq.com/tracing/advanced_usage/?tab=dotnet)
+- [Datadog APM - Tracing .NET Core Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core)
+- [Datadog APM - Tracing .NET Framework Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-framework)
 
 Microsoft .NET Profiling APIs
 - [Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@ docker-compose run IntegrationTests
 
 Datadog APM
 - [Datadog APM](https://docs.datadoghq.com/tracing/)
-- [Datadog APM - Tracing .NET Core Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core)
+- [Datadog APM - Tracing .NET Core and .NET 5 Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core)
 - [Datadog APM - Tracing .NET Framework Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-framework)
 
 Microsoft .NET Profiling APIs


### PR DESCRIPTION
Remove stale advanced usage link.
Separate core and netfx.

@DataDog/apm-dotnet