### PR TITLE
Replace map.count-> map[] with map.find in the native profiler

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -569,8 +569,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id) {
   }
 
   // remove module metadata from map
-  if (module_id_to_info_map_.count(module_id) > 0) {
-    ModuleMetadata* metadata = module_id_to_info_map_[module_id];
+  auto findRes = module_id_to_info_map_.find(module_id);
+  if (findRes != module_id_to_info_map_.end()) {
+    ModuleMetadata* metadata = findRes->second;
 
     // remove appdomain id from managed_profiler_loaded_app_domains set
     if (managed_profiler_loaded_app_domains.find(metadata->app_domain_id) !=
@@ -650,8 +651,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(
 
   // Verify that we have the metadata for this module
   ModuleMetadata* module_metadata = nullptr;
-  if (module_id_to_info_map_.count(module_id) > 0) {
-    module_metadata = module_id_to_info_map_[module_id];
+
+  auto findRes = module_id_to_info_map_.find(module_id);
+  if (findRes != module_id_to_info_map_.end()) {
+    module_metadata = findRes->second;
   }
 
   if (module_metadata == nullptr) {
@@ -2696,8 +2699,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdM
   ModuleMetadata* module_metadata = nullptr;
   {
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
-    if (module_id_to_info_map_.count(moduleId) > 0) {
-      module_metadata = module_id_to_info_map_[moduleId];
+    auto findRes = module_id_to_info_map_.find(moduleId);
+    if (findRes != module_id_to_info_map_.end()) {
+      module_metadata = findRes->second;
     } else {
       return S_OK;
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -41,8 +41,9 @@ bool RejitHandlerModuleMethod::ExistFunctionId(FunctionID functionId) {
 RejitHandlerModuleMethod* RejitHandlerModule::GetOrAddMethod(mdMethodDef methodDef) {
   std::lock_guard<std::mutex> guard(methods_lock);
 
-  if (methods.count(methodDef) > 0) {
-    return methods[methodDef];
+  auto find_res = methods.find(methodDef);
+  if (find_res != methods.end()) {
+    return find_res->second;
   }
 
   RejitHandlerModuleMethod* methodHandler = new RejitHandlerModuleMethod(methodDef, this);
@@ -53,8 +54,9 @@ bool RejitHandlerModule::TryGetMethod(mdMethodDef methodDef,
                                       RejitHandlerModuleMethod** methodHandler) {
   std::lock_guard<std::mutex> guard(methods_lock);
 
-  if (methods.count(methodDef) > 0) {
-    *methodHandler = methods[methodDef];
+  auto find_res = methods.find(methodDef);
+  if (find_res != methods.end()) {
+    *methodHandler = find_res->second;
     return true;
   }
   *methodHandler = nullptr;
@@ -65,8 +67,9 @@ RejitHandlerModuleMethod* RejitHandler::GetModuleMethodFromFunctionId(
     FunctionID functionId) {
   {
     std::lock_guard<std::mutex> guard(methodByFunctionId_lock);
-    if (methodByFunctionId.count(functionId) > 0) {
-      return methodByFunctionId[functionId];
+    auto find_res = methodByFunctionId.find(functionId);
+    if (find_res != methodByFunctionId.end()) {
+      return find_res->second;
     }
   }
 
@@ -95,8 +98,9 @@ RejitHandlerModuleMethod* RejitHandler::GetModuleMethodFromFunctionId(
 RejitHandlerModule* RejitHandler::GetOrAddModule(ModuleID moduleId) {
   std::lock_guard<std::mutex> guard(modules_lock);
 
-  if (modules.count(moduleId) > 0) {
-    return modules[moduleId];
+  auto find_res = modules.find(moduleId);
+  if (find_res != modules.end()) {
+    return find_res->second;
   }
 
   RejitHandlerModule* moduleHandler = new RejitHandlerModule(moduleId, this);
@@ -107,8 +111,10 @@ RejitHandlerModule* RejitHandler::GetOrAddModule(ModuleID moduleId) {
 bool RejitHandler::TryGetModule(ModuleID moduleId,
                               RejitHandlerModule** moduleHandler) {
   std::lock_guard<std::mutex> guard(modules_lock);
-  if (modules.count(moduleId) > 0) {
-    *moduleHandler = modules[moduleId];
+
+  auto find_res = modules.find(moduleId);
+  if (find_res != modules.end()) {
+    *moduleHandler = find_res->second;
     return true;
   }
   *moduleHandler = nullptr;


### PR DESCRIPTION
This PR replaces the map.count-> map[] with map.find in the native profiler avoiding the double hashing of the map key.


@DataDog/apm-dotnet