### PR TITLE
Attempt to fix flaky test Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests.StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.NoExceptions

### DIFF
--- a/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Datadog.StackExchange.Redis.StrongName.csproj
+++ b/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/Datadog.StackExchange.Redis.StrongName.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Datadog.StackExchange.Redis.csproj
+++ b/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis/Datadog.StackExchange.Redis.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="1.2.6" />
+    <PackageReference Include="StackExchange.Redis" Version="1.2.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Downgrade the pair of StackExchange.Redis and StackExchange.Redis.StrongName NuGet packages to v1.2.3 to try to avoid a transient RedisConnectionException that's appearing with the current pair of v1.2.6 packages.

Sources that lead me to believe the issue doesn't occur on v1.2.3:
- https://github.com/StackExchange/StackExchange.Redis/issues/762
- https://github.com/StackExchange/StackExchange.Redis/issues/1533#issuecomment-666941212

@DataDog/apm-dotnet