### PR TITLE
Enable SocketsHttpHandler, CurlHandler and WinHttpHandler integrations by default

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/CurlHandler/CurlHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/CurlHandler/CurlHandlerIntegration.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.CurlHand
         private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
         private static readonly IntegrationInfo CurlHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.CurlHandler));
-        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(CurlHandlerIntegrationId, defaultValue: false);
+        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(CurlHandlerIntegrationId, defaultValue: true);
 
         /// <summary>
         /// OnMethodBegin callback

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/SocketsHttpHandler/SocketsHttpHandlerIntegration.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.SocketsH
         private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
         private static readonly IntegrationInfo SocketHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.HttpSocketsHandler));
-        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(SocketHandlerIntegrationId, defaultValue: false);
+        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(SocketHandlerIntegrationId, defaultValue: true);
 
         /// <summary>
         /// OnMethodBegin callback

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/SocketsHttpHandler/SocketsHttpHandlerSyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/SocketsHttpHandler/SocketsHttpHandlerSyncIntegration.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.SocketsH
         private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
         private static readonly IntegrationInfo SocketHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.HttpSocketsHandler));
-        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(SocketHandlerIntegrationId, defaultValue: false);
+        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(SocketHandlerIntegrationId, defaultValue: true);
 
         /// <summary>
         /// OnMethodBegin callback

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/WinHttpHandler/WinHttpHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Http/HttpClient/WinHttpHandler/WinHttpHandlerIntegration.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.WinHttpH
         private const string IntegrationName = nameof(IntegrationIds.HttpMessageHandler);
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
         private static readonly IntegrationInfo WinHttpHandlerIntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.WinHttpHandler));
-        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(WinHttpHandlerIntegrationId, defaultValue: false);
+        private static readonly Func<bool> IsIntegrationEnabledFunc = () => Tracer.Instance.Settings.IsIntegrationEnabled(WinHttpHandlerIntegrationId, defaultValue: true);
 
         /// <summary>
         /// OnMethodBegin callback


### PR DESCRIPTION
This pr enables SocketsHttpHandler, CurlHandler and WinHttpHandler integrations by default.


@DataDog/apm-dotnet