### PR TITLE
Update default log rate limit in debug mode

### DIFF
--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -23,13 +23,13 @@ namespace Datadog.Trace.Logging
         static DatadogLogging()
         {
             // No-op for if we fail to construct the file logger
-            var defaultRateLimiter = new LogRateLimiter(DefaultLogMessageRateLimit);
+            var nullRateLimiter = new NullLogRateLimiter();
             InternalLogger =
                 new LoggerConfiguration()
                    .WriteTo.Sink<NullSink>()
                    .CreateLogger();
 
-            SharedLogger = new DatadogSerilogLogger(InternalLogger, defaultRateLimiter);
+            SharedLogger = new DatadogSerilogLogger(InternalLogger, nullRateLimiter);
 
             try
             {
@@ -88,11 +88,11 @@ namespace Datadog.Trace.Logging
                 }
 
                 InternalLogger = loggerConfiguration.CreateLogger();
-                SharedLogger = new DatadogSerilogLogger(InternalLogger, defaultRateLimiter);
+                SharedLogger = new DatadogSerilogLogger(InternalLogger, nullRateLimiter);
 
                 var rate = GetRateLimit();
                 ILogRateLimiter rateLimiter = rate == 0
-                    ? new NullLogRateLimiter()
+                    ? nullRateLimiter
                     : new LogRateLimiter(rate);
 
                 SharedLogger = new DatadogSerilogLogger(InternalLogger, rateLimiter);

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -156,7 +156,8 @@ namespace Datadog.Trace.Logging
                 return rate;
             }
 
-            return DefaultLogMessageRateLimit;
+            // We don't want to rate limit messages by default when in debug mode
+            return GlobalSettings.Source.DebugEnabled ? 0 : DefaultLogMessageRateLimit;
         }
 
         private static string GetLogDirectory()


### PR DESCRIPTION
Disables log rate limiting when `DD_TRACE_DEBUG` is set, so we don't rate-limit logs by default. Will still be overridden if `DD_TRACE_LOGGING_RATE` is set.

@DataDog/apm-dotnet