### PR TITLE
Rename test configuration tags to follow CIApp specification

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/CommonTags.cs
+++ b/src/Datadog.Trace.Ci.Shared/CommonTags.cs
@@ -116,19 +116,24 @@ namespace Datadog.Trace.Ci
         public const string RuntimeName = "runtime.name";
 
         /// <summary>
-        /// Runtime os architecture
+        /// OS architecture
         /// </summary>
-        public const string RuntimeOSArchitecture = "runtime.os_architecture";
+        public const string OSArchitecture = "os.architecture";
 
         /// <summary>
-        /// Runtime os platform
+        /// OS platform
         /// </summary>
-        public const string RuntimeOSPlatform = "runtime.os_platform";
+        public const string OSPlatform = "os.platform";
 
         /// <summary>
-        /// Runtime process architecture
+        /// OS version
         /// </summary>
-        public const string RuntimeProcessArchitecture = "runtime.process_architecture";
+        public const string OSVersion = "os.version";
+
+        /// <summary>
+        /// Runtime architecture
+        /// </summary>
+        public const string RuntimeArchitecture = "runtime.architecture";
 
         /// <summary>
         /// Runtime version

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -70,10 +70,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             var framework = FrameworkDescription.Instance;
 
             span.SetTag(CommonTags.RuntimeName, framework.Name);
-            span.SetTag(CommonTags.RuntimeOSArchitecture, framework.OSArchitecture);
-            span.SetTag(CommonTags.RuntimeOSPlatform, framework.OSPlatform);
-            span.SetTag(CommonTags.RuntimeProcessArchitecture, framework.ProcessArchitecture);
             span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
+            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
+            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
+            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
+            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
             // Get test parameters
             ParameterInfo[] methodParameters = testMethod.GetParameters();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -50,10 +50,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             var framework = FrameworkDescription.Instance;
 
             span.SetTag(CommonTags.RuntimeName, framework.Name);
-            span.SetTag(CommonTags.RuntimeOSArchitecture, framework.OSArchitecture);
-            span.SetTag(CommonTags.RuntimeOSPlatform, framework.OSPlatform);
-            span.SetTag(CommonTags.RuntimeProcessArchitecture, framework.ProcessArchitecture);
             span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
+            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
+            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
+            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
+            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
             // Get test parameters
             ParameterInfo[] methodParameters = testMethod.GetParameters();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -39,10 +39,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             var framework = FrameworkDescription.Instance;
 
             span.SetTag(CommonTags.RuntimeName, framework.Name);
-            span.SetTag(CommonTags.RuntimeOSArchitecture, framework.OSArchitecture);
-            span.SetTag(CommonTags.RuntimeOSPlatform, framework.OSPlatform);
-            span.SetTag(CommonTags.RuntimeProcessArchitecture, framework.ProcessArchitecture);
             span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
+            span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
+            span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
+            span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
+            span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
             // Get test parameters
             object[] testMethodArguments = runnerInstance.TestMethodArguments;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/NUnitIntegration.cs
@@ -234,10 +234,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                         var framework = FrameworkDescription.Instance;
 
                         span.SetTag(CommonTags.RuntimeName, framework.Name);
-                        span.SetTag(CommonTags.RuntimeOSArchitecture, framework.OSArchitecture);
-                        span.SetTag(CommonTags.RuntimeOSPlatform, framework.OSPlatform);
-                        span.SetTag(CommonTags.RuntimeProcessArchitecture, framework.ProcessArchitecture);
                         span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
+                        span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
+                        span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
+                        span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
+                        span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
                         if (testParameters != null)
                         {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -420,10 +420,11 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 var framework = FrameworkDescription.Instance;
 
                 span.SetTag(CommonTags.RuntimeName, framework.Name);
-                span.SetTag(CommonTags.RuntimeOSArchitecture, framework.OSArchitecture);
-                span.SetTag(CommonTags.RuntimeOSPlatform, framework.OSPlatform);
-                span.SetTag(CommonTags.RuntimeProcessArchitecture, framework.ProcessArchitecture);
                 span.SetTag(CommonTags.RuntimeVersion, framework.ProductVersion);
+                span.SetTag(CommonTags.RuntimeArchitecture, framework.ProcessArchitecture);
+                span.SetTag(CommonTags.OSArchitecture, framework.OSArchitecture);
+                span.SetTag(CommonTags.OSPlatform, framework.OSPlatform);
+                span.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
 
                 if (testParameters != null)
                 {

--- a/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -108,8 +108,9 @@ namespace Datadog.Trace.MSBuild
                 _buildSpan.SetTag(BuildTags.BuildWorkingFolder, Environment.CurrentDirectory);
                 _buildSpan.SetTag(BuildTags.BuildStartMessage, e.Message);
 
-                _buildSpan.SetTag(CommonTags.RuntimeOSArchitecture, Environment.Is64BitOperatingSystem ? "x64" : "x86");
-                _buildSpan.SetTag(CommonTags.RuntimeProcessArchitecture, Environment.Is64BitProcess ? "x64" : "x86");
+                _buildSpan.SetTag(CommonTags.OSArchitecture, Environment.Is64BitOperatingSystem ? "x64" : "x86");
+                _buildSpan.SetTag(CommonTags.OSVersion, Environment.OSVersion.VersionString);
+                _buildSpan.SetTag(CommonTags.RuntimeArchitecture, Environment.Is64BitProcess ? "x64" : "x86");
 
                 CIEnvironmentValues.DecorateSpan(_buildSpan);
             }


### PR DESCRIPTION
This PR renames the test configuration tags to follow the new CIApp specification.

@DataDog/apm-dotnet