### PR TITLE
Remove Sync-over-async in DatadogHttpClient

### DIFF
--- a/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -43,27 +43,18 @@ namespace Datadog.Trace.Agent.Transports
                 // send request, get response
                 var response = await _client.SendAsync(request, bidirectionalStream, bidirectionalStream).ConfigureAwait(false);
 
-                // buffer the entire contents for now
-                MemoryStream responseContentStream;
-                if (response.Content.Length.HasValue)
+                // Content-Length is required as we don't support chunked transfer
+                var contentLength = response.Content.Length;
+                if (!contentLength.HasValue)
                 {
-                    var buffer = new byte[response.Content.Length.Value];
-                    responseContentStream = new MemoryStream(buffer);
-                    await response.Content.CopyToAsync(buffer).ConfigureAwait(false);
-                    responseContentStream.Position = 0;
-                }
-                else
-                {
-                    responseContentStream = new MemoryStream();
-                    await response.Content.CopyToAsync(responseContentStream, ResponseReadBufferSize).ConfigureAwait(false);
-                    responseContentStream.Position = 0;
+                    throw new Exception("Content-Length is required but was not provided");
                 }
 
-                var contentLength = response.ContentLength;
-                if (contentLength != null && contentLength != responseContentStream.Length)
-                {
-                    throw new Exception("Content length from http headers does not match content's actual length.");
-                }
+                // buffer the entire contents for now
+                var buffer = new byte[contentLength.Value];
+                var responseContentStream = new MemoryStream(buffer);
+                await response.Content.CopyToAsync(buffer).ConfigureAwait(false);
+                responseContentStream.Position = 0;
 
                 return new HttpStreamResponse(response.StatusCode, responseContentStream.Length, response.GetContentEncoding(), responseContentStream);
             }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.HttpOverStreams
         public async Task<HttpResponse> SendAsync(HttpRequest request, Stream requestStream, Stream responseStream)
         {
             await SendRequestAsync(request, requestStream).ConfigureAwait(false);
-            return await ReadResponseAsync(responseStream);
+            return await ReadResponseAsync(responseStream).ConfigureAwait(false);
         }
 
         private async Task SendRequestAsync(HttpRequest request, Stream requestStream)
@@ -66,7 +66,7 @@ namespace Datadog.Trace.HttpOverStreams
 
             async Task GoNextChar()
             {
-                await responseStream.ReadAsync(chArray, offset: 0, count: 1);
+                await responseStream.ReadAsync(chArray, offset: 0, count: 1).ConfigureAwait(false);
                 currentChar = Encoding.ASCII.GetChars(chArray)[0];
                 streamPosition++;
             }
@@ -78,7 +78,7 @@ namespace Datadog.Trace.HttpOverStreams
                     // end of headers
                     // Next character should be a LineFeed, regardless of Linux/Windows
                     // Skip the newline indicator
-                    await GoNextChar();
+                    await GoNextChar().ConfigureAwait(false);
 
                     return true;
                 }
@@ -89,13 +89,13 @@ namespace Datadog.Trace.HttpOverStreams
             // Skip to status code
             while (streamPosition < statusCodeStart)
             {
-                await GoNextChar();
+                await GoNextChar().ConfigureAwait(false);
             }
 
             // Read status code
             while (streamPosition < statusCodeEnd)
             {
-                await GoNextChar();
+                await GoNextChar().ConfigureAwait(false);
                 stringBuilder.Append(currentChar);
             }
 
@@ -110,14 +110,14 @@ namespace Datadog.Trace.HttpOverStreams
             // Skip to reason
             while (streamPosition < startOfReasonPhrase)
             {
-                await GoNextChar();
+                await GoNextChar().ConfigureAwait(false);
             }
 
             // Read reason
             do
             {
-                await GoNextChar();
-                if (await IsNewLine())
+                await GoNextChar().ConfigureAwait(false);
+                if (await IsNewLine().ConfigureAwait(false))
                 {
                     break;
                 }
@@ -132,10 +132,10 @@ namespace Datadog.Trace.HttpOverStreams
             // Read headers
             do
             {
-                await GoNextChar();
+                await GoNextChar().ConfigureAwait(false);
 
                 // Check for end of headers
-                if (await IsNewLine())
+                if (await IsNewLine().ConfigureAwait(false))
                 {
                     // Empty line, content starts next
                     break;
@@ -151,7 +151,7 @@ namespace Datadog.Trace.HttpOverStreams
                     }
 
                     stringBuilder.Append(currentChar);
-                    await GoNextChar();
+                    await GoNextChar().ConfigureAwait(false);
                 }
                 while (true);
 
@@ -161,9 +161,9 @@ namespace Datadog.Trace.HttpOverStreams
                 // Read value
                 do
                 {
-                    await GoNextChar();
+                    await GoNextChar().ConfigureAwait(false);
 
-                    if (await IsNewLine())
+                    if (await IsNewLine().ConfigureAwait(false))
                     {
                         // Next header pair starts
                         break;

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -76,11 +76,9 @@ namespace Datadog.Trace.HttpOverStreams
                 if (currentChar.Equals(DatadogHttpValues.CarriageReturn))
                 {
                     // end of headers
-                    if (DatadogHttpValues.CrLfLength > 1)
-                    {
-                        // Skip the newline indicator
-                        await GoNextChar();
-                    }
+                    // Next character should be a LineFeed, regardless of Linux/Windows
+                    // Skip the newline indicator
+                    await GoNextChar();
 
                     return true;
                 }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.HttpOverStreams
                 await DatadogHttpHeaderHelper.WriteEndOfHeaders(writer).ConfigureAwait(false);
             }
 
-            await request.Content.CopyToAsync(requestStream, null).ConfigureAwait(false);
+            await request.Content.CopyToAsync(requestStream).ConfigureAwait(false);
             Logger.Debug("Datadog HTTP: Flushing stream.");
             await requestStream.FlushAsync().ConfigureAwait(false);
         }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -80,6 +80,11 @@ namespace Datadog.Trace.HttpOverStreams
                     // Skip the newline indicator
                     await GoNextChar().ConfigureAwait(false);
 
+                    if (!currentChar.Equals(DatadogHttpValues.LineFeed))
+                    {
+                        throw new Exception($"Unexpected character {currentChar} in headers: CR must be followed by LF");
+                    }
+
                     return true;
                 }
 

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.HttpOverStreams
                 if (_metadataHeaders == null)
                 {
                     _metadataHeaders =
-                        $"{AgentHttpHeaderNames.Language}: .NET{DatadogHttpValues.NewLine}{AgentHttpHeaderNames.TracerVersion}: {TracerConstants.AssemblyVersion}{DatadogHttpValues.NewLine}{HttpHeaderNames.TracingEnabled}: false{DatadogHttpValues.NewLine}";
+                        $"{AgentHttpHeaderNames.Language}: .NET{DatadogHttpValues.CrLf}{AgentHttpHeaderNames.TracerVersion}: {TracerConstants.AssemblyVersion}{DatadogHttpValues.CrLf}{HttpHeaderNames.TracingEnabled}: false{DatadogHttpValues.CrLf}";
                 }
 
                 return _metadataHeaders;
@@ -24,18 +24,18 @@ namespace Datadog.Trace.HttpOverStreams
         public static Task WriteLeadingHeaders(HttpRequest request, StreamWriter writer)
         {
             var leadingHeaders =
-                $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.NewLine}Host: {request.Host}{DatadogHttpValues.NewLine}Accept-Encoding: identity{DatadogHttpValues.NewLine}Content-Length: {request.Content.Length ?? 0}{DatadogHttpValues.NewLine}{MetadataHeaders}";
+                $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.CrLf}Host: {request.Host}{DatadogHttpValues.CrLf}Accept-Encoding: identity{DatadogHttpValues.CrLf}Content-Length: {request.Content.Length ?? 0}{DatadogHttpValues.CrLf}{MetadataHeaders}";
             return writer.WriteAsync(leadingHeaders);
         }
 
         public static Task WriteHeader(StreamWriter writer, HttpHeaders.HttpHeader header)
         {
-            return writer.WriteAsync($"{header.Name}: {header.Value}{DatadogHttpValues.NewLine}");
+            return writer.WriteAsync($"{header.Name}: {header.Value}{DatadogHttpValues.CrLf}");
         }
 
         public static Task WriteEndOfHeaders(StreamWriter writer)
         {
-            return writer.WriteAsync($"Content-Type: application/msgpack{DatadogHttpValues.NewLine}{DatadogHttpValues.NewLine}");
+            return writer.WriteAsync($"Content-Type: application/msgpack{DatadogHttpValues.CrLf}{DatadogHttpValues.CrLf}");
         }
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
@@ -5,6 +5,7 @@ namespace Datadog.Trace.HttpOverStreams
     internal static class DatadogHttpValues
     {
         public const char CarriageReturn = '\r';
+        public const char LineFeed = '\n';
         public const string CrLf = "\r\n";
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpValues.cs
@@ -5,7 +5,6 @@ namespace Datadog.Trace.HttpOverStreams
     internal static class DatadogHttpValues
     {
         public const char CarriageReturn = '\r';
-        public static readonly string NewLine = Environment.NewLine;
-        public static readonly int CrLfLength = NewLine.Length;
+        public const string CrLf = "\r\n";
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/BufferContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/BufferContent.cs
@@ -19,5 +19,22 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
         {
             return destination.WriteAsync(_buffer.Array, _buffer.Offset, _buffer.Count);
         }
+
+        public Task CopyToAsync(byte[] buffer)
+        {
+            if (_buffer.Count > buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(buffer),
+                    $"Buffer of size {buffer.Length} is not large enough to hold content of size {_buffer.Count}");
+            }
+
+            _buffer.Array?.CopyTo(buffer, _buffer.Offset);
+#if NET45
+            return Task.FromResult(false);
+#else
+            return Task.CompletedTask;
+#endif
+        }
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/BufferContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/BufferContent.cs
@@ -29,7 +29,12 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
                     $"Buffer of size {buffer.Length} is not large enough to hold content of size {_buffer.Count}");
             }
 
-            _buffer.Array?.CopyTo(buffer, _buffer.Offset);
+            Buffer.BlockCopy(
+                src: _buffer.Array,
+                srcOffset: _buffer.Offset,
+                dst: buffer,
+                dstOffset: 0,
+                count: _buffer.Count);
 #if NET45
             return Task.FromResult(false);
 #else

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/BufferContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/BufferContent.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
 
         public long? Length => _buffer.Count;
 
-        public Task CopyToAsync(Stream destination, int? bufferSize)
+        public Task CopyToAsync(Stream destination)
         {
             return destination.WriteAsync(_buffer.Array, _buffer.Offset, _buffer.Count);
         }

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -23,6 +24,30 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
             }
 
             return Stream.CopyToAsync(destination, bufferSize.Value);
+        }
+
+        public async Task CopyToAsync(byte[] buffer)
+        {
+            if (!Length.HasValue)
+            {
+                throw new InvalidOperationException("Unable to CopyToAsync with buffer when Length is unknown");
+            }
+
+            var length = 0;
+            var remaining = Length.Value;
+            while (true)
+            {
+                var bytesToRead = (int)Math.Min(remaining, int.MaxValue);
+                var bytesRead = await Stream.ReadAsync(buffer, offset: length, count: bytesToRead);
+
+                length += bytesRead;
+                remaining -= bytesRead;
+
+                if (bytesRead == 0 || remaining <= 0)
+                {
+                    return;
+                }
+            }
         }
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -30,7 +30,12 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
         {
             if (!Length.HasValue)
             {
-                throw new InvalidOperationException("Unable to CopyToAsync with buffer when Length is unknown");
+                throw new InvalidOperationException("Unable to CopyToAsync with buffer when content Length is unknown");
+            }
+
+            if (Length > buffer.Length)
+            {
+                throw new ArgumentException($"Provided buffer was smaller {buffer.Length} than the content length {Length}");
             }
 
             var length = 0;

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -16,14 +16,9 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
 
         public long? Length { get; }
 
-        public Task CopyToAsync(Stream destination, int? bufferSize)
+        public Task CopyToAsync(Stream destination)
         {
-            if (bufferSize == null)
-            {
-                return Stream.CopyToAsync(destination);
-            }
-
-            return Stream.CopyToAsync(destination, bufferSize.Value);
+            return Stream.CopyToAsync(destination);
         }
 
         public async Task CopyToAsync(byte[] buffer)

--- a/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
             }
 
             var length = 0;
-            var remaining = Length.Value;
+            long remaining = Length.Value;
             while (true)
             {
                 var bytesToRead = (int)Math.Min(remaining, int.MaxValue);

--- a/src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
@@ -8,5 +8,7 @@ namespace Datadog.Trace.HttpOverStreams
         long? Length { get; }
 
         Task CopyToAsync(Stream destination, int? bufferSize);
+
+        Task CopyToAsync(byte[] buffer);
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
+++ b/src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.HttpOverStreams
     {
         long? Length { get; }
 
-        Task CopyToAsync(Stream destination, int? bufferSize);
+        Task CopyToAsync(Stream destination);
 
         Task CopyToAsync(byte[] buffer);
     }

--- a/test/Datadog.Trace.IntegrationTests/DatadogHttpClientTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DatadogHttpClientTests.cs
@@ -26,13 +26,6 @@ namespace Datadog.Trace.IntegrationTests
 
             using (var agent = new MockTracerAgent(agentPort))
             {
-                agent.RequestDeserialized += (sender, args) =>
-                {
-                    var traces = args.Value.Select(
-                        trace => string.Join(", ", trace.Select(span => $"{span.Name}.{span.Resource}.{span.SpanId}")));
-                    _output.WriteLine($"Received {args.Value.Count} traces: {string.Join(";", traces)}");
-                };
-
                 var settings = new TracerSettings
                 {
                     AgentUri = new Uri($"http://localhost:{agent.Port}"),
@@ -45,7 +38,6 @@ namespace Datadog.Trace.IntegrationTests
                     scope.Span.ResourceName = "resourceName";
                 }
 
-                // When this is added in, the test deadlocks! :scream:
                 await tracer.FlushAsync();
 
                 var spans = agent.WaitForSpans(1);

--- a/test/Datadog.Trace.IntegrationTests/DatadogHttpClientTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DatadogHttpClientTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using Datadog.Core.Tools;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests
+{
+    public class DatadogHttpClientTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public DatadogHttpClientTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void DatadogHttpClient_CanSendTracesToAgent()
+        {
+            var agentPort = TcpPortProvider.GetOpenPort();
+
+            using (var agent = new MockTracerAgent(agentPort))
+            {
+                agent.RequestDeserialized += (sender, args) =>
+                {
+                    _output.WriteLine($"Received {args.Value.Count} traces");
+                };
+
+                var settings = new TracerSettings
+                {
+                    AgentUri = new Uri($"http://localhost:{agent.Port}"),
+                    TracesTransport = TransportStrategy.DatadogTcp,
+                };
+                var tracer = new Tracer(settings);
+
+                using (var scope = tracer.StartActive("operationName"))
+                {
+                    scope.Span.ResourceName = "resourceName";
+                }
+
+                // When this is added in, the test deadlocks! :scream:
+                // await tracer.FlushAsync();
+
+                var spans = agent.WaitForSpans(1);
+                Assert.Equal(1, spans.Count);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -265,8 +265,6 @@ namespace Datadog.Trace.TestHelpers
 
                     // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
                     // (Setting content-length avoids that)
-                    // Also, without Keep-Alive: false, the stream is never closed and FlushAsync hangs
-                    ctx.Response.KeepAlive = false;
 
                     ctx.Response.ContentType = "application/json";
                     var buffer = Encoding.UTF8.GetBytes("{}");

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -263,8 +263,14 @@ namespace Datadog.Trace.TestHelpers
                         }
                     }
 
+                    // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
+                    // (Setting content-length avoids that)
+                    // Also, without Keep-Alive: false, the stream is never closed and FlushAsync hangs
+                    ctx.Response.KeepAlive = false;
+
                     ctx.Response.ContentType = "application/json";
                     var buffer = Encoding.UTF8.GetBytes("{}");
+                    ctx.Response.ContentLength64 = buffer.LongLength;
                     ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
                     ctx.Response.Close();
                 }

--- a/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
+++ b/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.HttpOverStreams.HttpContent;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class DatadogHttpClientTests
+    {
+        [Fact]
+        public async Task DatadogHttpClient_CanParseResponse()
+        {
+            var client = new DatadogHttpClient();
+            var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
+            var htmlResponse = string.Join("\r\n", HtmlResponseLines());
+            using var requestStream = new MemoryStream();
+            using var responseStream = new MemoryStream(Encoding.UTF8.GetBytes(htmlResponse));
+
+            var request = new HttpRequest("POST", "localhost", string.Empty, new HttpHeaders(), requestContent);
+            var response = await client.SendAsync(request, requestStream, responseStream);
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("OK", response.ResponseMessage);
+            Assert.Equal("Test Server", response.Headers.GetValue(("Server")));
+            Assert.Equal(2, response.ContentLength);
+            Assert.Equal("application/json", response.ContentType);
+
+            var buffer = new byte[2];
+            await response.Content.CopyToAsync(buffer);
+            var content = Encoding.UTF8.GetString(buffer);
+            Assert.Equal("{}", content);
+        }
+
+        private static string[] HtmlResponseLines() =>
+        new[]
+        {
+            "HTTP/1.1 200 OK",
+            "Date: Mon, 27 Jul 2009 12:28:53 GMT",
+            "Server: Test Server",
+            "Last-Modified: Wed, 22 Jul 2009 19:15:56 GMT",
+            "Content-Length: 2",
+            "Content-Type: application/json",
+            string.Empty,
+            "{}"
+        };
+    }
+}

--- a/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
+++ b/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
@@ -34,6 +34,38 @@ namespace Datadog.Trace.Tests
             Assert.Equal("{}", content);
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(10)]
+        [InlineData(100)]
+        public async Task DatadogHttpClient_WhenOnlyPartOfResponseIsAvailable_ParsesCorrectly(int bytesToRead)
+        {
+            var client = new DatadogHttpClient();
+            var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
+            var htmlResponse = string.Join("\r\n", HtmlResponseLines());
+            using var requestStream = new MemoryStream();
+            var responseBytes = Encoding.UTF8.GetBytes(htmlResponse);
+            using var responseStream = new RegulatedStream(responseBytes, bytesToRead);
+
+            var request = new HttpRequest("POST", "localhost", string.Empty, new HttpHeaders(), requestContent);
+            var response = await client.SendAsync(request, requestStream, responseStream);
+
+            Assert.Equal(200, response.StatusCode);
+            Assert.Equal("OK", response.ResponseMessage);
+            Assert.Equal("Test Server", response.Headers.GetValue(("Server")));
+            Assert.Equal(2, response.ContentLength);
+            Assert.Equal("application/json", response.ContentType);
+
+            var buffer = new byte[2];
+            await response.Content.CopyToAsync(buffer);
+            var content = Encoding.UTF8.GetString(buffer);
+            Assert.Equal("{}", content);
+        }
+
         private static string[] HtmlResponseLines() =>
         new[]
         {
@@ -46,5 +78,62 @@ namespace Datadog.Trace.Tests
             string.Empty,
             "{}"
         };
+
+        public class RegulatedStream : Stream
+        {
+            private readonly byte[] _buffer;
+            private readonly int _bytesToRead;
+
+            public RegulatedStream(byte[] buffer, int bytesToRead)
+            {
+                _buffer = buffer;
+                _bytesToRead = bytesToRead;
+            }
+
+            public override bool CanRead => true;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => false;
+
+            public override long Length => _buffer.Length;
+
+            public override long Position { get; set; }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                var bytesToRead = Math.Min(_bytesToRead, count);
+
+                Buffer.BlockCopy(
+                    src: _buffer,
+                    srcOffset: (int)Position,
+                    dst: buffer,
+                    dstOffset: offset,
+                    count: bytesToRead);
+
+                Position += bytesToRead;
+                return bytesToRead;
+            }
+
+            public override void Flush()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void SetLength(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                throw new NotImplementedException();
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR removes the [sync-over-async we were previously doing](https://github.com/DataDog/dd-trace-dotnet/blob/c23974c1cc38d96da81cc61c64ee6540eec8cd9f/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs#L68) for simplicity.


@DataDog/apm-dotnet