### PR TITLE
Fix RequestReJIT deadlock.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2842,16 +2842,13 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
            ", Signature=", caller.signature.str(),
            "]");
 
-      rejit_handler->EnqueueForRejit(module_id, methodDef);
-      
       enumIterator = ++enumIterator;
     }
   }
 
   // Request the ReJIT for all integrations found in the module.
   if (!vtMethodDefs.empty()) {
-    //Info("Requesting ReJIT for ", vtMethodDefs.size(), " methods.");
-    //this->info_->RequestReJIT((ULONG)vtMethodDefs.size(), vtModules.data(), vtMethodDefs.data());
+    this->rejit_handler->EnqueueForRejit(vtMethodDefs.size(), vtModules.data(), vtMethodDefs.data());
   }
 
   // We return the number of ReJIT requests

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2840,6 +2840,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
            ", Method=", caller.name, 
            ", Signature=", caller.signature.str(),
            "]");
+
+      rejit_handler->EnqueueForRejit(module_id, methodDef);
       
       enumIterator = ++enumIterator;
     }
@@ -2847,8 +2849,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
 
   // Request the ReJIT for all integrations found in the module.
   if (!vtMethodDefs.empty()) {
-    Info("Requesting ReJIT for ", vtMethodDefs.size(), " methods.");
-    this->info_->RequestReJIT((ULONG)vtMethodDefs.size(), vtModules.data(), vtMethodDefs.data());
+    //Info("Requesting ReJIT for ", vtMethodDefs.size(), " methods.");
+    //this->info_->RequestReJIT((ULONG)vtMethodDefs.size(), vtModules.data(), vtMethodDefs.data());
   }
 
   // We return the number of ReJIT requests

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -592,6 +592,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown() {
   // to prevent it from unloading while in use
   std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
+  rejit_handler->Shutdown();
   Warn("Exiting.");
   is_attached_.store(false);
   Logger::Shutdown();

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -592,7 +592,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown() {
   // to prevent it from unloading while in use
   std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
-  // rejit_handler->Shutdown();
+  if (rejit_handler != nullptr) {
+    rejit_handler->Shutdown();
+  }
   Warn("Exiting.");
   is_attached_.store(false);
   Logger::Shutdown();
@@ -2841,7 +2843,6 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
            ", Method=", caller.name, 
            ", Signature=", caller.signature.str(),
            "]");
-
       enumIterator = ++enumIterator;
     }
   }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -592,7 +592,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown() {
   // to prevent it from unloading while in use
   std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
-  rejit_handler->Shutdown();
+  // rejit_handler->Shutdown();
   Warn("Exiting.");
   is_attached_.store(false);
   Logger::Shutdown();

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -2,6 +2,30 @@
 
 namespace trace {
 
+RejitItem::RejitItem(int length, ModuleID* modulesId, mdMethodDef* methodDefs) {
+  length_ = length;
+  if (length > 0) {
+    ModuleID* myModulesIds = new ModuleID[length];
+    memcpy(myModulesIds, modulesId, length * sizeof(ModuleID));
+    moduleIds_ = myModulesIds;
+
+    mdMethodDef* myMethodDefs = new mdMethodDef[length];
+    memcpy(myMethodDefs, methodDefs, length * sizeof(mdMethodDef));
+    methodDefs_ = myMethodDefs;
+  }
+}
+
+void RejitItem::DeleteArray() {
+  if (moduleIds_ != nullptr) {
+    delete[] moduleIds_;
+    moduleIds_ = nullptr;
+  }
+  if (methodDefs_ != nullptr) {
+    delete[] methodDefs_;
+    methodDefs_ = nullptr;
+  }
+}
+
 void RejitHandlerModuleMethod::AddFunctionId(FunctionID functionId) {
   std::lock_guard<std::mutex> guard(functionsIds_lock);
   auto moduleHandler = (RejitHandlerModule*)module;

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
@@ -151,7 +151,7 @@ class RejitHandler {
     auto profilerInfo = handler->profilerInfo;
 
     Info("Initializing ReJIT request thread.");
-    HRESULT hr =profilerInfo->InitializeCurrentThread();
+    HRESULT hr = profilerInfo->InitializeCurrentThread();
     if (FAILED(hr)) {
       Warn("Call to InitializeCurrentThread fail.");
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
@@ -18,10 +18,10 @@ struct RejitItem {
   const ModuleID moduleId_;
   const mdMethodDef methodDef_;
 
-  RejitItem() : moduleId_(0), methodDef_(0) {}
+  RejitItem() : moduleId_(NULL), methodDef_(mdMethodDefNil) {}
   RejitItem(ModuleID moduleId, mdMethodDef methodDef)
       : moduleId_(moduleId), methodDef_(methodDef) {}
-  bool IsEmpty() { return moduleId_ == 0 && methodDef_ == 0; }
+  bool IsEmpty() { return moduleId_ == NULL && methodDef_ == mdMethodDefNil; }
 };
 
 /// <summary>
@@ -138,7 +138,7 @@ class RejitHandler {
   }
 
   void Shutdown() {
-    rejit_queue_.push(RejitItem(0, 0));
+    rejit_queue_.push(RejitItem());
     rejit_queue_thread_->join();
   }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
@@ -137,8 +137,14 @@ class RejitHandler {
     rejit_queue_.push(RejitItem(moduleId, methodDef));
   }
 
+  void Shutdown() {
+    rejit_queue_.push(RejitItem(0, 0));
+    rejit_queue_thread_->join();
+  }
+
  private:
   static void enqueue_thread(RejitHandler* handler) {
+    Debug("Initializing ReJIT request thread.");
     while (true) {
       auto item = handler->rejit_queue_.pop();
       if (item.IsEmpty()) {
@@ -150,9 +156,10 @@ class RejitHandler {
       if (SUCCEEDED(hr)) {
         Info("Request ReJIT done for [ModuleId=", item.moduleId_, ", MethodDef=", item.methodDef_ ,"]");
       } else {
-        Warn("Error requesting ReJIT done for [ModuleId=", item.moduleId_, ", MethodDef=", item.methodDef_ ,"]");
+        Warn("Error requesting ReJIT for [ModuleId=", item.moduleId_, ", MethodDef=", item.methodDef_ ,"]");
       }
     }
+    Debug("Exiting ReJIT request thread.");
   }
 };
 

--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -85,14 +85,15 @@ class BlockingQueue : public UnCopyable {
     }
     T value = queue_.front();
     queue_.pop();
-    mlock.unlock();
     return value;
   }
   void push(const T &item) {
-    std::unique_lock<std::mutex> mlock(mutex_);
+    std::lock_guard<std::mutex> mlock(mutex_);
+    bool wake = queue_.empty();
     queue_.push(item);
-    mlock.unlock();
-    condition_.notify_one();
+    if (wake) {
+      condition_.notify_one();
+    }
   }
 };
 


### PR DESCRIPTION
This PR fixes the RequestReJIT deadlock by moving the call from the ModuleFinished callback to a custom not CLR thread.


@DataDog/apm-dotnet