### PR TITLE
Fix Container Tagging in Fargate 1.4

### DIFF
--- a/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -16,7 +16,8 @@ namespace Datadog.Trace.PlatformHelpers
         private const string ControlGroupsFilePath = "/proc/self/cgroup";
         private const string ContainerRegex = @"[0-9a-f]{64}";
         private const string UuidRegex = @"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}";
-        private const string ContainerIdRegex = @"^(?:\d+):(?:[^:]*):/?(?:.+/)(" + UuidRegex + "|" + ContainerRegex + @"(?:\.scope)?)$";
+        private const string TaskRegex = @"[0-9a-f]{32}-\d+";
+        private const string ContainerIdRegex = @"^(?:\d+):(?:[^:]*):/?(?:.+/)(" + UuidRegex + "|" + ContainerRegex + "|" + TaskRegex + @"(?:\.scope)?)$";
 
         private static readonly Lazy<string> ContainerId = new Lazy<string>(GetContainerIdInternal, LazyThreadSafetyMode.ExecutionAndPublication);
 

--- a/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -14,8 +14,9 @@ namespace Datadog.Trace.PlatformHelpers
     internal static class ContainerMetadata
     {
         private const string ControlGroupsFilePath = "/proc/self/cgroup";
-
-        private const string ContainerIdRegex = @"^(?:\d+):(?:[^:]*):/?(?:.+/)([0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|[0-9a-f]{64}(?:\.scope)?)$";
+        private const string ContainerRegex = @"[0-9a-f]{64}";
+        private const string UuidRegex = @"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}";
+        private const string ContainerIdRegex = @"^(?:\d+):(?:[^:]*):/?(?:.+/)(" + UuidRegex + "|" + ContainerRegex + @"(?:\.scope)?)$";
 
         private static readonly Lazy<string> ContainerId = new Lazy<string>(GetContainerIdInternal, LazyThreadSafetyMode.ExecutionAndPublication);
 

--- a/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 1:blkio:/ecs/haissam-ecs-classic/5a0d5ceddf6c44c1928d367a815d890f/38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce
 ";
 
-        public const string Fargate = @"
+        public const string Fargate1Dot3 = @"
 11:hugetlb:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
 10:pids:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
 9:cpuset:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
@@ -62,12 +62,27 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 1:name=systemd:/ecs/55091c13-b8cf-4801-b527-f4601742204d/432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da
 ";
 
+        public const string Fargate1Dot4 = @"
+11:hugetlb:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+10:pids:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+9:cpuset:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+8:net_cls,net_prio:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+7:cpu,cpuacct:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+6:perf_event:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+5:freezer:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+4:devices:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+3:blkio:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+2:memory:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+1:name=systemd:/ecs/34dc0b5e626f2c5c4c5170e34b10e765-1234567890
+";
+
         public static IEnumerable<object[]> GetCgroupFiles()
         {
             yield return new object[] { Docker, "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860" };
             yield return new object[] { Kubernetes, "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1" };
             yield return new object[] { Ecs, "38fac3e99302b3622be089dd41e7ccf38aff368a86cc339972075136ee2710ce" };
-            yield return new object[] { Fargate, "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da" };
+            yield return new object[] { Fargate1Dot3, "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da" };
+            yield return new object[] { Fargate1Dot4, "34dc0b5e626f2c5c4c5170e34b10e765-1234567890" };
         }
 
         /// <summary>


### PR DESCRIPTION
The Format of the cgroups file was changed in Fargate 1.4. We now extract the 'task id' from cgroups file, and report as 'Datadog-Container-ID' tag by tracers.