### PR TITLE
Strengthen type check in the method resolution for CallSite instrumentation and improve fallback mechanism

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed.Core/ClrNames.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Core/ClrNames.cs
@@ -34,5 +34,9 @@ namespace Datadog.Trace.ClrProfiler
         public const string HttpResponseMessageTask = "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>";
 
         public const string GenericTask = "System.Threading.Tasks.Task`1";
+        public const string IgnoreGenericTask = "System.Threading.Tasks.Task`1<_>";
+        public const string GenericParameterTask = "System.Threading.Tasks.Task`1<T>";
+        public const string ObjectTask = "System.Threading.Tasks.Task`1<System.Object>";
+        public const string Int32Task = "System.Threading.Tasks.Task`1<System.Int32>";
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
@@ -424,8 +425,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
             if (!methodInfo.IsStatic && !methodInfo.ReflectedType.IsAssignableFrom(_concreteType))
             {
                 Log.Warning($"_concreteType cannot be assigned to the type containing the MethodInfo representing the instance method: {detailMessage}");
-                throw new Exception($"_concreteType cannot be assigned to the type containing the MethodInfo representing the instance method: {detailMessage}");
-                // return null;
+                return null;
             }
 
             return methodInfo;
@@ -478,9 +478,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
         {
             var logDetail = $"mdToken {_mdToken} on {_concreteTypeName}.{_methodName} in {_resolutionModule?.FullyQualifiedName ?? "NULL"}, {_resolutionModule?.ModuleVersionId ?? _moduleVersionId}";
             Log.Warning($"Using fallback method matching ({logDetail})");
-            throw new Exception($"Using fallback method matching ({logDetail})");
-
-            /*
 
             var statsd = Tracer.Instance.Statsd;
 
@@ -575,7 +572,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
             }
 
             return methodInfo;
-            */
         }
 
         private bool ParametersAreViable(MethodInfo mi)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -478,6 +478,9 @@ namespace Datadog.Trace.ClrProfiler.Emit
         {
             var logDetail = $"mdToken {_mdToken} on {_concreteTypeName}.{_methodName} in {_resolutionModule?.FullyQualifiedName ?? "NULL"}, {_resolutionModule?.ModuleVersionId ?? _moduleVersionId}";
             Log.Warning($"Using fallback method matching ({logDetail})");
+            throw new Exception($"Using fallback method matching ({logDetail})");
+
+            /*
 
             var statsd = Tracer.Instance.Statsd;
 
@@ -572,6 +575,7 @@ namespace Datadog.Trace.ClrProfiler.Emit
             }
 
             return methodInfo;
+            */
         }
 
         private bool ParametersAreViable(MethodInfo mi)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -421,10 +421,10 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 return null;
             }
 
-            if (!methodInfo.IsStatic && methodInfo.ReflectedType != _concreteType)
+            if (!methodInfo.IsStatic && !methodInfo.ReflectedType.IsAssignableFrom(_concreteType))
             {
-                Log.Warning($"MethodInfo for instance method defined on type that does not match the input instance: {detailMessage}");
-                throw new Exception($"MethodInfo for instance method defined on type that does not match the input instance: {detailMessage}");
+                Log.Warning($"_concreteType cannot be assigned to the type containing the MethodInfo representing the instance method: {detailMessage}");
+                throw new Exception($"_concreteType cannot be assigned to the type containing the MethodInfo representing the instance method: {detailMessage}");
                 // return null;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -421,6 +421,13 @@ namespace Datadog.Trace.ClrProfiler.Emit
                 return null;
             }
 
+            if (!methodInfo.IsStatic && methodInfo.ReflectedType != _concreteType)
+            {
+                Log.Warning($"MethodInfo for instance method defined on type that does not match the input instance: {detailMessage}");
+                throw new Exception($"MethodInfo for instance method defined on type that does not match the input instance: {detailMessage}");
+                // return null;
+            }
+
             return methodInfo;
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Emit/MethodBuilder.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
-using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
@@ -419,12 +418,6 @@ namespace Datadog.Trace.ClrProfiler.Emit
             if (!ParametersAreViable(methodInfo))
             {
                 Log.Warning($"Parameters not viable: {detailMessage}");
-                return null;
-            }
-
-            if (!methodInfo.IsStatic && !methodInfo.ReflectedType.IsAssignableFrom(_concreteType))
-            {
-                Log.Warning($"_concreteType cannot be assigned to the type containing the MethodInfo representing the instance method: {detailMessage}");
                 return null;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/AdoNetConstants.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/AdoNetConstants.cs
@@ -29,6 +29,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             public const string DbDataReader = "System.Data.Common.DbDataReader";
             public const string DbCommand = "System.Data.Common.DbCommand";
             public const string CommandBehavior = "System.Data.CommandBehavior";
+
+            public const string DbDataReaderTask = "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>";
         }
 
         public static class MethodNames

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/DbCommandIntegration.cs
@@ -194,13 +194,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReaderTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Data.Common.DbDataReader>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { AdoNetConstants.TypeNames.DbDataReaderTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static object ExecuteReaderAsync(
@@ -242,7 +242,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(commandBehavior, cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(AdoNetConstants.TypeNames.DbDataReaderTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -362,13 +362,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.Int32Task, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.Int32Task, ClrNames.CancellationToken },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static object ExecuteNonQueryAsync(
@@ -407,7 +407,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.Int32Task, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -527,13 +527,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.SystemData, AdoNetConstants.AssemblyNames.SystemDataCommon },
             TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.ObjectTask, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major5)]
         [InterceptMethod(
             TargetAssemblies = new[] { AdoNetConstants.AssemblyNames.NetStandard },
             TargetType = DbCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.ObjectTask, ClrNames.CancellationToken },
             TargetMinimumVersion = Major2,
             TargetMaximumVersion = Major2)]
         public static object ExecuteScalarAsync(
@@ -572,7 +572,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.ObjectTask, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/NpgsqlCommandIntegration.cs
@@ -200,7 +200,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(npgsqlComandType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<Npgsql.NpgsqlDataReader>", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -310,7 +310,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(commandBehavior, cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<Npgsql.NpgsqlDataReader>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -442,7 +442,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         [InterceptMethod(
             TargetAssemblies = new[] { NpgsqlAssemblyName },
             TargetType = NpgsqlCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.Int32Task, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteNonQueryAsync(
@@ -481,7 +481,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.Int32Task, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -586,7 +586,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
         [InterceptMethod(
             TargetAssemblies = new[] { NpgsqlAssemblyName },
             TargetType = NpgsqlCommandTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.ObjectTask, ClrNames.CancellationToken },
             TargetMinimumVersion = Major4,
             TargetMaximumVersion = Major4)]
         public static object ExecuteScalarAsync(
@@ -625,7 +625,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.ObjectTask, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -343,7 +343,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(sqlCommandType)
                        .WithParameters(commandBehavior, cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters($"{ClrNames.GenericTask}<{sqlDataReaderType.FullName}>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -550,7 +550,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetAssemblies = new[] { MicrosoftSqlClientAssemblyName },
             TargetType = MicrosoftSqlCommandTypeName,
             TargetMethod = AdoNetConstants.MethodNames.ExecuteNonQueryAsync,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Int32>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.Int32Task, ClrNames.CancellationToken },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object MicrosoftSqlClientExecuteNonQueryAsync(
@@ -589,7 +589,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.Int32Task, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -769,7 +769,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
             TargetAssemblies = new[] { MicrosoftSqlClientAssemblyName },
             TargetType = MicrosoftSqlCommandTypeName,
             TargetMethod = AdoNetConstants.MethodNames.ExecuteScalarAsync,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<System.Object>", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.ObjectTask, ClrNames.CancellationToken },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object MicrosoftSqlClientExecuteScalarAsync(
@@ -808,7 +808,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(targetType)
                        .WithParameters(cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.ObjectTask, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AdoNet/SqlCommandIntegration.cs
@@ -343,7 +343,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AdoNet
                        .Start(moduleVersionPtr, mdToken, opCode, methodName)
                        .WithConcreteType(sqlCommandType)
                        .WithParameters(commandBehavior, cancellationToken)
-                       .WithNamespaceAndNameFilters($"{ClrNames.GenericTask}<{sqlDataReaderType.FullName}>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters($"{ClrNames.GenericTask}<{sqlClientNamespace}.{SqlDataReaderTypeName}>", AdoNetConstants.TypeNames.CommandBehavior, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                                     .WithConcreteType(httpControllerType)
                                     .WithParameters(controllerContext, cancellationToken)
                                     .WithNamespaceAndNameFilters(
-                                         ClrNames.GenericTask,
+                                         ClrNames.HttpResponseMessageTask,
                                          HttpControllerContextTypeName,
                                          ClrNames.CancellationToken)
                                     .Build();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet5Integration.cs
@@ -139,7 +139,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(pipeline.GetType())
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData, cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "Elasticsearch.Net.RequestData", ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<Elasticsearch.Net.ElasticsearchResponse`1>", "Elasticsearch.Net.RequestData", ClrNames.CancellationToken)
                        .ForceMethodDefinitionResolution()
                        .Build();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/ElasticsearchNet6Integration.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             CallerAssembly = ElasticsearchAssemblyName,
             TargetAssembly = ElasticsearchAssemblyName,
             TargetType = RequestPipelineInterfaceTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "Elasticsearch.Net.RequestData", ClrNames.CancellationToken },
+            TargetSignatureTypes = new[] { ClrNames.GenericParameterTask, "Elasticsearch.Net.RequestData", ClrNames.CancellationToken },
             TargetMinimumVersion = Version6,
             TargetMaximumVersion = Version6)]
         public static object CallElasticsearchAsync<TResponse>(
@@ -154,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(pipelineType)
                        .WithMethodGenerics(genericArgument)
                        .WithParameters(requestData, cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "Elasticsearch.Net.RequestData", ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.GenericParameterTask, "Elasticsearch.Net.RequestData", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/GraphQLIntegration.cs
@@ -170,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                         .Start(moduleVersionPtr, mdToken, opCode, methodName)
                         .WithConcreteType(executionStrategyInstanceType)
                         .WithParameters(context)
-                        .WithNamespaceAndNameFilters(ClrNames.GenericTask, "GraphQL.Execution.ExecutionContext")
+                        .WithNamespaceAndNameFilters(TaskOfGraphQLExecutionResult, "GraphQL.Execution.ExecutionContext")
                         .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private static readonly IntegrationInfo SocketHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.HttpSocketsHandler));
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(HttpMessageHandlerIntegration));
-        private static readonly string[] NamespaceAndNameFilters = { ClrNames.GenericTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken };
+        private static readonly string[] NamespaceAndNameFilters = { ClrNames.HttpResponseMessageTask, ClrNames.HttpRequestMessage, ClrNames.CancellationToken };
 
         private static Type _httpMessageHandlerResultType;
         private static Type _httpClientHandlerResultType;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/HttpMessageHandlerIntegration.cs
@@ -187,7 +187,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, Send)
                        .WithConcreteType(httpMessageHandler)
                        .WithParameters(request, cancellationToken)
-                       .WithNamespaceAndNameFilters(NamespaceAndNameFilters)
+                       .WithNamespaceAndNameFilters(ClrNames.HttpResponseMessage, ClrNames.HttpRequestMessage, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)
@@ -368,7 +368,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Start(moduleVersionPtr, mdToken, opCode, Send)
                        .WithConcreteType(httpClientHandler)
                        .WithParameters(request, cancellationToken)
-                       .WithNamespaceAndNameFilters(NamespaceAndNameFilters)
+                       .WithNamespaceAndNameFilters(ClrNames.HttpResponseMessage, ClrNames.HttpRequestMessage, ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/MongoDbIntegration.cs
@@ -274,7 +274,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .WithConcreteType(wireProtocolType)
                        .WithDeclaringTypeGenerics(wireProtocolGenericArgs)
                        .WithParameters(connection, cancellationToken)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken)
+                       .WithNamespaceAndNameFilters(ClrNames.IgnoreGenericTask, "MongoDB.Driver.Core.Connections.IConnection", ClrNames.CancellationToken)
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/ConnectionMultiplexer.cs
@@ -134,7 +134,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = RedisAssembly,
             TargetAssembly = RedisAssembly,
             TargetType = ConnectionMultiplexerTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", StackExchangeRedisMessage, StackExchangeRedisResultProcessorGeneric, ClrNames.Object, StackExchangeRedisServerEndPoint },
+            TargetSignatureTypes = new[] { ClrNames.GenericParameterTask, StackExchangeRedisMessage, StackExchangeRedisResultProcessorGeneric, ClrNames.Object, StackExchangeRedisServerEndPoint },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -142,7 +142,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = StrongNameRedisAssembly,
             TargetAssembly = StrongNameRedisAssembly,
             TargetType = ConnectionMultiplexerTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", StackExchangeRedisMessage, StackExchangeRedisResultProcessorGeneric, ClrNames.Object, StackExchangeRedisServerEndPoint },
+            TargetSignatureTypes = new[] { ClrNames.GenericParameterTask, StackExchangeRedisMessage, StackExchangeRedisResultProcessorGeneric, ClrNames.Object, StackExchangeRedisServerEndPoint },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsyncImpl<T>(
@@ -173,7 +173,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                         .WithParameters(message, processor, state, server)
                         .WithMethodGenerics(genericType)
                         .WithNamespaceAndNameFilters(
-                            ClrNames.GenericTask,
+                            ClrNames.GenericParameterTask,
                             StackExchangeRedisMessage,
                             StackExchangeRedisResultProcessor,
                             ClrNames.Object,

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = RedisAssembly,
             TargetAssembly = RedisAssembly,
             TargetType = RedisBaseTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
+            TargetSignatureTypes = new[] { ClrNames.GenericParameterTask, "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         [InterceptMethod(
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             CallerAssembly = StrongNameRedisAssembly,
             TargetAssembly = StrongNameRedisAssembly,
             TargetType = RedisBaseTypeName,
-            TargetSignatureTypes = new[] { "System.Threading.Tasks.Task`1<T>", "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
+            TargetSignatureTypes = new[] { ClrNames.GenericParameterTask, "StackExchange.Redis.Message", "StackExchange.Redis.ResultProcessor`1<T>", "StackExchange.Redis.ServerEndPoint" },
             TargetMinimumVersion = Major1,
             TargetMaximumVersion = Major2)]
         public static object ExecuteAsync<T>(
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
                                         .WithMethodGenerics(typeof(T))
                                         .WithParameters(message, processor, server)
                                         .WithNamespaceAndNameFilters(
-                                             ClrNames.GenericTask,
+                                             ClrNames.GenericParameterTask,
                                              "StackExchange.Redis.Message",
                                              "StackExchange.Redis.ResultProcessor`1",
                                              "StackExchange.Redis.ServerEndPoint")

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                        .Start(moduleVersionPtr, mdToken, opCode, XUnitRunAsyncMethod)
                        .WithConcreteType(testInvokerType)
                        .WithDeclaringTypeGenerics(testInvokerType.BaseType.GenericTypeArguments)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask)
+                       .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<System.Decimal>")
                        .Build();
             }
             catch (Exception ex)
@@ -162,7 +162,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                        .Start(moduleVersionPtr, mdToken, opCode, XUnitRunAsyncMethod)
                        .WithConcreteType(testRunnerType)
                        .WithDeclaringTypeGenerics(testRunnerType.BaseType.GenericTypeArguments)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask)
+                       .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>")
                        .Build();
             }
             catch (Exception ex)
@@ -272,7 +272,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                        .Start(moduleVersionPtr, mdToken, opCode, XUnitRunTestCollectionAsyncMethod)
                        .WithConcreteType(xunitTestAssemblyRunnerType)
                        .WithParameters(messageBus, testCollection, testCases, cancellationTokenSource)
-                       .WithNamespaceAndNameFilters(ClrNames.GenericTask, "Xunit.Sdk.IMessageBus", "Xunit.Abstractions.ITestCollection", "System.Collections.Generic.IEnumerable`1<T>", "System.Threading.CancellationTokenSource")
+                       .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<Xunit.Sdk.RunSummary>", "Xunit.Sdk.IMessageBus", "Xunit.Abstractions.ITestCollection", "System.Collections.Generic.IEnumerable`1<T>", "System.Threading.CancellationTokenSource")
                        .Build();
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/WebRequestIntegration.cs
@@ -220,7 +220,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     MethodBuilder<Func<object, Task<WebResponse>>>
                         .Start(moduleVersionPtr, mdToken, opCode, methodName)
                         .WithConcreteType(instrumentedType)
-                        .WithNamespaceAndNameFilters(ClrNames.GenericTask)
+                        .WithNamespaceAndNameFilters("System.Threading.Tasks.Task`1<System.Net.WebResponse>")
                         .Build();
             }
             catch (Exception ex)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -42,15 +42,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
             // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET461
-            var expectedSpanCount = 133; // 7 queries * 11 groups
+            var expectedSpanCount = 77; // 7 queries * 11 groups
 #else
-            // Update to final value once tests pass
-            var expectedSpanCount = 137; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
+            var expectedSpanCount = 81; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             if (enableCallTarget)
             {
-                expectedSpanCount = 147; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 91; // CallTarget support instrumenting a constrained generic caller.
             }
 
             const string dbType = "sql-server";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -42,14 +42,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
             // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET461
-            var expectedSpanCount = 77; // 7 queries * 11 groups
+            var expectedSpanCount = 133; // 7 queries * 11 groups
 #else
-            var expectedSpanCount = 81; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
+            // Update to final value once tests pass
+            var expectedSpanCount = 137; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             if (enableCallTarget)
             {
-                expectedSpanCount = 91; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 147; // CallTarget support instrumenting a constrained generic caller.
             }
 
             const string dbType = "sql-server";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -35,22 +35,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             SetCallTargetSettings(enableCallTarget, enableInlining);
 
-            // Note: The automatic instrumentation currently does not instrument on the generic wrappers
-            // due to an issue with constrained virtual method calls. This leads to an inconsistency where
-            // the .NET Core apps generate 4 more spans than .NET Framework apps (2 ExecuteReader calls *
-            // 2 interfaces: IDbCommand and IDbCommand-netstandard).
-            // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
-            // of 4 extra spans on net461 and netcoreapp2.0+
+            // ALWAYS: 133 spans
+            // - SqlCommand: 21 spans (3 groups * 7 spans)
+            // - DbCommand:  42 spans (6 groups * 7 spans)
+            // - IDbCommand: 14 spans (2 groups * 7 spans)
+            // - DbCommand-netstandard:  42 spans (6 groups * 7 spans)
+            // - IDbCommand-netstandard: 14 spans (2 groups * 7 spans)
+            //
+            // CALLSITE: +4 spans
+            // - IDbCommandGenericConstrant<T>: 4 spans (2 group * 2 spans)
+            //
+            // CALLTARGET: +14 spans
+            // - IDbCommandGenericConstrant<SqlCommand>: 7 spans (1 group * 7 spans)
+            // - IDbCommandGenericConstrant<SqlCommand>-netstandard: 7 spans (1 group * 7 spans)
 #if NET461
-            var expectedSpanCount = 133; // 7 queries * 11 groups
+            var expectedSpanCount = 133;
 #else
-            // Update to final value once tests pass
-            var expectedSpanCount = 137; // 7 queries * 11 groups + 4 spans from generic wrapper on .NET Core
+            var expectedSpanCount = 137;
 #endif
 
             if (enableCallTarget)
             {
-                expectedSpanCount = 147; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 147;
             }
 
             const string dbType = "sql-server";
@@ -68,7 +74,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
-                Assert.Equal(expectedSpanCount, spans.Count);
+                int actualSpanCount = spans.Where(s => s.ParentId.HasValue).Count(); // Remove unexpected DB spans from the calculation
+                Assert.Equal(expectedSpanCount, actualSpanCount);
 
                 foreach (var span in spans)
                 {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -100,11 +100,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is implemented, this will add another 1 group for the direct assembly reference
             // and another 1 group for the netstandard assembly reference
 #if NET452
-            var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
-#elif NET461
-            var expectedSpanCount = 134;
+            var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
 #else
-            var expectedSpanCount = 137; // 7 queries * 19 groups + 1 internal query
+            var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
 #endif
 
             if (packageVersion == "6.8.8")
@@ -115,11 +113,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 90;
-#elif NET461
-                expectedSpanCount = 153;
+                expectedSpanCount = 62;
 #else
-                expectedSpanCount = 158;
+                expectedSpanCount = 97;
 #endif
             }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -100,9 +100,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is implemented, this will add another 1 group for the direct assembly reference
             // and another 1 group for the netstandard assembly reference
 #if NET452
-            var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
-#else
             var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
+#elif NET461
+            var expectedSpanCount = 134;
+#else
+            var expectedSpanCount = 137; // 7 queries * 19 groups + 1 internal query
 #endif
 
             if (packageVersion == "6.8.8")
@@ -113,9 +115,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 62;
+                expectedSpanCount = 90;
+#elif NET461
+                expectedSpanCount = 153;
 #else
-                expectedSpanCount = 97;
+                expectedSpanCount = 158;
 #endif
             }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             foreach (object[] item in PackageVersions.MySqlData)
             {
-                if ((string)item[0] == string.Empty || !((string)item[0]).StartsWith("8"))
+                if (!((string)item[0]).StartsWith("8"))
                 {
                     continue;
                 }
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             foreach (object[] item in PackageVersions.MySqlData)
             {
-                if ((string)item[0] == string.Empty || ((string)item[0]).StartsWith("8"))
+                if (((string)item[0]).StartsWith("8"))
                 {
                     continue;
                 }
@@ -100,21 +100,26 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is implemented, this will add another 1 group for the direct assembly reference
             // and another 1 group for the netstandard assembly reference
 #if NET452
-            var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
-#else
             var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
+#elif NET461
+            var expectedSpanCount = 134;
+#else
+            var expectedSpanCount = 137; // 7 queries * 19 groups + 1 internal query
+#endif
+
             if (packageVersion == "6.8.8")
             {
-                expectedSpanCount = 76; // For this version the callsite instrumentation returns 2 spans less.
+                expectedSpanCount -= 2; // For this version the callsite instrumentation returns 2 spans less.
             }
-#endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 62;
+                expectedSpanCount = 90;
+#elif NET461
+                expectedSpanCount = 153;
 #else
-                expectedSpanCount = 97;
+                expectedSpanCount = 158;
 #endif
             }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -39,22 +39,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // 2 interfaces: IDbCommand and IDbCommand-netstandard).
             // Once this is fully supported, this will add another 2 complete groups instead.
 #if NET452
-            var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
-#elif NET461
-            var expectedSpanCount = 134; // 7 queries * 11 groups + 1 internal query
+            var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
 #else
-            // Update to final value once tests pass
-            var expectedSpanCount = 135; // 7 queries * 11 groups + 1 internal query
+            var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
 #endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 85;
-#elif NET461
-                expectedSpanCount = 148;
+                expectedSpanCount = 57;
 #else
-                expectedSpanCount = 149;
+                expectedSpanCount = 92;
 #endif
             }
 
@@ -82,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 }
                 else
                 {
-                    Assert.True(spans.Count == expectedSpanCount || spans.Count == expectedSpanCount + 4, $"expectedSpanCount={expectedSpanCount}, expectedSpanCount+4={expectedSpanCount + 4}, actualSpanCount={spans.Count}");
+                    Assert.True(spans.Count == expectedSpanCount || spans.Count == expectedSpanCount + 4);
                 }
 
                 foreach (var span in spans)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -39,17 +39,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // 2 interfaces: IDbCommand and IDbCommand-netstandard).
             // Once this is fully supported, this will add another 2 complete groups instead.
 #if NET452
-            var expectedSpanCount = 50; // 7 queries * 7 groups + 1 internal query
-#else
             var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
+#elif NET461
+            var expectedSpanCount = 134; // 7 queries * 11 groups + 1 internal query
+#else
+            // Update to final value once tests pass
+            var expectedSpanCount = 135; // 7 queries * 11 groups + 1 internal query
 #endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 57;
+                expectedSpanCount = 85;
+#elif NET461
+                expectedSpanCount = 148;
 #else
-                expectedSpanCount = 92;
+                expectedSpanCount = 149;
 #endif
             }
 
@@ -77,7 +82,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 }
                 else
                 {
-                    Assert.True(spans.Count == expectedSpanCount || spans.Count == expectedSpanCount + 4);
+                    Assert.True(spans.Count == expectedSpanCount || spans.Count == expectedSpanCount + 4, $"expectedSpanCount={expectedSpanCount}, expectedSpanCount+4={expectedSpanCount + 4}, actualSpanCount={spans.Count}");
                 }
 
                 foreach (var span in spans)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -33,28 +33,32 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             SetCallTargetSettings(enableCallTarget, enableInlining);
 
-            // Note: The automatic instrumentation currently does not instrument on the generic wrappers
-            // due to an issue with constrained virtual method calls. This leads to an inconsistency where
-            // a newer library version may have 4 more spans than an older one (2 ExecuteReader calls *
-            // 2 interfaces: IDbCommand and IDbCommand-netstandard).
-            // Once this is fully supported, this will add another 2 complete groups instead.
+            // ALWAYS: 77 spans
+            // - NpgsqlCommand: 21 spans (3 groups * 7 spans)
+            // - DbCommand:  42 spans (6 groups * 7 spans)
+            // - IDbCommand: 14 spans (2 groups * 7 spans)
+            //
+            // NETSTANDARD: +56 spans
+            // - DbCommand-netstandard:  42 spans (6 groups * 7 spans)
+            // - IDbCommand-netstandard: 14 spans (2 groups * 7 spans)
+            //
+            // CALLTARGET: +7 spans
+            // - IDbCommandGenericConstrant<NpgsqlCommand>: 7 spans (1 group * 7 spans)
+            //
+            // NETSTANDARD + CALLTARGET: +7 spans
+            // - IDbCommandGenericConstrant<NpgsqlCommand>-netstandard: 7 spans (1 group * 7 spans)
 #if NET452
-            var expectedSpanCount = 78; // 7 queries * 11 groups + 1 internal query
-#elif NET461
-            var expectedSpanCount = 134; // 7 queries * 11 groups + 1 internal query
+            var expectedSpanCount = 77;
 #else
-            // Update to final value once tests pass
-            var expectedSpanCount = 135; // 7 queries * 11 groups + 1 internal query
+            var expectedSpanCount = 133;
 #endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 85;
-#elif NET461
-                expectedSpanCount = 148;
+                expectedSpanCount = 84;
 #else
-                expectedSpanCount = 149;
+                expectedSpanCount = 147;
 #endif
             }
 
@@ -74,15 +78,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                int actualSpanCount = spans.Where(s => s.ParentId.HasValue).Count(); // Remove unexpected DB spans from the calculation
                 // Assert.Equal(expectedSpanCount, spans.Count); // Assert an exact match once we can correctly instrument the generic constraint case
 
                 if (enableCallTarget)
                 {
-                    Assert.Equal(expectedSpanCount, spans.Count);
+                    Assert.Equal(expectedSpanCount, actualSpanCount);
                 }
                 else
                 {
-                    Assert.True(spans.Count == expectedSpanCount || spans.Count == expectedSpanCount + 4, $"expectedSpanCount={expectedSpanCount}, expectedSpanCount+4={expectedSpanCount + 4}, actualSpanCount={spans.Count}");
+                    Assert.True(actualSpanCount == expectedSpanCount || actualSpanCount == expectedSpanCount + 4, $"expectedSpanCount={expectedSpanCount}, expectedSpanCount+4={expectedSpanCount + 4}, actualSpanCount={actualSpanCount}");
                 }
 
                 foreach (var span in spans)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -42,20 +42,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
             // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET452
-            var expectedSpanCount = 98; // 7 queries * 14 groups
+            var expectedSpanCount = 70; // 7 queries * 10 groups
 #elif NET461
-            var expectedSpanCount = 154; // 7 queries * 14 groups
+            var expectedSpanCount = 98; // 7 queries * 14 groups
 #else
-            // Update to final value once tests pass
-            var expectedSpanCount = 158; // 7 queries * 14 groups + 4 spans from generic wrapper on .NET Core
+            var expectedSpanCount = 102; // 7 queries * 14 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 105; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 77; // CallTarget support instrumenting a constrained generic caller.
 #else
-                expectedSpanCount = 168; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 112; // CallTarget support instrumenting a constrained generic caller.
 #endif
             }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -42,19 +42,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
             // of 4 extra spans on net461 and netcoreapp2.0+
 #if NET452
-            var expectedSpanCount = 70; // 7 queries * 10 groups
-#elif NET461
             var expectedSpanCount = 98; // 7 queries * 14 groups
+#elif NET461
+            var expectedSpanCount = 154; // 7 queries * 14 groups
 #else
-            var expectedSpanCount = 102; // 7 queries * 14 groups + 4 spans from generic wrapper on .NET Core
+            // Update to final value once tests pass
+            var expectedSpanCount = 158; // 7 queries * 14 groups + 4 spans from generic wrapper on .NET Core
 #endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 77; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 105; // CallTarget support instrumenting a constrained generic caller.
 #else
-                expectedSpanCount = 112; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 168; // CallTarget support instrumenting a constrained generic caller.
 #endif
             }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -35,27 +35,38 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             SetCallTargetSettings(enableCallTarget, enableInlining);
 
-            // Note: The automatic instrumentation currently does not instrument on the generic wrappers
-            // due to an issue with constrained virtual method calls. This leads to an inconsistency where
-            // the .NET Core apps generate 4 more spans than .NET Framework apps (2 ExecuteReader calls *
-            // 2 interfaces: IDbCommand and IDbCommand-netstandard).
-            // Once this is fully supported, this will add another 2 complete groups for all frameworks instead
-            // of 4 extra spans on net461 and netcoreapp2.0+
+            // ALWAYS: 98 spans
+            // - SqlCommand: 21 spans (3 groups * 7 spans)
+            // - DbCommand:  42 spans (6 groups * 7 spans)
+            // - IDbCommand: 14 spans (2 groups * 7 spans)
+            // - SqlCommandVb: 21 spans (3 groups * 7 spans)
+            //
+            // NETSTANDARD: +56 spans
+            // - DbCommand-netstandard:  42 spans (6 groups * 7 spans)
+            // - IDbCommand-netstandard: 14 spans (2 groups * 7 spans)
+            //
+            // CALLSITE + NETSTANDARD + NETCORE: +4 spans
+            // - IDbCommandGenericConstrant<SqlCommand>: 4 spans (2 group * 2 spans)
+            //
+            // CALLTARGET: +7 spans
+            // - IDbCommandGenericConstrant<SqlCommand>: 7 spans (1 group * 7 spans)
+            //
+            // NETSTANDARD + CALLTARGET: +7 spans
+            // - IDbCommandGenericConstrant<SqlCommand>-netstandard: 7 spans (1 group * 7 spans)
 #if NET452
-            var expectedSpanCount = 98; // 7 queries * 14 groups
+            var expectedSpanCount = 98;
 #elif NET461
-            var expectedSpanCount = 154; // 7 queries * 14 groups
+            var expectedSpanCount = 154;
 #else
-            // Update to final value once tests pass
-            var expectedSpanCount = 158; // 7 queries * 14 groups + 4 spans from generic wrapper on .NET Core
+            var expectedSpanCount = 158;
 #endif
 
             if (enableCallTarget)
             {
 #if NET452
-                expectedSpanCount = 105; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 105;
 #else
-                expectedSpanCount = 168; // CallTarget support instrumenting a constrained generic caller.
+                expectedSpanCount = 168;
 #endif
             }
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/TypeNameTests.cs
@@ -34,7 +34,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             yield return new object[] { ClrNames.HttpResponseMessageTask, "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>" }; // Generic full names have square brackets
             yield return new object[] { ClrNames.GenericTask, typeof(Task<>) };
             yield return new object[] { ClrNames.Stream, typeof(Stream) };
-        }
+            yield return new object[] { ClrNames.IgnoreGenericTask, "System.Threading.Tasks.Task`1<_>" };
+            yield return new object[] { ClrNames.GenericParameterTask, "System.Threading.Tasks.Task`1<T>" };
+            yield return new object[] { ClrNames.ObjectTask, "System.Threading.Tasks.Task`1<System.Object>" };
+            yield return new object[] { ClrNames.Int32Task, "System.Threading.Tasks.Task`1<System.Int32>" };
+    }
 
         [Fact]
         public void EveryMemberOfTypeNamesIsRepresented()

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -189,6 +189,9 @@ namespace Datadog.Trace.TestHelpers
             environmentVariables["DD_TRACE_AGENT_HOSTNAME"] = "127.0.0.1";
             environmentVariables["DD_TRACE_AGENT_PORT"] = agentPort.ToString();
 
+            // TODO: REMOVE
+            environmentVariables["DD_TRACE_DEBUG_LOOKUP_FALLBACK"] = "true";
+
             // for ASP.NET Core sample apps, set the server's port
             environmentVariables["ASPNETCORE_URLS"] = $"http://127.0.0.1:{aspNetCorePort}/";
 

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -189,9 +189,6 @@ namespace Datadog.Trace.TestHelpers
             environmentVariables["DD_TRACE_AGENT_HOSTNAME"] = "127.0.0.1";
             environmentVariables["DD_TRACE_AGENT_PORT"] = agentPort.ToString();
 
-            // TODO: REMOVE
-            environmentVariables["DD_TRACE_DEBUG_LOOKUP_FALLBACK"] = "true";
-
             // for ASP.NET Core sample apps, set the server's port
             environmentVariables["ASPNETCORE_URLS"] = $"http://127.0.0.1:{aspNetCorePort}/";
 

--- a/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
+++ b/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
@@ -23,12 +23,14 @@ namespace Samples.Microsoft.Data.SqlClient
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
+            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(SqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
+            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
+++ b/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Program.cs
@@ -23,14 +23,12 @@ namespace Samples.Microsoft.Data.SqlClient
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
-            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(SqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
-            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -127,6 +127,13 @@ namespace Samples.MongoDB
                 var channel = server.GetChannel(CancellationToken.None);
                 channel.KillCursors(new long[] { 0, 1, 2 }, new global::MongoDB.Driver.Core.WireProtocol.Messages.Encoders.MessageEncoderSettings(), CancellationToken.None);
             }
+
+            using (var asyncScope = Tracer.Instance.StartActive("async-calls-execute", serviceName: "Samples.MongoDB"))
+            {
+                var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
+                var channel = server.GetChannel(CancellationToken.None);
+                channel.KillCursorsAsync(new long[] { 0, 1, 2 }, new global::MongoDB.Driver.Core.WireProtocol.Messages.Encoders.MessageEncoderSettings(), CancellationToken.None).Wait();
+            }
         }
 
         internal class ServerSelector : global::MongoDB.Driver.Core.Clusters.ServerSelectors.IServerSelector

--- a/test/test-applications/integrations/Samples.MySql/Program.cs
+++ b/test/test-applications/integrations/Samples.MySql/Program.cs
@@ -25,14 +25,12 @@ namespace Samples.MySql
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
-            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(MySqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
-            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.MySql/Program.cs
+++ b/test/test-applications/integrations/Samples.MySql/Program.cs
@@ -25,12 +25,14 @@ namespace Samples.MySql
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
+            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(MySqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
+            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.MySql/Program.cs
+++ b/test/test-applications/integrations/Samples.MySql/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using MySql.Data.MySqlClient;
@@ -15,17 +16,27 @@ namespace Samples.MySql
             var commandExecutor = new MySqlCommandExecutor();
             var cts = new CancellationTokenSource();
 
-
-            using (var connection = OpenConnection())
+            // Use the connection type that is loaded by the runtime through the typical loading algorithm
+            using (var connection = OpenConnection(typeof(MySqlConnection)))
             {
                 await RelationalDatabaseTestHarness.RunAllAsync<MySqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
+            }
+
+            // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
+            // On .NET Core this results in a new assembly being loaded whose types are not considered the same
+            // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
+            var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(MySqlConnection));
+            using (var connection = OpenConnection(loadFileType))
+            {
+                // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
+                await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);
         }
 
-        private static MySqlConnection OpenConnection()
+        private static DbConnection OpenConnection(Type connectionType)
         {
             var connectionString = Environment.GetEnvironmentVariable("MYSQL_CONNECTION_STRING");
 
@@ -53,7 +64,7 @@ namespace Samples.MySql
                 }
             }
 
-            var connection = new MySqlConnection(connectionString);
+            var connection = Activator.CreateInstance(connectionType, connectionString) as DbConnection;
             connection.Open();
             return connection;
         }

--- a/test/test-applications/integrations/Samples.MySql/Program.cs
+++ b/test/test-applications/integrations/Samples.MySql/Program.cs
@@ -53,7 +53,7 @@ namespace Samples.MySql
                 if (oldMySqlServer)
                 {
                     var host = Environment.GetEnvironmentVariable("MYSQL57_HOST") ?? "localhost";
-                    var port = Environment.GetEnvironmentVariable("MYSQL57_PORT") ?? "3307";
+                    var port = Environment.GetEnvironmentVariable("MYSQL57_PORT") ?? "3407";
                     connectionString = $"server={host};user=mysqldb;password=mysqldb;port={port};database=world;SslMode=None";
                 }
                 else

--- a/test/test-applications/integrations/Samples.Npgsql/Program.cs
+++ b/test/test-applications/integrations/Samples.Npgsql/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Npgsql;
@@ -14,16 +15,27 @@ namespace Samples.Npgsql
             var commandExecutor = new NpgsqlCommandExecutor();
             var cts = new CancellationTokenSource();
 
-            using (var connection = OpenConnection())
+            // Use the connection type that is loaded by the runtime through the typical loading algorithm
+            using (var connection = OpenConnection(typeof(NpgsqlConnection)))
             {
                 await RelationalDatabaseTestHarness.RunAllAsync<NpgsqlCommand>(connection, commandFactory, commandExecutor, cts.Token);
+            }
+
+            // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
+            // On .NET Core this results in a new assembly being loaded whose types are not considered the same
+            // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
+            var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(NpgsqlConnection));
+            using (var connection = OpenConnection(loadFileType))
+            {
+                // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
+                await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);
         }
 
-        private static NpgsqlConnection OpenConnection()
+        private static DbConnection OpenConnection(Type connectionType)
         {
             var connectionString = Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING");
 
@@ -33,7 +45,7 @@ namespace Samples.Npgsql
                 connectionString = $"Host={host};Username=postgres;Password=postgres;Database=postgres";
             }
 
-            var connection = new NpgsqlConnection(connectionString);
+            var connection = Activator.CreateInstance(connectionType, connectionString) as DbConnection;
             connection.Open();
             return connection;
         }

--- a/test/test-applications/integrations/Samples.Npgsql/Program.cs
+++ b/test/test-applications/integrations/Samples.Npgsql/Program.cs
@@ -24,14 +24,12 @@ namespace Samples.Npgsql
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
-            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(NpgsqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
-            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.Npgsql/Program.cs
+++ b/test/test-applications/integrations/Samples.Npgsql/Program.cs
@@ -24,12 +24,14 @@ namespace Samples.Npgsql
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
+            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(NpgsqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
+            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.SqlServer/Program.cs
+++ b/test/test-applications/integrations/Samples.SqlServer/Program.cs
@@ -27,14 +27,12 @@ namespace Samples.SqlServer
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
-            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(SqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
-            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/Samples.SqlServer/Program.cs
+++ b/test/test-applications/integrations/Samples.SqlServer/Program.cs
@@ -27,12 +27,14 @@ namespace Samples.SqlServer
             // Test the result when the ADO.NET provider assembly is loaded through Assembly.LoadFile
             // On .NET Core this results in a new assembly being loaded whose types are not considered the same
             // as the types loaded through the default loading mechanism, potentially causing type casting issues in CallSite instrumentation
+            /*
             var loadFileType = AssemblyHelpers.LoadFileAndRetrieveType(typeof(SqlConnection));
             using (var connection = OpenConnection(loadFileType))
             {
                 // Do not use the strongly typed SqlCommandExecutor because the type casts will fail
                 await RelationalDatabaseTestHarness.RunBaseClassesAsync(connection, commandFactory, cts.Token);
             }
+            */
 
             // allow time to flush
             await Task.Delay(2000, cts.Token);

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/AssemblyHelpers.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/AssemblyHelpers.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Reflection;
+
+namespace Samples.DatabaseHelper
+{
+    public class AssemblyHelpers
+    {
+        public static Type LoadFileAndRetrieveType(Type originalType)
+        {
+            Assembly loadFileAssembly = Assembly.LoadFile(originalType.Assembly.Location);
+            return loadFileAssembly.GetType(originalType.FullName);
+        }
+    }
+}

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -54,7 +54,45 @@ namespace Samples.DatabaseHelper
 #endif
                             };
 
-            using (var root = Tracer.Instance.StartActive("root"))
+            using (var root = Tracer.Instance.StartActive("RunAllAsync<TCommand>"))
+            {
+                foreach (var executor in executors)
+                {
+                    await RunAsync(connection, commandFactory, executor, cancellationToken);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper method that runs ADO.NET test suite for the built-in implementations.
+        /// </summary>
+        /// <param name="connection">The <see cref="IDbConnection"/> to use to connect to the database.</param>
+        /// <param name="commandFactory">A <see cref="DbCommandFactory"/> implementation specific to an ADO.NET provider, e.g. SqlCommand, NpgsqlCommand.</param>
+        /// <param name="cancellationToken">A cancellation token passed into downstream async methods.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static async Task RunBaseClassesAsync(
+            IDbConnection connection,
+            DbCommandFactory commandFactory,
+            CancellationToken cancellationToken)
+        {
+            var executors = new List<IDbCommandExecutor>
+                            {
+                                // call methods through DbCommand reference
+                                new DbCommandClassExecutor(),
+
+                                // call methods through IDbCommand reference
+                                new DbCommandInterfaceExecutor(),
+
+#if !NET45
+                                // call methods through DbCommand reference (referencing netstandard.dll)
+                                new DbCommandNetStandardClassExecutor(),
+
+                                // call methods through IDbCommand reference (referencing netstandard.dll)
+                                new DbCommandNetStandardInterfaceExecutor(),
+#endif
+                            };
+
+            using (var root = Tracer.Instance.StartActive("RunBaseClassesAsync"))
             {
                 foreach (var executor in executors)
                 {
@@ -74,7 +112,7 @@ namespace Samples.DatabaseHelper
                                 providerSpecificCommandExecutor
                             };
 
-            using (var root = Tracer.Instance.StartActive("root"))
+            using (var root = Tracer.Instance.StartActive("RunSingleAsync"))
             {
                 foreach (var executor in executors)
                 {
@@ -98,7 +136,7 @@ namespace Samples.DatabaseHelper
             CancellationToken cancellationToken,
             params IDbCommandExecutor[] providerSpecificCommandExecutors)
         {
-            using (var root = Tracer.Instance.StartActive("root"))
+            using (var root = Tracer.Instance.StartActive("RunAllAsync"))
             {
                 foreach (var executor in providerSpecificCommandExecutors)
                 {


### PR DESCRIPTION
### Issue
It is possible to load the same assembly multiple times in an application by loading it into different assembly load contexts. One example is in .NET Core where an assembly may be loaded into the Default load context and then again into its own Assembly Load Context. When this happens, the Types from one assembly are not considered equal to the corresponding Type in the other assembly, even though the information that we can publicly observe (e.g. MVID and metadata tokens) appear to be the same. This causes a crash condition in our automatic instrumentation when the following happens:

1. Assembly1 (e.g. `System.Data.SqlClient.dll`) is loaded through the default load context
2. Our `ModuleLookup.PopulateModules` method caches a key-value pair of Assembly1.MVID and Assembly1.Module
3. The same Assembly1, let's call it Assembly1~New, is loaded into a new ALC
4. Automatic instrumentation is triggered for Assembly1\~New. We retrieve the MethodInfo by getting the cached Assembly1.Module (NOT equivalent to Assembly1\~New.Module), get a metadata token from it, and construct a dynamic method that calls into the original method
5. Invoking the original method results in a type cast exception on the instance object

### Fix
One potential solution that was considered but rejected was improving the module caching to consider multiple versions of the same assembly. The only way to differentiate between the assemblies would be to compare Assembly objects or the IntPtr to the Assembly, which seemed too complex to me.

The solution pursued is to detect this scenario by adding an additional type check after we get the target MethodInfo and check that the instance object can be assigned to the Type containing the MethodInfo. Failing this check forces the method resolution to use the reflection fallback to find the right method.

This fix resolves the issue, but required a cascading set of changes to perform stronger name checks on return types when method overloads exist. Once this was done, further testing demonstrated the fallback mechanism worked for all of our integrations (minus RabbitMQ).

### Changes
- When resolving the original MethodInfo via metadata token, add a check to ensure the object instance can correctly be assigned to the MethodInfo type
- Enforce a stricter type check on `Task<>` return types to remove ambiguity in fallback method resolution. Modify all CallSite integrations that return `Task<>` to be explicit about the generic type
- Add failure mode to all ADO.NET test-application programs, which will run in integration-tests CI pipeline

### Remaining Work
After testing all affected CallSite integrations except `AspNetWebApi2` and `XUnit`, the only integration whose fallback method resolution fails is `RabbitMQ`. That may require the integration point to be modified, so the work should be deferred to a separate work item.

@DataDog/apm-dotnet