### PR TITLE
Fix CiApp Tests ServiceName

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -73,6 +73,7 @@ stages:
         projects: '$(System.DefaultWorkingDirectory)/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
         arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
       env:
+        DD_ENV: CI
         DD_SERVICE: dd-trace-dotnet
 
     - task: PowerShell@2

--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -73,7 +73,7 @@ stages:
         projects: '$(System.DefaultWorkingDirectory)/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
         arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
       env:
-        DD_SERVICE: dd-tracer-dotnet
+        DD_SERVICE: dd-trace-dotnet
 
     - task: PowerShell@2
       inputs:

--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -73,7 +73,7 @@ stages:
         projects: '$(System.DefaultWorkingDirectory)/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
         arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
       env:
-        DD_SERVICE_NAME: dd-tracer-dotnet
+        DD_SERVICE: dd-tracer-dotnet
 
     - task: PowerShell@2
       inputs:

--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -72,6 +72,9 @@ stages:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
         arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
+      env:
+        DD_SERVICE_NAME: dd-tracer-dotnet
+
     - task: PowerShell@2
       inputs:
         targetType: 'inline'

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -190,7 +190,7 @@ jobs:
         benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
     env:
-      DD_SERVICE: dd-tracer-dotnet
+      DD_SERVICE: dd-trace-dotnet
       
   - task: NuGetToolInstaller@1
     displayName: install nuget
@@ -208,7 +208,7 @@ jobs:
       msbuildArguments: /t:BuildTool /l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       maximumCpuCount: true
     env:
-      DD_SERVICE: dd-tracer-dotnet-runner-tool
+      DD_SERVICE: dd-trace-dotnet-runner-tool
 
   - task: MSBuild@1
     displayName: standalone build
@@ -217,7 +217,7 @@ jobs:
       msbuildArguments: /t:BuildStandalone /l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       maximumCpuCount: true
     env:
-      DD_SERVICE: dd-tracer-dotnet-runner-tool
+      DD_SERVICE: dd-trace-dotnet-runner-tool
 
   - task: DeleteFiles@1
     displayName: 'Remove unneeded files'

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -190,7 +190,7 @@ jobs:
         benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet
+      DD_SERVICE: dd-tracer-dotnet
       
   - task: NuGetToolInstaller@1
     displayName: install nuget
@@ -208,7 +208,7 @@ jobs:
       msbuildArguments: /t:BuildTool /l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       maximumCpuCount: true
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet-runner-tool
+      DD_SERVICE: dd-tracer-dotnet-runner-tool
 
   - task: MSBuild@1
     displayName: standalone build
@@ -217,7 +217,7 @@ jobs:
       msbuildArguments: /t:BuildStandalone /l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       maximumCpuCount: true
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet-runner-tool
+      DD_SERVICE: dd-tracer-dotnet-runner-tool
 
   - task: DeleteFiles@1
     displayName: 'Remove unneeded files'

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
         test/benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
     env:
-      DD_SERVICE: dd-tracer-dotnet
+      DD_SERVICE: dd-trace-dotnet
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -97,7 +97,7 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
     env:
-      DD_SERVICE: dd-tracer-dotnet
+      DD_SERVICE: dd-trace-dotnet
 
 - job: managed_linux_arm64
   pool: Arm64
@@ -118,7 +118,7 @@ jobs:
         benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
     env:
-      DD_SERVICE: dd-tracer-dotnet
+      DD_SERVICE: dd-trace-dotnet
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -127,7 +127,7 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
     env:
-      DD_SERVICE: dd-tracer-dotnet
+      DD_SERVICE: dd-trace-dotnet
 
 - job: managed_macos
   pool:
@@ -178,7 +178,7 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
     env:
-      DD_SERVICE: dd-tracer-dotnet
+      DD_SERVICE: dd-trace-dotnet
 
 
 - job: windows_profiler

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -88,7 +88,7 @@ jobs:
         test/benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet
+      DD_SERVICE: dd-tracer-dotnet
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -97,7 +97,7 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet
+      DD_SERVICE: dd-tracer-dotnet
 
 - job: managed_linux_arm64
   pool: Arm64
@@ -118,7 +118,7 @@ jobs:
         benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet
+      DD_SERVICE: dd-tracer-dotnet
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -127,7 +127,7 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet
+      DD_SERVICE: dd-tracer-dotnet
 
 - job: managed_macos
   pool:
@@ -178,7 +178,7 @@ jobs:
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
     env:
-      DD_SERVICE_NAME: dd-tracer-dotnet
+      DD_SERVICE: dd-tracer-dotnet
 
 
 - job: windows_profiler

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -117,6 +117,8 @@ jobs:
         test/**/*.Tests.csproj
         benchmarks/**/*.csproj
         !src/Datadog.Trace.Tools.Runner/*.csproj
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet
 
   - task: DotNetCoreCLI@2
     displayName: dotnet test
@@ -124,6 +126,8 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet
 
 - job: managed_macos
   pool:
@@ -173,6 +177,8 @@ jobs:
       command: test
       configuration: $(buildConfiguration)
       projects: test/**/*.Tests.csproj
+    env:
+      DD_SERVICE_NAME: dd-tracer-dotnet
 
 
 - job: windows_profiler

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -1,0 +1,20 @@
+using Datadog.Trace.Ci;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
+{
+    internal static class Common
+    {
+        static Common()
+        {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
+            // Preload environment variables.
+            CIEnvironmentValues.DecorateSpan(null);
+        }
+
+        internal static Tracer TestTracer { get; private set; }
+
+        internal static string ServiceName { get; private set; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodAttributeExecuteIntegration.cs
@@ -47,9 +47,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
-                Scope scope = Tracer.Instance.ActiveScope;
+                Scope scope = Common.TestTracer.ActiveScope;
                 if (scope != null)
                 {
                     Array returnValueArray = returnValue as Array;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -25,9 +25,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
     {
         private const string IntegrationName = nameof(IntegrationIds.MsTestV2);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
+        private static readonly Tracer TestTracer;
+        private static readonly string ServiceName;
 
         static TestMethodRunnerExecuteIntegration()
         {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
             // Preload environment variables.
             CIEnvironmentValues.DecorateSpan(null);
         }
@@ -54,8 +59,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             string testSuite = testMethodInfo.TestClassName;
             string testName = testMethodInfo.TestMethodName;
 
-            Tracer tracer = Tracer.Instance;
-            Scope scope = tracer.StartActive("mstest.test");
+            Scope scope = TestTracer.StartActive("mstest.test", serviceName: ServiceName);
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -25,17 +25,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
     {
         private const string IntegrationName = nameof(IntegrationIds.MsTestV2);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
-        private static readonly Tracer TestTracer;
-        private static readonly string ServiceName;
-
-        static TestMethodRunnerExecuteIntegration()
-        {
-            TestTracer = Tracer.Instance;
-            ServiceName = TestTracer.DefaultServiceName;
-
-            // Preload environment variables.
-            CIEnvironmentValues.DecorateSpan(null);
-        }
 
         /// <summary>
         /// OnMethodBegin callback
@@ -46,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
             where TTarget : ITestMethodRunner, IDuckType
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (!Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 return CallTargetState.GetDefault();
             }
@@ -59,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             string testSuite = testMethodInfo.TestClassName;
             string testName = testMethodInfo.TestMethodName;
 
-            Scope scope = TestTracer.StartActive("mstest.test", serviceName: ServiceName);
+            Scope scope = Common.TestTracer.StartActive("mstest.test", serviceName: Common.ServiceName);
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/UnitTestRunnerRunCleanupIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/UnitTestRunnerRunCleanupIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // We have to ensure the flush of the buffer after we finish the tests of an assembly.
                 // For some reason, sometimes when all test are finished none of the callbacks to handling the tracer disposal is triggered.
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                 try
                 {
                     SynchronizationContext.SetSynchronizationContext(null);
-                    Tracer.Instance.FlushAsync().GetAwaiter().GetResult();
+                    Common.TestTracer.FlushAsync().GetAwaiter().GetResult();
                 }
                 finally
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Ci;
 using Datadog.Trace.ExtensionMethods;
@@ -10,8 +9,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 {
     internal static class NUnitIntegration
     {
+        private static readonly Tracer TestTracer;
+        private static readonly string ServiceName;
+
         static NUnitIntegration()
         {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
             // Preload environment variables.
             CIEnvironmentValues.DecorateSpan(null);
         }
@@ -34,8 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             string testName = testMethod.Name;
             string skipReason = null;
 
-            Tracer tracer = Tracer.Instance;
-            Scope scope = tracer.StartActive("nunit.test");
+            Scope scope = TestTracer.StartActive("nunit.test", serviceName: ServiceName);
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -9,18 +9,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 {
     internal static class NUnitIntegration
     {
-        private static readonly Tracer TestTracer;
-        private static readonly string ServiceName;
-
-        static NUnitIntegration()
-        {
-            TestTracer = Tracer.Instance;
-            ServiceName = TestTracer.DefaultServiceName;
-
-            // Preload environment variables.
-            CIEnvironmentValues.DecorateSpan(null);
-        }
-
         internal static Scope CreateScope<TContext>(TContext executionContext, Type targetType)
             where TContext : ITestExecutionContext
         {
@@ -39,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             string testName = testMethod.Name;
             string skipReason = null;
 
-            Scope scope = TestTracer.StartActive("nunit.test", serviceName: ServiceName);
+            Scope scope = Common.TestTracer.StartActive("nunit.test", serviceName: Common.ServiceName);
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitSkipCommandExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitSkipCommandExecuteIntegration.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         public static CallTargetState OnMethodBegin<TTarget, TContext>(TTarget instance, TContext executionContext)
             where TContext : ITestExecutionContext
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (!Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 return CallTargetState.GetDefault();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitTestAdapterUnloadIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitTestAdapterUnloadIntegration.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         /// <returns>Return value of the method</returns>
         public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 SynchronizationContext context = SynchronizationContext.Current;
                 try
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                     // So the last spans in buffer aren't send to the agent.
                     // Other times we reach the 500 items of the buffer in a sec and the tracer start to drop spans.
                     // In a test scenario we must keep all spans.
-                    Tracer.Instance.FlushAsync().GetAwaiter().GetResult();
+                    Common.TestTracer.FlushAsync().GetAwaiter().GetResult();
                 }
                 finally
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitTestMethodCommandExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitTestMethodCommandExecuteIntegration.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         public static CallTargetState OnMethodBegin<TTarget, TContext>(TTarget instance, TContext executionContext)
             where TContext : ITestExecutionContext
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (!Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 return CallTargetState.GetDefault();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -8,8 +8,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 {
     internal static class XUnitIntegration
     {
+        private static readonly Tracer TestTracer;
+        private static readonly string ServiceName;
+
         static XUnitIntegration()
         {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
             // Preload environment variables.
             CIEnvironmentValues.DecorateSpan(null);
         }
@@ -21,10 +27,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 
             AssemblyName testInvokerAssemblyName = targetType.Assembly.GetName();
 
-            Tracer tracer = Tracer.Instance;
             string testFramework = "xUnit " + testInvokerAssemblyName.Version.ToString();
 
-            Scope scope = tracer.StartActive("xunit.test");
+            Scope scope = TestTracer.StartActive("xunit.test", serviceName: ServiceName);
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -8,18 +8,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 {
     internal static class XUnitIntegration
     {
-        private static readonly Tracer TestTracer;
-        private static readonly string ServiceName;
-
-        static XUnitIntegration()
-        {
-            TestTracer = Tracer.Instance;
-            ServiceName = TestTracer.DefaultServiceName;
-
-            // Preload environment variables.
-            CIEnvironmentValues.DecorateSpan(null);
-        }
-
         internal static Scope CreateScope(ref TestRunnerStruct runnerInstance, Type targetType)
         {
             string testSuite = runnerInstance.TestClass.ToString();
@@ -29,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 
             string testFramework = "xUnit " + testInvokerAssemblyName.Version.ToString();
 
-            Scope scope = TestTracer.StartActive("xunit.test", serviceName: ServiceName);
+            Scope scope = Common.TestTracer.StartActive("xunit.test", serviceName: Common.ServiceName);
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerRunTestCollectionAsyncIntegration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // We have to ensure the flush of the buffer after we finish the tests of an assembly.
                 // For some reason, sometimes when all test are finished none of the callbacks to handling the tracer disposal is triggered.
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                 try
                 {
                     SynchronizationContext.SetSynchronizationContext(null);
-                    Tracer.Instance.FlushAsync().GetAwaiter().GetResult();
+                    Common.TestTracer.FlushAsync().GetAwaiter().GetResult();
                 }
                 finally
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestInvokerRunAsyncIntegration.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (!Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 return CallTargetState.GetDefault();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Common.TestTracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 TestRunnerStruct runnerInstance = instance.DuckCast<TestRunnerStruct>();
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
@@ -1,0 +1,20 @@
+using Datadog.Trace.Ci;
+
+namespace Datadog.Trace.ClrProfiler.Integrations.Testing
+{
+    internal static class Common
+    {
+        static Common()
+        {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
+            // Preload environment variables.
+            CIEnvironmentValues.DecorateSpan(null);
+        }
+
+        internal static Tracer TestTracer { get; private set; }
+
+        internal static string ServiceName { get; private set; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -34,17 +34,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
         private const string NUnitTestExecutionContextType = "NUnit.Framework.Internal.TestExecutionContext";
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(NUnitIntegration));
-        private static readonly Tracer TestTracer;
-        private static readonly string ServiceName;
-
-        static NUnitIntegration()
-        {
-            TestTracer = Tracer.Instance;
-            ServiceName = TestTracer.DefaultServiceName;
-
-            // Preload environment variables.
-            CIEnvironmentValues.DecorateSpan(null);
-        }
 
         /// <summary>
         /// Wrap the original NUnit.Framework.Internal.Commands.TestMethodCommand.Execute method by adding instrumentation code around it
@@ -223,7 +212,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                             }
                         }
 
-                        scope = TestTracer.StartActive("nunit.test", serviceName: ServiceName);
+                        scope = Common.TestTracer.StartActive("nunit.test", serviceName: Common.ServiceName);
                         Span span = scope.Span;
 
                         span.Type = SpanTypes.Test;
@@ -361,7 +350,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 // So the last spans in buffer aren't send to the agent.
                 // Other times we reach the 500 items of the buffer in a sec and the tracer start to drop spans.
                 // In a test scenario we must keep all spans.
-                Tracer.Instance.FlushAsync().GetAwaiter().GetResult();
+                Common.TestTracer.FlushAsync().GetAwaiter().GetResult();
             }
             finally
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -34,9 +34,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
         private const string NUnitTestExecutionContextType = "NUnit.Framework.Internal.TestExecutionContext";
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(NUnitIntegration));
+        private static readonly Tracer TestTracer;
+        private static readonly string ServiceName;
 
         static NUnitIntegration()
         {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
             // Preload environment variables.
             CIEnvironmentValues.DecorateSpan(null);
         }
@@ -218,8 +223,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                             }
                         }
 
-                        Tracer tracer = Tracer.Instance;
-                        scope = tracer.StartActive("nunit.test");
+                        scope = TestTracer.StartActive("nunit.test", serviceName: ServiceName);
                         Span span = scope.Span;
 
                         span.Type = SpanTypes.Test;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -31,9 +31,14 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
 
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.XUnit));
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(XUnitIntegration));
+        private static readonly Tracer TestTracer;
+        private static readonly string ServiceName;
 
         static XUnitIntegration()
         {
+            TestTracer = Tracer.Instance;
+            ServiceName = TestTracer.DefaultServiceName;
+
             // Preload environment variables.
             CIEnvironmentValues.DecorateSpan(null);
         }
@@ -402,10 +407,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                     }
                 }
 
-                Tracer tracer = Tracer.Instance;
                 string testFramework = "xUnit " + testInvokerAssemblyName.Version.ToString();
 
-                scope = tracer.StartActive("xunit.test");
+                scope = TestTracer.StartActive("xunit.test", serviceName: ServiceName);
                 Span span = scope.Span;
 
                 span.Type = SpanTypes.Test;


### PR DESCRIPTION
This PR fixes the problem with the tests ServiceName using the test suite inside CiApp.

This is done by:
1. Storing the tracer instance as the TestTracer in the integration static constructor.
2. Storing the service name in the integration static constructor.
3. Modify azure pipelines to include the `DD_SERVICE_NAME`.

This protects both variables of any modification inside the tracer tests.

Previous service list:

![image](https://user-images.githubusercontent.com/69803/109358865-c4efd400-7884-11eb-994e-c667ff7885bd.png)


@DataDog/apm-dotnet