### PR TITLE
update builder tag to reference new builder with dotnet5

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - binary_build
   
 variables:
-  DATADOG_AGENT_WINBUILDIMAGES: v3945590-9d1aa1e
+  DATADOG_AGENT_WINBUILDIMAGES: v3946939-487746f
     
 driver_build:
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - binary_build
   
 variables:
-  DATADOG_AGENT_WINBUILDIMAGES: v3324313-6d0a8f4
+  DATADOG_AGENT_WINBUILDIMAGES: v3945590-9d1aa1e
     
 driver_build:
   only:


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet