### PR TITLE
Call the right Log overload

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationOptions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationOptions.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void LogException(Exception exception, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
         {
+            // ReSharper disable twice ExplicitCallerInfoArgument
             Log.Error(exception, exception?.Message, sourceLine, sourceFile);
             if (exception is DuckTypeException)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/LoggerExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/LoggerExtensions.cs
@@ -34,6 +34,8 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             }
 
             var moduleVersionId = PointerHelpers.GetGuidFromNativePointer(moduleVersionPointer);
+
+            // ReSharper disable twice ExplicitCallerInfoArgument
             logger.Error(
                 exception,
                 $"Error (MVID: {moduleVersionId}, mdToken: {mdToken}, opCode: {opCode}) could not retrieve: {instrumentedMethod}",

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/TestLoggerExtensions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/TestLoggerExtensions.cs
@@ -10,11 +10,13 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
     {
         public static void TestMethodNotFound(this IDatadogLogger logger, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
         {
+            // ReSharper disable twice ExplicitCallerInfoArgument
             logger.Error("Error: the test method can't be retrieved.", sourceLine, sourceFile);
         }
 
         public static void TestClassTypeNotFound(this IDatadogLogger logger, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
         {
+            // ReSharper disable twice ExplicitCallerInfoArgument
             logger.Error("Error: the test class type can't be retrieved.", sourceLine, sourceFile);
         }
     }

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Agent
 #if DEBUG
                     if (ex.InnerException is InvalidOperationException ioe)
                     {
-                        Log.Error(ex, "An error occurred while sending {Count} traces to the agent at {AgentEndpoint}", numberOfTraces, _apiRequestFactory.Info(_tracesEndpoint));
+                        Log.Error<int, string>(ex, "An error occurred while sending {Count} traces to the agent at {AgentEndpoint}", numberOfTraces, _apiRequestFactory.Info(_tracesEndpoint));
                         return false;
                     }
 #endif
@@ -93,7 +93,7 @@ namespace Datadog.Trace.Agent
                     if (isFinalTry)
                     {
                         // stop retrying
-                        Log.Error(exception, "An error occurred while sending {Count} traces to the agent at {AgentEndpoint}", numberOfTraces, _apiRequestFactory.Info(_tracesEndpoint));
+                        Log.Error<int, string>(exception, "An error occurred while sending {Count} traces to the agent at {AgentEndpoint}", numberOfTraces, _apiRequestFactory.Info(_tracesEndpoint));
                         return false;
                     }
 
@@ -177,7 +177,7 @@ namespace Datadog.Trace.Agent
                         try
                         {
                             string responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                            Log.Error("Failed to submit traces with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, responseContent);
+                            Log.Error<int, string>("Failed to submit traces with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, responseContent);
                         }
                         catch (Exception ex)
                         {

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
@@ -134,7 +134,7 @@ namespace Datadog.Trace.RuntimeMetrics
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Error while processing event {EventId} {EventName}", eventData.EventId, eventData.EventName);
+                Log.Warning<int, string>(ex, "Error while processing event {EventId} {EventName}", eventData.EventId, eventData.EventName);
             }
         }
 


### PR DESCRIPTION
In some places, we call the Log overload expecting a line number, instead of the one with generic parameters.

Also disabled the Resharper warning in the places where we call the right one, to make the warning more efficient. I recommend turning the inspection severity to Error on your local machines to prevent similar mistakes in the future.

