### PR TITLE
Replacing DuckType `As<T>` with DuckCast, TryDuckCast, DuckAs and DuckIs

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                     {
                         object testResultObject = returnValueArray.GetValue(0);
                         if (testResultObject != null &&
-                            testResultObject.DuckIs<TestResultStruct>(out var testResult) &&
+                            testResultObject.TryDuckCast<TestResultStruct>(out var testResult) &&
                             testResult.TestFailureException != null)
                         {
                             Exception testException = testResult.TestFailureException.InnerException ?? testResult.TestFailureException;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
@@ -56,17 +56,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                     if (returnValueArray.Length == 1)
                     {
                         object testResultObject = returnValueArray.GetValue(0);
-                        if (testResultObject != null)
+                        if (testResultObject != null &&
+                            testResultObject.DuckIs<TestResultStruct>(out var testResult) &&
+                            testResult.TestFailureException != null)
                         {
-                            TestResultStruct testResult = testResultObject.As<TestResultStruct>();
-                            if (testResult.TestFailureException != null)
+                            Exception testException = testResult.TestFailureException.InnerException ?? testResult.TestFailureException;
+                            string testExceptionName = testException.GetType().Name;
+                            if (testExceptionName != "UnitTestAssertException" && testExceptionName != "AssertInconclusiveException")
                             {
-                                Exception testException = testResult.TestFailureException.InnerException ?? testResult.TestFailureException;
-                                string testExceptionName = testException.GetType().Name;
-                                if (testExceptionName != "UnitTestAssertException" && testExceptionName != "AssertInconclusiveException")
-                                {
-                                    scope.Span.SetException(testException);
-                                }
+                                scope.Span.SetException(testException);
                             }
                         }
                     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -129,7 +129,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                 if (returnValueArray.Length == 1)
                 {
                     object unitTestResultObject = returnValueArray.GetValue(0);
-                    if (unitTestResultObject != null && unitTestResultObject.DuckIs<UnitTestResultStruct>(out var unitTestResult))
+                    if (unitTestResultObject != null && unitTestResultObject.TryDuckCast<UnitTestResultStruct>(out var unitTestResult))
                     {
                         switch (unitTestResult.Outcome)
                         {
@@ -179,7 +179,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                     testProperties["Category"] = categoryList;
                 }
 
-                if (tattr.DuckIs<TestCategoryAttributeStruct>(out var tattrStruct))
+                if (tattr.TryDuckCast<TestCategoryAttributeStruct>(out var tattrStruct))
                 {
                     categoryList.AddRange(tattrStruct.TestCategories);
                 }
@@ -202,7 +202,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                         testProperties["Category"] = categoryList;
                     }
 
-                    if (tattr.DuckIs<TestCategoryAttributeStruct>(out var tattrStruct))
+                    if (tattr.TryDuckCast<TestCategoryAttributeStruct>(out var tattrStruct))
                     {
                         categoryList.AddRange(tattrStruct.TestCategories);
                     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -129,10 +129,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                 if (returnValueArray.Length == 1)
                 {
                     object unitTestResultObject = returnValueArray.GetValue(0);
-                    if (unitTestResultObject != null)
+                    if (unitTestResultObject != null && unitTestResultObject.DuckIs<UnitTestResultStruct>(out var unitTestResult))
                     {
-                        UnitTestResultStruct unitTestResult = unitTestResultObject.As<UnitTestResultStruct>();
-
                         switch (unitTestResult.Outcome)
                         {
                             case UnitTestResultOutcome.Error:
@@ -181,7 +179,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                     testProperties["Category"] = categoryList;
                 }
 
-                categoryList.AddRange(tattr.As<TestCategoryAttributeStruct>().TestCategories);
+                if (tattr.DuckIs<TestCategoryAttributeStruct>(out var tattrStruct))
+                {
+                    categoryList.AddRange(tattrStruct.TestCategories);
+                }
             }
 
             var classCategories = methodInfo.DeclaringType?.GetCustomAttributes(true);
@@ -201,7 +202,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                         testProperties["Category"] = categoryList;
                     }
 
-                    categoryList.AddRange(tattr.As<TestCategoryAttributeStruct>().TestCategories);
+                    if (tattr.DuckIs<TestCategoryAttributeStruct>(out var tattrStruct))
+                    {
+                        categoryList.AddRange(tattrStruct.TestCategories);
+                    }
                 }
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                 return CallTargetState.GetDefault();
             }
 
-            TestInvokerStruct invokerInstance = instance.As<TestInvokerStruct>();
+            TestInvokerStruct invokerInstance = instance.DuckCast<TestInvokerStruct>();
             TestRunnerStruct runnerInstance = new TestRunnerStruct
             {
                 Aggregator = invokerInstance.Aggregator,
@@ -62,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             Scope scope = state.Scope;
             if (scope != null)
             {
-                TestInvokerStruct invokerInstance = instance.As<TestInvokerStruct>();
+                TestInvokerStruct invokerInstance = instance.DuckCast<TestInvokerStruct>();
                 XUnitIntegration.FinishScope(scope, invokerInstance.Aggregator);
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
         {
             if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
             {
-                TestRunnerStruct runnerInstance = instance.As<TestRunnerStruct>();
+                TestRunnerStruct runnerInstance = instance.DuckCast<TestRunnerStruct>();
 
                 // Skip test support
                 if (runnerInstance.SkipReason != null)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -101,7 +101,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             var reportedType = callOpCode == OpCodeValue.Call ? httpMessageHandler : handler.GetType();
-            var requestValue = request.As<HttpRequestMessageStruct>();
+
+            var requestValue = request.DuckCast<HttpRequestMessageStruct>();
 
             var isHttpClientHandler = handler.GetInstrumentedType(SystemNetHttp, HttpClientHandlerTypeName) != null;
 
@@ -204,7 +205,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             var reportedType = callOpCode == OpCodeValue.Call ? httpMessageHandler : handler.GetType();
-            var requestValue = request.As<HttpRequestMessageStruct>();
+            var requestValue = request.DuckCast<HttpRequestMessageStruct>();
 
             var isHttpClientHandler = handler.GetInstrumentedType(SystemNetHttp, HttpClientHandlerTypeName) != null;
 
@@ -285,7 +286,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            var requestValue = request.As<HttpRequestMessageStruct>();
+            var requestValue = request.DuckCast<HttpRequestMessageStruct>();
             var reportedType = callOpCode == OpCodeValue.Call ? httpClientHandler : handler.GetType();
 
             if (!IsTracingEnabled(requestValue.Headers))
@@ -384,7 +385,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            var requestValue = request.As<HttpRequestMessageStruct>();
+            var requestValue = request.DuckCast<HttpRequestMessageStruct>();
             var reportedType = callOpCode == OpCodeValue.Call ? httpClientHandler : handler.GetType();
 
             if (!IsTracingEnabled(requestValue.Headers))
@@ -428,10 +429,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     var task = (Task)sendAsync(handler, request, cancellationToken);
                     await task.ConfigureAwait(false);
 
-                    var response = task.As<TaskObjectStruct>().Result;
+                    var response = task.DuckCast<TaskObjectStruct>().Result;
 
                     // this tag can only be set after the response is returned
-                    int statusCode = response.As<HttpResponseMessageStruct>().StatusCode;
+                    int statusCode = response.DuckCast<HttpResponseMessageStruct>().StatusCode;
 
                     if (scope != null)
                     {
@@ -474,7 +475,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     var response = send(handler, request, cancellationToken);
 
                     // this tag can only be set after the response is returned
-                    int statusCode = response.As<HttpResponseMessageStruct>().StatusCode;
+                    int statusCode = response.DuckCast<HttpResponseMessageStruct>().StatusCode;
 
                     if (scope != null)
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -117,37 +117,42 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             SpanContext propagatedContext = null;
-            var basicPropertiesValue = basicProperties.As<IBasicProperties>();
-
-            // try to extract propagated context values from headers
-            if (basicPropertiesValue?.Headers != null)
+            if (basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
             {
-                try
+                // try to extract propagated context values from headers
+                if (basicPropertiesValue.Headers != null)
                 {
-                    propagatedContext = SpanContextPropagator.Instance.Extract(basicPropertiesValue.Headers, headersGetter);
+                    try
+                    {
+                        propagatedContext = SpanContextPropagator.Instance.Extract(basicPropertiesValue.Headers, headersGetter);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error extracting propagated headers.");
+                    }
                 }
-                catch (Exception ex)
+
+                using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
-                    Log.Error(ex, "Error extracting propagated headers.");
+                    if (tags != null)
+                    {
+                        tags.MessageSize = body?.Length.ToString() ?? "0";
+                    }
+
+                    try
+                    {
+                        instrumentedMethod(model, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
+                    }
+                    catch (Exception ex)
+                    {
+                        scope?.Span.SetException(ex);
+                        throw;
+                    }
                 }
             }
-
-            using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
+            else
             {
-                if (tags != null)
-                {
-                    tags.MessageSize = body?.Length.ToString() ?? "0";
-                }
-
-                try
-                {
-                    instrumentedMethod(model, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
-                }
-                catch (Exception ex)
-                {
-                    scope?.Span.SetException(ex);
-                    throw;
-                }
+                instrumentedMethod(model, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
             }
         }
 
@@ -216,37 +221,42 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             SpanContext propagatedContext = null;
-            var basicPropertiesValue = basicProperties.As<IBasicProperties>();
-
-            // try to extract propagated context values from headers
-            if (basicPropertiesValue?.Headers != null)
+            if (basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
             {
-                try
+                // try to extract propagated context values from headers
+                if (basicPropertiesValue.Headers != null)
                 {
-                    propagatedContext = SpanContextPropagator.Instance.Extract(basicPropertiesValue.Headers, headersGetter);
+                    try
+                    {
+                        propagatedContext = SpanContextPropagator.Instance.Extract(basicPropertiesValue.Headers, headersGetter);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error extracting propagated headers.");
+                    }
                 }
-                catch (Exception ex)
+
+                using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
-                    Log.Error(ex, "Error extracting propagated headers.");
+                    if (tags != null && body != null && body.DuckIs<BodyStruct>(out var bodyStruct))
+                    {
+                        tags.MessageSize = bodyStruct.Length.ToString() ?? "0";
+                    }
+
+                    try
+                    {
+                        instrumentedMethod(model, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
+                    }
+                    catch (Exception ex)
+                    {
+                        scope?.Span.SetException(ex);
+                        throw;
+                    }
                 }
             }
-
-            using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
+            else
             {
-                if (tags != null)
-                {
-                    tags.MessageSize = body?.As<BodyStruct>().Length.ToString() ?? "0";
-                }
-
-                try
-                {
-                    instrumentedMethod(model, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
-                }
-                catch (Exception ex)
-                {
-                    scope?.Span.SetException(ex);
-                    throw;
-                }
+                instrumentedMethod(model, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
             }
         }
 
@@ -326,9 +336,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 SpanContext propagatedContext = null;
                 string messageSize = null;
 
-                if (result != null)
+                if (result != null && result.DuckIs<BasicGetResultStruct>(out var basicGetResult))
                 {
-                    var basicGetResult = result.As<BasicGetResultStruct>();
                     messageSize = basicGetResult.Body.Length.ToString();
                     var basicPropertiesHeaders = basicGetResult.BasicProperties?.Headers;
 
@@ -442,10 +451,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         tags.MessageSize = body?.Length.ToString() ?? "0";
                     }
 
-                    if (basicProperties != null)
+                    if (basicProperties != null && basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
                     {
-                        var basicPropertiesValue = basicProperties.As<IBasicProperties>();
-
                         if (tags != null && basicPropertiesValue.IsDeliveryModePresent())
                         {
                             tags.DeliveryMode = DeliveryModeStrings[0x3 & basicPropertiesValue.DeliveryMode];
@@ -543,13 +550,18 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (tags != null)
                     {
-                        tags.MessageSize = body?.As<BodyStruct>().Length.ToString() ?? "0";
+                        if (body != null && body.DuckIs<BodyStruct>(out var bodyStruct))
+                        {
+                            tags.MessageSize = bodyStruct.Length.ToString();
+                        }
+                        else
+                        {
+                            tags.MessageSize = "0";
+                        }
                     }
 
-                    if (basicProperties != null)
+                    if (basicProperties != null && basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
                     {
-                        var basicPropertiesValue = basicProperties.As<IBasicProperties>();
-
                         if (tags != null && basicPropertiesValue.IsDeliveryModePresent())
                         {
                             tags.DeliveryMode = DeliveryModeStrings[0x3 & basicPropertiesValue.DeliveryMode];

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/RabbitMQIntegration.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             SpanContext propagatedContext = null;
-            if (basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
+            if (basicProperties.TryDuckCast<IBasicProperties>(out var basicPropertiesValue))
             {
                 // try to extract propagated context values from headers
                 if (basicPropertiesValue.Headers != null)
@@ -221,7 +221,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             SpanContext propagatedContext = null;
-            if (basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
+            if (basicProperties.TryDuckCast<IBasicProperties>(out var basicPropertiesValue))
             {
                 // try to extract propagated context values from headers
                 if (basicPropertiesValue.Headers != null)
@@ -238,7 +238,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 using (var scope = CreateScope(Tracer.Instance, out RabbitMQTags tags, command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, exchange: exchange, routingKey: routingKey))
                 {
-                    if (tags != null && body != null && body.DuckIs<BodyStruct>(out var bodyStruct))
+                    if (tags != null && body != null && body.TryDuckCast<BodyStruct>(out var bodyStruct))
                     {
                         tags.MessageSize = bodyStruct.Length.ToString() ?? "0";
                     }
@@ -336,7 +336,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 SpanContext propagatedContext = null;
                 string messageSize = null;
 
-                if (result != null && result.DuckIs<BasicGetResultStruct>(out var basicGetResult))
+                if (result != null && result.TryDuckCast<BasicGetResultStruct>(out var basicGetResult))
                 {
                     messageSize = basicGetResult.Body.Length.ToString();
                     var basicPropertiesHeaders = basicGetResult.BasicProperties?.Headers;
@@ -451,7 +451,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         tags.MessageSize = body?.Length.ToString() ?? "0";
                     }
 
-                    if (basicProperties != null && basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
+                    if (basicProperties != null && basicProperties.TryDuckCast<IBasicProperties>(out var basicPropertiesValue))
                     {
                         if (tags != null && basicPropertiesValue.IsDeliveryModePresent())
                         {
@@ -550,7 +550,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                     if (tags != null)
                     {
-                        if (body != null && body.DuckIs<BodyStruct>(out var bodyStruct))
+                        if (body != null && body.TryDuckCast<BodyStruct>(out var bodyStruct))
                         {
                             tags.MessageSize = bodyStruct.Length.ToString();
                         }
@@ -560,7 +560,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         }
                     }
 
-                    if (basicProperties != null && basicProperties.DuckIs<IBasicProperties>(out var basicPropertiesValue))
+                    if (basicProperties != null && basicProperties.TryDuckCast<IBasicProperties>(out var basicPropertiesValue))
                     {
                         if (tags != null && basicPropertiesValue.IsDeliveryModePresent())
                         {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -83,25 +83,28 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            RedisNativeClientData clientData = redisNativeClient.As<RedisNativeClientData>();
-
-            using (var scope = RedisHelper.CreateScope(
+            if (redisNativeClient.DuckIs<RedisNativeClientData>(out var clientData))
+            {
+                using (var scope = RedisHelper.CreateScope(
                 Tracer.Instance,
                 IntegrationId,
                 clientData.Host ?? string.Empty,
                 clientData.Port.ToString(CultureInfo.InvariantCulture),
                 GetRawCommand(cmdWithBinaryArgs)))
-            {
-                try
                 {
-                    return instrumentedMethod(redisNativeClient, cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead);
-                }
-                catch (Exception ex)
-                {
-                    scope?.Span?.SetException(ex);
-                    throw;
+                    try
+                    {
+                        return instrumentedMethod(redisNativeClient, cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead);
+                    }
+                    catch (Exception ex)
+                    {
+                        scope?.Span?.SetException(ex);
+                        throw;
+                    }
                 }
             }
+
+            return instrumentedMethod(redisNativeClient, cmdWithBinaryArgs, fn, completePipelineFn, sendWithoutRead);
         }
 
         private static string GetRawCommand(byte[][] cmdWithBinaryArgs)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ServiceStackRedisIntegration.cs
@@ -83,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 throw;
             }
 
-            if (redisNativeClient.DuckIs<RedisNativeClientData>(out var clientData))
+            if (redisNativeClient.TryDuckCast<RedisNativeClientData>(out var clientData))
             {
                 using (var scope = RedisHelper.CreateScope(
                 Tracer.Instance,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -233,10 +233,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
 
         private static Scope CreateScope(object multiplexer, object message)
         {
-            if (multiplexer.DuckIs<MultiplexerData>(out var multiplexerData))
+            if (multiplexer.TryDuckCast<MultiplexerData>(out var multiplexerData))
             {
                 var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(multiplexerData.Configuration);
-                if (message.DuckIs<MessageData>(out var messageData))
+                if (message.TryDuckCast<MessageData>(out var messageData))
                 {
                     var rawCommand = messageData.CommandAndKey ?? "COMMAND";
                     return RedisHelper.CreateScope(Tracer.Instance, IntegrationId, hostAndPort.Host, hostAndPort.Port, rawCommand);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -153,11 +153,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
 
         private static Scope CreateScope(object batch, object message)
         {
-            if (batch.DuckIs<BatchData>(out var batchData))
+            if (batch.TryDuckCast<BatchData>(out var batchData))
             {
                 var multiplexerData = batchData.Multiplexer;
                 var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(multiplexerData.Configuration);
-                if (message.DuckIs<MessageData>(out var messageData))
+                if (message.TryDuckCast<MessageData>(out var messageData))
                 {
                     var rawCommand = messageData.CommandAndKey ?? "COMMAND";
                     return RedisHelper.CreateScope(Tracer.Instance, IntegrationId, hostAndPort.Host, hostAndPort.Port, rawCommand);

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -264,7 +264,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            if (arg.DuckIs<HttpRequestInStartStruct>(out var requestStruct))
+            if (arg.TryDuckCast<HttpRequestInStartStruct>(out var requestStruct))
             {
                 HttpRequest request = requestStruct.HttpContext.Request;
                 string host = request.Host.Value;
@@ -306,7 +306,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             Span span = tracer.ActiveScope?.Span;
 
-            if (span != null && arg.DuckIs<BeforeActionStruct>(out var typedArg))
+            if (span != null && arg.TryDuckCast<BeforeActionStruct>(out var typedArg))
             {
                 // NOTE: This event is the start of the action pipeline. The action has been selected, the route
                 //       has been selected but no filters have run and model binding hasn't occurred.
@@ -343,7 +343,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (scope != null)
             {
-                if (arg.DuckIs<HttpRequestInStopStruct>(out var httpRequest))
+                if (arg.TryDuckCast<HttpRequestInStopStruct>(out var httpRequest))
                 {
                     HttpContext httpContext = httpRequest.HttpContext;
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
@@ -364,7 +364,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             var span = tracer.ActiveScope?.Span;
 
-            if (span != null && arg.DuckIs<UnhandledExceptionStruct>(out var unhandledStruct))
+            if (span != null && arg.TryDuckCast<UnhandledExceptionStruct>(out var unhandledStruct))
             {
                 span.SetException(unhandledStruct.Exception);
             }

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -264,32 +264,35 @@ namespace Datadog.Trace.DiagnosticListeners
                 return;
             }
 
-            HttpRequest request = arg.As<HttpRequestInStartStruct>().HttpContext.Request;
-            string host = request.Host.Value;
-            string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
-            string url = GetUrl(request);
-
-            string absolutePath = request.Path.Value;
-
-            if (request.PathBase.HasValue)
+            if (arg.DuckIs<HttpRequestInStartStruct>(out var requestStruct))
             {
-                absolutePath = request.PathBase.Value + absolutePath;
+                HttpRequest request = requestStruct.HttpContext.Request;
+                string host = request.Host.Value;
+                string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
+                string url = GetUrl(request);
+
+                string absolutePath = request.Path.Value;
+
+                if (request.PathBase.HasValue)
+                {
+                    absolutePath = request.PathBase.Value + absolutePath;
+                }
+
+                string resourceUrl = UriHelpers.GetRelativeUrl(absolutePath, tryRemoveIds: true)
+                                               .ToLowerInvariant();
+
+                string resourceName = $"{httpMethod} {resourceUrl}";
+
+                SpanContext propagatedContext = ExtractPropagatedContext(request);
+                var tagsFromHeaders = ExtractHeaderTags(request, tracer);
+
+                var tags = new AspNetCoreTags();
+                var scope = tracer.StartActiveWithTags(HttpRequestInOperationName, propagatedContext, tags: tags);
+
+                scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders);
+
+                tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);
             }
-
-            string resourceUrl = UriHelpers.GetRelativeUrl(absolutePath, tryRemoveIds: true)
-                                           .ToLowerInvariant();
-
-            string resourceName = $"{httpMethod} {resourceUrl}";
-
-            SpanContext propagatedContext = ExtractPropagatedContext(request);
-            var tagsFromHeaders = ExtractHeaderTags(request, tracer);
-
-            var tags = new AspNetCoreTags();
-            var scope = tracer.StartActiveWithTags(HttpRequestInOperationName, propagatedContext, tags: tags);
-
-            scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders);
-
-            tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);
         }
 
         private void OnMvcBeforeAction(object arg)
@@ -303,11 +306,10 @@ namespace Datadog.Trace.DiagnosticListeners
 
             Span span = tracer.ActiveScope?.Span;
 
-            if (span != null)
+            if (span != null && arg.DuckIs<BeforeActionStruct>(out var typedArg))
             {
                 // NOTE: This event is the start of the action pipeline. The action has been selected, the route
                 //       has been selected but no filters have run and model binding hasn't occurred.
-                BeforeActionStruct typedArg = arg.As<BeforeActionStruct>();
                 ActionDescriptor actionDescriptor = typedArg.ActionDescriptor;
                 HttpRequest request = typedArg.HttpContext.Request;
 
@@ -341,9 +343,12 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (scope != null)
             {
-                HttpContext httpContext = arg.As<HttpRequestInStopStruct>().HttpContext;
+                if (arg.DuckIs<HttpRequestInStopStruct>(out var httpRequest))
+                {
+                    HttpContext httpContext = httpRequest.HttpContext;
+                    scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
+                }
 
-                scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                 scope.Dispose();
             }
         }
@@ -359,9 +364,9 @@ namespace Datadog.Trace.DiagnosticListeners
 
             var span = tracer.ActiveScope?.Span;
 
-            if (span != null)
+            if (span != null && arg.DuckIs<UnhandledExceptionStruct>(out var unhandledStruct))
             {
-                span.SetException(arg.As<UnhandledExceptionStruct>().Exception);
+                span.SetException(unhandledStruct.Exception);
             }
         }
 

--- a/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.DuckTyping
         /// <param name="instance">Object instance</param>
         /// <param name="value">Ducktype instance</param>
         /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
-        public static bool DuckIs<T>(this object instance, out T value)
+        public static bool TryDuckCast<T>(this object instance, out T value)
         {
             try
             {
@@ -60,7 +60,7 @@ namespace Datadog.Trace.DuckTyping
         /// <param name="targetType">Target type</param>
         /// <param name="value">Ducktype instance</param>
         /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
-        public static bool DuckIs(this object instance, Type targetType, out object value)
+        public static bool TryDuckCast(this object instance, Type targetType, out object value)
         {
             try
             {

--- a/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.DuckTyping
         /// <param name="instance">Object instance</param>
         /// <param name="value">Ducktype instance</param>
         /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryDuckCast<T>(this object instance, out T value)
         {
             try
@@ -60,6 +61,7 @@ namespace Datadog.Trace.DuckTyping
         /// <param name="targetType">Target type</param>
         /// <param name="value">Ducktype instance</param>
         /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryDuckCast(this object instance, Type targetType, out object value)
         {
             try
@@ -74,5 +76,60 @@ namespace Datadog.Trace.DuckTyping
                 return false;
             }
         }
+
+        /// <summary>
+        /// Gets the duck type instance for the object implementing a base class or interface T
+        /// </summary>
+        /// <param name="instance">Object instance</param>
+        /// <typeparam name="T">Target type</typeparam>
+        /// <returns>DuckType instance</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T DuckAs<T>(this object instance)
+            where T : class
+        {
+            if (DuckType.CanCreate<T>(instance))
+            {
+                return DuckType.Create<T>(instance);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the duck type instance for the object implementing a base class or interface T
+        /// </summary>
+        /// <param name="instance">Object instance</param>
+        /// <param name="targetType">Target type</param>
+        /// <returns>DuckType instance</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object DuckAs(this object instance, Type targetType)
+        {
+            if (DuckType.CanCreate(targetType, instance))
+            {
+                return DuckType.Create(targetType, instance);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets if a proxy can be created
+        /// </summary>
+        /// <param name="instance">Instance object</param>
+        /// <typeparam name="T">Duck type</typeparam>
+        /// <returns>true if the proxy can be created; otherwise, false</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool DuckIs<T>(this object instance)
+            => DuckType.CanCreate<T>(instance);
+
+        /// <summary>
+        /// Gets if a proxy can be created
+        /// </summary>
+        /// <param name="instance">Instance object</param>
+        /// <param name="targetType">Duck type</param>
+        /// <returns>true if the proxy can be created; otherwise, false</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool DuckIs(this object instance, Type targetType)
+            => DuckType.CanCreate(targetType, instance);
     }
 }

--- a/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Runtime.CompilerServices;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.DuckTyping
 {
@@ -7,13 +9,16 @@ namespace Datadog.Trace.DuckTyping
     /// </summary>
     public static class DuckTypeExtensions
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DuckType));
+
         /// <summary>
         /// Gets the duck type instance for the object implementing a base class or interface T
         /// </summary>
         /// <param name="instance">Object instance</param>
         /// <typeparam name="T">Target type</typeparam>
         /// <returns>DuckType instance</returns>
-        public static T As<T>(this object instance)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static T DuckCast<T>(this object instance)
             => DuckType.Create<T>(instance);
 
         /// <summary>
@@ -22,7 +27,52 @@ namespace Datadog.Trace.DuckTyping
         /// <param name="instance">Object instance</param>
         /// <param name="targetType">Target type</param>
         /// <returns>DuckType instance</returns>
-        public static object As(this object instance, Type targetType)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static object DuckCast(this object instance, Type targetType)
             => DuckType.Create(targetType, instance);
+
+        /// <summary>
+        /// Tries to ducktype the object implementing a base class or interface T
+        /// </summary>
+        /// <typeparam name="T">Target type</typeparam>
+        /// <param name="instance">Object instance</param>
+        /// <param name="value">Ducktype instance</param>
+        /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
+        public static bool DuckIs<T>(this object instance, out T value)
+        {
+            try
+            {
+                value = DuckType.Create<T>(instance);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, ex.Message);
+                value = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Tries to ducktype the object implementing a base class or interface T
+        /// </summary>
+        /// <param name="instance">Object instance</param>
+        /// <param name="targetType">Target type</param>
+        /// <param name="value">Ducktype instance</param>
+        /// <returns>true if the object instance was ducktyped; otherwise, false.</returns>
+        public static bool DuckIs(this object instance, Type targetType, out object value)
+        {
+            try
+            {
+                value = DuckType.Create(targetType, instance);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, ex.Message);
+                value = default;
+                return false;
+            }
+        }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckTypeExtensionsTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckTypeExtensionsTests.cs
@@ -29,9 +29,52 @@ namespace Datadog.Trace.DuckTyping.Tests
             Assert.Null(iTaskString);
         }
 
+        [Fact]
+        public void TryDuckCastTest()
+        {
+            Task task = (Task)Task.FromResult("Hello World");
+
+            bool tskResultBool = task.TryDuckCast<ITaskString>(out var tskResult);
+            Assert.True(tskResultBool);
+            Assert.Equal("Hello World", tskResult.Result);
+
+            bool tskErrorBool = task.TryDuckCast<ITaskError>(out var tskResultError);
+            Assert.False(tskErrorBool);
+            Assert.Null(tskResultError);
+        }
+
+        [Fact]
+        public void DuckAsTest()
+        {
+            Task task = (Task)Task.FromResult("Hello World");
+
+            var tskResult = task.DuckAs<ITaskString>();
+            var tskResultError = task.DuckAs<ITaskError>();
+
+            Assert.Equal("Hello World", tskResult.Result);
+            Assert.Null(tskResultError);
+        }
+
+        [Fact]
+        public void DuckIsTest()
+        {
+            Task task = (Task)Task.FromResult("Hello World");
+
+            bool bOk = task.DuckIs<ITaskString>();
+            bool bError = task.DuckIs<ITaskError>();
+
+            Assert.True(bOk);
+            Assert.False(bError);
+        }
+
         public interface ITaskString
         {
             string Result { get; }
+        }
+
+        public interface ITaskError
+        {
+            string ResultWrong { get; }
         }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckTypeExtensionsTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckTypeExtensionsTests.cs
@@ -9,12 +9,12 @@ namespace Datadog.Trace.DuckTyping.Tests
     public class DuckTypeExtensionsTests
     {
         [Fact]
-        public void AsTest()
+        public void DuckCastTest()
         {
             Task task = (Task)Task.FromResult("Hello World");
 
-            var iTaskString = task.As<ITaskString>();
-            var objTaskString = task.As(typeof(ITaskString));
+            var iTaskString = task.DuckCast<ITaskString>();
+            var objTaskString = task.DuckCast(typeof(ITaskString));
 
             Assert.Equal("Hello World", iTaskString.Result);
             Assert.True(iTaskString.GetType() == objTaskString.GetType());
@@ -24,7 +24,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         public void NullCheck()
         {
             object obj = null;
-            var iTaskString = obj.As<ITaskString>();
+            var iTaskString = obj.DuckCast<ITaskString>();
 
             Assert.Null(iTaskString);
         }

--- a/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
@@ -15,12 +15,12 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypePropertyCantBeReadException>(() =>
             {
-                target.As<IPropertyCantBeReadException>();
+                target.DuckCast<IPropertyCantBeReadException>();
             });
 
             Assert.Throws<DuckTypePropertyCantBeReadException>(() =>
             {
-                target.As<StructPropertyCantBeReadException>();
+                target.DuckCast<StructPropertyCantBeReadException>();
             });
         }
 
@@ -51,7 +51,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                target.As<IPropertyCantBeWrittenException>();
+                target.DuckCast<IPropertyCantBeWrittenException>();
             });
         }
 
@@ -74,17 +74,17 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypePropertyArgumentsLengthException>(() =>
             {
-                target.As<IPropertyArgumentsLengthException>();
+                target.DuckCast<IPropertyArgumentsLengthException>();
             });
 
             Assert.Throws<DuckTypePropertyArgumentsLengthException>(() =>
             {
-                target.As<StructPropertyArgumentsLengthException>();
+                target.DuckCast<StructPropertyArgumentsLengthException>();
             });
 
             Assert.Throws<DuckTypePropertyArgumentsLengthException>(() =>
             {
-                target.As<ISetPropertyArgumentsLengthException>();
+                target.DuckCast<ISetPropertyArgumentsLengthException>();
             });
         }
 
@@ -122,7 +122,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                target.As<IFieldIsReadonlyException>();
+                target.DuckCast<IFieldIsReadonlyException>();
             });
         }
 
@@ -154,27 +154,27 @@ namespace Datadog.Trace.DuckTyping.Tests
             {
                 Assert.Throws<DuckTypePropertyOrFieldNotFoundException>(() =>
                 {
-                    target.As<IPropertyOrFieldNotFoundException>();
+                    target.DuckCast<IPropertyOrFieldNotFoundException>();
                 });
 
                 Assert.Throws<DuckTypePropertyOrFieldNotFoundException>(() =>
                 {
-                    target.As<IPropertyOrFieldNotFound2Exception>();
+                    target.DuckCast<IPropertyOrFieldNotFound2Exception>();
                 });
 
                 Assert.Throws<DuckTypePropertyOrFieldNotFoundException>(() =>
                 {
-                    target.As<IPropertyOrFieldNotFound3Exception>();
+                    target.DuckCast<IPropertyOrFieldNotFound3Exception>();
                 });
 
                 Assert.Throws<DuckTypePropertyOrFieldNotFoundException>(() =>
                 {
-                    target.As<PropertyOrFieldNotFoundExceptionStruct>();
+                    target.DuckCast<PropertyOrFieldNotFoundExceptionStruct>();
                 });
 
                 Assert.Throws<DuckTypePropertyOrFieldNotFoundException>(() =>
                 {
-                    target.As<PropertyOrFieldNotFound2ExceptionStruct>();
+                    target.DuckCast<PropertyOrFieldNotFound2ExceptionStruct>();
                 });
             }
         }
@@ -222,12 +222,12 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeTypeIsNotPublicException>(() =>
             {
-                target.As<ITypeIsNotPublicException>();
+                target.DuckCast<ITypeIsNotPublicException>();
             });
 
             Assert.Throws<DuckTypeTypeIsNotPublicException>(() =>
             {
-                target.As(typeof(ITypeIsNotPublicException));
+                target.DuckCast(typeof(ITypeIsNotPublicException));
             });
         }
 
@@ -251,7 +251,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeStructMembersCannotBeChangedException>(() =>
             {
-                target.As<IStructMembersCannotBeChangedException>();
+                target.DuckCast<IStructMembersCannotBeChangedException>();
             });
         }
 
@@ -275,7 +275,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeStructMembersCannotBeChangedException>(() =>
             {
-                target.As<IStructMembersCannotBeChanged2Exception>();
+                target.DuckCast<IStructMembersCannotBeChanged2Exception>();
             });
         }
 
@@ -301,17 +301,17 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeTargetMethodNotFoundException>(() =>
             {
-                target.As<ITargetMethodNotFoundException>();
+                target.DuckCast<ITargetMethodNotFoundException>();
             });
 
             Assert.Throws<DuckTypeTargetMethodNotFoundException>(() =>
             {
-                target.As<ITargetMethodNotFound2Exception>();
+                target.DuckCast<ITargetMethodNotFound2Exception>();
             });
 
             Assert.Throws<DuckTypeTargetMethodNotFoundException>(() =>
             {
-                target.As<ITargetMethodNotFound3Exception>();
+                target.DuckCast<ITargetMethodNotFound3Exception>();
             });
         }
 
@@ -351,7 +351,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeProxyMethodParameterIsMissingException>(() =>
             {
-                target.As<IProxyMethodParameterIsMissingException>();
+                target.DuckCast<IProxyMethodParameterIsMissingException>();
             });
         }
 
@@ -377,12 +377,12 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeProxyAndTargetMethodParameterSignatureMismatchException>(() =>
             {
-                target.As<IProxyAndTargetMethodParameterSignatureMismatchException>();
+                target.DuckCast<IProxyAndTargetMethodParameterSignatureMismatchException>();
             });
 
             Assert.Throws<DuckTypeProxyAndTargetMethodParameterSignatureMismatchException>(() =>
             {
-                target.As<IProxyAndTargetMethodParameterSignatureMismatch2Exception>();
+                target.DuckCast<IProxyAndTargetMethodParameterSignatureMismatch2Exception>();
             });
         }
 
@@ -413,7 +413,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>(() =>
             {
-                target.As<IProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>();
+                target.DuckCast<IProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>();
             });
         }
 
@@ -438,7 +438,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeTargetMethodAmbiguousMatchException>(() =>
             {
-                target.As<ITargetMethodAmbiguousMatchException>();
+                target.DuckCast<ITargetMethodAmbiguousMatchException>();
             });
         }
 
@@ -495,7 +495,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeInvalidTypeConversionException>(() =>
             {
-                target.As<IInvalidTypeConversionException>();
+                target.DuckCast<IInvalidTypeConversionException>();
             });
         }
 
@@ -521,7 +521,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeInvalidTypeConversionException>(() =>
             {
-                target.As<IObjectInvalidTypeConversionException>();
+                target.DuckCast<IObjectInvalidTypeConversionException>();
             });
         }
 
@@ -544,7 +544,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeInvalidTypeConversionException>(() =>
             {
-                target.As<IObjectInvalidTypeConversion2Exception>();
+                target.DuckCast<IObjectInvalidTypeConversion2Exception>();
             });
         }
 
@@ -567,7 +567,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.Throws<DuckTypeInvalidTypeConversionException>(() =>
             {
-                target.As<IObjectInvalidTypeConversion3Exception>();
+                target.DuckCast<IObjectInvalidTypeConversion3Exception>();
             });
         }
 

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
         {
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                obscureObject.As<IObscureStaticReadonlyErrorDuckType>();
+                obscureObject.DuckCast<IObscureStaticReadonlyErrorDuckType>();
             });
         }
 
@@ -32,7 +32,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
         {
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                obscureObject.As<IObscureReadonlyErrorDuckType>();
+                obscureObject.DuckCast<IObscureReadonlyErrorDuckType>();
             });
         }
 
@@ -40,9 +40,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
         [MemberData(nameof(Data))]
         public void StaticReadonlyFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal("10", duckInterface.PublicStaticReadonlyReferenceTypeField);
@@ -69,9 +69,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
         [MemberData(nameof(Data))]
         public void StaticFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal("20", duckInterface.PublicStaticReferenceTypeField);
             Assert.Equal("20", duckAbstract.PublicStaticReferenceTypeField);
@@ -160,9 +160,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
         [MemberData(nameof(Data))]
         public void ReadonlyFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal("30", duckInterface.PublicReadonlyReferenceTypeField);
@@ -189,9 +189,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
         [MemberData(nameof(Data))]
         public void Fields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal("40", duckInterface.PublicReferenceTypeField);
             Assert.Equal("40", duckAbstract.PublicReferenceTypeField);

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/TypeChainingFieldTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/TypeChainingFieldTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
         {
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                obscureObject.As<IObscureStaticReadonlyErrorDuckType>();
+                obscureObject.DuckCast<IObscureStaticReadonlyErrorDuckType>();
             });
         }
 
@@ -34,7 +34,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
         {
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                obscureObject.As<IObscureReadonlyErrorDuckType>();
+                obscureObject.DuckCast<IObscureReadonlyErrorDuckType>();
             });
         }
 
@@ -42,9 +42,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
         [MemberData(nameof(Data))]
         public void StaticReadonlyFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
 
@@ -91,14 +91,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
         [MemberData(nameof(Data))]
         public void StaticFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             IDummyFieldObject newDummy = null;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.PublicStaticSelfTypeField = newDummy;
 
             Assert.Equal(42, duckInterface.PublicStaticSelfTypeField.MagicNumber);
@@ -106,7 +106,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(42, duckVirtual.PublicStaticSelfTypeField.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalStaticSelfTypeField = newDummy;
 
             Assert.Equal(52, duckInterface.InternalStaticSelfTypeField.MagicNumber);
@@ -114,7 +114,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(52, duckVirtual.InternalStaticSelfTypeField.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).DuckCast<IDummyFieldObject>();
             duckAbstract.ProtectedStaticSelfTypeField = newDummy;
 
             Assert.Equal(62, duckInterface.ProtectedStaticSelfTypeField.MagicNumber);
@@ -122,7 +122,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(62, duckVirtual.ProtectedStaticSelfTypeField.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).DuckCast<IDummyFieldObject>();
             duckAbstract.PrivateStaticSelfTypeField = newDummy;
 
             Assert.Equal(72, duckInterface.PrivateStaticSelfTypeField.MagicNumber);
@@ -134,9 +134,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
         [MemberData(nameof(Data))]
         public void ReadonlyFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
 
@@ -183,14 +183,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
         [MemberData(nameof(Data))]
         public void Fields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             IDummyFieldObject newDummy = null;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.PublicSelfTypeField = newDummy;
 
             Assert.Equal(42, duckInterface.PublicSelfTypeField.MagicNumber);
@@ -198,7 +198,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(42, duckVirtual.PublicSelfTypeField.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalSelfTypeField = newDummy;
 
             Assert.Equal(52, duckInterface.InternalSelfTypeField.MagicNumber);
@@ -206,7 +206,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(52, duckVirtual.InternalSelfTypeField.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).DuckCast<IDummyFieldObject>();
             duckInterface.ProtectedSelfTypeField = newDummy;
 
             Assert.Equal(62, duckInterface.ProtectedSelfTypeField.MagicNumber);
@@ -214,7 +214,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(62, duckVirtual.ProtectedSelfTypeField.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).DuckCast<IDummyFieldObject>();
             duckInterface.PrivateSelfTypeField = newDummy;
 
             Assert.Equal(72, duckInterface.PrivateSelfTypeField.MagicNumber);

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         {
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                obscureObject.As<IObscureStaticReadonlyErrorDuckType>();
+                obscureObject.DuckCast<IObscureStaticReadonlyErrorDuckType>();
             });
         }
 
@@ -32,7 +32,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         {
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
-                obscureObject.As<IObscureReadonlyErrorDuckType>();
+                obscureObject.DuckCast<IObscureReadonlyErrorDuckType>();
             });
         }
 
@@ -40,9 +40,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         [MemberData(nameof(Data))]
         public void StaticReadonlyFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal(10, duckInterface.PublicStaticReadonlyValueTypeField);
@@ -69,9 +69,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         [MemberData(nameof(Data))]
         public void StaticFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal(20, duckInterface.PublicStaticValueTypeField);
             Assert.Equal(20, duckAbstract.PublicStaticValueTypeField);
@@ -160,9 +160,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         [MemberData(nameof(Data))]
         public void ReadonlyFields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal(30, duckInterface.PublicReadonlyValueTypeField);
@@ -189,9 +189,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         [MemberData(nameof(Data))]
         public void Fields(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal(40, duckInterface.PublicValueTypeField);
             Assert.Equal(40, duckAbstract.PublicValueTypeField);
@@ -280,9 +280,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
         [MemberData(nameof(Data))]
         public void NullableOfKnown(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Null(duckInterface.PublicStaticNullableIntField);
             Assert.Null(duckAbstract.PublicStaticNullableIntField);

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -21,9 +21,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [MemberData(nameof(Data))]
         public void ReturnMethods(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // Integers
             Assert.Equal(20, duckInterface.Sum(10, 10));
@@ -56,7 +56,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Assert.Equal(20, duckVirtual.InternalSum(10, 10));
 
             var dummy = new ObscureObject.DummyFieldObject { MagicNumber = 987654 };
-            var dummyInt = dummy.As<IDummyFieldObject>();
+            var dummyInt = dummy.DuckCast<IDummyFieldObject>();
             Assert.Equal(dummy.MagicNumber, duckInterface.Bypass(dummyInt).MagicNumber);
             Assert.Equal(dummy.MagicNumber, duckAbstract.Bypass(dummyInt).MagicNumber);
             Assert.Equal(dummy.MagicNumber, duckVirtual.Bypass(dummyInt).MagicNumber);
@@ -66,9 +66,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [MemberData(nameof(Data))]
         public void VoidMethods(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // Void with object
             duckInterface.Add("Key01", new ObscureObject.DummyFieldObject());
@@ -90,9 +90,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [MemberData(nameof(Data))]
         public void RefParametersMethods(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // Ref parameter
             int value = 4;
@@ -129,11 +129,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             object refObject;
             refObject = null;
             Assert.True(duckInterface.TryGetReferenceObject(ref refObject));
-            Assert.Equal(100, refObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(100, refObject.DuckCast<IDummyFieldObject>().MagicNumber);
             Assert.True(duckAbstract.TryGetReferenceObject(ref refObject));
-            Assert.Equal(101, refObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(101, refObject.DuckCast<IDummyFieldObject>().MagicNumber);
             Assert.True(duckVirtual.TryGetReferenceObject(ref refObject));
-            Assert.Equal(102, refObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(102, refObject.DuckCast<IDummyFieldObject>().MagicNumber);
 
             // Private internal parameter type with duck type output
             refDuckType = null;
@@ -147,20 +147,20 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             // Private internal parameter type object output
             refObject = null;
             Assert.True(duckInterface.TryGetPrivateReferenceObject(ref refObject));
-            Assert.Equal(100, refObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(100, refObject.DuckCast<IDummyFieldObject>().MagicNumber);
             Assert.True(duckAbstract.TryGetPrivateReferenceObject(ref refObject));
-            Assert.Equal(101, refObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(101, refObject.DuckCast<IDummyFieldObject>().MagicNumber);
             Assert.True(duckVirtual.TryGetPrivateReferenceObject(ref refObject));
-            Assert.Equal(102, refObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(102, refObject.DuckCast<IDummyFieldObject>().MagicNumber);
         }
 
         [Theory]
         [MemberData(nameof(Data))]
         public void OutParametersMethods(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // Out parameter
             int outValue;
@@ -198,15 +198,15 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             object outObject;
             Assert.True(duckInterface.TryGetObscureObject(out outObject));
             Assert.NotNull(outObject);
-            Assert.Equal(99, outObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(99, outObject.DuckCast<IDummyFieldObject>().MagicNumber);
 
             Assert.True(duckAbstract.TryGetObscureObject(out outObject));
             Assert.NotNull(outObject);
-            Assert.Equal(99, outObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(99, outObject.DuckCast<IDummyFieldObject>().MagicNumber);
 
             Assert.True(duckVirtual.TryGetObscureObject(out outObject));
             Assert.NotNull(outObject);
-            Assert.Equal(99, outObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(99, outObject.DuckCast<IDummyFieldObject>().MagicNumber);
 
             // Private internal parameter type with duck type output
             Assert.True(duckInterface.TryGetPrivateObscure(out outDuckType));
@@ -224,15 +224,15 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             // Private internal parameter type object output
             Assert.True(duckInterface.TryGetPrivateObscureObject(out outObject));
             Assert.NotNull(outObject);
-            Assert.Equal(99, outObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(99, outObject.DuckCast<IDummyFieldObject>().MagicNumber);
 
             Assert.True(duckAbstract.TryGetPrivateObscureObject(out outObject));
             Assert.NotNull(outObject);
-            Assert.Equal(99, outObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(99, outObject.DuckCast<IDummyFieldObject>().MagicNumber);
 
             Assert.True(duckVirtual.TryGetPrivateObscureObject(out outObject));
             Assert.NotNull(outObject);
-            Assert.Equal(99, outObject.As<IDummyFieldObject>().MagicNumber);
+            Assert.Equal(99, outObject.DuckCast<IDummyFieldObject>().MagicNumber);
         }
 
         [Fact]
@@ -240,7 +240,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         {
             Dictionary<string, string> dictionary = new Dictionary<string, string>();
 
-            var duckInterface = dictionary.As<IDictioDuckType>();
+            var duckInterface = dictionary.DuckCast<IDictioDuckType>();
 
             duckInterface.Add("Key01", "Value01");
             duckInterface.Add("Key02", "Value02");
@@ -286,24 +286,24 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
                 Assert.Throws<DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>(
                     () =>
                     {
-                        obscureObject.As<IDefaultGenericMethodDuckType>();
+                        obscureObject.DuckCast<IDefaultGenericMethodDuckType>();
                     });
                 Assert.Throws<DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>(
                     () =>
                     {
-                        obscureObject.As<DefaultGenericMethodDuckTypeAbstractClass>();
+                        obscureObject.DuckCast<DefaultGenericMethodDuckTypeAbstractClass>();
                     });
                 Assert.Throws<DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>(
                     () =>
                     {
-                        obscureObject.As<DefaultGenericMethodDuckTypeVirtualClass>();
+                        obscureObject.DuckCast<DefaultGenericMethodDuckTypeVirtualClass>();
                     });
                 return;
             }
 
-            var duckInterface = obscureObject.As<IDefaultGenericMethodDuckType>();
-            var duckAbstract = obscureObject.As<DefaultGenericMethodDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<DefaultGenericMethodDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IDefaultGenericMethodDuckType>();
+            var duckAbstract = obscureObject.DuckCast<DefaultGenericMethodDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<DefaultGenericMethodDuckTypeVirtualClass>();
 
             // GetDefault int
             Assert.Equal(0, duckInterface.GetDefault<int>());
@@ -340,9 +340,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [MemberData(nameof(Data))]
         public void GenericsWithAttributeResolution(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IGenericsWithAttribute>();
-            var duckAttribute = obscureObject.As<AbstractGenericsWithAttribute>();
-            var duckVirtual = obscureObject.As<VirtualGenericsWithAttribute>();
+            var duckInterface = obscureObject.DuckCast<IGenericsWithAttribute>();
+            var duckAttribute = obscureObject.DuckCast<AbstractGenericsWithAttribute>();
+            var duckVirtual = obscureObject.DuckCast<VirtualGenericsWithAttribute>();
 
             Tuple<int, string> result;
 

--- a/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         {
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                obscureObject.As<IObscureStaticErrorDuckType>();
+                obscureObject.DuckCast<IObscureStaticErrorDuckType>();
             });
         }
 
@@ -32,7 +32,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         {
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                obscureObject.As<IObscureErrorDuckType>();
+                obscureObject.DuckCast<IObscureErrorDuckType>();
             });
         }
 
@@ -40,9 +40,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void StaticGetOnlyProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal("10", duckInterface.PublicStaticGetReferenceType);
@@ -69,9 +69,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void StaticProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal("20", duckInterface.PublicStaticGetSetReferenceType);
             Assert.Equal("20", duckAbstract.PublicStaticGetSetReferenceType);
@@ -168,9 +168,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void GetOnlyProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal("30", duckInterface.PublicGetReferenceType);
@@ -197,9 +197,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void Properties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal("40", duckInterface.PublicGetSetReferenceType);
             Assert.Equal("40", duckAbstract.PublicGetSetReferenceType);
@@ -296,9 +296,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void Indexer(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             duckInterface["1"] = "100";
             Assert.Equal("100", duckInterface["1"]);
@@ -320,7 +320,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void StructCopy(object obscureObject)
         {
-            var duckStructCopy = obscureObject.As<ObscureDuckTypeStruct>();
+            var duckStructCopy = obscureObject.DuckCast<ObscureDuckTypeStruct>();
 
             Assert.Equal("10", duckStructCopy.PublicStaticGetReferenceType);
             Assert.Equal("11", duckStructCopy.InternalStaticGetReferenceType);
@@ -347,7 +347,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
         [MemberData(nameof(Data))]
         public void UnionTest(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IDuckTypeUnion>();
+            var duckInterface = obscureObject.DuckCast<IDuckTypeUnion>();
 
             Assert.Equal("40", duckInterface.PublicGetSetReferenceType);
 

--- a/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/TypeChainingPropertyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/TypeChainingPropertyTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         {
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                obscureObject.As<IObscureStaticErrorDuckType>();
+                obscureObject.DuckCast<IObscureStaticErrorDuckType>();
             });
         }
 
@@ -32,7 +32,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         {
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                obscureObject.As<IObscureErrorDuckType>();
+                obscureObject.DuckCast<IObscureErrorDuckType>();
             });
         }
 
@@ -40,9 +40,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         [MemberData(nameof(Data))]
         public void StaticGetOnlyProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
 
@@ -89,14 +89,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         [MemberData(nameof(Data))]
         public void StaticProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             IDummyFieldObject newDummy = null;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.PublicStaticGetSetSelfType = newDummy;
 
             Assert.Equal(42, duckInterface.PublicStaticGetSetSelfType.MagicNumber);
@@ -104,36 +104,36 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
             Assert.Equal(42, duckVirtual.PublicStaticGetSetSelfType.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalStaticGetSetSelfType = newDummy;
 
             Assert.Equal(52, duckInterface.InternalStaticGetSetSelfType.MagicNumber);
             Assert.Equal(52, duckAbstract.InternalStaticGetSetSelfType.MagicNumber);
             Assert.Equal(52, duckVirtual.InternalStaticGetSetSelfType.MagicNumber);
 
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalStaticGetSetSelfType = newDummy;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).DuckCast<IDummyFieldObject>();
             duckAbstract.ProtectedStaticGetSetSelfType = newDummy;
 
             Assert.Equal(62, duckInterface.ProtectedStaticGetSetSelfType.MagicNumber);
             Assert.Equal(62, duckAbstract.ProtectedStaticGetSetSelfType.MagicNumber);
             Assert.Equal(62, duckVirtual.ProtectedStaticGetSetSelfType.MagicNumber);
 
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckAbstract.ProtectedStaticGetSetSelfType = newDummy;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).DuckCast<IDummyFieldObject>();
             duckAbstract.PrivateStaticGetSetSelfType = newDummy;
 
             Assert.Equal(72, duckInterface.PrivateStaticGetSetSelfType.MagicNumber);
             Assert.Equal(72, duckAbstract.PrivateStaticGetSetSelfType.MagicNumber);
             Assert.Equal(72, duckVirtual.PrivateStaticGetSetSelfType.MagicNumber);
 
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckAbstract.PrivateStaticGetSetSelfType = newDummy;
         }
 
@@ -141,9 +141,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         [MemberData(nameof(Data))]
         public void GetOnlyProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
 
@@ -190,14 +190,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         [MemberData(nameof(Data))]
         public void Properties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             IDummyFieldObject newDummy = null;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.PublicGetSetSelfType = newDummy;
 
             Assert.Equal(42, duckInterface.PublicGetSetSelfType.MagicNumber);
@@ -205,36 +205,36 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
             Assert.Equal(42, duckVirtual.PublicGetSetSelfType.MagicNumber);
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalGetSetSelfType = newDummy;
 
             Assert.Equal(52, duckInterface.InternalGetSetSelfType.MagicNumber);
             Assert.Equal(52, duckAbstract.InternalGetSetSelfType.MagicNumber);
             Assert.Equal(52, duckVirtual.InternalGetSetSelfType.MagicNumber);
 
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalGetSetSelfType = newDummy;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 62 }).DuckCast<IDummyFieldObject>();
             duckInterface.ProtectedGetSetSelfType = newDummy;
 
             Assert.Equal(62, duckInterface.ProtectedGetSetSelfType.MagicNumber);
             Assert.Equal(62, duckAbstract.ProtectedGetSetSelfType.MagicNumber);
             Assert.Equal(62, duckVirtual.ProtectedGetSetSelfType.MagicNumber);
 
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.ProtectedGetSetSelfType = newDummy;
 
             // *
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 72 }).DuckCast<IDummyFieldObject>();
             duckInterface.PrivateGetSetSelfType = newDummy;
 
             Assert.Equal(72, duckInterface.PrivateGetSetSelfType.MagicNumber);
             Assert.Equal(72, duckAbstract.PrivateGetSetSelfType.MagicNumber);
             Assert.Equal(72, duckVirtual.PrivateGetSetSelfType.MagicNumber);
 
-            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).As<IDummyFieldObject>();
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
             duckInterface.PrivateGetSetSelfType = newDummy;
         }
 
@@ -242,7 +242,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
         [MemberData(nameof(Data))]
         public void StructCopy(object obscureObject)
         {
-            var duckStructCopy = obscureObject.As<ObscureDuckTypeStruct>();
+            var duckStructCopy = obscureObject.DuckCast<ObscureDuckTypeStruct>();
 
             Assert.Equal(42, duckStructCopy.PublicStaticGetSelfType.MagicNumber);
             Assert.Equal(42, duckStructCopy.InternalStaticGetSelfType.MagicNumber);

--- a/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         {
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                obscureObject.As<IObscureStaticErrorDuckType>();
+                obscureObject.DuckCast<IObscureStaticErrorDuckType>();
             });
         }
 
@@ -33,7 +33,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         {
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
-                obscureObject.As<IObscureErrorDuckType>();
+                obscureObject.DuckCast<IObscureErrorDuckType>();
             });
         }
 
@@ -41,9 +41,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void StaticGetOnlyProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal(10, duckInterface.PublicStaticGetValueType);
@@ -70,9 +70,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void StaticProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal(20, duckInterface.PublicStaticGetSetValueType);
             Assert.Equal(20, duckAbstract.PublicStaticGetSetValueType);
@@ -169,9 +169,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void GetOnlyProperties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             // *
             Assert.Equal(30, duckInterface.PublicGetValueType);
@@ -198,9 +198,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void Properties(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal(40, duckInterface.PublicGetSetValueType);
             Assert.Equal(40, duckAbstract.PublicGetSetValueType);
@@ -297,9 +297,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void Indexer(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             duckInterface[1] = 100;
             Assert.Equal(100, duckInterface[1]);
@@ -321,9 +321,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void NullableOfKnown(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Null(duckInterface.PublicStaticNullableInt);
             Assert.Null(duckAbstract.PublicStaticNullableInt);
@@ -412,9 +412,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void KnownEnum(object obscureObject)
         {
-            var duckInterface = obscureObject.As<IObscureDuckType>();
-            var duckAbstract = obscureObject.As<ObscureDuckTypeAbstractClass>();
-            var duckVirtual = obscureObject.As<ObscureDuckTypeVirtualClass>();
+            var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
+            var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
+            var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             Assert.Equal(TaskStatus.RanToCompletion, duckInterface.Status);
             Assert.Equal(TaskStatus.RanToCompletion, duckAbstract.Status);
@@ -443,7 +443,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
         [MemberData(nameof(Data))]
         public void StructCopy(object obscureObject)
         {
-            var duckStructCopy = obscureObject.As<ObscureDuckTypeStruct>();
+            var duckStructCopy = obscureObject.DuckCast<ObscureDuckTypeStruct>();
 
             Assert.Equal(10, duckStructCopy.PublicStaticGetValueType);
             Assert.Equal(11, duckStructCopy.InternalStaticGetValueType);
@@ -472,7 +472,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             ObscureObject.PublicStruct source = default;
             source.PublicGetSetValueType = 42;
 
-            var dest = source.As<IStructDuckType>();
+            var dest = source.DuckCast<IStructDuckType>();
             Assert.Equal(source.PublicGetSetValueType, dest.PublicGetSetValueType);
         }
     }

--- a/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         public void NonPublicStructCopyTest()
         {
             PrivateStruct instance = default;
-            CopyStruct copy = instance.As<CopyStruct>();
+            CopyStruct copy = instance.DuckCast<CopyStruct>();
             Assert.Equal(instance.Value, copy.Value);
         }
 
@@ -19,7 +19,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         public void NonPublicStructInterfaceProxyTest()
         {
             PrivateStruct instance = default;
-            IPrivateStruct proxy = instance.As<IPrivateStruct>();
+            IPrivateStruct proxy = instance.DuckCast<IPrivateStruct>();
             Assert.Equal(instance.Value, proxy.Value);
         }
 
@@ -27,7 +27,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         public void NonPublicStructAbstractProxyTest()
         {
             PrivateStruct instance = default;
-            AbstractPrivateProxy proxy = instance.As<AbstractPrivateProxy>();
+            AbstractPrivateProxy proxy = instance.DuckCast<AbstractPrivateProxy>();
             Assert.Equal(instance.Value, proxy.Value);
         }
 
@@ -35,7 +35,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         public void NonPublicStructVirtualProxyTest()
         {
             PrivateStruct instance = default;
-            VirtualPrivateProxy proxy = instance.As<VirtualPrivateProxy>();
+            VirtualPrivateProxy proxy = instance.DuckCast<VirtualPrivateProxy>();
             Assert.Equal(instance.Value, proxy.Value);
         }
 
@@ -69,13 +69,13 @@ namespace Datadog.Trace.DuckTyping.Tests
         public void DuckChainingStructInterfaceProxyTest()
         {
             PrivateDuckChainingTarget instance = new PrivateDuckChainingTarget();
-            IPrivateDuckChainingTarget proxy = instance.As<IPrivateDuckChainingTarget>();
+            IPrivateDuckChainingTarget proxy = instance.DuckCast<IPrivateDuckChainingTarget>();
             Assert.Equal(instance.ChainingTestField.Name, proxy.ChainingTestField.Name);
             Assert.Equal(instance.ChainingTest.Name, proxy.ChainingTest.Name);
             Assert.Equal(instance.ChainingTestMethod().Name, proxy.ChainingTestMethod().Name);
 
             PublicDuckChainingTarget instance2 = new PublicDuckChainingTarget();
-            IPrivateDuckChainingTarget proxy2 = instance2.As<IPrivateDuckChainingTarget>();
+            IPrivateDuckChainingTarget proxy2 = instance2.DuckCast<IPrivateDuckChainingTarget>();
             Assert.Equal(instance2.ChainingTestField.Name, proxy2.ChainingTestField.Name);
             Assert.Equal(instance2.ChainingTest.Name, proxy2.ChainingTest.Name);
             Assert.Equal(instance2.ChainingTestMethod().Name, proxy2.ChainingTestMethod().Name);


### PR DESCRIPTION
Replacing DuckType `As<T>` with DuckCast, TryDuckCast, DuckAs and DuckIs

https://github.com/DataDog/dd-trace-dotnet/blob/tony/ducktyping-duckcast/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs#L14-L133

@DataDog/apm-dotnet