### PR TITLE
CallTarget: CurlHandler integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -428,6 +428,30 @@
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClientHandler.HttpClientHandlerSyncIntegration",
           "action": "CallTargetModification"
         }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Net.Http",
+          "type": "System.Net.Http.CurlHandler",
+          "method": "SendAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>",
+            "System.Net.Http.HttpRequestMessage",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler.CurlHandlerIntegration",
+          "action": "CallTargetModification"
+        }
       }
     ]
   },

--- a/integrations.json
+++ b/integrations.json
@@ -312,6 +312,30 @@
       {
         "caller": {},
         "target": {
+          "assembly": "System.Net.Http",
+          "type": "System.Net.Http.WinHttpHandler",
+          "method": "SendAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>",
+            "System.Net.Http.HttpRequestMessage",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.24.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WinHttpHandler.WinHttpHandlerIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
           "assembly": "System.Net.Http.WinHttpHandler",
           "type": "System.Net.Http.WinHttpHandler",
           "method": "SendAsync",
@@ -443,7 +467,7 @@
           "minimum_major": 4,
           "minimum_minor": 0,
           "minimum_patch": 0,
-          "maximum_major": 5,
+          "maximum_major": 4,
           "maximum_minor": 65535,
           "maximum_patch": 65535
         },

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/CurlHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/CurlHandlerIntegration.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
+{
+    /// <summary>
+    /// System.Net.Http.WinHttpHandler calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "System.Net.Http",
+        TypeName = "System.Net.Http.CurlHandler",
+        MethodName = "SendAsync",
+        ReturnTypeName = ClrNames.HttpResponseMessageTask,
+        ParameterTypeNames = new[] { ClrNames.HttpRequestMessage, ClrNames.CancellationToken },
+        MinimumVersion = "4.0.0",
+        MaximumVersion = "4.*.*",
+        IntegrationName = IntegrationName)]
+    public class CurlHandlerIntegration
+    {
+        private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
+        private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
+        private static readonly IntegrationInfo CurlHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.CurlHandler));
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TRequest">Type of the request</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="requestMessage">HttpRequest message instance</param>
+        /// <param name="cancellationToken">CancellationToken value</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TRequest>(TTarget instance, TRequest requestMessage, CancellationToken cancellationToken)
+            where TRequest : IHttpRequestMessage
+        {
+            if (IsTracingEnabled(requestMessage.Headers))
+            {
+                Scope scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, requestMessage.Method.Method, requestMessage.RequestUri, IntegrationId, out HttpTags tags);
+                if (scope != null)
+                {
+                    tags.HttpClientHandlerType = instance.GetType().FullName;
+
+                    // add distributed tracing headers to the HTTP request
+                    SpanContextPropagator.Instance.Inject(scope.Span.Context, new HttpHeadersCollection(requestMessage.Headers));
+
+                    return new CallTargetState(scope);
+                }
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// OnAsyncMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TResponse">Type of the response, in an async scenario will be T of Task of T</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="responseMessage">HttpResponse message instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, CallTargetState state)
+            where TResponse : IHttpResponseMessage
+        {
+            Scope scope = state.Scope;
+
+            if (scope is null)
+            {
+                return responseMessage;
+            }
+
+            try
+            {
+                scope.Span.SetHttpStatusCode(responseMessage.StatusCode, isServer: false);
+
+                if (exception != null)
+                {
+                    scope.Span.SetException(exception);
+                }
+            }
+            finally
+            {
+                scope.Dispose();
+            }
+
+            return responseMessage;
+        }
+
+        private static bool IsTracingEnabled(IRequestHeaders headers)
+        {
+            if (!Tracer.Instance.Settings.IsIntegrationEnabled(CurlHandlerIntegrationId, defaultValue: false))
+            {
+                return false;
+            }
+
+            if (headers.TryGetValues(HttpHeaderNames.TracingEnabled, out var headerValues))
+            {
+                if (headerValues is string[] arrayValues)
+                {
+                    for (var i = 0; i < arrayValues.Length; i++)
+                    {
+                        if (string.Equals(arrayValues[i], "false", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                if (headerValues != null && headerValues.Any(s => string.Equals(s, "false", StringComparison.OrdinalIgnoreCase)))
+                {
+                    // tracing is disabled for this request via http header
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/CurlHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/CurlHandlerIntegration.cs
@@ -9,7 +9,7 @@ using Datadog.Trace.Tagging;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
 {
     /// <summary>
-    /// System.Net.Http.WinHttpHandler calltarget instrumentation
+    /// System.Net.Http.CurlHandler calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
         AssemblyName = "System.Net.Http",

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/HttpHeadersCollection.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/HttpHeadersCollection.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Headers;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
+{
+    internal readonly struct HttpHeadersCollection : IHeadersCollection
+    {
+        private readonly IRequestHeaders _headers;
+
+        public HttpHeadersCollection(IRequestHeaders headers)
+        {
+            _headers = headers ?? throw new ArgumentNullException(nameof(headers));
+        }
+
+        public IEnumerable<string> GetValues(string name)
+        {
+            if (_headers.TryGetValues(name, out IEnumerable<string> values))
+            {
+                return values;
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
+        public void Set(string name, string value)
+        {
+            _headers.Remove(name);
+            _headers.Add(name, value);
+        }
+
+        public void Add(string name, string value)
+        {
+            _headers.Add(name, value);
+        }
+
+        public void Remove(string name)
+        {
+            _headers.Remove(name);
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/HttpMethodStruct.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/HttpMethodStruct.cs
@@ -1,0 +1,16 @@
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
+{
+    /// <summary>
+    /// Http method struct copy target for ducktyping
+    /// </summary>
+    [DuckCopy]
+    public struct HttpMethodStruct
+    {
+        /// <summary>
+        /// Gets the http method in string
+        /// </summary>
+        public string Method;
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/IHttpRequestMessage.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/IHttpRequestMessage.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
+{
+    /// <summary>
+    /// HttpRequestMessage interface for ducktyping
+    /// </summary>
+    public interface IHttpRequestMessage
+    {
+        /// <summary>
+        /// Gets the Http Method
+        /// </summary>
+        HttpMethodStruct Method { get; }
+
+        /// <summary>
+        /// Gets the request uri
+        /// </summary>
+        Uri RequestUri { get; }
+
+        /// <summary>
+        /// Gets the request headers
+        /// </summary>
+        IRequestHeaders Headers { get; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/IHttpResponseMessage.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/IHttpResponseMessage.cs
@@ -1,0 +1,13 @@
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
+{
+    /// <summary>
+    /// HttpResponseMessage interface for ducktyping
+    /// </summary>
+    public interface IHttpResponseMessage
+    {
+        /// <summary>
+        /// Gets the status code of the http response
+        /// </summary>
+        int StatusCode { get; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/IRequestHeaders.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/CurlHandler/IRequestHeaders.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.CurlHandler
+{
+    /// <summary>
+    /// RequestHeaders interface for ducktyping
+    /// </summary>
+    public interface IRequestHeaders
+    {
+        /// <summary>
+        /// Try get values from the headers
+        /// </summary>
+        /// <param name="name">Name of the header</param>
+        /// <param name="values">Values of the header in the request</param>
+        /// <returns>true if the header was found; otherwise, false</returns>
+        bool TryGetValues(string name, out IEnumerable<string> values);
+
+        /// <summary>
+        /// Removes a header from the request
+        /// </summary>
+        /// <param name="name">Name of the header</param>
+        /// <returns>true if the header was removed; otherwise, false.</returns>
+        bool Remove(string name);
+
+        /// <summary>
+        /// Adds a header to the request
+        /// </summary>
+        /// <param name="name">Name of the header</param>
+        /// <param name="value">Value of the header</param>
+        void Add(string name, string value);
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WinHttpHandler
     /// System.Net.Http.WinHttpHandler calltarget instrumentation
     /// </summary>
     [InstrumentMethod(
-        AssemblyName = "System.Net.Http.WinHttpHandler",
+        AssemblyNames = new[] { "System.Net.Http", "System.Net.Http.WinHttpHandler" },
         TypeName = "System.Net.Http.WinHttpHandler",
         MethodName = "SendAsync",
         ReturnTypeName = ClrNames.HttpResponseMessageTask,

--- a/src/Datadog.Trace/Configuration/IntegrationIds.cs
+++ b/src/Datadog.Trace/Configuration/IntegrationIds.cs
@@ -6,6 +6,7 @@ namespace Datadog.Trace.Configuration
         HttpMessageHandler,
         HttpSocketsHandler,
         WinHttpHandler,
+        CurlHandler,
         AspNetCore,
         AdoNet,
         AspNet,

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -104,7 +104,7 @@ namespace Samples.HttpMessageHandler
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     Console.WriteLine();
-                    Console.WriteLine("Sending async request with WinHttpHandler.");
+                    Console.WriteLine("Sending async request with internal WinHttpHandler.");
                     Type winHttpHandler = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "WinHttpHandler");
                     System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(winHttpHandler);
                     using (var invoker = new HttpMessageInvoker(handler, false))

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -104,7 +104,7 @@ namespace Samples.HttpMessageHandler
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     Console.WriteLine();
-                    Console.WriteLine("Sending sync request with WinHttpHandler.");
+                    Console.WriteLine("Sending async request with WinHttpHandler.");
                     Type winHttpHandler = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "WinHttpHandler");
                     System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(winHttpHandler);
                     using (var invoker = new HttpMessageInvoker(handler, false))
@@ -115,7 +115,7 @@ namespace Samples.HttpMessageHandler
                 else
                 {
                     Console.WriteLine();
-                    Console.WriteLine("Sending sync request with CurlHandler.");
+                    Console.WriteLine("Sending async request with CurlHandler.");
                     Type curlHandlerType = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "CurlHandler");
                     System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(curlHandlerType);
                     using (var invoker = new HttpMessageInvoker(handler, false))

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -107,7 +107,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Sending sync request with WinHttpHandler.");
                     Type winHttpHandler = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "WinHttpHandler");
                     System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(winHttpHandler);
-                    using (var invoker = new HttpMessageInvoker(handler))
+                    using (var invoker = new HttpMessageInvoker(handler, false))
                     {
                         await RequestHelpers.SendHttpMessageInvokerRequestsAsync(invoker, tracingDisabled, Url);
                     }
@@ -118,7 +118,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Sending sync request with CurlHandler.");
                     Type curlHandlerType = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "CurlHandler");
                     System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(curlHandlerType);
-                    using (var invoker = new HttpMessageInvoker(handler))
+                    using (var invoker = new HttpMessageInvoker(handler, false))
                     {
                         await RequestHelpers.SendHttpMessageInvokerRequestsAsync(invoker, tracingDisabled, Url);
                     }

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -99,6 +99,32 @@ namespace Samples.HttpMessageHandler
 
                 // sync http requests using HttpClient are not supported with WinHttpHandler
 #endif
+
+#if NETCOREAPP2_1 || NETCOREAPP3_0 || NETCOREAPP3_1
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("Sending sync request with WinHttpHandler.");
+                    Type winHttpHandler = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "WinHttpHandler");
+                    System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(winHttpHandler);
+                    using (var invoker = new HttpMessageInvoker(handler))
+                    {
+                        await RequestHelpers.SendHttpMessageInvokerRequestsAsync(invoker, tracingDisabled, Url);
+                    }
+                }
+                else
+                {
+                    Console.WriteLine();
+                    Console.WriteLine("Sending sync request with CurlHandler.");
+                    Type curlHandlerType = typeof(System.Net.Http.HttpMessageHandler).Assembly.GetTypes().FirstOrDefault(t => t.Name == "CurlHandler");
+                    System.Net.Http.HttpMessageHandler handler = (System.Net.Http.HttpMessageHandler)Activator.CreateInstance(curlHandlerType);
+                    using (var invoker = new HttpMessageInvoker(handler))
+                    {
+                        await RequestHelpers.SendHttpMessageInvokerRequestsAsync(invoker, tracingDisabled, Url);
+                    }
+                }
+#endif
+
                 Console.WriteLine();
                 Console.WriteLine("Stopping HTTP listener.");
                 listener.Stop();

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -260,5 +260,24 @@ namespace Samples.HttpMessageHandler
             }
         }
 #endif
+
+        public static async Task SendHttpMessageInvokerRequestsAsync(HttpMessageInvoker invoker, bool tracingDisabled, string url)
+        {
+            // Insert a call to the Tracer.Instance to include an AssemblyRef to Datadog.Trace assembly in the final executable
+            Console.WriteLine($"[HttpMessageInvoker] sending requests to {url}");
+
+            var httpRequest = new HttpRequestMessage();
+
+            if (tracingDisabled)
+            {
+                httpRequest.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+            }
+
+            httpRequest.Method = HttpMethod.Get;
+            httpRequest.RequestUri = new Uri(url);
+
+            Console.WriteLine("Received response for HttpMessageInvoker.SendAsync");
+            await invoker.SendAsync(httpRequest, CancellationToken.None);
+        }
     }
 }

--- a/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -263,7 +263,6 @@ namespace Samples.HttpMessageHandler
 
         public static async Task SendHttpMessageInvokerRequestsAsync(HttpMessageInvoker invoker, bool tracingDisabled, string url)
         {
-            // Insert a call to the Tracer.Instance to include an AssemblyRef to Datadog.Trace assembly in the final executable
             Console.WriteLine($"[HttpMessageInvoker] sending requests to {url}");
 
             var httpRequest = new HttpRequestMessage();


### PR DESCRIPTION
This PR adds a CurlHandler HttpMessageHandler integration contained in netcoreapp 2.x/3.x for linux and macos builds.

Note: Also fixes the WinHttpHandler integration contained in netcoreapp 2.x/3.x for windows build.

@DataDog/apm-dotnet