### PR TITLE
Fix Datadog.Trace.ClrProfiler.IntegrationTests.StackExchangeRedisTests.SubmitsTraces

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     // { "DEL", $"DEL key" },
                     { "DUMP", $"DUMP key" },
                     { "EXISTS", $"EXISTS key" },
-                    { "PEXPIREAT", $"PEXPIREAT key" },
+                    { "PEXPIRE", $"PEXPIRE key" },
                     { "MOVE", $"MOVE key" },
                     { "PERSIST", $"PERSIST key" },
                     { "RANDOMKEY", $"RANDOMKEY" },
@@ -191,7 +191,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     // { "DEL", $"DEL {dbPrefix}Key" },
                     { "DUMP", $"DUMP {dbPrefix}Key" },
                     { "EXISTS", $"EXISTS {dbPrefix}Key" },
-                    { "PEXPIREAT", $"PEXPIREAT {dbPrefix}Key" },
+                    { "PEXPIRE", $"PEXPIRE {dbPrefix}Key" },
                     { "MIGRATE", $"MIGRATE {dbPrefix}Key" }, // Only present on 1.0.297+
                     { "MOVE", $"MOVE {dbPrefix}Key" },
                     { "PERSIST", $"PERSIST {dbPrefix}Key" },

--- a/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -8,6 +8,11 @@ namespace Samples.StackExchangeRedis
 {
     class Program
     {
+        // Set the expire timespan so it cannot be represented in seconds, so the resulting redis command will always be PEXPIRE.
+        // This removes a bug where *sometimes* the expire could be represented as seconds and the resulting redis command
+        // was occasionally EXPIRE.
+        private static readonly TimeSpan ExpireTimeSpan = TimeSpan.FromMilliseconds(1500);
+
         static void Main(string[] args)
         {
             string prefix = "";
@@ -123,7 +128,7 @@ namespace Samples.StackExchangeRedis
                 { "KeyDelete", () => db.KeyDelete($"{prefix}Key") },
                 { "KeyDump", () => db.KeyDump($"{prefix}Key") },
                 { "KeyExists", () => db.KeyExists($"{prefix}Key") },
-                { "KeyExpire", () => db.KeyExpire($"{prefix}Key", DateTime.Now) },
+                { "KeyExpire", () => db.KeyExpire($"{prefix}Key", ExpireTimeSpan) },
 #if (STACKEXCHANGEREDIS_1_0_297 && !DEFAULT_SAMPLES)
                 { "KeyMigrate", () => { db.KeyMigrate($"{prefix}Key", db.IdentifyEndpoint());  return null; } },
 #endif
@@ -262,7 +267,7 @@ namespace Samples.StackExchangeRedis
                 { "KeyDeleteAsync", () => db.KeyDeleteAsync("key") },
                 { "KeyDumpAsync", () => db.KeyDumpAsync("key") },
                 { "KeyExistsAsync", () => db.KeyExistsAsync("key") },
-                { "KeyExpireAsync", () => db.KeyExpireAsync("key", DateTime.Now) },
+                { "KeyExpireAsync", () => db.KeyExpireAsync("key", ExpireTimeSpan) },
                 // () => db.KeyMigrateAsync("key", ???)
                 { "KeyMoveAsync", () => db.KeyMoveAsync("key", 1) },
                 { "KeyPersistAsync", () => db.KeyPersistAsync("key") },


### PR DESCRIPTION
The KeyExpire API calls used `DateTime.Now` whose timestamp could sometimes be represented as a multiple of seconds and other times as a multiple of milliseconds. This variability meant the resulting redis command could sometimes be EXPIREAT (seconds) and sometimes PEXPIREAT (milliseconds).

The fix is to make the final redis command deterministic by using a TimeSpan instead, so the command will always be PEXPIRE.

@DataDog/apm-dotnet