### PR TITLE
Prevent http client spans in serilog sink

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -42,6 +42,7 @@ namespace trace {
     "Microsoft.CSharp"_W,
     "Microsoft.Extensions"_W,
     "Microsoft.Web.Compilation.Snapshots"_W,
+    "Serilog.Sinks.Datadog"_W,
     "Sigil"_W,
     "System.Core"_W,
     "System.Console"_W,


### PR DESCRIPTION
Prevents noise and top level span problems.
Typically prevalent in AAS, but affects anywhere that uses the Datadog Serilog Sink package.

@DataDog/apm-dotnet