### PR TITLE
Update .gitignore and 3rd party license file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,6 @@ deploy/AzureAppServices/
 *..DS_Store
 .DS_Store/*
 .DS_Store
+
+# profiler output files
+src/Datadog.Trace.ClrProfiler.Native/build/

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -11,6 +11,7 @@ miniutf,https://github.com/dropbox/miniutf,MIT,"Copyright (c) 2013 Dropbox, Inc.
 Serilog,https://github.com/serilog/serilog,Apache-2.0,"Copyright (c) 2013-2018 Serilog Contributors"
 Serilog.Sinks.File,https://github.com/serilog/serilog-sinks-file,Apache-2.0,"Copyright (c) 2016 Serilog Contributors"
 opentracing-contrib/csharp-netcore,https://github.com/opentracing-contrib/csharp-netcore,Apache-2.0,
+opentelemetry-dotnet-instrumentation,https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation,Apache-2.0,
 Newtonsoft.Json,https://github.com/JamesNK/Newtonsoft.Json,MIT,Copyright (c) 2007 James Newton-King
 spdlog,https://github.com/gabime/spdlog,MIT,"Copyright (c) 2016 Gabi Melman."
 {fmt},https://github.com/fmtlib/fmt,MIT,"Copyright (c) 2012 - present, Victor Zverovich"


### PR DESCRIPTION
Changes proposed in this pull request:
- Update `.gitignore` to exclude automatic instrumentation build output. Based on changes in open-telemetry/opentelemetry-dotnet-instrumentation#47
- Add opentelemetry-dotnet-instrumentation to `LICENSE-3rdparty.csv`

@DataDog/apm-dotnet