### PR TITLE
CallTarget Integration: Add base DBCommand async overloads

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -215,6 +215,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docker", "docker", "{6ABAD0
 		build\docker\package.sh = build\docker\package.sh
 		build\docker\with-profiler-logs.bash = build\docker\with-profiler-logs.bash
 		build\docker\with-profiler.bash = build\docker\with-profiler.bash
+		build\docker\build.arm64.sh = build\docker\build.arm64.sh
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".azure-pipelines", ".azure-pipelines", "{C52D6695-4E05-4930-88F8-0EFF8056A967}"
@@ -407,6 +408,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LargePayload", "test\test-applications\regression\LargePayload\LargePayload.csproj", "{D20E8A18-DF59-46D3-A894-A448F7593237}"
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Samples.SqlServer.Vb", "test\test-applications\integrations\dependency-libs\Samples.SqlServer.Vb\Samples.SqlServer.Vb.vbproj", "{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.FakeDbCommand", "test\test-applications\integrations\Samples.FakeDbCommand\Samples.FakeDbCommand.csproj", "{0E036453-2C80-4FC9-A517-771F0071734B}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -1512,6 +1515,18 @@ Global
 		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x64.Build.0 = Release|Any CPU
 		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x86.ActiveCfg = Release|Any CPU
 		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895}.Release|x86.Build.0 = Release|Any CPU
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|Any CPU.Build.0 = Debug|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|x64.ActiveCfg = Debug|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|x64.Build.0 = Debug|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|x86.ActiveCfg = Debug|x86
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Debug|x86.Build.0 = Debug|x86
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|Any CPU.ActiveCfg = Release|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|Any CPU.Build.0 = Release|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|x64.ActiveCfg = Release|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|x64.Build.0 = Release|x64
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|x86.ActiveCfg = Release|x86
+		{0E036453-2C80-4FC9-A517-771F0071734B}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1630,6 +1645,7 @@ Global
 		{5C2829C2-ED0D-414C-B5A0-2BFDCA07B493} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{D20E8A18-DF59-46D3-A894-A448F7593237} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 		{CDE0C4D2-4B75-4ED0-988D-08E08B23B895} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{0E036453-2C80-4FC9-A517-771F0071734B} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -25,7 +25,7 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics Samples.FakeDbCommand ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -37,7 +37,7 @@ then
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 fi
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics Samples.FakeDbCommand ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,150 @@
 [
   {
+    "name": "AdoNet",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.Common.DbCommand",
+          "method": "ExecuteNonQueryAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Int32>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteNonQueryAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.Common.DbCommand",
+          "method": "ExecuteNonQueryAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Int32>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteNonQueryAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.Common.DbCommand",
+          "method": "ExecuteDbDataReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>",
+            "System.Data.CommandBehavior",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.Common.DbCommand",
+          "method": "ExecuteDbDataReaderAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>",
+            "System.Data.CommandBehavior",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteReaderWithBehaviorAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data",
+          "type": "System.Data.Common.DbCommand",
+          "method": "ExecuteScalarAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Object>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteScalarAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Data.Common",
+          "type": "System.Data.Common.DbCommand",
+          "method": "ExecuteScalarAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Object>",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.23.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteScalarAsyncIntegration",
+          "action": "CallTargetModification"
+        }
+      }
+    ]
+  },
+  {
     "name": "HttpMessageHandler",
     "method_replacements": [
       {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/AdoNetConstants.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/AdoNetConstants.cs
@@ -8,6 +8,40 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         internal const string IntegrationName = nameof(IntegrationIds.AdoNet);
         internal static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
 
+        internal struct SystemDataClientData : IAdoNetClientData
+        {
+            public string IntegrationName => AdoNet.AdoNetConstants.IntegrationName;
+
+            public string AssemblyName => "System.Data";
+
+            public string SqlCommandType => "System.Data.Common.DbCommand";
+
+            public string MinimumVersion => "4.0.0";
+
+            public string MaximumVersion => "4.*.*";
+
+            public string DataReaderType => AdoNet.AdoNetConstants.TypeNames.DbDataReaderType;
+
+            public string DataReaderTaskType => AdoNet.AdoNetConstants.TypeNames.DbDataReaderTaskType;
+        }
+
+        internal struct SystemDataCommonClientData : IAdoNetClientData
+        {
+            public string IntegrationName => AdoNet.AdoNetConstants.IntegrationName;
+
+            public string AssemblyName => "System.Data.Common";
+
+            public string SqlCommandType => "System.Data.Common.DbCommand";
+
+            public string MinimumVersion => "4.0.0";
+
+            public string MaximumVersion => "5.*.*";
+
+            public string DataReaderType => AdoNet.AdoNetConstants.TypeNames.DbDataReaderType;
+
+            public string DataReaderTaskType => AdoNet.AdoNetConstants.TypeNames.DbDataReaderTaskType;
+        }
+
         public static class TypeNames
         {
             public const string CommandBehavior = "System.Data.CommandBehavior";

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/AdoNetDefinitions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/AdoNetDefinitions.cs
@@ -1,0 +1,26 @@
+﻿using static Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.AdoNetClientInstrumentMethodAttribute;
+using static Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.AdoNetConstants;
+
+/********************************************************************************
+ * Task<int> .ExecuteNonQueryAsync(CancellationToken)
+ ********************************************************************************/
+
+// Task<int> System.Data.Common.DBCommand.ExecuteNonQueryAsync(CancellationToken)
+[assembly: CommandExecuteNonQueryAsync(typeof(SystemDataClientData))]
+[assembly: CommandExecuteNonQueryAsync(typeof(SystemDataCommonClientData))]
+
+/********************************************************************************
+ * Task<DbDataReader> .ExecuteDbDataReaderAsync(CommandBehavior, CancellationToken)
+ ********************************************************************************/
+
+// Task<DbDataReader> System.Data.Common.DBCommand.ExecuteDbDataReaderAsync(CommandBehavior, CancellationToken)
+[assembly: CommandExecuteDbDataReaderWithBehaviorAsync(typeof(SystemDataClientData))]
+[assembly: CommandExecuteDbDataReaderWithBehaviorAsync(typeof(SystemDataCommonClientData))]
+
+/********************************************************************************
+ * Task<object> .ExecuteScalarAsync(CancellationToken)
+ ********************************************************************************/
+
+// Task<object> System.Data.Common.DBCommand.ExecuteScalarAsync(CancellationToken)
+[assembly: CommandExecuteScalarAsync(typeof(SystemDataClientData))]
+[assembly: CommandExecuteScalarAsync(typeof(SystemDataCommonClientData))]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using Datadog.Core.Tools;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
+{
+    public class FakeCommandTests : TestHelper
+    {
+        public FakeCommandTests(ITestOutputHelper output)
+            : base("FakeDbCommand", output)
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [Trait("Category", "EndToEnd")]
+        public void SubmitsTracesWithNetStandard(bool enableCallTarget, bool enableInlining)
+        {
+            SetCallTargetSettings(enableCallTarget, enableInlining);
+
+#if NET452
+            var expectedSpanCount = 28;
+#else
+            var expectedSpanCount = 42;
+#endif
+
+            const string dbType = "fake";
+            const string expectedOperationName = dbType + ".query";
+            const string expectedServiceName = "Samples.FakeDbCommand-" + dbType;
+
+            // NOTE: opt into the additional instrumentation of calls into netstandard.dll
+            SetEnvironmentVariable("DD_TRACE_NETSTANDARD_ENABLED", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
+
+                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                Assert.Equal(expectedSpanCount, spans.Count);
+
+                foreach (var span in spans)
+                {
+                    Assert.Equal(expectedOperationName, span.Name);
+                    Assert.Equal(expectedServiceName, span.Service);
+                    Assert.Equal(SpanTypes.Sql, span.Type);
+                    Assert.Equal(dbType, span.Tags[Tags.DbType]);
+                    Assert.False(span.Tags?.ContainsKey(Tags.Version), "External service span should not have service version tag.");
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -72,11 +72,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "Samples.FakeDbCommand.FakeCommand;System.Data.Common.DbCommand;System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
 
-            string packageVersion = PackageVersions.Npgsql.First()[0] as string;
             int agentPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -56,5 +56,34 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 }
             }
         }
+
+        [Theory]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        [Trait("Category", "EndToEnd")]
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        {
+            SetCallTargetSettings(enableCallTarget, enableInlining);
+
+            var totalSpanCount = 21;
+
+            const string dbType = "fake";
+            const string expectedOperationName = dbType + ".query";
+
+            SetEnvironmentVariable(ConfigurationKeys.AdoNetExcludedTypes, "Samples.FakeDbCommand.FakeCommand;System.Data.Common.DbCommand;System.Data.SqlClient.SqlCommand;Microsoft.Data.SqlClient.SqlCommand;MySql.Data.MySqlClient.MySqlCommand;Npgsql.NpgsqlCommand");
+
+            string packageVersion = PackageVersions.Npgsql.First()[0] as string;
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
+            {
+                Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
+
+                var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+                Assert.NotEmpty(spans);
+                Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
+            }
+        }
     }
 }

--- a/test/test-applications/integrations/Samples.FakeDbCommand/FakeCommand.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/FakeCommand.cs
@@ -1,0 +1,45 @@
+﻿using System.Data;
+using System.Data.Common;
+
+namespace Samples.FakeDbCommand
+{
+    public class FakeCommand : DbCommand
+    {
+        public FakeCommand()
+        {
+            DbParameterCollection = new FakeParameterCollection();
+        }
+        
+        public override void Prepare()
+        {
+        }
+
+        public override string CommandText { get; set; }
+        
+        public override int CommandTimeout { get; set; }
+        
+        public override CommandType CommandType { get; set; }
+        
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        
+        protected override DbConnection DbConnection { get; set; }
+        
+        protected override DbParameterCollection DbParameterCollection { get; }
+        
+        protected override DbTransaction DbTransaction { get; set; }
+        
+        public override bool DesignTimeVisible { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter() => new FakeParameter();
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => null;
+
+        public override int ExecuteNonQuery() => 0;
+
+        public override object ExecuteScalar() => null;
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/FakeCommandExecutor.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/FakeCommandExecutor.cs
@@ -1,0 +1,57 @@
+﻿using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+
+namespace Samples.FakeDbCommand
+{
+    public class FakeCommandExecutor : DbCommandExecutor<FakeCommand>
+    {
+        public override string CommandTypeName => nameof(FakeCommand);
+        
+        public override bool SupportsAsyncMethods => true;
+        
+        public override void ExecuteNonQuery(FakeCommand command) => command.ExecuteNonQuery();
+
+        public override Task ExecuteNonQueryAsync(FakeCommand command) => command.ExecuteNonQueryAsync();
+
+        public override Task ExecuteNonQueryAsync(FakeCommand command, CancellationToken cancellationToken) => command.ExecuteNonQueryAsync(cancellationToken);
+
+        public override void ExecuteScalar(FakeCommand command) => command.ExecuteScalar();
+
+        public override Task ExecuteScalarAsync(FakeCommand command) => command.ExecuteScalarAsync();
+
+        public override Task ExecuteScalarAsync(FakeCommand command, CancellationToken cancellationToken) => command.ExecuteScalarAsync(cancellationToken);
+
+        public override void ExecuteReader(FakeCommand command)
+        {
+            using DbDataReader reader = command.ExecuteReader();
+        }
+
+        public override void ExecuteReader(FakeCommand command, CommandBehavior behavior)
+        {
+            using DbDataReader reader = command.ExecuteReader(behavior);
+        }
+
+        public override async Task ExecuteReaderAsync(FakeCommand command)
+        {
+            using DbDataReader reader = await command.ExecuteReaderAsync();
+        }
+
+        public override async Task ExecuteReaderAsync(FakeCommand command, CommandBehavior behavior)
+        {
+            using DbDataReader reader = await command.ExecuteReaderAsync(behavior);
+        }
+
+        public override async Task ExecuteReaderAsync(FakeCommand command, CancellationToken cancellationToken)
+        {
+            using DbDataReader reader = await command.ExecuteReaderAsync(cancellationToken);
+        }
+
+        public override async Task ExecuteReaderAsync(FakeCommand command, CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            using DbDataReader reader = await command.ExecuteReaderAsync(behavior, cancellationToken);
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/FakeConnection.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/FakeConnection.cs
@@ -1,0 +1,37 @@
+﻿using System.Data;
+using System.Data.Common;
+
+namespace Samples.FakeDbCommand
+{
+    internal class FakeConnection : DbConnection
+    {
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => new FakeTransaction(this, isolationLevel);
+
+        public override void Close()
+        {
+        }
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Open()
+        {
+        }
+
+        public override string ConnectionString { get; set; } = string.Empty;
+        
+        public override string Database { get; } = "Database";
+        
+        public override ConnectionState State { get; }
+        
+        public override string DataSource { get; } = "DataSource";
+        
+        public override string ServerVersion { get; } = "ServerVersion";
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return new FakeCommand { Connection =  this };
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/FakeParameter.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/FakeParameter.cs
@@ -1,0 +1,28 @@
+﻿using System.Data;
+using System.Data.Common;
+
+namespace Samples.FakeDbCommand
+{
+    internal class FakeParameter : DbParameter
+    {
+        public override void ResetDbType()
+        {
+        }
+        
+        public override DbType DbType { get; set; }
+        
+        public override ParameterDirection Direction { get; set; }
+        
+        public override bool IsNullable { get; set; }
+        
+        public override string ParameterName { get; set; }
+        
+        public override string SourceColumn { get; set; }
+        
+        public override object Value { get; set; }
+        
+        public override bool SourceColumnNullMapping { get; set; }
+        
+        public override int Size { get; set; }
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/FakeParameterCollection.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/FakeParameterCollection.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+using System.Data.Common;
+using System.Linq;
+
+namespace Samples.FakeDbCommand
+{
+    public class FakeParameterCollection : DbParameterCollection
+    {
+        public override int Add(object value) => 0;
+
+        public override bool Contains(object value) => false;
+
+        public override void Clear()
+        {
+        }
+
+        public override int IndexOf(object value) => -1;
+
+        public override void Insert(int index, object value)
+        {
+        }
+
+        public override void Remove(object value)
+        {
+        }
+
+        public override void RemoveAt(int index)
+        {
+        }
+
+        public override void RemoveAt(string parameterName)
+        {
+        }
+
+        protected override void SetParameter(int index, DbParameter value)
+        {
+        }
+
+        protected override void SetParameter(string parameterName, DbParameter value)
+        {
+        }
+
+        public override int Count { get; }
+        
+        public override object SyncRoot { get; }
+
+        public override int IndexOf(string parameterName) => -1;
+
+        public override IEnumerator GetEnumerator() => Enumerable.Empty<DbParameter>().GetEnumerator();
+
+        protected override DbParameter GetParameter(int index) => null;
+
+        protected override DbParameter GetParameter(string parameterName) => null;
+
+        public override bool Contains(string value) => false;
+
+        public override void CopyTo(Array array, int index)
+        {
+        }
+
+        public override void AddRange(Array values)
+        {
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/FakeTransaction.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/FakeTransaction.cs
@@ -1,0 +1,25 @@
+﻿using System.Data;
+using System.Data.Common;
+
+namespace Samples.FakeDbCommand
+{
+    internal class FakeTransaction : DbTransaction
+    {
+        internal FakeTransaction(DbConnection connection, IsolationLevel level)
+        {
+            DbConnection = connection;
+            IsolationLevel = level;
+        }
+        
+        public override void Commit()
+        {
+        }
+
+        public override void Rollback()
+        {
+        }
+
+        protected override DbConnection DbConnection { get; }
+        public override IsolationLevel IsolationLevel { get; }
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/Program.cs
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/Program.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Samples.DatabaseHelper;
+
+namespace Samples.FakeDbCommand
+{
+    internal static class Program
+    {
+        private static async Task Main()
+        {
+            var commandFactory = new DbCommandFactory($"[FakeDbCommand-Test-{Guid.NewGuid():N}]");
+            var commandExecutor = new FakeCommandExecutor();
+            var cts = new CancellationTokenSource();
+
+            using (var connection = OpenConnection())
+            {
+                await RelationalDatabaseTestHarness.RunAllAsync<FakeCommand>(connection, commandFactory, commandExecutor, cts.Token);
+            }
+
+            // allow time to flush
+            await Task.Delay(2000, cts.Token);
+        }
+
+        private static FakeConnection OpenConnection()
+        {
+            var connection = new FakeConnection();
+            connection.Open();
+            return connection;
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/Properties/launchSettings.json
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/Properties/launchSettings.json
@@ -1,0 +1,26 @@
+﻿{
+  "profiles": {
+    "Samples.FakeDbCommand": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json",
+        "DD_VERSION": "1.0.0",
+
+        "DD_TRACE_NETSTANDARD_ENABLED": "true",
+        
+        "DD_TRACE_CALLTARGET_ENABLED": "true",
+        "DD_CLR_ENABLE_INLINING": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/test/test-applications/integrations/Samples.FakeDbCommand/Samples.FakeDbCommand.csproj
+++ b/test/test-applications/integrations/Samples.FakeDbCommand/Samples.FakeDbCommand.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Required to build multiple projects with the same Configuration|Platform -->
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+    <Reference Include="System.Data" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
+    <PackageReference Include="System.Data.Common" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
+
+    <!-- this referenced project only targets netstandard2.0 -->
+    <ProjectReference Condition="'$(TargetFramework)' != 'net452'" Include="..\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This `PR` adds calltarget instrumentation to the base DBCommand standard async methods.

@DataDog/apm-dotnet