### PR TITLE
Use DD_TRACE_LOGGING_RATE instead of DD_LOGGING_RATE

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -229,7 +229,7 @@ namespace Datadog.Trace.Configuration
         /// identical log messages, for Tracer log files.
         /// Default value is 60s. Setting to 0 disables rate limiting.
         /// </summary>
-        public const string LogRateLimit = "DD_LOGGING_RATE";
+        public const string LogRateLimit = "DD_TRACE_LOGGING_RATE";
 
         /// <summary>
         /// Configuration key for setting the path to the .NET Tracer native log file.


### PR DESCRIPTION
In line with the [updated RFC](https://github.com/DataDog/architecture/blob/master/rfcs/apm/integrations/tracer-logging/rfc.md)

Follows on from #1153 

@DataDog/apm-dotnet