### PR TITLE
Propose fix to Datadog.Trace.Tests.RuntimeMetrics.RuntimeMetricsWriterTests.ShouldCaptureFirstChanceExceptions

### DIFF
--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -88,7 +88,11 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 writer.PushEvents();
 
                 statsd.Verify(
-                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), It.IsAny<string[]>()),
+                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), new[] { "exception_type:CustomException1" }),
+                    Times.Never);
+
+                statsd.Verify(
+                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), new[] { "exception_type:CustomException2" }),
                     Times.Never);
             }
         }

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -69,7 +69,11 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 }
 
                 statsd.Verify(
-                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), It.IsAny<string[]>()),
+                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), new[] { "exception_type:CustomException1" }),
+                    Times.Never);
+
+                statsd.Verify(
+                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), new[] { "exception_type:CustomException2" }),
                     Times.Never);
 
                 writer.PushEvents();

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -69,11 +69,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
                 }
 
                 statsd.Verify(
-                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), new[] { "exception_type:CustomException1" }),
-                    Times.Never);
-
-                statsd.Verify(
-                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), new[] { "exception_type:CustomException2" }),
+                    s => s.Increment(MetricsNames.ExceptionsCount, It.IsAny<int>(), It.IsAny<double>(), It.IsAny<string[]>()),
                     Times.Never);
 
                 writer.PushEvents();


### PR DESCRIPTION
We were previously asserting that no first exceptions were being recorded, however other threads in the same AppDomain could be throwing exceptions which our runtime metrics would catch. Replace this catch-all check with a more targeted one.

@DataDog/apm-dotnet