### PR TITLE
Include the count in the proxytype name to avoid name collisions.

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -34,6 +34,8 @@ namespace Datadog.Trace.DuckTyping
         private static ModuleBuilder _moduleBuilder = null;
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static AssemblyBuilder _assemblyBuilder = null;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static long _typeCount = 0;
 
         /// <summary>
         /// DynamicMethods delegates cache

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -151,7 +151,7 @@ namespace Datadog.Trace.DuckTyping
                     }
 
                     // Create a valid type name that can be used as a member of a class. (BenchmarkDotNet fails if is an invalid name)
-                    string proxyTypeName = $"{assembly}.{targetType.FullName.Replace(".", "_").Replace("+", "__")}.{proxyDefinitionType.FullName.Replace(".", "_").Replace("+", "__")}";
+                    string proxyTypeName = $"{assembly}.{targetType.FullName.Replace(".", "_").Replace("+", "__")}.{proxyDefinitionType.FullName.Replace(".", "_").Replace("+", "__")}_{++_typeCount}";
 
                     // Create Type
                     TypeBuilder proxyTypeBuilder = _moduleBuilder.DefineType(


### PR DESCRIPTION
This PR appends the type count in the proxy type name to avoid name collisions (possible when ducktyping the same type from different contexts).


@DataDog/apm-dotnet