### PR TITLE
CIApp: Traits as a Dictionary<string, string[]>

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -100,12 +100,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
 
             // Get traits
             Dictionary<string, List<string>> testTraits = GetTraits(testMethod);
-            if (testTraits != null)
+            if (testTraits != null && testTraits.Count > 0)
             {
-                foreach (KeyValuePair<string, List<string>> keyValuePair in testTraits)
-                {
-                    span.SetTag($"{TestTags.Traits}.{keyValuePair.Key}", string.Join(", ", keyValuePair.Value) ?? "(null)");
-                }
+                span.SetTag(TestTags.Traits, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(testTraits));
             }
 
             span.ResetStartTime();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -82,6 +82,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             // Get traits
             if (testMethodProperties != null)
             {
+                Dictionary<string, List<string>> traits = new Dictionary<string, List<string>>();
                 skipReason = (string)testMethodProperties.Get("_SKIPREASON");
                 foreach (var key in testMethodProperties.Keys)
                 {
@@ -104,12 +105,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                             lstValues.Add(valObj.ToString());
                         }
 
-                        span.SetTag($"{TestTags.Traits}.{key}", string.Join(", ", lstValues));
+                        traits[key] = lstValues;
                     }
                     else
                     {
-                        span.SetTag($"{TestTags.Traits}.{key}", "(null)");
+                        traits[key] = null;
                     }
+                }
+
+                if (traits.Count > 0)
+                {
+                    span.SetTag(TestTags.Traits, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(traits));
                 }
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -74,10 +74,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             Dictionary<string, List<string>> traits = runnerInstance.TestCase.Traits;
             if (traits.Count > 0)
             {
-                foreach (KeyValuePair<string, List<string>> traitValue in traits)
-                {
-                    span.SetTag($"{TestTags.Traits}.{traitValue.Key}", string.Join(", ", traitValue.Value) ?? "(null)");
-                }
+                span.SetTag(TestTags.Traits, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(traits));
             }
 
             // Skip tests


### PR DESCRIPTION
Change `test.traits` format following the CiApp specs.


@DataDog/apm-dotnet