### PR TITLE
Don't use target-typed expression as it fails in Gitlab CI

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -6,7 +6,7 @@ trigger:
 
 variables:
   buildConfiguration: release
-  dotnetCoreSdkVersion: 5.0.100
+  dotnetCoreSdkVersion: 5.0.103
   ddApiKey: $(DD_API_KEY)
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -23,7 +23,7 @@ variables:
   buildConfiguration: Release
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100
+  dotnetCoreSdk5Version: 5.0.103
 
 jobs:
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -7,7 +7,7 @@ pr: none
 
 variables:
   buildConfiguration: release
-  dotnetCoreSdkVersion: 5.0.100
+  dotnetCoreSdkVersion: 5.0.103
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
 stages:

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -12,7 +12,7 @@ trigger:
 variables:
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
   dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100
+  dotnetCoreSdk5Version: 5.0.103
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -12,7 +12,7 @@ trigger:
 variables:
   buildConfiguration: Debug
   dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100
+  dotnetCoreSdk5Version: 5.0.103
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
 

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -91,8 +91,8 @@ namespace Datadog.Trace.Logging
                 SharedLogger = new DatadogSerilogLogger(InternalLogger, defaultRateLimiter);
 
                 var rate = GetRateLimit();
-                ILogRateLimiter rateLimiter = rate == 0
-                    ? new NullLogRateLimiter()
+                var rateLimiter = rate == 0
+                    ? (ILogRateLimiter)new NullLogRateLimiter()
                     : new LogRateLimiter(rate);
 
                 SharedLogger = new DatadogSerilogLogger(InternalLogger, rateLimiter);


### PR DESCRIPTION
Build is failing in GitLab CI due to use of target typed expression. Work around the issue for now, rather than waiting for that to be updated.

Bonus: update .NET SDK from 5.0.100 to 5.0.103 

@DataDog/apm-dotnet