### PR TITLE
NUnit: Add support for TestCase custom name

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/Datadog.Trace.Ci.Shared.projitems
+++ b/src/Datadog.Trace.Ci.Shared/Datadog.Trace.Ci.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)BuildTags.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CIEnvironmentValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CommonTags.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestParameters.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestTags.cs" />
   </ItemGroup>
 </Project>

--- a/src/Datadog.Trace.Ci.Shared/TestParameters.cs
+++ b/src/Datadog.Trace.Ci.Shared/TestParameters.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Ci
+{
+    internal class TestParameters
+    {
+        [JsonProperty("metadata")]
+        public Dictionary<string, object> Metadata { get; set; }
+
+        [JsonProperty("arguments")]
+        public Dictionary<string, object> Arguments { get; set; }
+
+        internal string ToJSON()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/src/Datadog.Trace.Ci.Shared/TestTags.cs
+++ b/src/Datadog.Trace.Ci.Shared/TestTags.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Ci
         /// <summary>
         /// Test parameters
         /// </summary>
-        public const string Arguments = "test.arguments";
+        public const string Parameters = "test.parameters";
 
         /// <summary>
         /// Test traits
@@ -69,5 +69,15 @@ namespace Datadog.Trace.Ci
         /// Test skip reason
         /// </summary>
         public const string SkipReason = "test.skip_reason";
+
+        /// <summary>
+        /// Parameterized Test Name
+        /// </summary>
+        public const string ParameterizedTestName = "test.metadata.parameterized_test_name";
+
+        /// <summary>
+        /// Parameters metadata TestName
+        /// </summary>
+        public const string MetadataTestName = "test_name";
     }
 }

--- a/src/Datadog.Trace.Ci.Shared/TestTags.cs
+++ b/src/Datadog.Trace.Ci.Shared/TestTags.cs
@@ -71,11 +71,6 @@ namespace Datadog.Trace.Ci
         public const string SkipReason = "test.skip_reason";
 
         /// <summary>
-        /// Parameterized Test Name
-        /// </summary>
-        public const string ParameterizedTestName = "test.metadata.parameterized_test_name";
-
-        /// <summary>
         /// Parameters metadata TestName
         /// </summary>
         public const string MetadataTestName = "test_name";

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -79,17 +79,23 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             ParameterInfo[] methodParameters = testMethod.GetParameters();
             if (methodParameters?.Length > 0)
             {
+                TestParameters testParameters = new TestParameters();
+                testParameters.Metadata = new Dictionary<string, object>();
+                testParameters.Arguments = new Dictionary<string, object>();
+
                 for (int i = 0; i < methodParameters.Length; i++)
                 {
                     if (testMethodArguments != null && i < testMethodArguments.Length)
                     {
-                        span.SetTag($"{TestTags.Arguments}.{methodParameters[i].Name}", testMethodArguments[i]?.ToString() ?? "(null)");
+                        testParameters.Arguments[methodParameters[i].Name] = testMethodArguments[i]?.ToString() ?? "(null)";
                     }
                     else
                     {
-                        span.SetTag($"{TestTags.Arguments}.{methodParameters[i].Name}", "(default)");
+                        testParameters.Arguments[methodParameters[i].Name] = "(default)";
                     }
                 }
+
+                span.SetTag(TestTags.Parameters, testParameters.ToJSON());
             }
 
             // Get traits

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/ITest.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/ITest.cs
@@ -6,6 +6,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
     public interface ITest
     {
         /// <summary>
+        /// Gets the test name
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
         /// Gets a MethodInfo for the method implementing this test.
         /// Returns null if the test is not implemented as a method.
         /// </summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -76,7 +76,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                     }
                 }
 
-                span.SetTag(TestTags.ParameterizedTestName, currentTest.Name);
                 span.SetTag(TestTags.Parameters, testParameters.ToJSON());
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/TestCaseStruct.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/TestCaseStruct.cs
@@ -10,6 +10,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
     public struct TestCaseStruct
     {
         /// <summary>
+        /// Display name
+        /// </summary>
+        public string DisplayName;
+
+        /// <summary>
         /// Traits dictionary
         /// </summary>
         public Dictionary<string, List<string>> Traits;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -67,7 +67,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                     }
                 }
 
-                span.SetTag(TestTags.ParameterizedTestName, runnerInstance.TestCase.DisplayName);
                 span.SetTag(TestTags.Parameters, testParameters.ToJSON());
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 return CallTargetState.GetDefault();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -244,7 +244,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
 
                         if (testParameters != null)
                         {
-                            span.SetTag(TestTags.ParameterizedTestName, testCaseName);
                             span.SetTag(TestTags.Parameters, testParameters.ToJSON());
                         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -439,7 +439,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
 
                 if (testParameters != null)
                 {
-                    span.SetTag(TestTags.ParameterizedTestName, displayName);
                     span.SetTag(TestTags.Parameters, testParameters.ToJSON());
                 }
 


### PR DESCRIPTION
This PR adds support for NUnit testcase custom name and support for IgnoreException.

@DataDog/apm-dotnet