### PR TITLE
Update .NET SDK versions in build

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -6,7 +6,7 @@ trigger:
 
 variables:
   buildConfiguration: release
-  dotnetCoreSdkVersion: 5.0.100
+  dotnetCoreSdkVersion: 5.0.103
   ddApiKey: $(DD_API_KEY)
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -22,8 +22,7 @@ pool:
 variables:
   buildConfiguration: Release
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
-  dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100
+  dotnetCoreSdk5Version: 5.0.103
 
 jobs:
 
@@ -31,9 +30,10 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5
@@ -131,9 +131,10 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5
@@ -266,22 +267,22 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 2.1
+    displayName: install dotnet core runtime 2.1
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 2.1.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.0
+    displayName: install dotnet core runtime 3.0
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 3.0.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5
@@ -379,22 +380,22 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 2.1
+    displayName: install dotnet core runtime 2.1
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 2.1.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.0
+    displayName: install dotnet core runtime 3.0
     inputs:
-      packageType: sdk
+      packageType: runtime
       version: 3.0.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -267,21 +267,21 @@ jobs:
 
   steps:
   - task: UseDotNet@2
-    displayName: install dotnet core runtime 2.1
+    displayName: install dotnet core sdk 2.1
     inputs:
-      packageType: runtime
+      packageType: sdk
       version: 2.1.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core runtime 3.0
+    displayName: install dotnet core sdk 3.0
     inputs:
-      packageType: runtime
+      packageType: sdk
       version: 3.0.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core runtime 3.1
+    displayName: install dotnet core sdk 3.1
     inputs:
-      packageType: runtime
+      packageType: sdk
       version: 3.1.x
 
   - task: UseDotNet@2

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -7,7 +7,7 @@ pr: none
 
 variables:
   buildConfiguration: release
-  dotnetCoreSdkVersion: 5.0.100
+  dotnetCoreSdkVersion: 5.0.103
   publishOutput: $(Build.SourcesDirectory)/src/bin/managed-publish
 
 stages:

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -11,8 +11,7 @@ trigger:
 
 variables:
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish
-  dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100
+  dotnetCoreSdk5Version: 5.0.103
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
 
@@ -82,10 +81,10 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0
@@ -166,10 +165,10 @@ jobs:
       version: 3.0.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
       
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -11,8 +11,7 @@ trigger:
 
 variables:
   buildConfiguration: Debug
-  dotnetCoreSdkVersion: 3.1.107
-  dotnetCoreSdk5Version: 5.0.100
+  dotnetCoreSdk5Version: 5.0.103
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
 
@@ -65,10 +64,10 @@ jobs:
       version: 3.0.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0
@@ -144,10 +143,10 @@ jobs:
       version: 3.0.x
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0
@@ -188,10 +187,10 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0
@@ -245,10 +244,10 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0
@@ -304,10 +303,10 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: install dotnet core sdk 3.1
+    displayName: install dotnet core runtime 3.1
     inputs:
-      packageType: sdk
-      version: $(dotnetCoreSdkVersion)
+      packageType: runtime
+      version: 3.1.x
 
   - task: UseDotNet@2
     displayName: install dotnet core sdk 5.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Integration tests | [![Build Status](https://dev.azure.com/datadoghq/dd-trace-do
 
 ### Minimum requirements
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/) or newer
+- [Visual Studio 2019 (16.8)](https://visualstudio.microsoft.com/downloads/) or newer
   - Workloads
     - Desktop development with C++
     - .NET desktop development

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,9 +38,10 @@ Integration tests | [![Build Status](https://dev.azure.com/datadoghq/dd-trace-do
     - Optional: ASP.NET and web development (to build samples)
   - Individual components
     - .NET Framework 4.7 targeting pack
-- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+- [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
 - Optional: [.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
 - Optional: [.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
+- Optional: [.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - Requires .NET Framework 3.5 SP2 (install from Windows Features control panel: `OptionalFeatures.exe`)
@@ -88,7 +89,10 @@ msbuild Datadog.Trace.proj /t:CreateHomeDirectory /p:Configuration=Release;Platf
 ### Minimum requirements
 
 To build C# projects and NuGet packages only
-- [.NET Core SDK 3.1](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+- [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
+- Optional: [.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
+- Optional: [.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
+- Optional: [.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
 
 To build everything and run integration tests
 - [Docker Compose](https://docs.docker.com/compose/install/)


### PR DESCRIPTION
* Update .NET SDK/runtime versions (we don't need the SDK for versions < 5.0)
* Update README with latest SDK requirements

Based on changes in https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/53

@DataDog/apm-dotnet