### PR TITLE
Propose fix to Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests.StackExchangeRedisStackOverflowExceptionSmokeTest.NoExceptions

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
@@ -1,11 +1,10 @@
-using Datadog.Core.Tools;
-using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
-using Datadog.Trace.TestHelpers;
+using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
+    [Collection(nameof(StackExchangeRedisTestCollection))]
     public class StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest : SmokeTestBase
     {
         public StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
@@ -1,11 +1,11 @@
 using Datadog.Core.Tools;
-using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
-using Datadog.Trace.TestHelpers;
+using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
+    [Collection(nameof(StackExchangeRedisTestCollection))]
     public class StackExchangeRedisAssemblyConflictSdkProjectSmokeTest : SmokeTestBase
     {
         public StackExchangeRedisAssemblyConflictSdkProjectSmokeTest(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisStackOverflowExceptionSmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisStackOverflowExceptionSmokeTest.cs
@@ -1,11 +1,12 @@
 #if !NET452
 using Datadog.Core.Tools;
-using Datadog.Trace.TestHelpers;
+using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 {
+    [Collection(nameof(StackExchangeRedisTestCollection))]
     public class StackExchangeRedisStackOverflowExceptionSmokeTest : SmokeTestBase
     {
         public StackExchangeRedisStackOverflowExceptionSmokeTest(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
+using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,6 +13,7 @@ using Datadog.Trace.ExtensionMethods; // needed for Dictionary<K,V>.GetValueOrDe
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    [Collection(nameof(StackExchangeRedisTestCollection))]
     public class StackExchangeRedisTests : TestHelper
     {
         public StackExchangeRedisTests(ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestCollections/StackExchangeRedisTestCollection.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestCollections/StackExchangeRedisTestCollection.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections
+{
+    [CollectionDefinition(nameof(StackExchangeRedisTestCollection), DisableParallelization = true)]
+    public class StackExchangeRedisTestCollection
+    {
+    }
+}


### PR DESCRIPTION
The purpose of this small regression test iterates over all keys in the redis database to test the stack overflow failure from https://github.com/DataDog/dd-trace-dotnet/issues/447.

However, when a GET is issued for each key, some values are not strings. This is likely happening because another test application using the same redis instance (`stackexchangeredis` container in `docker-compose.yml`) is simultaneously adding other key/value pairs during its execution. While we could just patch the smoke test, the real fix is to make sure the tests that use the same instance for the operations do not run in parallel. This proposal should not significantly increase the test execution time because the regression tests only run one test each, whereas the `StackExchangeRedisTests` is already running a larger matrix of tests based on CallSite/CallTarget + PackageVersion combinations.

The fix I'm proposing is to put all StackExchange tests into a new `StackExchangeRedisTestCollection`.

@DataDog/apm-dotnet