### PR TITLE
Minimize usages of Tracer.Instance in Datadog.Trace.Tests

### DIFF
--- a/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -10,7 +10,7 @@ using Xunit.Sdk;
 
 namespace Datadog.Trace.Tests
 {
-    [CollectionDefinition(nameof(CorrelationIdentifierTests), DisableParallelization = true)]
+    [Collection(nameof(TracerInstanceTestCollection))]
     [TracerRestorer]
     public class CorrelationIdentifierTests
     {

--- a/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -20,7 +20,7 @@ using Xunit.Sdk;
 
 namespace Datadog.Trace.Tests.DiagnosticListeners
 {
-    [CollectionDefinition(nameof(AspNetCoreDiagnosticObserverTests), DisableParallelization = true)]
+    [Collection(nameof(TracerInstanceTestCollection))]
     [TracerRestorer]
     public class AspNetCoreDiagnosticObserverTests
     {

--- a/test/Datadog.Trace.Tests/DistributedTraceTests.cs
+++ b/test/Datadog.Trace.Tests/DistributedTraceTests.cs
@@ -27,8 +27,9 @@ namespace Datadog.Trace.Tests
             }
 
             var distributedTraceContext = new SpanContext(traceId, parentSpanId);
+            var secondTracer = new Tracer();
 
-            using (var scope = Tracer.Instance.StartActive("manual.trace", parent: distributedTraceContext))
+            using (var scope = secondTracer.StartActive("manual.trace", parent: distributedTraceContext))
             {
                 scope.Span.SetTag(Tags.SamplingPriority, samplingPriorityText);
                 Assert.True(scope.Span.TraceId == traceId, "Trace ID must match the parent trace.");

--- a/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void One_Is_Allowed()
         {
-            var traceContext = new TraceContext(Tracer.Instance);
+            var traceContext = new TraceContext(new Tracer());
             var spanContext = new SpanContext(null, traceContext, "Weeeee");
             var span = new Span(spanContext, null);
             var rateLimiter = new RateLimiter(maxTracesPerInterval: null);
@@ -105,7 +105,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static int AskTheRateLimiterABunchOfTimes(RateLimiter rateLimiter, int howManyTimes)
         {
-            var traceContext = new TraceContext(Tracer.Instance);
+            var traceContext = new TraceContext(new Tracer());
             var spanContext = new SpanContext(null, traceContext, "Weeeee");
             var span = new Span(spanContext, null);
 

--- a/test/Datadog.Trace.Tests/TracerInstanceTestCollection.cs
+++ b/test/Datadog.Trace.Tests/TracerInstanceTestCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    [CollectionDefinition(nameof(TracerInstanceTestCollection), DisableParallelization = true)]
+    public class TracerInstanceTestCollection
+    {
+    }
+}


### PR DESCRIPTION
Attempts to fix flaky test `Datadog.Trace.Tests.CorrelationIdentifierTests.TraceIdSpanId_MatchActiveSpan` by doing the following:
- Remove usages of `Tracer.Instance` except those that actually test the ambient tracer (log injection and AspNetCore diagnostic observer)
- Place the remaining usages into one TestCollection so they're not run in parallel

@DataDog/apm-dotnet