### PR TITLE
Switch integration tests to release

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -20,7 +20,7 @@ pool:
   vmImage: ubuntu-18.04
 
 variables:
-  buildConfiguration: Debug
+  buildConfiguration: Release
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.107
   dotnetCoreSdk5Version: 5.0.100

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -343,19 +343,17 @@ jobs:
     displayName: dotnet test
     inputs:
       command: test
-      configuration: $(buildConfiguration)
       projects: |
         test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
         test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
-      arguments: -p:Platform=$(buildPlatform)
+      arguments: -c $(buildConfiguration) -p:Platform=$(buildPlatform)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
       command: test
-      configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True&IIS!=True" -p:Platform=$(buildPlatform)
+      arguments: -c $(buildConfiguration) --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True&IIS!=True" -p:Platform=$(buildPlatform)
 
   - task: DockerCompose@0
     displayName: docker-compose stop services
@@ -490,17 +488,15 @@ jobs:
     displayName: dotnet test --filter LoadFromGAC=True
     inputs:
       command: test
-      configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True&IIS!=True" -p:Platform=$(buildPlatform)
+      arguments: -c $(buildConfiguration) --filter "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True&IIS!=True" -p:Platform=$(buildPlatform)
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test IIS
     inputs:
       command: test
-      configuration: $(buildConfiguration)
       projects: test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
-      arguments: --filter "(IIS=True)" -p:Platform=$(buildPlatform)
+      arguments: -c $(buildConfiguration) --filter "(IIS=True)" -p:Platform=$(buildPlatform)
 
   - task: DockerCompose@0
     displayName: docker-compose stop services

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -72,7 +72,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run Profiler
 
-  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Debug/x64
+  - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Release/x64
     displayName: Uploading linux tracer home artifact
     artifact: linux-tracer-home
 

--- a/build/docker/Datadog.Trace.ClrProfiler.Native.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.Native.sh
@@ -12,11 +12,11 @@ cd src/Datadog.Trace.ClrProfiler.Native
 mkdir -p build
 (cd build && cmake ../ && make)
 
-mkdir -p bin/Debug/x64
-cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/Debug/x64/Datadog.Trace.ClrProfiler.Native.so
+mkdir -p bin/Release/x64
+cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/Release/x64/Datadog.Trace.ClrProfiler.Native.so
 
-mkdir -p bin/Debug/x64/netstandard2.0
-cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/Debug/x64/netstandard2.0/
+mkdir -p bin/Release/x64/netstandard2.0
+cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/Release/x64/netstandard2.0/
 
-mkdir -p bin/Debug/x64/netcoreapp3.1
-cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/Debug/x64/netcoreapp3.1/
+mkdir -p bin/Release/x64/netcoreapp3.1
+cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/Release/x64/netcoreapp3.1/


### PR DESCRIPTION
- trying to optimize run time of tests
- run tests with code closer to what user run (with compiler optimizations)
- nobody will debug code in CI