### PR TITLE
DuckIgnoreAttribute to ignore members to be used when ducktyping

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckIgnoreAttribute.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckIgnoreAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Datadog.Trace.DuckTyping
+{
+    /// <summary>
+    /// Ignores the member when DuckTyping
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Field, AllowMultiple = false)]
+    public class DuckIgnoreAttribute : Attribute
+    {
+    }
+}

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -22,30 +22,30 @@ namespace Datadog.Trace.DuckTyping
                     continue;
                 }
 
-                foreach (MethodInfo intMethod in imInterface.GetMethods())
+                foreach (MethodInfo interfaceMethod in imInterface.GetMethods())
                 {
-                    if (intMethod.IsSpecialName)
+                    if (interfaceMethod.IsSpecialName)
                     {
                         continue;
                     }
 
-                    string intMethodName = intMethod.ToString();
-                    bool found = false;
+                    string interfaceMethodName = interfaceMethod.ToString();
+                    bool methodAlreadySelected = false;
                     foreach (MethodInfo currentMethod in selectedMethods)
                     {
-                        if (currentMethod.ToString() == intMethodName)
+                        if (currentMethod.ToString() == interfaceMethodName)
                         {
-                            found = true;
+                            methodAlreadySelected = true;
                             break;
                         }
                     }
 
-                    if (!found)
+                    if (!methodAlreadySelected)
                     {
-                        MethodInfo prevMethod = baseType.GetMethod(intMethod.Name, DuckAttribute.DefaultFlags, null, intMethod.GetParameters().Select(p => p.ParameterType).ToArray(), null);
+                        MethodInfo prevMethod = baseType.GetMethod(interfaceMethod.Name, DuckAttribute.DefaultFlags, null, interfaceMethod.GetParameters().Select(p => p.ParameterType).ToArray(), null);
                         if (prevMethod == null || prevMethod.GetCustomAttribute<DuckIgnoreAttribute>() is null)
                         {
-                            selectedMethods.Add(intMethod);
+                            selectedMethods.Add(interfaceMethod);
                         }
                     }
                 }

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -285,6 +285,12 @@ namespace Datadog.Trace.DuckTyping
 
             foreach (PropertyInfo proxyProperty in proxyTypeProperties)
             {
+                // Ignore the properties marked with `DuckIgnore` attribute
+                if (proxyProperty.GetCustomAttribute<DuckIgnoreAttribute>(true) is not null)
+                {
+                    continue;
+                }
+
                 PropertyBuilder propertyBuilder = null;
 
                 // If the property is abstract or interface we make sure that we have the property defined in the new class
@@ -410,6 +416,12 @@ namespace Datadog.Trace.DuckTyping
                     continue;
                 }
 
+                // Ignore the fields marked with `DuckIgnore` attribute
+                if (proxyFieldInfo.GetCustomAttribute<DuckIgnoreAttribute>(true) is not null)
+                {
+                    continue;
+                }
+
                 PropertyBuilder propertyBuilder = null;
 
                 DuckAttribute duckAttribute = proxyFieldInfo.GetCustomAttribute<DuckAttribute>(true) ?? new DuckAttribute();
@@ -531,6 +543,12 @@ namespace Datadog.Trace.DuckTyping
             {
                 // Skip readonly fields
                 if ((finfo.Attributes & FieldAttributes.InitOnly) != 0)
+                {
+                    continue;
+                }
+
+                // Ignore the fields marked with `DuckIgnore` attribute
+                if (finfo.GetCustomAttribute<DuckIgnoreAttribute>(true) is not null)
                 {
                     continue;
                 }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckIgnoreTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckIgnoreTests.cs
@@ -13,6 +13,8 @@ namespace Datadog.Trace.DuckTyping.Tests
             PrivateStruct instance = default;
             CopyStruct copy = instance.DuckCast<CopyStruct>();
             Assert.Equal((int)instance.Value, (int)copy.Value);
+            Assert.Equal(ValuesDuckType.Third.ToString(), copy.GetValue());
+            Assert.Equal(ValuesDuckType.Third.ToString(), ((IGetValue)copy).GetValueProp);
         }
 
 #if NETCOREAPP3_0_OR_GREATER
@@ -22,6 +24,8 @@ namespace Datadog.Trace.DuckTyping.Tests
             PrivateStruct instance = default;
             IPrivateStruct proxy = instance.DuckCast<IPrivateStruct>();
             Assert.Equal((int)instance.Value, (int)proxy.Value);
+            Assert.Equal(ValuesDuckType.Third.ToString(), proxy.GetValue());
+            Assert.Equal(ValuesDuckType.Third.ToString(), proxy.GetValueProp);
         }
 #endif
 
@@ -31,6 +35,8 @@ namespace Datadog.Trace.DuckTyping.Tests
             PrivateStruct instance = default;
             AbstractPrivateProxy proxy = instance.DuckCast<AbstractPrivateProxy>();
             Assert.Equal((int)instance.Value, (int)proxy.Value);
+            Assert.Equal(ValuesDuckType.Third.ToString(), proxy.GetValue());
+            Assert.Equal(ValuesDuckType.Third.ToString(), ((IGetValue)proxy).GetValueProp);
         }
 
         [Fact]
@@ -39,6 +45,8 @@ namespace Datadog.Trace.DuckTyping.Tests
             PrivateStruct instance = default;
             VirtualPrivateProxy proxy = instance.DuckCast<VirtualPrivateProxy>();
             Assert.Equal((int)instance.Value, (int)proxy.Value);
+            Assert.Equal(ValuesDuckType.Third.ToString(), proxy.GetValue());
+            Assert.Equal(ValuesDuckType.Third.ToString(), ((IGetValue)proxy).GetValueProp);
         }
 
         [DuckCopy]
@@ -52,6 +60,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         }
 
 #if NETCOREAPP3_0_OR_GREATER
+        // Interface with a default implementation
         public interface IPrivateStruct
         {
             ValuesDuckType Value { get; }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckIgnoreTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckIgnoreTests.cs
@@ -1,0 +1,137 @@
+using Xunit;
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+#pragma warning disable SA1402 // File may only contain a single class
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class DuckIgnoreTests
+    {
+        [Fact]
+        public void NonPublicStructCopyTest()
+        {
+            PrivateStruct instance = default;
+            CopyStruct copy = instance.DuckCast<CopyStruct>();
+            Assert.Equal((int)instance.Value, (int)copy.Value);
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        [Fact]
+        public void NonPublicStructInterfaceProxyTest()
+        {
+            PrivateStruct instance = default;
+            IPrivateStruct proxy = instance.DuckCast<IPrivateStruct>();
+            Assert.Equal((int)instance.Value, (int)proxy.Value);
+        }
+#endif
+
+        [Fact]
+        public void NonPublicStructAbstractProxyTest()
+        {
+            PrivateStruct instance = default;
+            AbstractPrivateProxy proxy = instance.DuckCast<AbstractPrivateProxy>();
+            Assert.Equal((int)instance.Value, (int)proxy.Value);
+        }
+
+        [Fact]
+        public void NonPublicStructVirtualProxyTest()
+        {
+            PrivateStruct instance = default;
+            VirtualPrivateProxy proxy = instance.DuckCast<VirtualPrivateProxy>();
+            Assert.Equal((int)instance.Value, (int)proxy.Value);
+        }
+
+        [DuckCopy]
+        public struct CopyStruct : IGetValue
+        {
+            public ValuesDuckType Value;
+
+            string IGetValue.GetValueProp => Value.ToString();
+
+            public string GetValue() => Value.ToString();
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        public interface IPrivateStruct
+        {
+            ValuesDuckType Value { get; }
+
+            [DuckIgnore]
+            public string GetValueProp => Value.ToString();
+
+            [DuckIgnore]
+            public string GetValue() => Value.ToString();
+        }
+#endif
+
+        public abstract class AbstractPrivateProxy : IGetValue
+        {
+            public abstract ValuesDuckType Value { get; }
+
+            [DuckIgnore]
+            public string GetValueProp => Value.ToString();
+
+            [DuckIgnore]
+            public string GetValue() => Value.ToString();
+        }
+
+        public class VirtualPrivateProxy : IGetValue
+        {
+            public virtual ValuesDuckType Value { get; }
+
+            [DuckIgnore]
+            public string GetValueProp => Value.ToString();
+
+            [DuckIgnore]
+            public string GetValue() => Value.ToString();
+        }
+
+        private readonly struct PrivateStruct
+        {
+            public readonly Values Value => Values.Third;
+        }
+
+        public interface IGetValue
+        {
+            string GetValueProp { get; }
+
+            string GetValue();
+        }
+
+        public enum ValuesDuckType
+        {
+            /// <summary>
+            /// First
+            /// </summary>
+            First,
+
+            /// <summary>
+            /// Second
+            /// </summary>
+            Second,
+
+            /// <summary>
+            /// Third
+            /// </summary>
+            Third
+        }
+
+        public enum Values
+        {
+            /// <summary>
+            /// First
+            /// </summary>
+            First,
+
+            /// <summary>
+            /// Second
+            /// </summary>
+            Second,
+
+            /// <summary>
+            /// Third
+            /// </summary>
+            Third
+        }
+    }
+}


### PR DESCRIPTION
This PR Adds the DuckIgnoreAttribute to ignore members when the ducktype proxy is created.

@DataDog/apm-dotnet