### PR TITLE
Update test dependencies + fix warnings

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -196,6 +196,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public class InliningOptions : IXunitSerializable
         {
+            // ReSharper disable once UnusedMember.Global
+            public InliningOptions()
+            {
+            }
+
             internal InliningOptions(
                 bool enableCallTarget,
                 bool enableInlining)
@@ -226,6 +231,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public class InstrumentationOptions : IXunitSerializable
         {
+            // ReSharper disable once UnusedMember.Global
+            public InstrumentationOptions()
+            {
+            }
+
             internal InstrumentationOptions(
                 bool? instrumentSocketHandler,
                 bool? instrumentWinHttpHandler)

--- a/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
+++ b/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
@@ -41,9 +41,9 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         {
             var vars = GetMockVariables(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
             var metadata = new AzureAppServices(vars);
-            Assert.Equal(actual: AzureContext.AzureAppService, expected: metadata.AzureContext);
-            Assert.Equal(actual: AppServiceKind, expected: metadata.SiteKind);
-            Assert.Equal(actual: AppServiceType, expected: metadata.SiteType);
+            Assert.Equal(expected: AzureContext.AzureAppService, actual: metadata.AzureContext);
+            Assert.Equal(expected: AppServiceKind, actual: metadata.SiteKind);
+            Assert.Equal(expected: AppServiceType, actual: metadata.SiteType);
         }
 
         [Fact]
@@ -58,9 +58,9 @@ namespace Datadog.Trace.Tests.PlatformHelpers
                 functionsRuntime: FunctionsRuntime);
 
             var metadata = new AzureAppServices(vars);
-            Assert.Equal(actual: AzureContext.AzureFunction, expected: metadata.AzureContext);
-            Assert.Equal(actual: FunctionKind, expected: metadata.SiteKind);
-            Assert.Equal(actual: FunctionType, expected: metadata.SiteType);
+            Assert.Equal(expected: AzureContext.AzureFunction, actual: metadata.AzureContext);
+            Assert.Equal(expected: FunctionKind, actual: metadata.SiteKind);
+            Assert.Equal(expected: FunctionType, actual: metadata.SiteType);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Verify(s => s.Gauge(MetricsNames.LohSize, It.IsAny<double>(), 1, null), Times.Once);
 
             statsd.VerifyNoOtherCalls();
-            statsd.ResetCalls();
+            statsd.Invocations.Clear();
 
             listener.Refresh();
 

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeEventListenerTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
             using var listener = new RuntimeEventListener(statsd.Object, TimeSpan.FromSeconds(10));
 
-            statsd.ResetCalls();
+            statsd.Invocations.Clear();
 
             for (int i = 0; i < 3; i++)
             {

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                     s => s.Increment(MetricsNames.ExceptionsCount, 5, It.IsAny<double>(), new[] { "exception_type:CustomException2" }),
                     Times.Once);
 
-                statsd.ResetCalls();
+                statsd.Invocations.Clear();
 
                 // Make sure stats are reset when pushed
                 writer.PushEvents();

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Tests
 
             Assert.Equal(areTracesEnabled, tracerSettings.TraceEnabled);
 
-            _writerMock.ResetCalls();
+            _writerMock.Invocations.Clear();
 
             var tracer = new Tracer(tracerSettings, _writerMock.Object, _samplerMock.Object, scopeManager: null, statsd: null);
             var span = tracer.StartSpan("TestTracerDisabled");

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -12,9 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -15,7 +15,6 @@
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <!-- StyleCop -->


### PR DESCRIPTION
We had an unexpected error in unit tests caused by Moq, I'm hoping it's fixed in newer versions. Also updating xunit while I'm at it.

Removing calls to `ResetCalls` because it's obsolete now.
The code analyzer that ships with xunit raised a few new warnings, so I fixed them as well.