### PR TITLE
Remove _W string operator from the native profiler

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -134,8 +134,8 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens() {
     assembly_metadata.usMinorVersion = assemblyReference.version.minor;
     assembly_metadata.usBuildNumber = assemblyReference.version.build;
     assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-    if (assemblyReference.locale == _LU("neutral")) {
-      assembly_metadata.szLocale = const_cast<WCHAR*>(_LU("\0"));
+    if (assemblyReference.locale == WStr("neutral")) {
+      assembly_metadata.szLocale = const_cast<WCHAR*>(WStr("\0"));
       assembly_metadata.cbLocale = 0;
     } else {
       assembly_metadata.szLocale =

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -34,7 +34,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
   // *** Ensure System.Object type ref
   if (objectTypeRef == mdTypeRefNil) {
     auto hr = module_metadata->metadata_emit->DefineTypeRefByName(
-        corLibAssemblyRef, SystemObject.data(), &objectTypeRef);
+        corLibAssemblyRef, SystemObject, &objectTypeRef);
     if (FAILED(hr)) {
       Warn("Wrapper objectTypeRef could not be defined.");
       return hr;
@@ -44,7 +44,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
   // *** Ensure System.Exception type ref
   if (exTypeRef == mdTypeRefNil) {
     auto hr = module_metadata->metadata_emit->DefineTypeRefByName(
-        corLibAssemblyRef, SystemException.data(), &exTypeRef);
+        corLibAssemblyRef, SystemException, &exTypeRef);
     if (FAILED(hr)) {
       Warn("Wrapper exTypeRef could not be defined.");
       return hr;
@@ -54,7 +54,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
   // *** Ensure System.Type type ref
   if (typeRef == mdTypeRefNil) {
     auto hr = module_metadata->metadata_emit->DefineTypeRefByName(
-        corLibAssemblyRef, SystemTypeName.data(), &typeRef);
+        corLibAssemblyRef, SystemTypeName, &typeRef);
     if (FAILED(hr)) {
       Warn("Wrapper typeRef could not be defined.");
       return hr;
@@ -64,7 +64,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
   // *** Ensure System.RuntimeTypeHandle type ref
   if (runtimeTypeHandleRef == mdTypeRefNil) {
     auto hr = module_metadata->metadata_emit->DefineTypeRefByName(
-        corLibAssemblyRef, RuntimeTypeHandleTypeName.data(),
+        corLibAssemblyRef, RuntimeTypeHandleTypeName,
         &runtimeTypeHandleRef);
     if (FAILED(hr)) {
       Warn("Wrapper runtimeTypeHandleRef could not be defined.");
@@ -94,7 +94,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
     offset += runtimeTypeHandle_size;
 
     auto hr = module_metadata->metadata_emit->DefineMemberRef(
-        typeRef, GetTypeFromHandleMethodName.data(), signature, offset,
+        typeRef, GetTypeFromHandleMethodName, signature, offset,
         &getTypeFromHandleToken);
     if (FAILED(hr)) {
       Warn("Wrapper getTypeFromHandleToken could not be defined.");
@@ -105,7 +105,7 @@ HRESULT CallTargetTokens::EnsureCorLibTokens() {
   // *** Ensure System.RuntimeMethodHandle type ref
   if (runtimeMethodHandleRef == mdTypeRefNil) {
     auto hr = module_metadata->metadata_emit->DefineTypeRefByName(
-        corLibAssemblyRef, RuntimeMethodHandleTypeName.data(),
+        corLibAssemblyRef, RuntimeMethodHandleTypeName,
         &runtimeMethodHandleRef);
     if (FAILED(hr)) {
       Warn("Wrapper runtimeMethodHandleRef could not be defined.");
@@ -134,8 +134,8 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens() {
     assembly_metadata.usMinorVersion = assemblyReference.version.minor;
     assembly_metadata.usBuildNumber = assemblyReference.version.build;
     assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-    if (assemblyReference.locale == "neutral"_W) {
-      assembly_metadata.szLocale = const_cast<WCHAR*>("\0"_W.c_str());
+    if (assemblyReference.locale == _LU("neutral")) {
+      assembly_metadata.szLocale = const_cast<WCHAR*>(_LU("\0"));
       assembly_metadata.cbLocale = 0;
     } else {
       assembly_metadata.szLocale =

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
@@ -24,20 +24,20 @@ class CallTargetTokens {
   void* module_metadata_ptr = nullptr;
 
   // CallTarget constants
-  WSTRING managed_profiler_calltarget_type = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetInvoker");
-  WSTRING managed_profiler_calltarget_beginmethod_name = _LU("BeginMethod");
-  WSTRING managed_profiler_calltarget_endmethod_name = _LU("EndMethod");
-  WSTRING managed_profiler_calltarget_logexception_name = _LU("LogException");
-  WSTRING managed_profiler_calltarget_getdefaultvalue_name = _LU("GetDefaultValue");
+  WSTRING managed_profiler_calltarget_type = WStr("Datadog.Trace.ClrProfiler.CallTarget.CallTargetInvoker");
+  WSTRING managed_profiler_calltarget_beginmethod_name = WStr("BeginMethod");
+  WSTRING managed_profiler_calltarget_endmethod_name = WStr("EndMethod");
+  WSTRING managed_profiler_calltarget_logexception_name = WStr("LogException");
+  WSTRING managed_profiler_calltarget_getdefaultvalue_name = WStr("GetDefaultValue");
 
-  WSTRING managed_profiler_calltarget_statetype = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetState");
-  WSTRING managed_profiler_calltarget_statetype_getdefault_name =_LU("GetDefault");
+  WSTRING managed_profiler_calltarget_statetype = WStr("Datadog.Trace.ClrProfiler.CallTarget.CallTargetState");
+  WSTRING managed_profiler_calltarget_statetype_getdefault_name =WStr("GetDefault");
 
-  WSTRING managed_profiler_calltarget_returntype = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn");
-  WSTRING managed_profiler_calltarget_returntype_getdefault_name = _LU("GetDefault");
+  WSTRING managed_profiler_calltarget_returntype = WStr("Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn");
+  WSTRING managed_profiler_calltarget_returntype_getdefault_name = WStr("GetDefault");
 
-  WSTRING managed_profiler_calltarget_returntype_generics = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn`1");
-  WSTRING managed_profiler_calltarget_returntype_getreturnvalue_name = _LU("GetReturnValue");
+  WSTRING managed_profiler_calltarget_returntype_generics = WStr("Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn`1");
+  WSTRING managed_profiler_calltarget_returntype_getreturnvalue_name = WStr("GetReturnValue");
 
   // CorLib tokens
   mdAssemblyRef corLibAssemblyRef = mdAssemblyRefNil;

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
@@ -24,28 +24,20 @@ class CallTargetTokens {
   void* module_metadata_ptr = nullptr;
 
   // CallTarget constants
-  WSTRING managed_profiler_calltarget_type =
-      "Datadog.Trace.ClrProfiler.CallTarget.CallTargetInvoker"_W;
-  WSTRING managed_profiler_calltarget_beginmethod_name = "BeginMethod"_W;
-  WSTRING managed_profiler_calltarget_endmethod_name = "EndMethod"_W;
-  WSTRING managed_profiler_calltarget_logexception_name = "LogException"_W;
-  WSTRING managed_profiler_calltarget_getdefaultvalue_name =
-      "GetDefaultValue"_W;
+  WSTRING managed_profiler_calltarget_type = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetInvoker");
+  WSTRING managed_profiler_calltarget_beginmethod_name = _LU("BeginMethod");
+  WSTRING managed_profiler_calltarget_endmethod_name = _LU("EndMethod");
+  WSTRING managed_profiler_calltarget_logexception_name = _LU("LogException");
+  WSTRING managed_profiler_calltarget_getdefaultvalue_name = _LU("GetDefaultValue");
 
-  WSTRING managed_profiler_calltarget_statetype =
-      "Datadog.Trace.ClrProfiler.CallTarget.CallTargetState"_W;
-  WSTRING managed_profiler_calltarget_statetype_getdefault_name =
-      "GetDefault"_W;
+  WSTRING managed_profiler_calltarget_statetype = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetState");
+  WSTRING managed_profiler_calltarget_statetype_getdefault_name =_LU("GetDefault");
 
-  WSTRING managed_profiler_calltarget_returntype =
-      "Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn"_W;
-  WSTRING managed_profiler_calltarget_returntype_getdefault_name =
-      "GetDefault"_W;
+  WSTRING managed_profiler_calltarget_returntype = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn");
+  WSTRING managed_profiler_calltarget_returntype_getdefault_name = _LU("GetDefault");
 
-  WSTRING managed_profiler_calltarget_returntype_generics =
-      "Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn`1"_W;
-  WSTRING managed_profiler_calltarget_returntype_getreturnvalue_name =
-      "GetReturnValue"_W;
+  WSTRING managed_profiler_calltarget_returntype_generics = _LU("Datadog.Trace.ClrProfiler.CallTarget.CallTargetReturn`1");
+  WSTRING managed_profiler_calltarget_returntype_getreturnvalue_name = _LU("GetReturnValue");
 
   // CorLib tokens
   mdAssemblyRef corLibAssemblyRef = mdAssemblyRefNil;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -222,8 +222,8 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                                             &type_extends);
       if (type_extends != mdTokenNil) {
         extendsInfo = new TypeInfo(GetTypeInfo(metadata_import, type_extends));
-        type_valueType = extendsInfo->name == "System.ValueType"_W ||
-                         extendsInfo->name == "System.Enum"_W;
+        type_valueType = extendsInfo->name == _LU("System.ValueType") ||
+                         extendsInfo->name == _LU("System.Enum");
       }
       break;
     case mdtTypeRef:
@@ -265,7 +265,7 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
   }
 
   const auto type_name_string = WSTRING(type_name);
-  const auto generic_token_index = type_name_string.rfind("`"_W);
+  const auto generic_token_index = type_name_string.rfind(_LU("`"));
   if (generic_token_index != std::string::npos) {
     const auto idxFromRight = type_name_string.length() - generic_token_index - 1;
     type_isGeneric = idxFromRight == 1 || idxFromRight == 2;
@@ -434,8 +434,8 @@ bool DisableOptimizations() {
   const auto disable_optimizations =
       GetEnvironmentValue(environment::clr_disable_optimizations);
 
-  if (disable_optimizations == "1"_W ||
-      disable_optimizations == "true"_W) {
+  if (disable_optimizations == _LU("1") ||
+      disable_optimizations == _LU("true")) {
     return true;
   }
 
@@ -447,7 +447,7 @@ bool EnableInlining() {
   const auto enable_inlining =
       GetEnvironmentValue(environment::clr_enable_inlining);
 
-  if (enable_inlining == "1"_W || enable_inlining == "true"_W) {
+  if (enable_inlining == _LU("1") || enable_inlining == _LU("true")) {
     return true;
   }
 
@@ -459,7 +459,7 @@ bool IsCallTargetEnabled() {
   const auto calltarget_enabled =
       GetEnvironmentValue(environment::calltarget_enabled);
 
-  if (calltarget_enabled == "1"_W || calltarget_enabled == "true"_W) {
+  if (calltarget_enabled == _LU("1") || calltarget_enabled == _LU("true")) {
     return true;
   }
 
@@ -497,8 +497,8 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
     std::vector<WSTRING> type_names(expected_number_of_types);
 
     std::stack<int> generic_arg_stack;
-    WSTRING append_to_type = ""_W;
-    WSTRING current_type_name = ""_W;
+    WSTRING append_to_type = _LU("");
+    WSTRING current_type_name = _LU("");
 
     for (; current_index < signature_size; current_index++) {
       mdToken type_token;
@@ -508,77 +508,77 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
       switch (cor_element_type) {
         case ELEMENT_TYPE_VOID: {
-          current_type_name.append("System.Void"_W);
+          current_type_name.append(_LU("System.Void"));
           break;
         }
 
         case ELEMENT_TYPE_BOOLEAN: {
-          current_type_name.append("System.Boolean"_W);
+          current_type_name.append(_LU("System.Boolean"));
           break;
         }
 
         case ELEMENT_TYPE_CHAR: {
-          current_type_name.append("System.Char16"_W);
+          current_type_name.append(_LU("System.Char16"));
           break;
         }
 
         case ELEMENT_TYPE_I1: {
-          current_type_name.append("System.SByte"_W);
+          current_type_name.append(_LU("System.SByte"));
           break;
         }
 
         case ELEMENT_TYPE_U1: {
-          current_type_name.append("System.Byte"_W);
+          current_type_name.append(_LU("System.Byte"));
           break;
         }
 
         case ELEMENT_TYPE_I2: {
-          current_type_name.append("System.Int16"_W);
+          current_type_name.append(_LU("System.Int16"));
           break;
         }
 
         case ELEMENT_TYPE_U2: {
-          current_type_name.append("System.UInt16"_W);
+          current_type_name.append(_LU("System.UInt16"));
           break;
         }
 
         case ELEMENT_TYPE_I4: {
-          current_type_name.append("System.Int32"_W);
+          current_type_name.append(_LU("System.Int32"));
           break;
         }
 
         case ELEMENT_TYPE_U4: {
-          current_type_name.append("System.UInt32"_W);
+          current_type_name.append(_LU("System.UInt32"));
           break;
         }
 
         case ELEMENT_TYPE_I8: {
-          current_type_name.append("System.Int64"_W);
+          current_type_name.append(_LU("System.Int64"));
           break;
         }
 
         case ELEMENT_TYPE_U8: {
-          current_type_name.append("System.UInt64"_W);
+          current_type_name.append(_LU("System.UInt64"));
           break;
         }
 
         case ELEMENT_TYPE_R4: {
-          current_type_name.append("System.Single"_W);
+          current_type_name.append(_LU("System.Single"));
           break;
         }
 
         case ELEMENT_TYPE_R8: {
-          current_type_name.append("System.Double"_W);
+          current_type_name.append(_LU("System.Double"));
           break;
         }
 
         case ELEMENT_TYPE_STRING: {
-          current_type_name.append("System.String"_W);
+          current_type_name.append(_LU("System.String"));
           break;
         }
 
         case ELEMENT_TYPE_OBJECT: {
-          current_type_name.append("System.Object"_W);
+          current_type_name.append(_LU("System.Object"));
           break;
         }
 
@@ -593,7 +593,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
           auto ongoing_type_name = examined_type_name;
 
           // check for whether this may be a nested class
-          while (examined_type_name.find_first_of("."_W) == std::string::npos) {
+          while (examined_type_name.find_first_of(_LU(".")) == std::string::npos) {
             // This may possibly be a nested class, check for the parent
             mdToken potentialParentToken;
             metadata_import->GetNestedClassProps(examined_type_token,
@@ -609,7 +609,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
             examined_type_token = nesting_type.id;
             examined_type_name = nesting_type.name;
 
-            ongoing_type_name = examined_type_name + "+"_W + ongoing_type_name;
+            ongoing_type_name = examined_type_name + _LU("+") + ongoing_type_name;
           }
 
           // index will be moved up one on every loop
@@ -620,10 +620,10 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
         }
 
         case ELEMENT_TYPE_SZARRAY: {
-          append_to_type.append("[]"_W);
+          append_to_type.append(_LU("[]"));
           while (function_info.signature.data[(current_index + 1)] ==
                  ELEMENT_TYPE_SZARRAY) {
-            append_to_type.append("[]"_W);
+            append_to_type.append(_LU("[]"));
             current_index++;
           }
           // Next will be the type of the array(s)
@@ -635,7 +635,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
           token_length = CorSigUncompressToken(
               PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
               &type_token);
-          current_type_name.append("T"_W);
+          current_type_name.append(_LU("T"));
           current_index += token_length;
           // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
           // current_type_name.append(std::to_wstring(type_token));
@@ -647,7 +647,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
           token_length = CorSigUncompressToken(
               PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
               &type_token);
-          current_type_name.append("T"_W);
+          current_type_name.append(_LU("T"));
           current_index += token_length;
           // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
           // current_type_name.append(std::to_wstring(type_token));
@@ -663,7 +663,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
               metadata_import, function_info, current_index, token_length);
           auto type_name = generic_type_data.name;
           current_type_name.append(type_name);
-          current_type_name.append("<"_W);  // Begin generic args
+          current_type_name.append(_LU("<"));  // Begin generic args
 
           // Because we are starting a new generic, decrement any existing level
           if (!generic_arg_stack.empty()) {
@@ -682,7 +682,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
         case ELEMENT_TYPE_BYREF: {
           // TODO: This hasn't been encountered yet
-          current_type_name.append("ref"_W);
+          current_type_name.append(_LU("ref"));
           break;
         }
 
@@ -700,7 +700,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
       if (!append_to_type.empty()) {
         current_type_name.append(append_to_type);
-        append_to_type = ""_W;
+        append_to_type = _LU("");
       }
 
       if (!generic_arg_stack.empty()) {
@@ -709,18 +709,18 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
         if (generic_arg_stack.top() > 0) {
           // we're in the middle of generic type args
-          current_type_name.append(", "_W);
+          current_type_name.append(_LU(", "));
         }
       }
 
       while (!generic_arg_stack.empty() && generic_arg_stack.top() == 0) {
         // unwind the generics with no args left
         generic_arg_stack.pop();
-        current_type_name.append(">"_W);
+        current_type_name.append(_LU(">"));
 
         if (!generic_arg_stack.empty() && generic_arg_stack.top() > 0) {
           // We are in a nested generic and we need a comma to separate args
-          current_type_name.append(", "_W);
+          current_type_name.append(_LU(", "));
         }
       }
 
@@ -734,7 +734,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
       }
 
       type_names[current_type_index] = current_type_name;
-      current_type_name = ""_W;
+      current_type_name = _LU("");
       current_type_index++;
     }
 
@@ -759,7 +759,7 @@ HRESULT CreateAssemblyRefToMscorlib(const ComPtr<IMetaDataAssemblyEmit>& assembl
   metadata.usRevisionNumber = 0;
   BYTE public_key[] = {0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89};
   HRESULT hr = assembly_emit->DefineAssemblyRef(public_key, sizeof(public_key),
-                                   "mscorlib"_W.c_str(), &metadata, NULL, 0, 0,
+                                   _LU("mscorlib"), &metadata, NULL, 0, 0,
                                    mscorlib_ref);
 
   return hr;
@@ -770,7 +770,7 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
                                             const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
                                             mdToken* ret_type_token) {
   const auto cor_element_type = CorElementType(*p_sig);
-  WSTRING managed_type_name = ""_W;
+  WSTRING managed_type_name = _LU("");
 
   switch (cor_element_type) {
     case ELEMENT_TYPE_VALUETYPE: {
@@ -785,52 +785,52 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
     }
 
     case ELEMENT_TYPE_VOID:     // 0x01  // System.Void (struct)
-      managed_type_name = "System.Void"_W;
+      managed_type_name = _LU("System.Void");
       break;
     case ELEMENT_TYPE_BOOLEAN:  // 0x02  // System.Boolean (struct)
-      managed_type_name = "System.Boolean"_W;
+      managed_type_name = _LU("System.Boolean");
       break;
     case ELEMENT_TYPE_CHAR:     // 0x03  // System.Char (struct)
-      managed_type_name = "System.Char"_W;
+      managed_type_name = _LU("System.Char");
       break;
     case ELEMENT_TYPE_I1:       // 0x04  // System.SByte (struct)
-      managed_type_name = "System.SByte"_W;
+      managed_type_name = _LU("System.SByte");
       break;
     case ELEMENT_TYPE_U1:       // 0x05  // System.Byte (struct)
-      managed_type_name = "System.Byte"_W;
+      managed_type_name = _LU("System.Byte");
       break;
     case ELEMENT_TYPE_I2:       // 0x06  // System.Int16 (struct)
-      managed_type_name = "System.Int16"_W;
+      managed_type_name = _LU("System.Int16");
       break;
     case ELEMENT_TYPE_U2:       // 0x07  // System.UInt16 (struct)
-      managed_type_name = "System.UInt16"_W;
+      managed_type_name = _LU("System.UInt16");
       break;
     case ELEMENT_TYPE_I4:       // 0x08  // System.Int32 (struct)
-      managed_type_name = "System.Int32"_W;
+      managed_type_name = _LU("System.Int32");
       break;
     case ELEMENT_TYPE_U4:       // 0x09  // System.UInt32 (struct)
-      managed_type_name = "System.UInt32"_W;
+      managed_type_name = _LU("System.UInt32");
       break;
     case ELEMENT_TYPE_I8:       // 0x0a  // System.Int64 (struct)
-      managed_type_name = "System.Int64"_W;
+      managed_type_name = _LU("System.Int64");
       break;
     case ELEMENT_TYPE_U8:       // 0x0b  // System.UInt64 (struct)
-      managed_type_name = "System.UInt64"_W;
+      managed_type_name = _LU("System.UInt64");
       break;
     case ELEMENT_TYPE_R4:       // 0x0c  // System.Single (struct)
-      managed_type_name = "System.Single"_W;
+      managed_type_name = _LU("System.Single");
       break;
     case ELEMENT_TYPE_R8:       // 0x0d  // System.Double (struct)
-      managed_type_name = "System.Double"_W;
+      managed_type_name = _LU("System.Double");
       break;
     case ELEMENT_TYPE_TYPEDBYREF:  // 0X16  // System.TypedReference (struct)
-      managed_type_name = "System.TypedReference"_W;
+      managed_type_name = _LU("System.TypedReference");
       break;
     case ELEMENT_TYPE_I:           // 0x18  // System.IntPtr (struct)
-      managed_type_name = "System.IntPtr"_W;
+      managed_type_name = _LU("System.IntPtr");
       break;
     case ELEMENT_TYPE_U:           // 0x19  // System.UIntPtr (struct)
-      managed_type_name = "System.UIntPtr"_W;
+      managed_type_name = _LU("System.UIntPtr");
       break;
     default:
       return false;
@@ -847,7 +847,7 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
   }
 
   // Create/Get TypeRef to the listed type
-  if (managed_type_name == ""_W) {
+  if (managed_type_name == _LU("")) {
     Warn("[trace::ReturnTypeTokenforElementType] no managed type name given");
     return false;
   }
@@ -1115,52 +1115,52 @@ mdToken FunctionMethodArgument::GetTypeTok(ComPtr<IMetaDataEmit2>& pEmit, mdAsse
 
   switch (*pbCur) {
     case ELEMENT_TYPE_BOOLEAN:
-      pEmit->DefineTypeRefByName(corLibRef, SystemBoolean.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemBoolean, &token);
       break;
     case ELEMENT_TYPE_CHAR:
-      pEmit->DefineTypeRefByName(corLibRef, SystemChar.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemChar, &token);
       break;
     case ELEMENT_TYPE_I1:
-      pEmit->DefineTypeRefByName(corLibRef, SystemByte.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemByte, &token);
       break;
     case ELEMENT_TYPE_U1:
-      pEmit->DefineTypeRefByName(corLibRef, SystemSByte.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemSByte, &token);
       break;
     case ELEMENT_TYPE_U2:
-      pEmit->DefineTypeRefByName(corLibRef, SystemUInt16.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemUInt16, &token);
       break;
     case ELEMENT_TYPE_I2:
-      pEmit->DefineTypeRefByName(corLibRef, SystemInt16.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemInt16, &token);
       break;
     case ELEMENT_TYPE_I4:
-      pEmit->DefineTypeRefByName(corLibRef, SystemInt32.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemInt32, &token);
       break;
     case ELEMENT_TYPE_U4:
-      pEmit->DefineTypeRefByName(corLibRef, SystemUInt32.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemUInt32, &token);
       break;
     case ELEMENT_TYPE_I8:
-      pEmit->DefineTypeRefByName(corLibRef, SystemInt64.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemInt64, &token);
       break;
     case ELEMENT_TYPE_U8:
-      pEmit->DefineTypeRefByName(corLibRef, SystemUInt64.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemUInt64, &token);
       break;
     case ELEMENT_TYPE_R4:
-      pEmit->DefineTypeRefByName(corLibRef, SystemSingle.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemSingle, &token);
       break;
     case ELEMENT_TYPE_R8:
-      pEmit->DefineTypeRefByName(corLibRef, SystemDouble.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemDouble, &token);
       break;
     case ELEMENT_TYPE_I:
-      pEmit->DefineTypeRefByName(corLibRef, SystemIntPtr.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemIntPtr, &token);
       break;
     case ELEMENT_TYPE_U:
-      pEmit->DefineTypeRefByName(corLibRef, SystemUIntPtr.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemUIntPtr, &token);
       break;
     case ELEMENT_TYPE_STRING:
-      pEmit->DefineTypeRefByName(corLibRef, SystemString.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemString, &token);
       break;
     case ELEMENT_TYPE_OBJECT:
-      pEmit->DefineTypeRefByName(corLibRef, SystemObject.data(), &token);
+      pEmit->DefineTypeRefByName(corLibRef, SystemObject, &token);
       break;
     case ELEMENT_TYPE_CLASS:
       pbCur++;
@@ -1184,7 +1184,7 @@ mdToken FunctionMethodArgument::GetTypeTok(ComPtr<IMetaDataEmit2>& pEmit, mdAsse
 }
 
 WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport) {
-  WSTRING tokenName = ""_W;
+  WSTRING tokenName = _LU("");
   bool ref_flag = false;
   if (*pbCur == ELEMENT_TYPE_BYREF) {
     pbCur++;
@@ -1266,36 +1266,36 @@ WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>
     }
     case ELEMENT_TYPE_SZARRAY: {
       pbCur++;
-      tokenName = GetSigTypeTokName(pbCur, pImport) + "[]"_W;
+      tokenName = GetSigTypeTokName(pbCur, pImport) + _LU("[]");
       break;
     }
     case ELEMENT_TYPE_GENERICINST: {
       pbCur++;
       tokenName = GetSigTypeTokName(pbCur, pImport);
-      tokenName += "["_W;
+      tokenName += _LU("[");
       ULONG num = 0;
       pbCur += CorSigUncompressData(pbCur, &num);
       for (ULONG i = 0; i < num; i++) {
         tokenName += GetSigTypeTokName(pbCur, pImport);
         if (i != num - 1) {
-          tokenName += ","_W;
+          tokenName += _LU(",");
         }
       }
-      tokenName += "]"_W;
+      tokenName += _LU("]");
       break;
     }
     case ELEMENT_TYPE_MVAR: {
       pbCur++;
       ULONG num = 0;
       pbCur += CorSigUncompressData(pbCur, &num);
-      tokenName = "!!"_W + ToWSTRING(std::to_string(num));
+      tokenName = _LU("!!") + ToWSTRING(std::to_string(num));
       break;
     }
     case ELEMENT_TYPE_VAR: {
       pbCur++;
       ULONG num = 0;
       pbCur += CorSigUncompressData(pbCur, &num);
-      tokenName = "!"_W + ToWSTRING(std::to_string(num));
+      tokenName = _LU("!") + ToWSTRING(std::to_string(num));
       break;
     }
     default:
@@ -1303,7 +1303,7 @@ WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>
   }
 
   if (ref_flag) {
-    tokenName += "&"_W;
+    tokenName += _LU("&");
   }
   return tokenName;
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -222,8 +222,8 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
                                             &type_extends);
       if (type_extends != mdTokenNil) {
         extendsInfo = new TypeInfo(GetTypeInfo(metadata_import, type_extends));
-        type_valueType = extendsInfo->name == _LU("System.ValueType") ||
-                         extendsInfo->name == _LU("System.Enum");
+        type_valueType = extendsInfo->name == WStr("System.ValueType") ||
+                         extendsInfo->name == WStr("System.Enum");
       }
       break;
     case mdtTypeRef:
@@ -265,7 +265,7 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import,
   }
 
   const auto type_name_string = WSTRING(type_name);
-  const auto generic_token_index = type_name_string.rfind(_LU("`"));
+  const auto generic_token_index = type_name_string.rfind(WStr("`"));
   if (generic_token_index != std::string::npos) {
     const auto idxFromRight = type_name_string.length() - generic_token_index - 1;
     type_isGeneric = idxFromRight == 1 || idxFromRight == 2;
@@ -434,8 +434,8 @@ bool DisableOptimizations() {
   const auto disable_optimizations =
       GetEnvironmentValue(environment::clr_disable_optimizations);
 
-  if (disable_optimizations == _LU("1") ||
-      disable_optimizations == _LU("true")) {
+  if (disable_optimizations == WStr("1") ||
+      disable_optimizations == WStr("true")) {
     return true;
   }
 
@@ -447,7 +447,7 @@ bool EnableInlining() {
   const auto enable_inlining =
       GetEnvironmentValue(environment::clr_enable_inlining);
 
-  if (enable_inlining == _LU("1") || enable_inlining == _LU("true")) {
+  if (enable_inlining == WStr("1") || enable_inlining == WStr("true")) {
     return true;
   }
 
@@ -459,7 +459,7 @@ bool IsCallTargetEnabled() {
   const auto calltarget_enabled =
       GetEnvironmentValue(environment::calltarget_enabled);
 
-  if (calltarget_enabled == _LU("1") || calltarget_enabled == _LU("true")) {
+  if (calltarget_enabled == WStr("1") || calltarget_enabled == WStr("true")) {
     return true;
   }
 
@@ -497,8 +497,8 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
     std::vector<WSTRING> type_names(expected_number_of_types);
 
     std::stack<int> generic_arg_stack;
-    WSTRING append_to_type = _LU("");
-    WSTRING current_type_name = _LU("");
+    WSTRING append_to_type = WStr("");
+    WSTRING current_type_name = WStr("");
 
     for (; current_index < signature_size; current_index++) {
       mdToken type_token;
@@ -508,77 +508,77 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
       switch (cor_element_type) {
         case ELEMENT_TYPE_VOID: {
-          current_type_name.append(_LU("System.Void"));
+          current_type_name.append(WStr("System.Void"));
           break;
         }
 
         case ELEMENT_TYPE_BOOLEAN: {
-          current_type_name.append(_LU("System.Boolean"));
+          current_type_name.append(WStr("System.Boolean"));
           break;
         }
 
         case ELEMENT_TYPE_CHAR: {
-          current_type_name.append(_LU("System.Char16"));
+          current_type_name.append(WStr("System.Char16"));
           break;
         }
 
         case ELEMENT_TYPE_I1: {
-          current_type_name.append(_LU("System.SByte"));
+          current_type_name.append(WStr("System.SByte"));
           break;
         }
 
         case ELEMENT_TYPE_U1: {
-          current_type_name.append(_LU("System.Byte"));
+          current_type_name.append(WStr("System.Byte"));
           break;
         }
 
         case ELEMENT_TYPE_I2: {
-          current_type_name.append(_LU("System.Int16"));
+          current_type_name.append(WStr("System.Int16"));
           break;
         }
 
         case ELEMENT_TYPE_U2: {
-          current_type_name.append(_LU("System.UInt16"));
+          current_type_name.append(WStr("System.UInt16"));
           break;
         }
 
         case ELEMENT_TYPE_I4: {
-          current_type_name.append(_LU("System.Int32"));
+          current_type_name.append(WStr("System.Int32"));
           break;
         }
 
         case ELEMENT_TYPE_U4: {
-          current_type_name.append(_LU("System.UInt32"));
+          current_type_name.append(WStr("System.UInt32"));
           break;
         }
 
         case ELEMENT_TYPE_I8: {
-          current_type_name.append(_LU("System.Int64"));
+          current_type_name.append(WStr("System.Int64"));
           break;
         }
 
         case ELEMENT_TYPE_U8: {
-          current_type_name.append(_LU("System.UInt64"));
+          current_type_name.append(WStr("System.UInt64"));
           break;
         }
 
         case ELEMENT_TYPE_R4: {
-          current_type_name.append(_LU("System.Single"));
+          current_type_name.append(WStr("System.Single"));
           break;
         }
 
         case ELEMENT_TYPE_R8: {
-          current_type_name.append(_LU("System.Double"));
+          current_type_name.append(WStr("System.Double"));
           break;
         }
 
         case ELEMENT_TYPE_STRING: {
-          current_type_name.append(_LU("System.String"));
+          current_type_name.append(WStr("System.String"));
           break;
         }
 
         case ELEMENT_TYPE_OBJECT: {
-          current_type_name.append(_LU("System.Object"));
+          current_type_name.append(WStr("System.Object"));
           break;
         }
 
@@ -593,7 +593,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
           auto ongoing_type_name = examined_type_name;
 
           // check for whether this may be a nested class
-          while (examined_type_name.find_first_of(_LU(".")) == std::string::npos) {
+          while (examined_type_name.find_first_of(WStr(".")) == std::string::npos) {
             // This may possibly be a nested class, check for the parent
             mdToken potentialParentToken;
             metadata_import->GetNestedClassProps(examined_type_token,
@@ -609,7 +609,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
             examined_type_token = nesting_type.id;
             examined_type_name = nesting_type.name;
 
-            ongoing_type_name = examined_type_name + _LU("+") + ongoing_type_name;
+            ongoing_type_name = examined_type_name + WStr("+") + ongoing_type_name;
           }
 
           // index will be moved up one on every loop
@@ -620,10 +620,10 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
         }
 
         case ELEMENT_TYPE_SZARRAY: {
-          append_to_type.append(_LU("[]"));
+          append_to_type.append(WStr("[]"));
           while (function_info.signature.data[(current_index + 1)] ==
                  ELEMENT_TYPE_SZARRAY) {
-            append_to_type.append(_LU("[]"));
+            append_to_type.append(WStr("[]"));
             current_index++;
           }
           // Next will be the type of the array(s)
@@ -635,7 +635,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
           token_length = CorSigUncompressToken(
               PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
               &type_token);
-          current_type_name.append(_LU("T"));
+          current_type_name.append(WStr("T"));
           current_index += token_length;
           // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
           // current_type_name.append(std::to_wstring(type_token));
@@ -647,7 +647,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
           token_length = CorSigUncompressToken(
               PCCOR_SIGNATURE(&function_info.signature.data[current_index]),
               &type_token);
-          current_type_name.append(_LU("T"));
+          current_type_name.append(WStr("T"));
           current_index += token_length;
           // TODO: implement conventions for generics (eg., TC1, TC2, TM1, TM2)
           // current_type_name.append(std::to_wstring(type_token));
@@ -663,7 +663,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
               metadata_import, function_info, current_index, token_length);
           auto type_name = generic_type_data.name;
           current_type_name.append(type_name);
-          current_type_name.append(_LU("<"));  // Begin generic args
+          current_type_name.append(WStr("<"));  // Begin generic args
 
           // Because we are starting a new generic, decrement any existing level
           if (!generic_arg_stack.empty()) {
@@ -682,7 +682,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
         case ELEMENT_TYPE_BYREF: {
           // TODO: This hasn't been encountered yet
-          current_type_name.append(_LU("ref"));
+          current_type_name.append(WStr("ref"));
           break;
         }
 
@@ -700,7 +700,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
       if (!append_to_type.empty()) {
         current_type_name.append(append_to_type);
-        append_to_type = _LU("");
+        append_to_type = WStr("");
       }
 
       if (!generic_arg_stack.empty()) {
@@ -709,18 +709,18 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
 
         if (generic_arg_stack.top() > 0) {
           // we're in the middle of generic type args
-          current_type_name.append(_LU(", "));
+          current_type_name.append(WStr(", "));
         }
       }
 
       while (!generic_arg_stack.empty() && generic_arg_stack.top() == 0) {
         // unwind the generics with no args left
         generic_arg_stack.pop();
-        current_type_name.append(_LU(">"));
+        current_type_name.append(WStr(">"));
 
         if (!generic_arg_stack.empty() && generic_arg_stack.top() > 0) {
           // We are in a nested generic and we need a comma to separate args
-          current_type_name.append(_LU(", "));
+          current_type_name.append(WStr(", "));
         }
       }
 
@@ -734,7 +734,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
       }
 
       type_names[current_type_index] = current_type_name;
-      current_type_name = _LU("");
+      current_type_name = WStr("");
       current_type_index++;
     }
 
@@ -759,7 +759,7 @@ HRESULT CreateAssemblyRefToMscorlib(const ComPtr<IMetaDataAssemblyEmit>& assembl
   metadata.usRevisionNumber = 0;
   BYTE public_key[] = {0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89};
   HRESULT hr = assembly_emit->DefineAssemblyRef(public_key, sizeof(public_key),
-                                   _LU("mscorlib"), &metadata, NULL, 0, 0,
+                                   WStr("mscorlib"), &metadata, NULL, 0, 0,
                                    mscorlib_ref);
 
   return hr;
@@ -770,7 +770,7 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
                                             const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
                                             mdToken* ret_type_token) {
   const auto cor_element_type = CorElementType(*p_sig);
-  WSTRING managed_type_name = _LU("");
+  WSTRING managed_type_name = WStr("");
 
   switch (cor_element_type) {
     case ELEMENT_TYPE_VALUETYPE: {
@@ -785,52 +785,52 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
     }
 
     case ELEMENT_TYPE_VOID:     // 0x01  // System.Void (struct)
-      managed_type_name = _LU("System.Void");
+      managed_type_name = WStr("System.Void");
       break;
     case ELEMENT_TYPE_BOOLEAN:  // 0x02  // System.Boolean (struct)
-      managed_type_name = _LU("System.Boolean");
+      managed_type_name = WStr("System.Boolean");
       break;
     case ELEMENT_TYPE_CHAR:     // 0x03  // System.Char (struct)
-      managed_type_name = _LU("System.Char");
+      managed_type_name = WStr("System.Char");
       break;
     case ELEMENT_TYPE_I1:       // 0x04  // System.SByte (struct)
-      managed_type_name = _LU("System.SByte");
+      managed_type_name = WStr("System.SByte");
       break;
     case ELEMENT_TYPE_U1:       // 0x05  // System.Byte (struct)
-      managed_type_name = _LU("System.Byte");
+      managed_type_name = WStr("System.Byte");
       break;
     case ELEMENT_TYPE_I2:       // 0x06  // System.Int16 (struct)
-      managed_type_name = _LU("System.Int16");
+      managed_type_name = WStr("System.Int16");
       break;
     case ELEMENT_TYPE_U2:       // 0x07  // System.UInt16 (struct)
-      managed_type_name = _LU("System.UInt16");
+      managed_type_name = WStr("System.UInt16");
       break;
     case ELEMENT_TYPE_I4:       // 0x08  // System.Int32 (struct)
-      managed_type_name = _LU("System.Int32");
+      managed_type_name = WStr("System.Int32");
       break;
     case ELEMENT_TYPE_U4:       // 0x09  // System.UInt32 (struct)
-      managed_type_name = _LU("System.UInt32");
+      managed_type_name = WStr("System.UInt32");
       break;
     case ELEMENT_TYPE_I8:       // 0x0a  // System.Int64 (struct)
-      managed_type_name = _LU("System.Int64");
+      managed_type_name = WStr("System.Int64");
       break;
     case ELEMENT_TYPE_U8:       // 0x0b  // System.UInt64 (struct)
-      managed_type_name = _LU("System.UInt64");
+      managed_type_name = WStr("System.UInt64");
       break;
     case ELEMENT_TYPE_R4:       // 0x0c  // System.Single (struct)
-      managed_type_name = _LU("System.Single");
+      managed_type_name = WStr("System.Single");
       break;
     case ELEMENT_TYPE_R8:       // 0x0d  // System.Double (struct)
-      managed_type_name = _LU("System.Double");
+      managed_type_name = WStr("System.Double");
       break;
     case ELEMENT_TYPE_TYPEDBYREF:  // 0X16  // System.TypedReference (struct)
-      managed_type_name = _LU("System.TypedReference");
+      managed_type_name = WStr("System.TypedReference");
       break;
     case ELEMENT_TYPE_I:           // 0x18  // System.IntPtr (struct)
-      managed_type_name = _LU("System.IntPtr");
+      managed_type_name = WStr("System.IntPtr");
       break;
     case ELEMENT_TYPE_U:           // 0x19  // System.UIntPtr (struct)
-      managed_type_name = _LU("System.UIntPtr");
+      managed_type_name = WStr("System.UIntPtr");
       break;
     default:
       return false;
@@ -847,7 +847,7 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
   }
 
   // Create/Get TypeRef to the listed type
-  if (managed_type_name == _LU("")) {
+  if (managed_type_name == WStr("")) {
     Warn("[trace::ReturnTypeTokenforElementType] no managed type name given");
     return false;
   }
@@ -1184,7 +1184,7 @@ mdToken FunctionMethodArgument::GetTypeTok(ComPtr<IMetaDataEmit2>& pEmit, mdAsse
 }
 
 WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>& pImport) {
-  WSTRING tokenName = _LU("");
+  WSTRING tokenName = WStr("");
   bool ref_flag = false;
   if (*pbCur == ELEMENT_TYPE_BYREF) {
     pbCur++;
@@ -1266,36 +1266,36 @@ WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>
     }
     case ELEMENT_TYPE_SZARRAY: {
       pbCur++;
-      tokenName = GetSigTypeTokName(pbCur, pImport) + _LU("[]");
+      tokenName = GetSigTypeTokName(pbCur, pImport) + WStr("[]");
       break;
     }
     case ELEMENT_TYPE_GENERICINST: {
       pbCur++;
       tokenName = GetSigTypeTokName(pbCur, pImport);
-      tokenName += _LU("[");
+      tokenName += WStr("[");
       ULONG num = 0;
       pbCur += CorSigUncompressData(pbCur, &num);
       for (ULONG i = 0; i < num; i++) {
         tokenName += GetSigTypeTokName(pbCur, pImport);
         if (i != num - 1) {
-          tokenName += _LU(",");
+          tokenName += WStr(",");
         }
       }
-      tokenName += _LU("]");
+      tokenName += WStr("]");
       break;
     }
     case ELEMENT_TYPE_MVAR: {
       pbCur++;
       ULONG num = 0;
       pbCur += CorSigUncompressData(pbCur, &num);
-      tokenName = _LU("!!") + ToWSTRING(std::to_string(num));
+      tokenName = WStr("!!") + ToWSTRING(std::to_string(num));
       break;
     }
     case ELEMENT_TYPE_VAR: {
       pbCur++;
       ULONG num = 0;
       pbCur += CorSigUncompressData(pbCur, &num);
-      tokenName = _LU("!") + ToWSTRING(std::to_string(num));
+      tokenName = WStr("!") + ToWSTRING(std::to_string(num));
       break;
     }
     default:
@@ -1303,7 +1303,7 @@ WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaDataImport2>
   }
 
   if (ref_flag) {
-    tokenName += _LU("&");
+    tokenName += WStr("&");
   }
   return tokenName;
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -17,29 +17,29 @@ class ModuleMetadata;
 const size_t kNameMaxSize = 1024;
 const ULONG kEnumeratorMax = 256;
 
-const auto SystemBoolean = _LU("System.Boolean");
-const auto SystemChar = _LU("System.Char");
-const auto SystemByte = _LU("System.Byte");
-const auto SystemSByte = _LU("System.SByte");
-const auto SystemUInt16 = _LU("System.UInt16");
-const auto SystemInt16 = _LU("System.Int16");
-const auto SystemInt32 = _LU("System.Int32");
-const auto SystemUInt32 = _LU("System.UInt32");
-const auto SystemInt64 = _LU("System.Int64");
-const auto SystemUInt64 = _LU("System.UInt64");
-const auto SystemSingle = _LU("System.Single");
-const auto SystemDouble = _LU("System.Double");
-const auto SystemIntPtr = _LU("System.IntPtr");
-const auto SystemUIntPtr = _LU("System.UIntPtr");
-const auto SystemString = _LU("System.String");
-const auto SystemObject = _LU("System.Object");
-const auto SystemException = _LU("System.Exception");
-const auto SystemTypeName = _LU("System.Type");
-const auto GetTypeFromHandleMethodName = _LU("GetTypeFromHandle");
-const auto RuntimeTypeHandleTypeName = _LU("System.RuntimeTypeHandle");
-const auto SystemReflectionMethodBaseName = _LU("System.Reflection.MethodBase");
-const auto GetMethodFromHandleMethodName = _LU("GetMethodFromHandle");
-const auto RuntimeMethodHandleTypeName = _LU("System.RuntimeMethodHandle");
+const auto SystemBoolean = WStr("System.Boolean");
+const auto SystemChar = WStr("System.Char");
+const auto SystemByte = WStr("System.Byte");
+const auto SystemSByte = WStr("System.SByte");
+const auto SystemUInt16 = WStr("System.UInt16");
+const auto SystemInt16 = WStr("System.Int16");
+const auto SystemInt32 = WStr("System.Int32");
+const auto SystemUInt32 = WStr("System.UInt32");
+const auto SystemInt64 = WStr("System.Int64");
+const auto SystemUInt64 = WStr("System.UInt64");
+const auto SystemSingle = WStr("System.Single");
+const auto SystemDouble = WStr("System.Double");
+const auto SystemIntPtr = WStr("System.IntPtr");
+const auto SystemUIntPtr = WStr("System.UIntPtr");
+const auto SystemString = WStr("System.String");
+const auto SystemObject = WStr("System.Object");
+const auto SystemException = WStr("System.Exception");
+const auto SystemTypeName = WStr("System.Type");
+const auto GetTypeFromHandleMethodName = WStr("GetTypeFromHandle");
+const auto RuntimeTypeHandleTypeName = WStr("System.RuntimeTypeHandle");
+const auto SystemReflectionMethodBaseName = WStr("System.Reflection.MethodBase");
+const auto GetMethodFromHandleMethodName = WStr("GetMethodFromHandle");
+const auto RuntimeMethodHandleTypeName = WStr("System.RuntimeMethodHandle");
 
 template <typename T>
 class EnumeratorIterator;
@@ -229,7 +229,7 @@ struct AssemblyInfo {
   const AppDomainID app_domain_id;
   const WSTRING app_domain_name;
 
-  AssemblyInfo() : id(0), name(_LU("")), manifest_module_id(0), app_domain_id(0), app_domain_name(_LU("")) {}
+  AssemblyInfo() : id(0), name(WStr("")), manifest_module_id(0), app_domain_id(0), app_domain_name(WStr("")) {}
 
   AssemblyInfo(AssemblyID id, WSTRING name, ModuleID manifest_module_id, AppDomainID app_domain_id,
                WSTRING app_domain_name)
@@ -248,7 +248,7 @@ struct AssemblyMetadata {
   const mdAssembly assembly_token;
   const Version version;
 
-  AssemblyMetadata() : module_id(0), name(_LU("")), assembly_token(mdTokenNil) {}
+  AssemblyMetadata() : module_id(0), name(WStr("")), assembly_token(mdTokenNil) {}
 
   AssemblyMetadata(ModuleID module_id, WSTRING name, mdAssembly assembly_token,
                    USHORT major, USHORT minor, USHORT build, USHORT revision)
@@ -269,7 +269,7 @@ struct AssemblyProperty {
   DWORD assemblyFlags = 0;
 
   AssemblyProperty()
-      : ppbPublicKey(nullptr), pcbPublicKey(0), pulHashAlgId(0), szName(_LU("")) {}
+      : ppbPublicKey(nullptr), pcbPublicKey(0), pulHashAlgId(0), szName(WStr("")) {}
 };
 
 struct ModuleInfo {
@@ -278,7 +278,7 @@ struct ModuleInfo {
   const AssemblyInfo assembly;
   const DWORD flags;
 
-  ModuleInfo() : id(0), path(_LU("")), assembly({}), flags(0) {}
+  ModuleInfo() : id(0), path(WStr("")), assembly({}), flags(0) {}
   ModuleInfo(ModuleID id, WSTRING path, AssemblyInfo assembly, DWORD flags)
       : id(id), path(path), assembly(assembly), flags(flags) {}
 
@@ -300,7 +300,7 @@ struct TypeInfo {
 
   TypeInfo()
       : id(0),
-        name(_LU("")),
+        name(WStr("")),
         type_spec(0),
         token_type(0),
         extend_from(nullptr),
@@ -378,7 +378,7 @@ struct FunctionInfo {
   FunctionMethodSignature method_signature;
 
   FunctionInfo()
-      : id(0), name(_LU("")), type({}), is_generic(false), method_def_id(0), method_signature({}) {}
+      : id(0), name(WStr("")), type({}), is_generic(false), method_def_id(0), method_signature({}) {}
 
   FunctionInfo(mdToken id, WSTRING name, TypeInfo type,
                MethodSignature signature,

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -17,29 +17,29 @@ class ModuleMetadata;
 const size_t kNameMaxSize = 1024;
 const ULONG kEnumeratorMax = 256;
 
-const auto SystemBoolean = "System.Boolean"_W;
-const auto SystemChar = "System.Char"_W;
-const auto SystemByte = "System.Byte"_W;
-const auto SystemSByte = "System.SByte"_W;
-const auto SystemUInt16 = "System.UInt16"_W;
-const auto SystemInt16 = "System.Int16"_W;
-const auto SystemInt32 = "System.Int32"_W;
-const auto SystemUInt32 = "System.UInt32"_W;
-const auto SystemInt64 = "System.Int64"_W;
-const auto SystemUInt64 = "System.UInt64"_W;
-const auto SystemSingle = "System.Single"_W;
-const auto SystemDouble = "System.Double"_W;
-const auto SystemIntPtr = "System.IntPtr"_W;
-const auto SystemUIntPtr = "System.UIntPtr"_W;
-const auto SystemString = "System.String"_W;
-const auto SystemObject = "System.Object"_W;
-const auto SystemException = "System.Exception"_W;
-const auto SystemTypeName = "System.Type"_W;
-const auto GetTypeFromHandleMethodName = "GetTypeFromHandle"_W;
-const auto RuntimeTypeHandleTypeName = "System.RuntimeTypeHandle"_W;
-const auto SystemReflectionMethodBaseName = "System.Reflection.MethodBase"_W;
-const auto GetMethodFromHandleMethodName = "GetMethodFromHandle"_W;
-const auto RuntimeMethodHandleTypeName = "System.RuntimeMethodHandle"_W;
+const auto SystemBoolean = _LU("System.Boolean");
+const auto SystemChar = _LU("System.Char");
+const auto SystemByte = _LU("System.Byte");
+const auto SystemSByte = _LU("System.SByte");
+const auto SystemUInt16 = _LU("System.UInt16");
+const auto SystemInt16 = _LU("System.Int16");
+const auto SystemInt32 = _LU("System.Int32");
+const auto SystemUInt32 = _LU("System.UInt32");
+const auto SystemInt64 = _LU("System.Int64");
+const auto SystemUInt64 = _LU("System.UInt64");
+const auto SystemSingle = _LU("System.Single");
+const auto SystemDouble = _LU("System.Double");
+const auto SystemIntPtr = _LU("System.IntPtr");
+const auto SystemUIntPtr = _LU("System.UIntPtr");
+const auto SystemString = _LU("System.String");
+const auto SystemObject = _LU("System.Object");
+const auto SystemException = _LU("System.Exception");
+const auto SystemTypeName = _LU("System.Type");
+const auto GetTypeFromHandleMethodName = _LU("GetTypeFromHandle");
+const auto RuntimeTypeHandleTypeName = _LU("System.RuntimeTypeHandle");
+const auto SystemReflectionMethodBaseName = _LU("System.Reflection.MethodBase");
+const auto GetMethodFromHandleMethodName = _LU("GetMethodFromHandle");
+const auto RuntimeMethodHandleTypeName = _LU("System.RuntimeMethodHandle");
 
 template <typename T>
 class EnumeratorIterator;
@@ -229,7 +229,7 @@ struct AssemblyInfo {
   const AppDomainID app_domain_id;
   const WSTRING app_domain_name;
 
-  AssemblyInfo() : id(0), name(""_W), manifest_module_id(0), app_domain_id(0), app_domain_name(""_W) {}
+  AssemblyInfo() : id(0), name(_LU("")), manifest_module_id(0), app_domain_id(0), app_domain_name(_LU("")) {}
 
   AssemblyInfo(AssemblyID id, WSTRING name, ModuleID manifest_module_id, AppDomainID app_domain_id,
                WSTRING app_domain_name)
@@ -248,7 +248,7 @@ struct AssemblyMetadata {
   const mdAssembly assembly_token;
   const Version version;
 
-  AssemblyMetadata() : module_id(0), name(""_W), assembly_token(mdTokenNil) {}
+  AssemblyMetadata() : module_id(0), name(_LU("")), assembly_token(mdTokenNil) {}
 
   AssemblyMetadata(ModuleID module_id, WSTRING name, mdAssembly assembly_token,
                    USHORT major, USHORT minor, USHORT build, USHORT revision)
@@ -269,7 +269,7 @@ struct AssemblyProperty {
   DWORD assemblyFlags = 0;
 
   AssemblyProperty()
-      : ppbPublicKey(nullptr), pcbPublicKey(0), pulHashAlgId(0), szName(""_W) {}
+      : ppbPublicKey(nullptr), pcbPublicKey(0), pulHashAlgId(0), szName(_LU("")) {}
 };
 
 struct ModuleInfo {
@@ -278,7 +278,7 @@ struct ModuleInfo {
   const AssemblyInfo assembly;
   const DWORD flags;
 
-  ModuleInfo() : id(0), path(""_W), assembly({}), flags(0) {}
+  ModuleInfo() : id(0), path(_LU("")), assembly({}), flags(0) {}
   ModuleInfo(ModuleID id, WSTRING path, AssemblyInfo assembly, DWORD flags)
       : id(id), path(path), assembly(assembly), flags(flags) {}
 
@@ -300,7 +300,7 @@ struct TypeInfo {
 
   TypeInfo()
       : id(0),
-        name(""_W),
+        name(_LU("")),
         type_spec(0),
         token_type(0),
         extend_from(nullptr),
@@ -378,7 +378,7 @@ struct FunctionInfo {
   FunctionMethodSignature method_signature;
 
   FunctionInfo()
-      : id(0), name(""_W), type({}), is_generic(false), method_def_id(0), method_signature({}) {}
+      : id(0), name(_LU("")), type({}), is_generic(false), method_def_id(0), method_signature({}) {}
 
   FunctionInfo(mdToken id, WSTRING name, TypeInfo type,
                MethodSignature signature,

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -38,7 +38,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto debug_enabled_value =
       GetEnvironmentValue(environment::debug_enabled);
 
-  if (debug_enabled_value == _LU("1") || debug_enabled_value == _LU("true")) {
+  if (debug_enabled_value == WStr("1") || debug_enabled_value == WStr("true")) {
     debug_logging_enabled = true;
   }
 
@@ -46,8 +46,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto dump_il_rewrite_enabled_value = 
       GetEnvironmentValue(environment::dump_il_rewrite_enabled);
 
-  if (dump_il_rewrite_enabled_value == _LU("1") ||
-      dump_il_rewrite_enabled_value == _LU("true")) {
+  if (dump_il_rewrite_enabled_value == WStr("1") ||
+      dump_il_rewrite_enabled_value == WStr("true")) {
     dump_il_rewrite_enabled = true;
   }
 
@@ -57,7 +57,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const WSTRING tracing_enabled =
       GetEnvironmentValue(environment::tracing_enabled);
 
-  if (tracing_enabled == _LU("0") || tracing_enabled == _LU("false")) {
+  if (tracing_enabled == WStr("0") || tracing_enabled == WStr("false")) {
     Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled in ", environment::tracing_enabled);
     return E_FAIL;
   }
@@ -105,7 +105,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const WSTRING azure_app_services_value =
       GetEnvironmentValue(environment::azure_app_services);
 
-  if (azure_app_services_value == _LU("1")) {
+  if (azure_app_services_value == WStr("1")) {
     Info("Profiler is operating within Azure App Services context.");
     in_azure_app_services = true;
 
@@ -122,7 +122,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     const auto cli_telemetry_profile_value = GetEnvironmentValue(
         environment::azure_app_services_cli_telemetry_profile_value);
 
-    if (cli_telemetry_profile_value == _LU("AzureKudu")) {
+    if (cli_telemetry_profile_value == WStr("AzureKudu")) {
       Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", app_pool_id_value,
            " is recognized as Kudu, an Azure App Services reserved process.");
       return E_FAIL;
@@ -180,9 +180,9 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   // https://github.com/DataDog/dd-trace-dotnet/pull/753.
   // users can opt-in to the additional instrumentation by setting environment
   // variable DD_TRACE_NETSTANDARD_ENABLED
-  if (netstandard_enabled != _LU("1") && netstandard_enabled != _LU("true")) {
+  if (netstandard_enabled != WStr("1") && netstandard_enabled != WStr("true")) {
     integration_methods_ = FilterIntegrationsByTargetAssemblyName(
-        integration_methods_, {_LU("netstandard")});
+        integration_methods_, {WStr("netstandard")});
   }
 
   DWORD event_mask = COR_PRF_MONITOR_JIT_COMPILATION |
@@ -213,7 +213,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const WSTRING domain_neutral_instrumentation =
       GetEnvironmentValue(environment::domain_neutral_instrumentation);
 
-  if (domain_neutral_instrumentation == _LU("1") || domain_neutral_instrumentation == _LU("true")) {
+  if (domain_neutral_instrumentation == WStr("1") || domain_neutral_instrumentation == WStr("true")) {
     instrument_domain_neutral_assemblies = true;
   }
 
@@ -247,8 +247,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   }
 
   runtime_information_ = GetRuntimeInformation(this->info_);
-  if (process_name == _LU("w3wp.exe")  ||
-      process_name == _LU("iisexpress.exe")) {
+  if (process_name == WStr("w3wp.exe")  ||
+      process_name == WStr("iisexpress.exe")) {
     is_desktop_iis = runtime_information_.is_desktop();
   }
 
@@ -319,7 +319,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
     Debug("AssemblyLoadFinished: AssemblyName=", assembly_info.name, " AssemblyVersion=", assembly_metadata.version.str());
   }
 
-  if (assembly_info.name == _LU("Datadog.Trace.ClrProfiler.Managed")) {
+  if (assembly_info.name == WStr("Datadog.Trace.ClrProfiler.Managed")) {
     // Configure a version string to compare with the profiler version
     std::stringstream ss;
     ss << assembly_metadata.version.major << '.'
@@ -390,8 +390,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   // Identify the AppDomain ID of mscorlib which will be the Shared Domain
   // because mscorlib is always a domain-neutral assembly
   if (!corlib_module_loaded &&
-      (module_info.assembly.name == _LU("mscorlib") ||
-       module_info.assembly.name == _LU("System.Private.CoreLib"))) {
+      (module_info.assembly.name == WStr("mscorlib") ||
+       module_info.assembly.name == WStr("System.Private.CoreLib"))) {
     corlib_module_loaded = true;
     corlib_app_domain_id = app_domain_id;
     
@@ -427,7 +427,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   // but the Datadog.Trace.ClrProfiler.Managed.Loader assembly that the startup hook loads from a
   // byte array will be loaded into a non-shared AppDomain.
   // In this case, do not insert another startup hook into that non-shared AppDomain
-  if (module_info.assembly.name == _LU("Datadog.Trace.ClrProfiler.Managed.Loader")) {
+  if (module_info.assembly.name == WStr("Datadog.Trace.ClrProfiler.Managed.Loader")) {
     Info("ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain ",
           app_domain_id, " ", module_info.assembly.app_domain_name);
     first_jit_compilation_app_domains.insert(app_domain_id);
@@ -492,8 +492,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   // subscribe to DiagnosticSource events.
   // don't skip Dapper: it makes ADO.NET calls even though it doesn't reference
   // System.Data or System.Data.Common
-  if (module_info.assembly.name != _LU("Microsoft.AspNetCore.Hosting") &&
-      module_info.assembly.name != _LU("Dapper")) {
+  if (module_info.assembly.name != WStr("Microsoft.AspNetCore.Hosting") &&
+      module_info.assembly.name != WStr("Dapper")) {
     filtered_integrations =
         FilterIntegrationsByTarget(filtered_integrations, assembly_import);
 
@@ -687,11 +687,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   auto valid_startup_hook_callsite = true;
   if (is_desktop_iis) {
       valid_startup_hook_callsite =
-            module_metadata->assemblyName == _LU("System.Web") &&
-            caller.type.name == _LU("System.Web.Compilation.BuildManager") &&
-            caller.name == _LU("InvokePreStartInitMethods");
-  } else if (module_metadata->assemblyName == _LU("System") ||
-             module_metadata->assemblyName == _LU("System.Net.Http")) {
+            module_metadata->assemblyName == WStr("System.Web") &&
+            caller.type.name == WStr("System.Web.Compilation.BuildManager") &&
+            caller.name == WStr("InvokePreStartInitMethods");
+  } else if (module_metadata->assemblyName == WStr("System") ||
+             module_metadata->assemblyName == WStr("System.Net.Http")) {
     valid_startup_hook_callsite = false;
   }
 
@@ -734,7 +734,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   // we don't actually need to instrument anything in
   // Microsoft.AspNetCore.Hosting, it was included only to ensure the startup
   // hook is called for AspNetCore applications
-  if (module_metadata->assemblyName == _LU("Microsoft.AspNetCore.Hosting")) {
+  if (module_metadata->assemblyName == WStr("Microsoft.AspNetCore.Hosting")) {
     return S_OK;
   }
 
@@ -864,8 +864,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(
   assembly_metadata.usMinorVersion = assemblyReference.version.minor;
   assembly_metadata.usBuildNumber = assemblyReference.version.build;
   assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-  if (assemblyReference.locale == _LU("neutral")) {
-    assembly_metadata.szLocale = const_cast<WCHAR*>(_LU("\0"));
+  if (assemblyReference.locale == WStr("neutral")) {
+    assembly_metadata.szLocale = const_cast<WCHAR*>(WStr("\0"));
     assembly_metadata.cbLocale = 0;
   } else {
     assembly_metadata.szLocale =
@@ -934,7 +934,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
   // Perform method call replacements
   for (auto& method_replacement : method_replacements) {
     // Exit early if the method replacement isn't actually doing a replacement
-    if (method_replacement.wrapper_method.action != _LU("ReplaceTargetMethod")) {
+    if (method_replacement.wrapper_method.action != WStr("ReplaceTargetMethod")) {
       continue;
     }
 
@@ -1094,7 +1094,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
 
       auto is_match = true;
       for (size_t i = 0; i < expected_sig.size(); i++) {
-        if (expected_sig[i] == _LU("_")) {
+        if (expected_sig[i] == WStr("_")) {
           // We are supposed to ignore this index
           continue;
         }
@@ -1242,7 +1242,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
 
         // Currently, we only expect to see `System.Threading.CancellationToken` as a valuetype in this position
         // If we expand this to a general case, we would always perform the boxing regardless of type
-        if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == _LU("System.Threading.CancellationToken")) {
+        if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == WStr("System.Threading.CancellationToken")) {
           rewriter_wrapper.Box(valuetype_type_token);
         }
       }
@@ -1261,7 +1261,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
           // `System.ReadOnlyMemory<T>` as a valuetype in this
           // position If we expand this to a general case, we would always
           // perform the boxing regardless of type
-          if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == _LU("System.ReadOnlyMemory`1")
+          if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == WStr("System.ReadOnlyMemory`1")
               && ParseType(&p_end_byte)) {
             size_t length = p_end_byte - p_start_byte;
             mdTypeSpec type_token;
@@ -1369,7 +1369,7 @@ HRESULT CorProfiler::ProcessInsertionCalls(
   ILInstr* lastInstr = rewriter.GetILList()->m_pPrev; // Should be a 'ret' instruction
 
   for (auto& method_replacement : method_replacements) {
-    if (method_replacement.wrapper_method.action == _LU("ReplaceTargetMethod")) {
+    if (method_replacement.wrapper_method.action == WStr("ReplaceTargetMethod")) {
       continue;
     }
 
@@ -1399,7 +1399,7 @@ HRESULT CorProfiler::ProcessInsertionCalls(
     }
 
     // After successfully getting the method reference, insert a call to it
-    if (method_replacement.wrapper_method.action == _LU("InsertFirst")) {
+    if (method_replacement.wrapper_method.action == WStr("InsertFirst")) {
       // Get first instruction and set the rewriter to that location
       rewriter_wrapper.SetILPosition(firstInstr);
       rewriter_wrapper.CallMember(wrapper_method_ref, false);
@@ -1739,7 +1739,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   // Define a TypeRef for System.Object
   mdTypeRef object_type_ref;
-  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, _LU("System.Object"), &object_type_ref);
+  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, WStr("System.Object"), &object_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
     return hr;
@@ -1747,7 +1747,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   // Define a new TypeDef __DDVoidMethodType__ that extends System.Object
   mdTypeDef new_type_def;
-  hr = metadata_emit->DefineTypeDef(_LU("__DDVoidMethodType__"), tdAbstract | tdSealed,
+  hr = metadata_emit->DefineTypeDef(WStr("__DDVoidMethodType__"), tdAbstract | tdSealed,
                                object_type_ref, NULL, &new_type_def);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeDef failed");
@@ -1762,7 +1762,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
     ELEMENT_TYPE_OBJECT            // List of parameter types
   };
   hr = metadata_emit->DefineMethod(new_type_def,
-                              _LU("__DDVoidMethodCall__"),
+                              WStr("__DDVoidMethodCall__"),
                               mdStatic,
                               initialize_signature,
                               sizeof(initialize_signature),
@@ -1782,7 +1782,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   };
   mdFieldDef isAssemblyLoadedFieldToken;
   hr = metadata_emit->DefineField(new_type_def, 
-                          _LU("_isAssemblyLoaded"),
+                          WStr("_isAssemblyLoaded"),
                           fdStatic | fdPrivate, 
                           field_signature, 
                           sizeof(field_signature),
@@ -1804,7 +1804,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   };
   mdMethodDef alreadyLoadedMethodToken;
   hr = metadata_emit->DefineMethod(
-      new_type_def, _LU("IsAlreadyLoaded"), mdStatic | mdPrivate,
+      new_type_def, WStr("IsAlreadyLoaded"), mdStatic | mdPrivate,
       already_loaded_signature, sizeof(already_loaded_signature), 0, 0,
       &alreadyLoadedMethodToken);
   if (FAILED(hr)) {
@@ -1814,7 +1814,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   // Get a TypeRef for System.Threading.Interlocked
   mdTypeRef interlocked_type_ref;
-  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, _LU("System.Threading.Interlocked"), &interlocked_type_ref);
+  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, WStr("System.Threading.Interlocked"), &interlocked_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName interlocked_type_ref failed");
     return hr;
@@ -1833,7 +1833,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   mdMemberRef interlocked_compare_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      interlocked_type_ref, _LU("CompareExchange"),
+      interlocked_type_ref, WStr("CompareExchange"),
       interlocked_compare_exchange_signature,
       sizeof(interlocked_compare_exchange_signature),
       &interlocked_compare_member_ref);
@@ -1921,7 +1921,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
       ELEMENT_TYPE_I4,
   };
   hr = metadata_emit->DefineMethod(
-      new_type_def, _LU("GetAssemblyAndSymbolsBytes"), mdStatic | mdPinvokeImpl | mdHideBySig,
+      new_type_def, WStr("GetAssemblyAndSymbolsBytes"), mdStatic | mdPinvokeImpl | mdHideBySig,
       get_assembly_bytes_signature, sizeof(get_assembly_bytes_signature), 0, 0,
       &pinvoke_method_def);
   if (FAILED(hr)) {
@@ -1936,21 +1936,21 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   }
 
 #ifdef _WIN32
-  WSTRING native_profiler_file = _LU("DATADOG.TRACE.CLRPROFILER.NATIVE.DLL");
+  WSTRING native_profiler_file = WStr("DATADOG.TRACE.CLRPROFILER.NATIVE.DLL");
 #else // _WIN32
 
 #ifdef BIT64
-  WSTRING native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH_64"));
+  WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_64"));
   Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_64 defined as: ", native_profiler_file);
-  if (native_profiler_file == _LU("")) {
-    native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH"));
+  if (native_profiler_file == WStr("")) {
+    native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
   }
 #else // BIT64
-  WSTRING native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH_32"));
+  WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_32"));
   Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_32 defined as: ", native_profiler_file);
-  if (native_profiler_file == _LU("")) {
-    native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH"));
+  if (native_profiler_file == WStr("")) {
+    native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
   }
 #endif // BIT64
@@ -1968,7 +1968,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   hr = metadata_emit->DefinePinvokeMap(pinvoke_method_def,
                                        0,
-                                       _LU("GetAssemblyAndSymbolsBytes"),
+                                       WStr("GetAssemblyAndSymbolsBytes"),
                                        profiler_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefinePinvokeMap failed");
@@ -1978,7 +1978,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.Byte
   mdTypeRef byte_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          _LU("System.Byte"),
+                                          WStr("System.Byte"),
                                           &byte_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -1988,7 +1988,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.Runtime.InteropServices.Marshal
   mdTypeRef marshal_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          _LU("System.Runtime.InteropServices.Marshal"),
+                                          WStr("System.Runtime.InteropServices.Marshal"),
                                           &marshal_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2008,7 +2008,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
       ELEMENT_TYPE_I4
   };
   hr = metadata_emit->DefineMemberRef(
-      marshal_type_ref, _LU("Copy"), marshal_copy_signature,
+      marshal_type_ref, WStr("Copy"), marshal_copy_signature,
       sizeof(marshal_copy_signature), &marshal_copy_member_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineMemberRef failed");
@@ -2018,7 +2018,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.Reflection.Assembly
   mdTypeRef system_reflection_assembly_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          _LU("System.Reflection.Assembly"),
+                                          WStr("System.Reflection.Assembly"),
                                           &system_reflection_assembly_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2028,7 +2028,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a MemberRef for System.Object.ToString()
   mdTypeRef system_object_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          _LU("System.Object"),
+                                          WStr("System.Object"),
                                           &system_object_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2038,7 +2038,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.AppDomain
   mdTypeRef system_appdomain_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          _LU("System.AppDomain"),
+                                          WStr("System.AppDomain"),
                                           &system_appdomain_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2072,7 +2072,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   mdMemberRef appdomain_get_current_domain_member_ref;
   hr = metadata_emit->DefineMemberRef(
       system_appdomain_type_ref,
-      _LU("get_CurrentDomain"),
+      WStr("get_CurrentDomain"),
       appdomain_get_current_domain_signature,
       appdomain_get_current_domain_signature_length,
       &appdomain_get_current_domain_member_ref);
@@ -2114,7 +2114,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   mdMemberRef appdomain_load_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_appdomain_type_ref, _LU("Load"),
+      system_appdomain_type_ref, WStr("Load"),
       appdomain_load_signature,
       appdomain_load_signature_length,
       &appdomain_load_member_ref);
@@ -2133,7 +2133,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   mdMemberRef assembly_create_instance_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_reflection_assembly_type_ref, _LU("CreateInstance"),
+      system_reflection_assembly_type_ref, WStr("CreateInstance"),
       assembly_create_instance_signature,
       sizeof(assembly_create_instance_signature),
       &assembly_create_instance_member_ref);
@@ -2467,7 +2467,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
   // Get System.AppDomain type ref
   mdTypeRef system_appdomain_type_ref;
   hr = metadata_emit->DefineTypeRefByName(
-      mscorlib_ref, _LU("System.AppDomain"), &system_appdomain_type_ref);
+      mscorlib_ref, WStr("System.AppDomain"), &system_appdomain_type_ref);
   if (FAILED(hr)) {
     Warn("Wrapper objectTypeRef could not be defined.");
     return hr;
@@ -2495,7 +2495,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
 
   mdMemberRef appdomain_get_current_domain_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_appdomain_type_ref, _LU("get_CurrentDomain"),
+      system_appdomain_type_ref, WStr("get_CurrentDomain"),
       appdomain_get_current_domain_signature, 
       appdomain_get_current_domain_signature_length,
       &appdomain_get_current_domain_member_ref);
@@ -2510,7 +2510,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
   };
   mdMemberRef appdomain_set_data_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_appdomain_type_ref, _LU("SetData"),
+      system_appdomain_type_ref, WStr("SetData"),
       appdomain_set_data_signature,
       sizeof(appdomain_set_data_signature),
       &appdomain_set_data_member_ref);
@@ -2810,7 +2810,7 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
         const auto argumentTypeName = methodArguments[i].GetTypeTokName(metadata_import);
         const auto integrationArgumentTypeName = integration.replacement.target_method.signature_types[i + 1];
         Debug("  -> ", argumentTypeName, " = ", integrationArgumentTypeName);
-        if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != _LU("_")) {
+        if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != WStr("_")) {
           argumentsMismatch = true;
           break;
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -38,7 +38,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto debug_enabled_value =
       GetEnvironmentValue(environment::debug_enabled);
 
-  if (debug_enabled_value == "1"_W || debug_enabled_value == "true"_W) {
+  if (debug_enabled_value == _LU("1") || debug_enabled_value == _LU("true")) {
     debug_logging_enabled = true;
   }
 
@@ -46,8 +46,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const auto dump_il_rewrite_enabled_value = 
       GetEnvironmentValue(environment::dump_il_rewrite_enabled);
 
-  if (dump_il_rewrite_enabled_value == "1"_W ||
-      dump_il_rewrite_enabled_value == "true"_W) {
+  if (dump_il_rewrite_enabled_value == _LU("1") ||
+      dump_il_rewrite_enabled_value == _LU("true")) {
     dump_il_rewrite_enabled = true;
   }
 
@@ -57,7 +57,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const WSTRING tracing_enabled =
       GetEnvironmentValue(environment::tracing_enabled);
 
-  if (tracing_enabled == "0"_W || tracing_enabled == "false"_W) {
+  if (tracing_enabled == _LU("0") || tracing_enabled == _LU("false")) {
     Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled in ", environment::tracing_enabled);
     return E_FAIL;
   }
@@ -105,7 +105,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const WSTRING azure_app_services_value =
       GetEnvironmentValue(environment::azure_app_services);
 
-  if (azure_app_services_value == "1"_W) {
+  if (azure_app_services_value == _LU("1")) {
     Info("Profiler is operating within Azure App Services context.");
     in_azure_app_services = true;
 
@@ -122,7 +122,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
     const auto cli_telemetry_profile_value = GetEnvironmentValue(
         environment::azure_app_services_cli_telemetry_profile_value);
 
-    if (cli_telemetry_profile_value == "AzureKudu"_W) {
+    if (cli_telemetry_profile_value == _LU("AzureKudu")) {
       Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", app_pool_id_value,
            " is recognized as Kudu, an Azure App Services reserved process.");
       return E_FAIL;
@@ -180,9 +180,9 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   // https://github.com/DataDog/dd-trace-dotnet/pull/753.
   // users can opt-in to the additional instrumentation by setting environment
   // variable DD_TRACE_NETSTANDARD_ENABLED
-  if (netstandard_enabled != "1"_W && netstandard_enabled != "true"_W) {
+  if (netstandard_enabled != _LU("1") && netstandard_enabled != _LU("true")) {
     integration_methods_ = FilterIntegrationsByTargetAssemblyName(
-        integration_methods_, {"netstandard"_W});
+        integration_methods_, {_LU("netstandard")});
   }
 
   DWORD event_mask = COR_PRF_MONITOR_JIT_COMPILATION |
@@ -213,7 +213,7 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   const WSTRING domain_neutral_instrumentation =
       GetEnvironmentValue(environment::domain_neutral_instrumentation);
 
-  if (domain_neutral_instrumentation == "1"_W || domain_neutral_instrumentation == "true"_W) {
+  if (domain_neutral_instrumentation == _LU("1") || domain_neutral_instrumentation == _LU("true")) {
     instrument_domain_neutral_assemblies = true;
   }
 
@@ -247,8 +247,8 @@ CorProfiler::Initialize(IUnknown* cor_profiler_info_unknown) {
   }
 
   runtime_information_ = GetRuntimeInformation(this->info_);
-  if (process_name == "w3wp.exe"_W  ||
-      process_name == "iisexpress.exe"_W) {
+  if (process_name == _LU("w3wp.exe")  ||
+      process_name == _LU("iisexpress.exe")) {
     is_desktop_iis = runtime_information_.is_desktop();
   }
 
@@ -319,7 +319,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
     Debug("AssemblyLoadFinished: AssemblyName=", assembly_info.name, " AssemblyVersion=", assembly_metadata.version.str());
   }
 
-  if (assembly_info.name == "Datadog.Trace.ClrProfiler.Managed"_W) {
+  if (assembly_info.name == _LU("Datadog.Trace.ClrProfiler.Managed")) {
     // Configure a version string to compare with the profiler version
     std::stringstream ss;
     ss << assembly_metadata.version.major << '.'
@@ -390,8 +390,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   // Identify the AppDomain ID of mscorlib which will be the Shared Domain
   // because mscorlib is always a domain-neutral assembly
   if (!corlib_module_loaded &&
-      (module_info.assembly.name == "mscorlib"_W ||
-       module_info.assembly.name == "System.Private.CoreLib"_W)) {
+      (module_info.assembly.name == _LU("mscorlib") ||
+       module_info.assembly.name == _LU("System.Private.CoreLib"))) {
     corlib_module_loaded = true;
     corlib_app_domain_id = app_domain_id;
     
@@ -427,7 +427,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   // but the Datadog.Trace.ClrProfiler.Managed.Loader assembly that the startup hook loads from a
   // byte array will be loaded into a non-shared AppDomain.
   // In this case, do not insert another startup hook into that non-shared AppDomain
-  if (module_info.assembly.name == "Datadog.Trace.ClrProfiler.Managed.Loader"_W) {
+  if (module_info.assembly.name == _LU("Datadog.Trace.ClrProfiler.Managed.Loader")) {
     Info("ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain ",
           app_domain_id, " ", module_info.assembly.app_domain_name);
     first_jit_compilation_app_domains.insert(app_domain_id);
@@ -492,8 +492,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id,
   // subscribe to DiagnosticSource events.
   // don't skip Dapper: it makes ADO.NET calls even though it doesn't reference
   // System.Data or System.Data.Common
-  if (module_info.assembly.name != "Microsoft.AspNetCore.Hosting"_W &&
-      module_info.assembly.name != "Dapper"_W) {
+  if (module_info.assembly.name != _LU("Microsoft.AspNetCore.Hosting") &&
+      module_info.assembly.name != _LU("Dapper")) {
     filtered_integrations =
         FilterIntegrationsByTarget(filtered_integrations, assembly_import);
 
@@ -687,11 +687,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   auto valid_startup_hook_callsite = true;
   if (is_desktop_iis) {
       valid_startup_hook_callsite =
-            module_metadata->assemblyName == "System.Web"_W &&
-            caller.type.name == "System.Web.Compilation.BuildManager"_W &&
-            caller.name == "InvokePreStartInitMethods"_W;
-  } else if (module_metadata->assemblyName == "System"_W ||
-             module_metadata->assemblyName == "System.Net.Http"_W) {
+            module_metadata->assemblyName == _LU("System.Web") &&
+            caller.type.name == _LU("System.Web.Compilation.BuildManager") &&
+            caller.name == _LU("InvokePreStartInitMethods");
+  } else if (module_metadata->assemblyName == _LU("System") ||
+             module_metadata->assemblyName == _LU("System.Net.Http")) {
     valid_startup_hook_callsite = false;
   }
 
@@ -734,7 +734,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
   // we don't actually need to instrument anything in
   // Microsoft.AspNetCore.Hosting, it was included only to ensure the startup
   // hook is called for AspNetCore applications
-  if (module_metadata->assemblyName == "Microsoft.AspNetCore.Hosting"_W) {
+  if (module_metadata->assemblyName == _LU("Microsoft.AspNetCore.Hosting")) {
     return S_OK;
   }
 
@@ -864,8 +864,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(
   assembly_metadata.usMinorVersion = assemblyReference.version.minor;
   assembly_metadata.usBuildNumber = assemblyReference.version.build;
   assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-  if (assemblyReference.locale == "neutral"_W) {
-    assembly_metadata.szLocale = const_cast<WCHAR*>("\0"_W.c_str());
+  if (assemblyReference.locale == _LU("neutral")) {
+    assembly_metadata.szLocale = const_cast<WCHAR*>(_LU("\0"));
     assembly_metadata.cbLocale = 0;
   } else {
     assembly_metadata.szLocale =
@@ -934,7 +934,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
   // Perform method call replacements
   for (auto& method_replacement : method_replacements) {
     // Exit early if the method replacement isn't actually doing a replacement
-    if (method_replacement.wrapper_method.action != "ReplaceTargetMethod"_W) {
+    if (method_replacement.wrapper_method.action != _LU("ReplaceTargetMethod")) {
       continue;
     }
 
@@ -1094,7 +1094,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
 
       auto is_match = true;
       for (size_t i = 0; i < expected_sig.size(); i++) {
-        if (expected_sig[i] == "_"_W) {
+        if (expected_sig[i] == _LU("_")) {
           // We are supposed to ignore this index
           continue;
         }
@@ -1242,7 +1242,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
 
         // Currently, we only expect to see `System.Threading.CancellationToken` as a valuetype in this position
         // If we expand this to a general case, we would always perform the boxing regardless of type
-        if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == "System.Threading.CancellationToken"_W) {
+        if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == _LU("System.Threading.CancellationToken")) {
           rewriter_wrapper.Box(valuetype_type_token);
         }
       }
@@ -1261,7 +1261,7 @@ HRESULT CorProfiler::ProcessReplacementCalls(
           // `System.ReadOnlyMemory<T>` as a valuetype in this
           // position If we expand this to a general case, we would always
           // perform the boxing regardless of type
-          if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == "System.ReadOnlyMemory`1"_W
+          if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name == _LU("System.ReadOnlyMemory`1")
               && ParseType(&p_end_byte)) {
             size_t length = p_end_byte - p_start_byte;
             mdTypeSpec type_token;
@@ -1369,7 +1369,7 @@ HRESULT CorProfiler::ProcessInsertionCalls(
   ILInstr* lastInstr = rewriter.GetILList()->m_pPrev; // Should be a 'ret' instruction
 
   for (auto& method_replacement : method_replacements) {
-    if (method_replacement.wrapper_method.action == "ReplaceTargetMethod"_W) {
+    if (method_replacement.wrapper_method.action == _LU("ReplaceTargetMethod")) {
       continue;
     }
 
@@ -1399,7 +1399,7 @@ HRESULT CorProfiler::ProcessInsertionCalls(
     }
 
     // After successfully getting the method reference, insert a call to it
-    if (method_replacement.wrapper_method.action == "InsertFirst"_W) {
+    if (method_replacement.wrapper_method.action == _LU("InsertFirst")) {
       // Get first instruction and set the rewriter to that location
       rewriter_wrapper.SetILPosition(firstInstr);
       rewriter_wrapper.CallMember(wrapper_method_ref, false);
@@ -1739,8 +1739,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   // Define a TypeRef for System.Object
   mdTypeRef object_type_ref;
-  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, "System.Object"_W.c_str(),
-                                          &object_type_ref);
+  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, _LU("System.Object"), &object_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
     return hr;
@@ -1748,7 +1747,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   // Define a new TypeDef __DDVoidMethodType__ that extends System.Object
   mdTypeDef new_type_def;
-  hr = metadata_emit->DefineTypeDef("__DDVoidMethodType__"_W.c_str(), tdAbstract | tdSealed,
+  hr = metadata_emit->DefineTypeDef(_LU("__DDVoidMethodType__"), tdAbstract | tdSealed,
                                object_type_ref, NULL, &new_type_def);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeDef failed");
@@ -1763,7 +1762,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
     ELEMENT_TYPE_OBJECT            // List of parameter types
   };
   hr = metadata_emit->DefineMethod(new_type_def,
-                              "__DDVoidMethodCall__"_W.c_str(),
+                              _LU("__DDVoidMethodCall__"),
                               mdStatic,
                               initialize_signature,
                               sizeof(initialize_signature),
@@ -1783,7 +1782,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   };
   mdFieldDef isAssemblyLoadedFieldToken;
   hr = metadata_emit->DefineField(new_type_def, 
-                          "_isAssemblyLoaded"_W.c_str(),
+                          _LU("_isAssemblyLoaded"),
                           fdStatic | fdPrivate, 
                           field_signature, 
                           sizeof(field_signature),
@@ -1805,7 +1804,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   };
   mdMethodDef alreadyLoadedMethodToken;
   hr = metadata_emit->DefineMethod(
-      new_type_def, "IsAlreadyLoaded"_W.c_str(), mdStatic | mdPrivate,
+      new_type_def, _LU("IsAlreadyLoaded"), mdStatic | mdPrivate,
       already_loaded_signature, sizeof(already_loaded_signature), 0, 0,
       &alreadyLoadedMethodToken);
   if (FAILED(hr)) {
@@ -1815,7 +1814,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   // Get a TypeRef for System.Threading.Interlocked
   mdTypeRef interlocked_type_ref;
-  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, "System.Threading.Interlocked"_W.c_str(), &interlocked_type_ref);
+  hr = metadata_emit->DefineTypeRefByName(mscorlib_ref, _LU("System.Threading.Interlocked"), &interlocked_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName interlocked_type_ref failed");
     return hr;
@@ -1834,7 +1833,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 
   mdMemberRef interlocked_compare_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      interlocked_type_ref, "CompareExchange"_W.c_str(),
+      interlocked_type_ref, _LU("CompareExchange"),
       interlocked_compare_exchange_signature,
       sizeof(interlocked_compare_exchange_signature),
       &interlocked_compare_member_ref);
@@ -1922,7 +1921,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
       ELEMENT_TYPE_I4,
   };
   hr = metadata_emit->DefineMethod(
-      new_type_def, "GetAssemblyAndSymbolsBytes"_W.c_str(), mdStatic | mdPinvokeImpl | mdHideBySig,
+      new_type_def, _LU("GetAssemblyAndSymbolsBytes"), mdStatic | mdPinvokeImpl | mdHideBySig,
       get_assembly_bytes_signature, sizeof(get_assembly_bytes_signature), 0, 0,
       &pinvoke_method_def);
   if (FAILED(hr)) {
@@ -1937,7 +1936,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
   }
 
 #ifdef _WIN32
-  WSTRING native_profiler_file = "DATADOG.TRACE.CLRPROFILER.NATIVE.DLL"_W;
+  WSTRING native_profiler_file = _LU("DATADOG.TRACE.CLRPROFILER.NATIVE.DLL");
 #else // _WIN32
 
 #ifdef BIT64
@@ -1969,7 +1968,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   hr = metadata_emit->DefinePinvokeMap(pinvoke_method_def,
                                        0,
-                                       "GetAssemblyAndSymbolsBytes"_W.c_str(),
+                                       _LU("GetAssemblyAndSymbolsBytes"),
                                        profiler_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefinePinvokeMap failed");
@@ -1979,7 +1978,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.Byte
   mdTypeRef byte_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          "System.Byte"_W.c_str(),
+                                          _LU("System.Byte"),
                                           &byte_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -1989,7 +1988,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.Runtime.InteropServices.Marshal
   mdTypeRef marshal_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          "System.Runtime.InteropServices.Marshal"_W.c_str(),
+                                          _LU("System.Runtime.InteropServices.Marshal"),
                                           &marshal_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2009,7 +2008,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
       ELEMENT_TYPE_I4
   };
   hr = metadata_emit->DefineMemberRef(
-      marshal_type_ref, "Copy"_W.c_str(), marshal_copy_signature,
+      marshal_type_ref, _LU("Copy"), marshal_copy_signature,
       sizeof(marshal_copy_signature), &marshal_copy_member_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineMemberRef failed");
@@ -2019,7 +2018,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.Reflection.Assembly
   mdTypeRef system_reflection_assembly_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          "System.Reflection.Assembly"_W.c_str(),
+                                          _LU("System.Reflection.Assembly"),
                                           &system_reflection_assembly_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2029,7 +2028,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a MemberRef for System.Object.ToString()
   mdTypeRef system_object_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          "System.Object"_W.c_str(),
+                                          _LU("System.Object"),
                                           &system_object_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2039,7 +2038,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   // Get a TypeRef for System.AppDomain
   mdTypeRef system_appdomain_type_ref;
   hr = metadata_emit->DefineTypeRefByName(mscorlib_ref,
-                                          "System.AppDomain"_W.c_str(),
+                                          _LU("System.AppDomain"),
                                           &system_appdomain_type_ref);
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
@@ -2073,7 +2072,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   mdMemberRef appdomain_get_current_domain_member_ref;
   hr = metadata_emit->DefineMemberRef(
       system_appdomain_type_ref,
-      "get_CurrentDomain"_W.c_str(),
+      _LU("get_CurrentDomain"),
       appdomain_get_current_domain_signature,
       appdomain_get_current_domain_signature_length,
       &appdomain_get_current_domain_member_ref);
@@ -2115,7 +2114,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   mdMemberRef appdomain_load_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_appdomain_type_ref, "Load"_W.c_str(),
+      system_appdomain_type_ref, _LU("Load"),
       appdomain_load_signature,
       appdomain_load_signature_length,
       &appdomain_load_member_ref);
@@ -2134,7 +2133,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
 
   mdMemberRef assembly_create_instance_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_reflection_assembly_type_ref, "CreateInstance"_W.c_str(),
+      system_reflection_assembly_type_ref, _LU("CreateInstance"),
       assembly_create_instance_signature,
       sizeof(assembly_create_instance_signature),
       &assembly_create_instance_member_ref);
@@ -2462,13 +2461,13 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
 
   // Get System.Boolean type token
   mdToken boolToken;
-  metadata_emit->DefineTypeRefByName(mscorlib_ref, SystemBoolean.data(),
+  metadata_emit->DefineTypeRefByName(mscorlib_ref, SystemBoolean,
                                      &boolToken);
 
   // Get System.AppDomain type ref
   mdTypeRef system_appdomain_type_ref;
   hr = metadata_emit->DefineTypeRefByName(
-      mscorlib_ref, "System.AppDomain"_W.c_str(), &system_appdomain_type_ref);
+      mscorlib_ref, _LU("System.AppDomain"), &system_appdomain_type_ref);
   if (FAILED(hr)) {
     Warn("Wrapper objectTypeRef could not be defined.");
     return hr;
@@ -2496,8 +2495,8 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
 
   mdMemberRef appdomain_get_current_domain_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_appdomain_type_ref, "get_CurrentDomain"_W.c_str(),
-      appdomain_get_current_domain_signature,
+      system_appdomain_type_ref, _LU("get_CurrentDomain"),
+      appdomain_get_current_domain_signature, 
       appdomain_get_current_domain_signature_length,
       &appdomain_get_current_domain_member_ref);
 
@@ -2511,7 +2510,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
   };
   mdMemberRef appdomain_set_data_member_ref;
   hr = metadata_emit->DefineMemberRef(
-      system_appdomain_type_ref, "SetData"_W.c_str(),
+      system_appdomain_type_ref, _LU("SetData"),
       appdomain_set_data_signature,
       sizeof(appdomain_set_data_signature),
       &appdomain_set_data_member_ref);
@@ -2811,7 +2810,7 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
         const auto argumentTypeName = methodArguments[i].GetTypeTokName(metadata_import);
         const auto integrationArgumentTypeName = integration.replacement.target_method.signature_types[i + 1];
         Debug("  -> ", argumentTypeName, " = ", integrationArgumentTypeName);
-        if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != "_"_W) {
+        if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != _LU("_")) {
           argumentsMismatch = true;
           break;
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1940,17 +1940,17 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
 #else // _WIN32
 
 #ifdef BIT64
-  WSTRING native_profiler_file = GetEnvironmentValue("CORECLR_PROFILER_PATH_64"_W);
+  WSTRING native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH_64"));
   Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_64 defined as: ", native_profiler_file);
-  if (native_profiler_file == ""_W) {
-    native_profiler_file = GetEnvironmentValue("CORECLR_PROFILER_PATH"_W);
+  if (native_profiler_file == _LU("")) {
+    native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
   }
 #else // BIT64
-  WSTRING native_profiler_file = GetEnvironmentValue("CORECLR_PROFILER_PATH_32"_W);
+  WSTRING native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH_32"));
   Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_32 defined as: ", native_profiler_file);
-  if (native_profiler_file == ""_W) {
-    native_profiler_file = GetEnvironmentValue("CORECLR_PROFILER_PATH"_W);
+  if (native_profiler_file == _LU("")) {
+    native_profiler_file = GetEnvironmentValue(_LU("CORECLR_PROFILER_PATH"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
   }
 #endif // BIT64

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -34,41 +34,43 @@ namespace trace {
     environment::azure_app_services_cli_telemetry_profile_value};
 
   inline WSTRING skip_assembly_prefixes[]{
-    "Datadog.Trace"_W,
-    "MessagePack"_W,
-    "Microsoft.AI"_W,
-    "Microsoft.ApplicationInsights"_W,
-    "Microsoft.Build"_W,
-    "Microsoft.CSharp"_W,
-    "Microsoft.Extensions"_W,
-    "Microsoft.Web.Compilation.Snapshots"_W,
-    "Sigil"_W,
-    "System.Core"_W,
-    "System.Console"_W,
-    "System.Collections"_W,
-    "System.ComponentModel"_W,
-    "System.Diagnostics"_W,
-    "System.Drawing"_W,
-    "System.EnterpriseServices"_W,
-    "System.IO"_W,
-    "System.Runtime"_W,
-    "System.Text"_W,
-    "System.Threading"_W,
-    "System.Xml"_W,
-    "Newtonsoft"_W,};
+    _LU("Datadog.Trace"),
+    _LU("MessagePack"),
+    _LU("Microsoft.AI"),
+    _LU("Microsoft.ApplicationInsights"),
+    _LU("Microsoft.Build"),
+    _LU("Microsoft.CSharp"),
+    _LU("Microsoft.Extensions"),
+    _LU("Microsoft.Web.Compilation.Snapshots"),
+    _LU("Sigil"),
+    _LU("System.Core"),
+    _LU("System.Console"),
+    _LU("System.Collections"),
+    _LU("System.ComponentModel"),
+    _LU("System.Diagnostics"),
+    _LU("System.Drawing"),
+    _LU("System.EnterpriseServices"),
+    _LU("System.IO"),
+    _LU("System.Runtime"),
+    _LU("System.Text"),
+    _LU("System.Threading"),
+    _LU("System.Xml"),
+    _LU("Newtonsoft"),
+  };
 
   inline WSTRING skip_assemblies[]{
-      "mscorlib"_W,
-      "netstandard"_W,
-      "System.Configuration"_W,
-      "Microsoft.AspNetCore.Razor.Language"_W,
-      "Microsoft.AspNetCore.Mvc.RazorPages"_W,
-      "Anonymously Hosted DynamicMethods Assembly"_W,
-      "ISymWrapper"_W};
+      _LU("mscorlib"),
+      _LU("netstandard"),
+      _LU("System.Configuration"),
+      _LU("Microsoft.AspNetCore.Razor.Language"),
+      _LU("Microsoft.AspNetCore.Mvc.RazorPages"),
+      _LU("Anonymously Hosted DynamicMethods Assembly"),
+      _LU("ISymWrapper")
+  };
 
-  inline WSTRING managed_profiler_full_assembly_version = "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb"_W;
+  inline WSTRING managed_profiler_full_assembly_version = _LU("Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
-  inline WSTRING calltarget_modification_action = "CallTargetModification"_W;
+  inline WSTRING calltarget_modification_action = _LU("CallTargetModification");
 
 }  // namespace trace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -34,43 +34,43 @@ namespace trace {
     environment::azure_app_services_cli_telemetry_profile_value};
 
   inline WSTRING skip_assembly_prefixes[]{
-    _LU("Datadog.Trace"),
-    _LU("MessagePack"),
-    _LU("Microsoft.AI"),
-    _LU("Microsoft.ApplicationInsights"),
-    _LU("Microsoft.Build"),
-    _LU("Microsoft.CSharp"),
-    _LU("Microsoft.Extensions"),
-    _LU("Microsoft.Web.Compilation.Snapshots"),
-    _LU("Sigil"),
-    _LU("System.Core"),
-    _LU("System.Console"),
-    _LU("System.Collections"),
-    _LU("System.ComponentModel"),
-    _LU("System.Diagnostics"),
-    _LU("System.Drawing"),
-    _LU("System.EnterpriseServices"),
-    _LU("System.IO"),
-    _LU("System.Runtime"),
-    _LU("System.Text"),
-    _LU("System.Threading"),
-    _LU("System.Xml"),
-    _LU("Newtonsoft"),
+    WStr("Datadog.Trace"),
+    WStr("MessagePack"),
+    WStr("Microsoft.AI"),
+    WStr("Microsoft.ApplicationInsights"),
+    WStr("Microsoft.Build"),
+    WStr("Microsoft.CSharp"),
+    WStr("Microsoft.Extensions"),
+    WStr("Microsoft.Web.Compilation.Snapshots"),
+    WStr("Sigil"),
+    WStr("System.Core"),
+    WStr("System.Console"),
+    WStr("System.Collections"),
+    WStr("System.ComponentModel"),
+    WStr("System.Diagnostics"),
+    WStr("System.Drawing"),
+    WStr("System.EnterpriseServices"),
+    WStr("System.IO"),
+    WStr("System.Runtime"),
+    WStr("System.Text"),
+    WStr("System.Threading"),
+    WStr("System.Xml"),
+    WStr("Newtonsoft"),
   };
 
   inline WSTRING skip_assemblies[]{
-      _LU("mscorlib"),
-      _LU("netstandard"),
-      _LU("System.Configuration"),
-      _LU("Microsoft.AspNetCore.Razor.Language"),
-      _LU("Microsoft.AspNetCore.Mvc.RazorPages"),
-      _LU("Anonymously Hosted DynamicMethods Assembly"),
-      _LU("ISymWrapper")
+      WStr("mscorlib"),
+      WStr("netstandard"),
+      WStr("System.Configuration"),
+      WStr("Microsoft.AspNetCore.Razor.Language"),
+      WStr("Microsoft.AspNetCore.Mvc.RazorPages"),
+      WStr("Anonymously Hosted DynamicMethods Assembly"),
+      WStr("ISymWrapper")
   };
 
-  inline WSTRING managed_profiler_full_assembly_version = _LU("Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+  inline WSTRING managed_profiler_full_assembly_version = WStr("Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
-  inline WSTRING calltarget_modification_action = _LU("CallTargetModification");
+  inline WSTRING calltarget_modification_action = WStr("CallTargetModification");
 
 }  // namespace trace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -8,71 +8,71 @@ namespace environment {
 
 // Sets whether the profiler is enabled. Default is true.
 // Setting this to false disabled the profiler entirely.
-const WSTRING tracing_enabled = _LU("DD_TRACE_ENABLED");
+const WSTRING tracing_enabled = WStr("DD_TRACE_ENABLED");
 
 // Sets whether debug mode is enabled. Default is false.
-const WSTRING debug_enabled = _LU("DD_TRACE_DEBUG");
+const WSTRING debug_enabled = WStr("DD_TRACE_DEBUG");
 
 // Sets the paths to integration definition JSON files.
 // Supports multiple values separated with semi-colons, for example:
 // "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
-const WSTRING integrations_path = _LU("DD_INTEGRATIONS");
+const WSTRING integrations_path = WStr("DD_INTEGRATIONS");
 
 // Sets the path to the profiler's home directory, for example:
 // "C:\Program Files\Datadog .NET Tracer\" or "/opt/datadog/"
-const WSTRING profiler_home_path = _LU("DD_DOTNET_TRACER_HOME");
+const WSTRING profiler_home_path = WStr("DD_DOTNET_TRACER_HOME");
 
 // Sets the filename of executables the profiler can attach to.
 // If not defined (default), the profiler will attach to any process.
 // Supports multiple values separated with semi-colons, for example:
 // "MyApp.exe;dotnet.exe"
-const WSTRING include_process_names = _LU("DD_PROFILER_PROCESSES");
+const WSTRING include_process_names = WStr("DD_PROFILER_PROCESSES");
 
 // Sets the filename of executables the profiler cannot attach to.
 // If not defined (default), the profiler will attach to any process.
 // Supports multiple values separated with semi-colons, for example:
 // "MyApp.exe;dotnet.exe"
-const WSTRING exclude_process_names = _LU("DD_PROFILER_EXCLUDE_PROCESSES");
+const WSTRING exclude_process_names = WStr("DD_PROFILER_EXCLUDE_PROCESSES");
 
 // Sets the Agent's host. Default is localhost.
-const WSTRING agent_host = _LU("DD_AGENT_HOST");
+const WSTRING agent_host = WStr("DD_AGENT_HOST");
 
 // Sets the Agent's port. Default is 8126.
-const WSTRING agent_port = _LU("DD_TRACE_AGENT_PORT");
+const WSTRING agent_port = WStr("DD_TRACE_AGENT_PORT");
 
 // Sets the "env" tag for every span.
-const WSTRING env = _LU("DD_ENV");
+const WSTRING env = WStr("DD_ENV");
 
 // Sets the default service name for every span.
 // If not set, Tracer will try to determine service name automatically
 // from application name (e.g. entry assembly or IIS application name).
-const WSTRING service_name = _LU("DD_SERVICE");
+const WSTRING service_name = WStr("DD_SERVICE");
 
 // Sets the "service_version" tag for every span that belong to the root service (and not an external service).
-const WSTRING service_version = _LU("DD_VERSION");
+const WSTRING service_version = WStr("DD_VERSION");
 
 // Sets a list of integrations to disable. All other integrations will remain
 // enabled. If not set (default), all integrations are enabled. Supports
 // multiple values separated with semi-colons, for example:
 // "ElasticsearchNet;AspNetWebApi2"
-const WSTRING disabled_integrations = _LU("DD_DISABLED_INTEGRATIONS");
+const WSTRING disabled_integrations = WStr("DD_DISABLED_INTEGRATIONS");
 
 // Sets the path for the profiler's log file.
 // Environment variable DD_TRACE_LOG_DIRECTORY takes precedence over this setting, if set.
-const WSTRING log_path = _LU("DD_TRACE_LOG_PATH");
+const WSTRING log_path = WStr("DD_TRACE_LOG_PATH");
 
 // Sets the directory for the profiler's log file.
 // If set, this setting takes precedence over environment variable DD_TRACE_LOG_PATH.
 // If not set, default is
 // "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows or
 // "/var/log/datadog/dotnet/" on Linux.
-const WSTRING log_directory = _LU("DD_TRACE_LOG_DIRECTORY");
+const WSTRING log_directory = WStr("DD_TRACE_LOG_DIRECTORY");
 
 // Sets whether to disable all JIT optimizations.
 // Default value is false (do not disable all optimizations).
 // https://github.com/dotnet/coreclr/issues/24676
 // https://github.com/dotnet/coreclr/issues/12468
-const WSTRING clr_disable_optimizations = _LU("DD_CLR_DISABLE_OPTIMIZATIONS");
+const WSTRING clr_disable_optimizations = WStr("DD_CLR_DISABLE_OPTIMIZATIONS");
 
 // Sets whether to intercept method calls when the caller method is inside a
 // domain-neutral assembly. This is dangerous because the integration assembly
@@ -83,30 +83,30 @@ const WSTRING clr_disable_optimizations = _LU("DD_CLR_DISABLE_OPTIMIZATIONS");
 // one application.
 // Default is false. Only used in .NET Framework 4.5 and 4.5.1.
 // https://github.com/DataDog/dd-trace-dotnet/pull/671
-const WSTRING domain_neutral_instrumentation = _LU("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION");
+const WSTRING domain_neutral_instrumentation = WStr("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION");
 
 // Indicates whether the profiler is running in the context
 // of Azure App Services
-const WSTRING azure_app_services = _LU("DD_AZURE_APP_SERVICES");
+const WSTRING azure_app_services = WStr("DD_AZURE_APP_SERVICES");
 
 // The app_pool_id in the context of azure app services
-const WSTRING azure_app_services_app_pool_id = _LU("APP_POOL_ID");
+const WSTRING azure_app_services_app_pool_id = WStr("APP_POOL_ID");
 
 // The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
-const WSTRING azure_app_services_cli_telemetry_profile_value = _LU("DOTNET_CLI_TELEMETRY_PROFILE");
+const WSTRING azure_app_services_cli_telemetry_profile_value = WStr("DOTNET_CLI_TELEMETRY_PROFILE");
 
 // Determine whether to instrument calls into netstandard.dll.
 // Default to false for now to avoid the unexpected overhead of additional spans.
-const WSTRING netstandard_enabled = _LU("DD_TRACE_NETSTANDARD_ENABLED");
+const WSTRING netstandard_enabled = WStr("DD_TRACE_NETSTANDARD_ENABLED");
 
 // Enable the profiler to dump the IL original code and modification to the log.
-const WSTRING dump_il_rewrite_enabled = _LU("DD_DUMP_ILREWRITE_ENABLED");
+const WSTRING dump_il_rewrite_enabled = WStr("DD_DUMP_ILREWRITE_ENABLED");
 
 // Sets whether to enable JIT inlining
-const WSTRING clr_enable_inlining = _LU("DD_CLR_ENABLE_INLINING");
+const WSTRING clr_enable_inlining = WStr("DD_CLR_ENABLE_INLINING");
 
 // Sets whether to enable the CallTarget instrumentation mode
-const WSTRING calltarget_enabled = _LU("DD_TRACE_CALLTARGET_ENABLED");
+const WSTRING calltarget_enabled = WStr("DD_TRACE_CALLTARGET_ENABLED");
 
 }  // namespace environment
 }  // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -8,71 +8,71 @@ namespace environment {
 
 // Sets whether the profiler is enabled. Default is true.
 // Setting this to false disabled the profiler entirely.
-const WSTRING tracing_enabled = "DD_TRACE_ENABLED"_W;
+const WSTRING tracing_enabled = _LU("DD_TRACE_ENABLED");
 
 // Sets whether debug mode is enabled. Default is false.
-const WSTRING debug_enabled = "DD_TRACE_DEBUG"_W;
+const WSTRING debug_enabled = _LU("DD_TRACE_DEBUG");
 
 // Sets the paths to integration definition JSON files.
 // Supports multiple values separated with semi-colons, for example:
 // "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
-const WSTRING integrations_path = "DD_INTEGRATIONS"_W;
+const WSTRING integrations_path = _LU("DD_INTEGRATIONS");
 
 // Sets the path to the profiler's home directory, for example:
 // "C:\Program Files\Datadog .NET Tracer\" or "/opt/datadog/"
-const WSTRING profiler_home_path = "DD_DOTNET_TRACER_HOME"_W;
+const WSTRING profiler_home_path = _LU("DD_DOTNET_TRACER_HOME");
 
 // Sets the filename of executables the profiler can attach to.
 // If not defined (default), the profiler will attach to any process.
 // Supports multiple values separated with semi-colons, for example:
 // "MyApp.exe;dotnet.exe"
-const WSTRING include_process_names = "DD_PROFILER_PROCESSES"_W;
+const WSTRING include_process_names = _LU("DD_PROFILER_PROCESSES");
 
 // Sets the filename of executables the profiler cannot attach to.
 // If not defined (default), the profiler will attach to any process.
 // Supports multiple values separated with semi-colons, for example:
 // "MyApp.exe;dotnet.exe"
-const WSTRING exclude_process_names = "DD_PROFILER_EXCLUDE_PROCESSES"_W;
+const WSTRING exclude_process_names = _LU("DD_PROFILER_EXCLUDE_PROCESSES");
 
 // Sets the Agent's host. Default is localhost.
-const WSTRING agent_host = "DD_AGENT_HOST"_W;
+const WSTRING agent_host = _LU("DD_AGENT_HOST");
 
 // Sets the Agent's port. Default is 8126.
-const WSTRING agent_port = "DD_TRACE_AGENT_PORT"_W;
+const WSTRING agent_port = _LU("DD_TRACE_AGENT_PORT");
 
 // Sets the "env" tag for every span.
-const WSTRING env = "DD_ENV"_W;
+const WSTRING env = _LU("DD_ENV");
 
 // Sets the default service name for every span.
 // If not set, Tracer will try to determine service name automatically
 // from application name (e.g. entry assembly or IIS application name).
-const WSTRING service_name = "DD_SERVICE"_W;
+const WSTRING service_name = _LU("DD_SERVICE");
 
 // Sets the "service_version" tag for every span that belong to the root service (and not an external service).
-const WSTRING service_version = "DD_VERSION"_W;
+const WSTRING service_version = _LU("DD_VERSION");
 
 // Sets a list of integrations to disable. All other integrations will remain
 // enabled. If not set (default), all integrations are enabled. Supports
 // multiple values separated with semi-colons, for example:
 // "ElasticsearchNet;AspNetWebApi2"
-const WSTRING disabled_integrations = "DD_DISABLED_INTEGRATIONS"_W;
+const WSTRING disabled_integrations = _LU("DD_DISABLED_INTEGRATIONS");
 
 // Sets the path for the profiler's log file.
 // Environment variable DD_TRACE_LOG_DIRECTORY takes precedence over this setting, if set.
-const WSTRING log_path = "DD_TRACE_LOG_PATH"_W;
+const WSTRING log_path = _LU("DD_TRACE_LOG_PATH");
 
 // Sets the directory for the profiler's log file.
 // If set, this setting takes precedence over environment variable DD_TRACE_LOG_PATH.
 // If not set, default is
 // "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows or
 // "/var/log/datadog/dotnet/" on Linux.
-const WSTRING log_directory = "DD_TRACE_LOG_DIRECTORY"_W;
+const WSTRING log_directory = _LU("DD_TRACE_LOG_DIRECTORY");
 
 // Sets whether to disable all JIT optimizations.
 // Default value is false (do not disable all optimizations).
 // https://github.com/dotnet/coreclr/issues/24676
 // https://github.com/dotnet/coreclr/issues/12468
-const WSTRING clr_disable_optimizations = "DD_CLR_DISABLE_OPTIMIZATIONS"_W;
+const WSTRING clr_disable_optimizations = _LU("DD_CLR_DISABLE_OPTIMIZATIONS");
 
 // Sets whether to intercept method calls when the caller method is inside a
 // domain-neutral assembly. This is dangerous because the integration assembly
@@ -83,31 +83,30 @@ const WSTRING clr_disable_optimizations = "DD_CLR_DISABLE_OPTIMIZATIONS"_W;
 // one application.
 // Default is false. Only used in .NET Framework 4.5 and 4.5.1.
 // https://github.com/DataDog/dd-trace-dotnet/pull/671
-const WSTRING domain_neutral_instrumentation = "DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION"_W;
+const WSTRING domain_neutral_instrumentation = _LU("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION");
 
 // Indicates whether the profiler is running in the context
 // of Azure App Services
-const WSTRING azure_app_services = "DD_AZURE_APP_SERVICES"_W;
+const WSTRING azure_app_services = _LU("DD_AZURE_APP_SERVICES");
 
 // The app_pool_id in the context of azure app services
-const WSTRING azure_app_services_app_pool_id = "APP_POOL_ID"_W;
+const WSTRING azure_app_services_app_pool_id = _LU("APP_POOL_ID");
 
 // The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
-const WSTRING azure_app_services_cli_telemetry_profile_value =
-    "DOTNET_CLI_TELEMETRY_PROFILE"_W;
+const WSTRING azure_app_services_cli_telemetry_profile_value = _LU("DOTNET_CLI_TELEMETRY_PROFILE");
 
 // Determine whether to instrument calls into netstandard.dll.
 // Default to false for now to avoid the unexpected overhead of additional spans.
-const WSTRING netstandard_enabled = "DD_TRACE_NETSTANDARD_ENABLED"_W;
+const WSTRING netstandard_enabled = _LU("DD_TRACE_NETSTANDARD_ENABLED");
 
 // Enable the profiler to dump the IL original code and modification to the log.
-const WSTRING dump_il_rewrite_enabled = "DD_DUMP_ILREWRITE_ENABLED"_W;
+const WSTRING dump_il_rewrite_enabled = _LU("DD_DUMP_ILREWRITE_ENABLED");
 
 // Sets whether to enable JIT inlining
-const WSTRING clr_enable_inlining = "DD_CLR_ENABLE_INLINING"_W;
+const WSTRING clr_enable_inlining = _LU("DD_CLR_ENABLE_INLINING");
 
 // Sets whether to enable the CallTarget instrumentation mode
-const WSTRING calltarget_enabled = "DD_TRACE_CALLTARGET_ENABLED"_W;
+const WSTRING calltarget_enabled = _LU("DD_TRACE_CALLTARGET_ENABLED");
 
 }  // namespace environment
 }  // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -23,13 +23,13 @@ namespace {
 WSTRING GetNameFromAssemblyReferenceString(const WSTRING& wstr) {
   WSTRING name = wstr;
 
-  auto pos = name.find(_LU(','));
+  auto pos = name.find(WStr(','));
   if (pos != WSTRING::npos) {
     name = name.substr(0, pos);
   }
 
   // strip spaces
-  pos = name.rfind(_LU(' '));
+  pos = name.rfind(WStr(' '));
   if (pos != WSTRING::npos) {
     name = name.substr(0, pos);
   }
@@ -46,7 +46,7 @@ Version GetVersionFromAssemblyReferenceString(const WSTRING& str) {
 #ifdef _WIN32
 
   static auto re =
-      std::wregex(_LU("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
+      std::wregex(WStr("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
 
   std::wsmatch match;
   if (std::regex_search(str, match, re) && match.size() == 5) {
@@ -68,11 +68,11 @@ Version GetVersionFromAssemblyReferenceString(const WSTRING& str) {
 }
 
 WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& str) {
-  WSTRING locale = _LU("neutral");
+  WSTRING locale = WStr("neutral");
 
 #ifdef _WIN32
 
-  static auto re = std::wregex(_LU("Culture=([a-zA-Z0-9]+)"));
+  static auto re = std::wregex(WStr("Culture=([a-zA-Z0-9]+)"));
   std::wsmatch match;
   if (std::regex_search(str, match, re) && match.size() == 2) {
     locale = match.str(1);
@@ -97,7 +97,7 @@ PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& str) {
 
 #ifdef _WIN32
 
-  static auto re = std::wregex(_LU("PublicKeyToken=([a-fA-F0-9]{16})"));
+  static auto re = std::wregex(WStr("PublicKeyToken=([a-fA-F0-9]{16})"));
   std::wsmatch match;
   if (std::regex_search(str, match, re) && match.size() == 2) {
     for (int i = 0; i < 8; i++) {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -23,13 +23,13 @@ namespace {
 WSTRING GetNameFromAssemblyReferenceString(const WSTRING& wstr) {
   WSTRING name = wstr;
 
-  auto pos = name.find(','_W);
+  auto pos = name.find(_LU(','));
   if (pos != WSTRING::npos) {
     name = name.substr(0, pos);
   }
 
   // strip spaces
-  pos = name.rfind(' '_W);
+  pos = name.rfind(_LU(' '));
   if (pos != WSTRING::npos) {
     name = name.substr(0, pos);
   }
@@ -46,7 +46,7 @@ Version GetVersionFromAssemblyReferenceString(const WSTRING& str) {
 #ifdef _WIN32
 
   static auto re =
-      std::wregex("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"_W);
+      std::wregex(_LU("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
 
   std::wsmatch match;
   if (std::regex_search(str, match, re) && match.size() == 5) {
@@ -68,11 +68,11 @@ Version GetVersionFromAssemblyReferenceString(const WSTRING& str) {
 }
 
 WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& str) {
-  WSTRING locale = "neutral"_W;
+  WSTRING locale = _LU("neutral");
 
 #ifdef _WIN32
 
-  static auto re = std::wregex("Culture=([a-zA-Z0-9]+)"_W);
+  static auto re = std::wregex(_LU("Culture=([a-zA-Z0-9]+)"));
   std::wsmatch match;
   if (std::regex_search(str, match, re) && match.size() == 2) {
     locale = match.str(1);
@@ -97,7 +97,7 @@ PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& str) {
 
 #ifdef _WIN32
 
-  static auto re = std::wregex("PublicKeyToken=([a-fA-F0-9]{16})"_W);
+  static auto re = std::wregex(_LU("PublicKeyToken=([a-fA-F0-9]{16})"));
   std::wsmatch match;
   if (std::regex_search(str, match, re) && match.size() == 2) {
     for (int i = 0; i < 8; i++) {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -113,8 +113,8 @@ struct AssemblyReference {
   }
 
   inline WSTRING str() const {
-    const auto ss = name + ", Version="_W + version.str() + ", Culture="_W + locale
-       + ", PublicKeyToken="_W + public_key.str();
+    const auto ss = name + _LU(", Version=") + version.str() + _LU(", Culture=") + locale
+       + _LU(", PublicKeyToken=") + public_key.str();
     return ss;
   }
 };
@@ -220,13 +220,13 @@ struct MethodReference {
         signature_types(signature_types) {}
 
   inline WSTRING get_type_cache_key() const {
-    return "["_W + assembly.name + "]"_W + type_name + "_vMin_"_W +
-           min_version.str() + "_vMax_"_W + max_version.str();
+    return _LU("[") + assembly.name + _LU("]") + type_name + _LU("_vMin_") +
+           min_version.str() + _LU("_vMax_") + max_version.str();
   }
 
   inline WSTRING get_method_cache_key() const {
-    return "["_W + assembly.name + "]"_W + type_name + "."_W + method_name +
-           "_vMin_"_W + min_version.str() + "_vMax_"_W + max_version.str();
+    return _LU("[") + assembly.name + _LU("]") + type_name + _LU(".") + method_name +
+           _LU("_vMin_") + min_version.str() + _LU("_vMax_") + max_version.str();
   }
 
   inline bool operator==(const MethodReference& other) const {
@@ -263,7 +263,7 @@ struct Integration {
   const WSTRING integration_name;
   std::vector<MethodReplacement> method_replacements;
 
-  Integration() : integration_name(""_W), method_replacements({}) {}
+  Integration() : integration_name(_LU("")), method_replacements({}) {}
 
   Integration(WSTRING integration_name,
               std::vector<MethodReplacement> method_replacements)
@@ -280,7 +280,7 @@ struct IntegrationMethod {
   const WSTRING integration_name;
   MethodReplacement replacement;
 
-  IntegrationMethod() : integration_name(""_W), replacement({}) {}
+  IntegrationMethod() : integration_name(_LU("")), replacement({}) {}
 
   IntegrationMethod(WSTRING integration_name, MethodReplacement replacement)
       : integration_name(integration_name), replacement(replacement) {}

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -113,8 +113,8 @@ struct AssemblyReference {
   }
 
   inline WSTRING str() const {
-    const auto ss = name + _LU(", Version=") + version.str() + _LU(", Culture=") + locale
-       + _LU(", PublicKeyToken=") + public_key.str();
+    const auto ss = name + WStr(", Version=") + version.str() + WStr(", Culture=") + locale
+       + WStr(", PublicKeyToken=") + public_key.str();
     return ss;
   }
 };
@@ -220,13 +220,13 @@ struct MethodReference {
         signature_types(signature_types) {}
 
   inline WSTRING get_type_cache_key() const {
-    return _LU("[") + assembly.name + _LU("]") + type_name + _LU("_vMin_") +
-           min_version.str() + _LU("_vMax_") + max_version.str();
+    return WStr("[") + assembly.name + WStr("]") + type_name + WStr("_vMin_") +
+           min_version.str() + WStr("_vMax_") + max_version.str();
   }
 
   inline WSTRING get_method_cache_key() const {
-    return _LU("[") + assembly.name + _LU("]") + type_name + _LU(".") + method_name +
-           _LU("_vMin_") + min_version.str() + _LU("_vMax_") + max_version.str();
+    return WStr("[") + assembly.name + WStr("]") + type_name + WStr(".") + method_name +
+           WStr("_vMin_") + min_version.str() + WStr("_vMax_") + max_version.str();
   }
 
   inline bool operator==(const MethodReference& other) const {
@@ -263,7 +263,7 @@ struct Integration {
   const WSTRING integration_name;
   std::vector<MethodReplacement> method_replacements;
 
-  Integration() : integration_name(_LU("")), method_replacements({}) {}
+  Integration() : integration_name(WStr("")), method_replacements({}) {}
 
   Integration(WSTRING integration_name,
               std::vector<MethodReplacement> method_replacements)
@@ -280,7 +280,7 @@ struct IntegrationMethod {
   const WSTRING integration_name;
   MethodReplacement replacement;
 
-  IntegrationMethod() : integration_name(_LU("")), replacement({}) {}
+  IntegrationMethod() : integration_name(WStr("")), replacement({}) {}
 
   IntegrationMethod(WSTRING integration_name, MethodReplacement replacement)
       : integration_name(integration_name), replacement(replacement) {}

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -148,7 +148,7 @@ MethodReference MethodReferenceFromJson(const json::value_type& src,
   USHORT max_minor = USHRT_MAX;
   USHORT max_patch = USHRT_MAX;
   std::vector<WSTRING> signature_type_array;
-  WSTRING action = _LU("");
+  WSTRING action = WStr("");
 
   if (is_target_method) {
     // these fields only exist in the target definition

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -148,7 +148,7 @@ MethodReference MethodReferenceFromJson(const json::value_type& src,
   USHORT max_minor = USHRT_MAX;
   USHORT max_patch = USHRT_MAX;
   std::vector<WSTRING> signature_type_array;
-  WSTRING action = ""_W;
+  WSTRING action = _LU("");
 
   if (is_target_method) {
     // these fields only exist in the target definition

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -15,7 +15,7 @@ HRESULT MetadataBuilder::EmitAssemblyRef(
   assembly_metadata.usMinorVersion = assembly_ref.version.minor;
   assembly_metadata.usBuildNumber = assembly_ref.version.build;
   assembly_metadata.usRevisionNumber = assembly_ref.version.revision;
-  if (assembly_ref.locale == "neutral"_W) {
+  if (assembly_ref.locale == _LU("neutral")) {
     assembly_metadata.szLocale = nullptr;
     assembly_metadata.cbLocale = 0;
   } else {

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -15,7 +15,7 @@ HRESULT MetadataBuilder::EmitAssemblyRef(
   assembly_metadata.usMinorVersion = assembly_ref.version.minor;
   assembly_metadata.usBuildNumber = assembly_ref.version.build;
   assembly_metadata.usRevisionNumber = assembly_ref.version.revision;
-  if (assembly_ref.locale == _LU("neutral")) {
+  if (assembly_ref.locale == WStr("neutral")) {
     assembly_metadata.szLocale = nullptr;
     assembly_metadata.cbLocale = 0;
   } else {

--- a/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
@@ -25,7 +25,7 @@ class ModuleMetadata {
   const ComPtr<IMetaDataEmit2> metadata_emit{};
   const ComPtr<IMetaDataAssemblyImport> assembly_import{};
   const ComPtr<IMetaDataAssemblyEmit> assembly_emit{};
-  WSTRING assemblyName = ""_W;
+  WSTRING assemblyName = _LU("");
   AppDomainID app_domain_id;
   GUID module_version_id;
   std::vector<IntegrationMethod> integrations = {};

--- a/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
@@ -25,7 +25,7 @@ class ModuleMetadata {
   const ComPtr<IMetaDataEmit2> metadata_emit{};
   const ComPtr<IMetaDataAssemblyImport> assembly_import{};
   const ComPtr<IMetaDataAssemblyEmit> assembly_emit{};
-  WSTRING assemblyName = _LU("");
+  WSTRING assemblyName = WStr("");
   AppDomainID app_domain_id;
   GUID module_version_id;
   std::vector<IntegrationMethod> integrations = {};

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -30,11 +30,11 @@ inline WSTRING DatadogLogFilePath() {
   if (directory.length() > 0) {
     return directory +
 #ifdef _WIN32
-           '\\'_W +
+           _LU('\\') +
 #else
-           '/'_W +
+           _LU('/') +
 #endif
-        "dotnet-tracer-native.log"_W;
+        _LU("dotnet-tracer-native.log");
   }
 
   WSTRING path = GetEnvironmentValue(environment::log_path);
@@ -58,7 +58,7 @@ inline WSTRING DatadogLogFilePath() {
   return ToWSTRING(program_data +
                    R"(\Datadog .NET Tracer\logs\dotnet-tracer-native.log)");
 #else
-  return "/var/log/datadog/dotnet/dotnet-tracer-native.log"_W;
+  return _LU("/var/log/datadog/dotnet/dotnet-tracer-native.log");
 #endif
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -30,11 +30,11 @@ inline WSTRING DatadogLogFilePath() {
   if (directory.length() > 0) {
     return directory +
 #ifdef _WIN32
-           _LU('\\') +
+           WStr('\\') +
 #else
-           _LU('/') +
+           WStr('/') +
 #endif
-        _LU("dotnet-tracer-native.log");
+        WStr("dotnet-tracer-native.log");
   }
 
   WSTRING path = GetEnvironmentValue(environment::log_path);
@@ -58,7 +58,7 @@ inline WSTRING DatadogLogFilePath() {
   return ToWSTRING(program_data +
                    R"(\Datadog .NET Tracer\logs\dotnet-tracer-native.log)");
 #else
-  return _LU("/var/log/datadog/dotnet/dotnet-tracer-native.log");
+  return WStr("/var/log/datadog/dotnet/dotnet-tracer-native.log");
 #endif
 }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/string.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.cpp
@@ -1,35 +1,56 @@
 #include "string.h"
+#ifdef _WIN32
+#include <Windows.h>
+#define tmp_buffer_size 512
+#else
 #include "miniutf.hpp"
+#endif
 
 namespace trace {
 
 std::string ToString(const std::string& str) { return str; }
 std::string ToString(const char* str) { return std::string(str); }
-std::string ToString(const uint64_t i) {
-  std::stringstream ss;
-  ss << i;
-  return ss.str();
-}
+std::string ToString(const uint64_t i) { return std::to_string(i); }
 std::string ToString(const WSTRING& wstr) {
+#ifdef _WIN32
+  if (wstr.empty()) return std::string();
+
+  std::string tmpStr(tmp_buffer_size, 0);
+  int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &tmpStr[0], tmp_buffer_size, NULL, NULL);
+  if (size_needed < tmp_buffer_size) {
+    return tmpStr.substr(0, size_needed);
+  }
+
+  std::string strTo(size_needed, 0);
+  WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+  return strTo;
+#else
   std::u16string ustr(reinterpret_cast<const char16_t*>(wstr.c_str()));
   return miniutf::to_utf8(ustr);
+#endif
 }
 
 WSTRING ToWSTRING(const std::string& str) {
+#ifdef _WIN32
+  if (str.empty()) return std::wstring();
+
+  std::wstring tmpStr(tmp_buffer_size, 0);
+  int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &tmpStr[0], tmp_buffer_size);
+  if (size_needed < tmp_buffer_size) {
+    return tmpStr.substr(0, size_needed);
+  }
+
+  std::wstring wstrTo(size_needed, 0);
+  MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstrTo[0], size_needed);
+  return wstrTo;
+#else
   auto ustr = miniutf::to_utf16(str);
   return WSTRING(reinterpret_cast<const WCHAR*>(ustr.c_str()));
+#endif
 }
 
 WSTRING ToWSTRING(const uint64_t i) {
-  const auto ustr = ToString(i);
-  return ToWSTRING(ustr);
-}
-
-WCHAR operator"" _W(const char c) { return WCHAR(c); }
-
-WSTRING operator"" _W(const char* arr, size_t size) {
-  std::string str(arr, size);
-  return ToWSTRING(str);
+  return WSTRING(reinterpret_cast<const WCHAR*>(std::to_wstring(i).c_str()));
 }
 
 }  // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/string.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.h
@@ -6,11 +6,11 @@
 #include <string>
 
 #ifdef _WIN32
-#define _LU(value) L##value
-#define _LU_len(value) (size_t) wcslen(value)
+#define WStr(value) L##value
+#define WStrLen(value) (size_t) wcslen(value)
 #else
-#define _LU(value) u##value
-#define _LU_len(value) (size_t) std::char_traits<char16_t>::length(value)
+#define WStr(value) u##value
+#define WStrLen(value) (size_t) std::char_traits<char16_t>::length(value)
 #endif
 
 namespace trace {

--- a/src/Datadog.Trace.ClrProfiler.Native/string.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.h
@@ -5,6 +5,14 @@
 #include <sstream>
 #include <string>
 
+#ifdef _WIN32
+#define _LU(value) L##value
+#define _LU_len(value) (size_t) wcslen(value)
+#else
+#define _LU(value) u##value
+#define _LU_len(value) (size_t) std::char_traits<char16_t>::length(value)
+#endif
+
 namespace trace {
 
 typedef std::basic_string<WCHAR> WSTRING;
@@ -20,9 +28,6 @@ std::string ToString(const WSTRING& wstr);
 
 WSTRING ToWSTRING(const std::string& str);
 WSTRING ToWSTRING(const uint64_t i);
-
-WCHAR operator"" _W(const char c);
-WSTRING operator"" _W(const char* arr, size_t size);
 
 }  // namespace trace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -58,7 +58,7 @@ WSTRING GetEnvironmentValue(const WSTRING &name) {
 #else
   auto cstr = std::getenv(ToString(name).c_str());
   if (cstr == nullptr) {
-    return ""_W;
+    return _LU("");
   }
   std::string str(cstr);
   auto wstr = ToWSTRING(str);

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -30,17 +30,17 @@ std::vector<WSTRING> Split(const WSTRING &s, wchar_t delim) {
 
 WSTRING Trim(const WSTRING &str) {
   if (str.length() == 0) {
-    return _LU("");
+    return WStr("");
   }
 
   WSTRING trimmed = str;
 
-  auto lpos = trimmed.find_first_not_of(_LU(" \t"));
+  auto lpos = trimmed.find_first_not_of(WStr(" \t"));
   if (lpos != WSTRING::npos && lpos > 0) {
     trimmed = trimmed.substr(lpos);
   }
 
-  auto rpos = trimmed.find_last_not_of(_LU(" \t"));
+  auto rpos = trimmed.find_last_not_of(WStr(" \t"));
   if (rpos != WSTRING::npos) {
     trimmed = trimmed.substr(0, rpos + 1);
   }
@@ -58,7 +58,7 @@ WSTRING GetEnvironmentValue(const WSTRING &name) {
 #else
   auto cstr = std::getenv(ToString(name).c_str());
   if (cstr == nullptr) {
-    return _LU("");
+    return WStr("");
   }
   std::string str(cstr);
   auto wstr = ToWSTRING(str);

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -30,17 +30,17 @@ std::vector<WSTRING> Split(const WSTRING &s, wchar_t delim) {
 
 WSTRING Trim(const WSTRING &str) {
   if (str.length() == 0) {
-    return ""_W;
+    return _LU("");
   }
 
   WSTRING trimmed = str;
 
-  auto lpos = trimmed.find_first_not_of(" \t"_W);
+  auto lpos = trimmed.find_first_not_of(_LU(" \t"));
   if (lpos != WSTRING::npos && lpos > 0) {
     trimmed = trimmed.substr(lpos);
   }
 
-  auto rpos = trimmed.find_last_not_of(" \t"_W);
+  auto rpos = trimmed.find_last_not_of(_LU(" \t"));
   if (rpos != WSTRING::npos) {
     trimmed = trimmed.substr(0, rpos + 1);
   }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -82,7 +82,7 @@ TEST_F(CLRHelperTest, FiltersEnabledIntegrations) {
       {{{}, {L"System.Runtime", L"", L"", L"ReplaceTargetMethod", min_ver_, max_ver_, {}, empty_sig_type_}, {}}}};
   std::vector<Integration> all = {i1, i2, i3};
   std::vector<Integration> expected = {i1, i3};
-  std::vector<WSTRING> disabled_integrations = {"integration-2"_W};
+  std::vector<WSTRING> disabled_integrations = {_LU("integration-2")};
   auto actual = FilterIntegrationsByName(all, disabled_integrations);
   EXPECT_EQ(actual, expected);
 }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -82,7 +82,7 @@ TEST_F(CLRHelperTest, FiltersEnabledIntegrations) {
       {{{}, {L"System.Runtime", L"", L"", L"ReplaceTargetMethod", min_ver_, max_ver_, {}, empty_sig_type_}, {}}}};
   std::vector<Integration> all = {i1, i2, i3};
   std::vector<Integration> expected = {i1, i3};
-  std::vector<WSTRING> disabled_integrations = {_LU("integration-2")};
+  std::vector<WSTRING> disabled_integrations = {WStr("integration-2")};
   auto actual = FilterIntegrationsByName(all, disabled_integrations);
   EXPECT_EQ(actual, expected);
 }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
@@ -14,7 +14,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleNoSignatureMethodHasOnlyVoid) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      "Samples.ExampleLibrary.FakeClient.DogClient`2"_W, "Silence"_W);
+      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("Silence"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -38,7 +38,7 @@ TEST_F(CLRHelperTypeCheckTest, GetsVeryComplexNestedGenericTypeStrings) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      "Samples.ExampleLibrary.FakeClient.DogClient`2"_W, "Sit"_W);
+      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("Sit"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -55,7 +55,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleStringReturnWithNestedTypeParamsNoGenerics)
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      "Samples.ExampleLibrary.FakeClient.DogClient`2"_W, "TellMeIfTheCookieIsYummy"_W);
+      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("TellMeIfTheCookieIsYummy"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -72,7 +72,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleClassReturnWithSimpleParamsNoGenerics) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      "Samples.ExampleLibrary.FakeClient.DogClient`2"_W, "Rollover"_W);
+      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("Rollover"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -93,7 +93,7 @@ TEST_F(CLRHelperTypeCheckTest, GenericAsyncMethodWithNestedGenericTask) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      "Samples.ExampleLibrary.FakeClient.DogClient`2"_W, "StayAndLayDown"_W);
+      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("StayAndLayDown"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_type_check_test.cpp
@@ -14,7 +14,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleNoSignatureMethodHasOnlyVoid) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("Silence"));
+      WStr("Samples.ExampleLibrary.FakeClient.DogClient`2"), WStr("Silence"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -38,7 +38,7 @@ TEST_F(CLRHelperTypeCheckTest, GetsVeryComplexNestedGenericTypeStrings) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("Sit"));
+      WStr("Samples.ExampleLibrary.FakeClient.DogClient`2"), WStr("Sit"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -55,7 +55,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleStringReturnWithNestedTypeParamsNoGenerics)
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("TellMeIfTheCookieIsYummy"));
+      WStr("Samples.ExampleLibrary.FakeClient.DogClient`2"), WStr("TellMeIfTheCookieIsYummy"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -72,7 +72,7 @@ TEST_F(CLRHelperTypeCheckTest, SimpleClassReturnWithSimpleParamsNoGenerics) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("Rollover"));
+      WStr("Samples.ExampleLibrary.FakeClient.DogClient`2"), WStr("Rollover"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 
@@ -93,7 +93,7 @@ TEST_F(CLRHelperTypeCheckTest, GenericAsyncMethodWithNestedGenericTask) {
   std::vector<std::wstring> actual;
 
   const auto target = FunctionToTest(
-      _LU("Samples.ExampleLibrary.FakeClient.DogClient`2"), _LU("StayAndLayDown"));
+      WStr("Samples.ExampleLibrary.FakeClient.DogClient`2"), WStr("StayAndLayDown"));
 
   EXPECT_TRUE(target.name.size() > 1) << "Test target method not found.";
 


### PR DESCRIPTION
This `PR` removes the `_W` string operator from the profiler and replace it with a new `WStr` macro that redirects to a `L` prefix on windows and an `u` prefix on non windows. Simplifying the wide string declaration and reducing the `_W` overhead.

@DataDog/apm-dotnet