### PR TITLE
Update ASP.NET / MVC / WebApi2 Resource Names

### DIFF
--- a/src/Datadog.Trace.AspNet/SharedConstants.cs
+++ b/src/Datadog.Trace.AspNet/SharedConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace Datadog.Trace.AspNet
+{
+    internal static class SharedConstants
+    {
+        public const string HttpContextPropagatedResourceNameKey = "__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename";
+    }
+}

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -161,6 +161,13 @@ namespace Datadog.Trace.AspNet
                     app.Context.Items[_httpContextScopeKey] is Scope scope)
                 {
                     scope.Span.SetHttpStatusCode(app.Context.Response.StatusCode, isServer: true);
+
+                    if (app.Context.Items["__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename"] is string resourceName
+                        && !string.IsNullOrEmpty(resourceName))
+                    {
+                        scope.Span.ResourceName = resourceName;
+                    }
+
                     scope.Dispose();
                 }
             }

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.AspNet
                     }
                     else
                     {
-                        string path = UriHelpers.GetRelativeUrl(app.Request.Url, tryRemoveIds: true);
+                        string path = UriHelpers.GetCleanUriPath(app.Request.Url);
                         scope.Span.ResourceName = $"{app.Request.HttpMethod.ToUpperInvariant()} {path.ToLowerInvariant()}";
                     }
 

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -161,7 +161,7 @@ namespace Datadog.Trace.AspNet
                 {
                     scope.Span.SetHttpStatusCode(app.Context.Response.StatusCode, isServer: true);
 
-                    if (app.Context.Items["__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename"] is string resourceName
+                    if (app.Context.Items[SharedConstants.HttpContextPropagatedResourceNameKey] is string resourceName
                         && !string.IsNullOrEmpty(resourceName))
                     {
                         scope.Span.ResourceName = resourceName;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
@@ -50,4 +50,10 @@ Users who need manual instrumentation should reference the "Datadog.Trace" packa
     <!-- Include Datadog.Trace.Build assembly as a reference for publishing purposes -->
     <ProjectReference Include="..\Datadog.Trace.MSBuild\Datadog.Trace.MSBuild.csproj" PrivateAssets="all" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Datadog.Trace.AspNet\SharedConstants.cs">
+      <Link>Integrations\AspNet\SharedConstants.cs</Link>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -90,21 +90,34 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     }
                 }
 
+                string routeUrl = route?.Url;
+                string areaName = (routeValues?.GetValueOrDefault("area") as string)?.ToLowerInvariant();
+                string controllerName = (routeValues?.GetValueOrDefault("controller") as string)?.ToLowerInvariant();
+                string actionName = (routeValues?.GetValueOrDefault("action") as string)?.ToLowerInvariant();
+
+                if (string.IsNullOrEmpty(resourceName) && !string.IsNullOrEmpty(routeUrl))
+                {
+                    resourceName = $"{httpMethod} /{routeUrl.ToLowerInvariant()}";
+                }
+
                 if (string.IsNullOrEmpty(resourceName) && httpContext.Request.Url != null)
                 {
                     var cleanUri = UriHelpers.GetRelativeUrl(httpContext.Request.Url, tryRemoveIds: true);
                     resourceName = $"{httpMethod} {cleanUri.ToLowerInvariant()}";
                 }
 
-                string areaName = (routeValues?.GetValueOrDefault("area") as string)?.ToLowerInvariant();
-                string controllerName = (routeValues?.GetValueOrDefault("controller") as string)?.ToLowerInvariant();
-                string actionName = (routeValues?.GetValueOrDefault("action") as string)?.ToLowerInvariant();
-
                 if (string.IsNullOrEmpty(resourceName))
                 {
                     // Keep the legacy resource name, just to have something
                     resourceName = $"{httpMethod} {controllerName}.{actionName}";
                 }
+
+                // Fail safe to catch templates in routing values
+                resourceName =
+                    resourceName
+                       .Replace("{area}", areaName)
+                       .Replace("{controller}", controllerName)
+                       .Replace("{action}", actionName);
 
                 SpanContext propagatedContext = null;
                 var tracer = Tracer.Instance;
@@ -129,13 +142,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 scope = Tracer.Instance.StartActiveWithTags(OperationName, propagatedContext, tags: tags);
                 Span span = scope.Span;
 
-                // Fail safe to catch templates in routing values
-                resourceName =
-                    resourceName
-                       .Replace("{area}", areaName)
-                       .Replace("{controller}", controllerName)
-                       .Replace("{action}", actionName);
-
                 span.DecorateWebServerSpan(
                     resourceName: resourceName,
                     method: httpMethod,
@@ -144,7 +150,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     tags,
                     tagsFromHeaders);
 
-                tags.AspNetRoute = route?.Url;
+                tags.AspNetRoute = routeUrl;
                 tags.AspNetArea = areaName;
                 tags.AspNetController = controllerName;
                 tags.AspNetAction = actionName;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using System.Web.Routing;
+using Datadog.Trace.AspNet;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ClrProfiler.Integrations.AspNet;
 using Datadog.Trace.Configuration;
@@ -180,7 +181,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 if (newResourceNamesEnabled)
                 {
                     // set the resource name in the HttpContext so TracingHttpModule can update root span
-                    httpContext.Items["__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename"] = resourceName;
+                    httpContext.Items[SharedConstants.HttpContextPropagatedResourceNameKey] = resourceName;
                 }
             }
             catch (Exception ex)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -65,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 RouteData routeData = controllerContext.RouteData;
                 Route route = routeData?.Route as Route;
                 RouteValueDictionary routeValues = routeData?.Values;
+                bool wasAttributeRouted = false;
 
                 if (route == null && routeData?.Route.GetType().FullName == RouteCollectionRouteTypeName)
                 {
@@ -74,6 +75,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     {
                         // route was defined using attribute routing i.e. [Route("/path/{id}")]
                         // get route and routeValues from the RouteData in routeMatches
+                        wasAttributeRouted = true;
                         route = routeMatches[0].Route as Route;
                         routeValues = routeMatches[0].Values;
 
@@ -118,6 +120,23 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                        .Replace("{area}", areaName)
                        .Replace("{controller}", controllerName)
                        .Replace("{action}", actionName);
+
+                if (!wasAttributeRouted && routeValues is not null && route is not null)
+                {
+                    // Remove unused parameters from conventional route templates
+                    // Don't bother with routes defined using attribute routing
+                    foreach (var parameter in route.Defaults)
+                    {
+                        var parameterName = parameter.Key;
+                        if (parameterName != "area"
+                            && parameterName != "controller"
+                            && parameterName != "action"
+                            && !routeValues.ContainsKey(parameterName))
+                        {
+                            resourceName = resourceName.Replace($"/{{{parameterName}}}", string.Empty);
+                        }
+                    }
+                }
 
                 SpanContext propagatedContext = null;
                 var tracer = Tracer.Instance;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -156,6 +156,9 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 tags.AspNetAction = actionName;
 
                 tags.SetAnalyticsSampleRate(IntegrationId, tracer.Settings, enabledWithGlobalSetting: true);
+
+                // set the resource name in the HttpContext so TracingHttpModule can update it
+                httpContext.Items["__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename"] = resourceName;
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 if (string.IsNullOrEmpty(resourceName) && httpContext.Request.Url != null)
                 {
-                    var cleanUri = UriHelpers.GetRelativeUrl(httpContext.Request.Url, tryRemoveIds: true);
+                    var cleanUri = UriHelpers.GetCleanUriPath(httpContext.Request.Url);
                     resourceName = $"{httpMethod} {cleanUri.ToLowerInvariant()}";
                 }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     resourceName = $"{httpMethod} {controllerName}.{actionName}";
                 }
 
-                // Fail safe to catch templates in routing values
+                // Replace well-known routing tokens
                 resourceName =
                     resourceName
                        .Replace("{area}", areaName)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     return null;
                 }
 
-                var newResourceNamesEnabled = Tracer.Instance.Settings.AspnetRouteTemplateResourceNamesEnabled;
+                var newResourceNamesEnabled = Tracer.Instance.Settings.RouteTemplateResourceNamesEnabled;
                 string host = httpContext.Request.Headers.Get("Host");
                 string httpMethod = httpContext.Request.HttpMethod.ToUpperInvariant();
                 string url = httpContext.Request.RawUrl.ToLowerInvariant();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -318,6 +318,16 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 tags.AspNetController = controller;
                 tags.AspNetArea = area;
                 tags.AspNetRoute = route;
+
+                if (Tracer.Instance.Settings.AspnetRouteTemplateResourceNamesEnabled)
+                {
+                    // set the resource name in the HttpContext so TracingHttpModule can update root span
+                    var httpContext = System.Web.HttpContext.Current;
+                    if (httpContext is not null)
+                    {
+                        httpContext.Items["__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename"] = resourceName;
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -254,6 +254,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             try
             {
+                var newResourceNamesEnabled = Tracer.Instance.Settings.AspnetRouteTemplateResourceNamesEnabled;
                 var request = controllerContext.Request;
                 Uri requestUri = request.RequestUri;
 
@@ -270,16 +271,20 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                 }
 
-                string resourceName = $"{method} {absoluteUri.ToLowerInvariant()}";
+                string resourceName;
 
                 if (route != null)
                 {
-                    resourceName = $"{method} {route.ToLowerInvariant()}";
+                    resourceName = $"{method} {(newResourceNamesEnabled ? "/" : string.Empty)}{route.ToLowerInvariant()}";
                 }
                 else if (requestUri != null)
                 {
                     var cleanUri = UriHelpers.GetRelativeUrl(requestUri, tryRemoveIds: true);
                     resourceName = $"{method} {cleanUri.ToLowerInvariant()}";
+                }
+                else
+                {
+                    resourceName = $"{method} {absoluteUri.ToLowerInvariant()}";
                 }
 
                 string controller = string.Empty;
@@ -319,7 +324,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 tags.AspNetArea = area;
                 tags.AspNetRoute = route;
 
-                if (Tracer.Instance.Settings.AspnetRouteTemplateResourceNamesEnabled)
+                if (newResourceNamesEnabled)
                 {
                     // set the resource name in the HttpContext so TracingHttpModule can update root span
                     var httpContext = System.Web.HttpContext.Current;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -304,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                 }
 
-                // Fail safe to catch templates in routing values
+                // Replace well-known routing tokens
                 resourceName =
                     resourceName
                        .Replace("{area}", area)

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -279,7 +279,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
                 else if (requestUri != null)
                 {
-                    var cleanUri = UriHelpers.GetRelativeUrl(requestUri, tryRemoveIds: true);
+                    var cleanUri = UriHelpers.GetCleanUriPath(requestUri);
                     resourceName = $"{method} {cleanUri.ToLowerInvariant()}";
                 }
                 else

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -260,7 +260,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 string host = request.Headers.Host ?? string.Empty;
                 string rawUrl = requestUri?.ToString().ToLowerInvariant() ?? string.Empty;
-                string absoluteUri = requestUri?.AbsoluteUri?.ToLowerInvariant() ?? string.Empty;
                 string method = request.Method.Method?.ToUpperInvariant() ?? "GET";
                 string route = null;
                 try
@@ -284,7 +283,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 }
                 else
                 {
-                    resourceName = $"{method} {absoluteUri.ToLowerInvariant()}";
+                    resourceName = $"{method}";
                 }
 
                 string controller = string.Empty;

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         {
             try
             {
-                var newResourceNamesEnabled = Tracer.Instance.Settings.AspnetRouteTemplateResourceNamesEnabled;
+                var newResourceNamesEnabled = Tracer.Instance.Settings.RouteTemplateResourceNamesEnabled;
                 var request = controllerContext.Request;
                 Uri requestUri = request.RequestUri;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.AspNet;
 using Datadog.Trace.ClrProfiler.Emit;
 using Datadog.Trace.ClrProfiler.Helpers;
 using Datadog.Trace.ClrProfiler.Integrations.AspNet;
@@ -329,7 +330,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     var httpContext = System.Web.HttpContext.Current;
                     if (httpContext is not null)
                     {
-                        httpContext.Items["__Datadog.Trace.ClrProfiler.Managed.AspNetMvcIntegration-aspnet.resourcename"] = resourceName;
+                        httpContext.Items[SharedConstants.HttpContextPropagatedResourceNameKey] = resourceName;
                     }
                 }
             }

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -342,7 +342,7 @@ namespace Datadog.Trace.Configuration
         internal static class FeatureFlags
         {
             /// <summary>
-            /// Feature Flag for whether to enable the updated ASP.NET resource names
+            /// Feature Flag: enables updated resource names on `aspnet.request`, `aspnet-mvc.request`, and `aspnet-webapi.request` spans
             /// </summary>
             /// <seealso cref="TracerSettings.AspnetRouteTemplateResourceNamesEnabled"/>
             public const string AspnetRouteTemplateResourceNamesEnabled = "DD_TRACE_ASPNET_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED";

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -338,5 +338,13 @@ namespace Datadog.Trace.Configuration
             /// </summary>
             public const string ForceFallbackLookup = "DD_TRACE_DEBUG_LOOKUP_FALLBACK";
         }
+
+        internal static class FeatureFlags
+        {
+            /// <summary>
+            /// Feature Flag for whether .NET Standard mode is enabled
+            /// </summary>
+            public const string NetStandardEnabled = "DD_TRACE_NETSTANDARD_ENABLED";
+        }
     }
 }

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -342,6 +342,12 @@ namespace Datadog.Trace.Configuration
         internal static class FeatureFlags
         {
             /// <summary>
+            /// Feature Flag for whether to enable the updated ASP.NET resource names
+            /// </summary>
+            /// <seealso cref="TracerSettings.AspnetRouteTemplateResourceNamesEnabled"/>
+            public const string AspnetRouteTemplateResourceNamesEnabled = "DD_TRACE_ASPNET_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED";
+
+            /// <summary>
             /// Feature Flag for whether .NET Standard mode is enabled
             /// </summary>
             public const string NetStandardEnabled = "DD_TRACE_NETSTANDARD_ENABLED";

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -348,7 +348,7 @@ namespace Datadog.Trace.Configuration
             public const string AspnetRouteTemplateResourceNamesEnabled = "DD_TRACE_ASPNET_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED";
 
             /// <summary>
-            /// Feature Flag for whether .NET Standard mode is enabled
+            /// Feature Flag: enables instrumenting calls to netstandard.dll (only applies to CallSite instrumentation)
             /// </summary>
             public const string NetStandardEnabled = "DD_TRACE_NETSTANDARD_ENABLED";
         }

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -342,10 +342,12 @@ namespace Datadog.Trace.Configuration
         internal static class FeatureFlags
         {
             /// <summary>
-            /// Feature Flag: enables updated resource names on `aspnet.request`, `aspnet-mvc.request`, and `aspnet-webapi.request` spans
+            /// Feature Flag: enables updated resource names on `aspnet.request`, `aspnet-mvc.request`,
+            /// `aspnet-webapi.request`, and `aspnet_core.request` spans. Enables `aspnet_core.mvc` spans and
+            /// additional features on `aspnet_core.request` spans.
             /// </summary>
-            /// <seealso cref="TracerSettings.AspnetRouteTemplateResourceNamesEnabled"/>
-            public const string AspnetRouteTemplateResourceNamesEnabled = "DD_TRACE_ASPNET_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED";
+            /// <seealso cref="TracerSettings.RouteTemplateResourceNamesEnabled"/>
+            public const string RouteTemplateResourceNamesEnabled = "DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED";
 
             /// <summary>
             /// Feature Flag: enables instrumenting calls to netstandard.dll (only applies to CallSite instrumentation)

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -181,7 +181,8 @@ namespace Datadog.Trace.Configuration
             TraceBatchInterval = source?.GetInt32(ConfigurationKeys.SerializationBatchInterval)
                         ?? 100;
 
-            AspnetRouteTemplateResourceNamesEnabled = IsFeatureFlagEnabled(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled);
+            AspnetRouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled)
+                                                   ?? false;
         }
 
         /// <summary>
@@ -496,12 +497,7 @@ namespace Datadog.Trace.Configuration
 
         internal bool IsNetStandardFeatureFlagEnabled()
         {
-            return IsFeatureFlagEnabled(ConfigurationKeys.FeatureFlags.NetStandardEnabled);
-        }
-
-        internal bool IsFeatureFlagEnabled(string featureFlag)
-        {
-            var value = EnvironmentHelpers.GetEnvironmentVariable(featureFlag, string.Empty);
+            var value = EnvironmentHelpers.GetEnvironmentVariable("DD_TRACE_NETSTANDARD_ENABLED", string.Empty);
 
             return value == "1" || value == "true";
         }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -181,7 +181,7 @@ namespace Datadog.Trace.Configuration
             TraceBatchInterval = source?.GetInt32(ConfigurationKeys.SerializationBatchInterval)
                         ?? 100;
 
-            AspnetRouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled)
+            RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
                                                    ?? false;
         }
 
@@ -388,8 +388,8 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled"/>
-        internal bool AspnetRouteTemplateResourceNamesEnabled { get; }
+        /// <seealso cref="ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled"/>
+        internal bool RouteTemplateResourceNamesEnabled { get; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -180,6 +180,8 @@ namespace Datadog.Trace.Configuration
 
             TraceBatchInterval = source?.GetInt32(ConfigurationKeys.SerializationBatchInterval)
                         ?? 100;
+
+            AspnetRouteTemplateResourceNamesEnabled = IsFeatureFlagEnabled(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled);
         }
 
         /// <summary>
@@ -381,6 +383,12 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating the batch interval for the serialization queue, in milliseconds
         /// </summary>
         internal int TraceBatchInterval { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
+        internal bool AspnetRouteTemplateResourceNamesEnabled { get; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -388,7 +388,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled
         /// </summary>
-        /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
+        /// <seealso cref="ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled"/>
         internal bool AspnetRouteTemplateResourceNamesEnabled { get; }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -488,7 +488,12 @@ namespace Datadog.Trace.Configuration
 
         internal bool IsNetStandardFeatureFlagEnabled()
         {
-            var value = EnvironmentHelpers.GetEnvironmentVariable("DD_TRACE_NETSTANDARD_ENABLED", string.Empty);
+            return IsFeatureFlagEnabled(ConfigurationKeys.FeatureFlags.NetStandardEnabled);
+        }
+
+        internal bool IsFeatureFlagEnabled(string featureFlag)
+        {
+            var value = EnvironmentHelpers.GetEnvironmentVariable(featureFlag, string.Empty);
 
             return value == "1" || value == "true";
         }

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -278,7 +278,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     absolutePath = request.PathBase.Value + absolutePath;
                 }
 
-                string resourceUrl = UriHelpers.GetRelativeUrl(absolutePath, tryRemoveIds: true)
+                string resourceUrl = UriHelpers.CleanUriSegment(absolutePath)
                                                .ToLowerInvariant();
 
                 string resourceName = $"{httpMethod} {resourceUrl}";

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -278,7 +278,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     absolutePath = request.PathBase.Value + absolutePath;
                 }
 
-                string resourceUrl = UriHelpers.CleanUriSegment(absolutePath)
+                string resourceUrl = UriHelpers.GetCleanUriPath(absolutePath)
                                                .ToLowerInvariant();
 
                 string resourceName = $"{httpMethod} {resourceUrl}";

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -537,6 +537,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("netstandard_enabled");
                     writer.WriteValue(Settings.IsNetStandardFeatureFlagEnabled());
 
+                    writer.WritePropertyName("routetemplate_resourcenames_enabled");
+                    writer.WriteValue(Settings.RouteTemplateResourceNamesEnabled);
+
                     writer.WritePropertyName("agent_reachable");
                     writer.WriteValue(agentError == null);
 

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.Util
     {
         public static string CleanUri(Uri uri, bool removeScheme, bool tryRemoveIds)
         {
-            var path = tryRemoveIds ? CleanUriSegment(uri.AbsolutePath) : uri.AbsolutePath;
+            var path = tryRemoveIds ? GetCleanUriPath(uri.AbsolutePath) : uri.AbsolutePath;
 
             if (removeScheme)
             {
@@ -23,10 +23,10 @@ namespace Datadog.Trace.Util
 
         public static string GetCleanUriPath(Uri uri)
         {
-            return CleanUriSegment(uri.AbsolutePath);
+            return GetCleanUriPath(uri.AbsolutePath);
         }
 
-        public static string CleanUriSegment(string absolutePath)
+        public static string GetCleanUriPath(string absolutePath)
         {
             if (string.IsNullOrWhiteSpace(absolutePath) || (absolutePath.Length == 1 && absolutePath[0] == '/'))
             {

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -21,6 +21,21 @@ namespace Datadog.Trace.Util
             return $"{uri.Scheme}{Uri.SchemeDelimiter}{uri.Authority}{path}";
         }
 
+        [Obsolete("This method is deprecated and will be removed. Use GetCleanUriPath() instead. " +
+                  "Kept for backwards compatability where there is a version mismatch between manual and automatic instrumentation")]
+        public static string GetRelativeUrl(Uri uri, bool tryRemoveIds)
+            => GetRelativeUrl(uri.AbsolutePath, tryRemoveIds);
+
+        [Obsolete("This method is deprecated and will be removed. Use GetCleanUriPath() instead. " +
+                  "Kept for backwards compatability where there is a version mismatch between manual and automatic instrumentation")]
+        public static string GetRelativeUrl(string uri, bool tryRemoveIds)
+            => tryRemoveIds ? GetCleanUriPath(uri) : uri;
+
+        [Obsolete("This method is deprecated and will be removed. Use GetCleanUriPath() instead. " +
+                  "Kept for backwards compatability where there is a version mismatch between manual and automatic instrumentation")]
+        public static string CleanUriSegment(string absolutePath)
+            => GetCleanUriPath(absolutePath);
+
         public static string GetCleanUriPath(Uri uri)
         {
             return GetCleanUriPath(uri.AbsolutePath);

--- a/src/Datadog.Trace/Util/UriHelpers.cs
+++ b/src/Datadog.Trace/Util/UriHelpers.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.Util
     {
         public static string CleanUri(Uri uri, bool removeScheme, bool tryRemoveIds)
         {
-            var path = GetRelativeUrl(uri, tryRemoveIds);
+            var path = tryRemoveIds ? CleanUriSegment(uri.AbsolutePath) : uri.AbsolutePath;
 
             if (removeScheme)
             {
@@ -21,15 +21,9 @@ namespace Datadog.Trace.Util
             return $"{uri.Scheme}{Uri.SchemeDelimiter}{uri.Authority}{path}";
         }
 
-        public static string GetRelativeUrl(Uri uri, bool tryRemoveIds)
+        public static string GetCleanUriPath(Uri uri)
         {
-            return GetRelativeUrl(uri.AbsolutePath, tryRemoveIds);
-        }
-
-        public static string GetRelativeUrl(string uri, bool tryRemoveIds)
-        {
-            // try to remove segments that look like ids
-            return tryRemoveIds ? CleanUriSegment(uri) : uri;
+            return CleanUriSegment(uri.AbsolutePath);
         }
 
         public static string CleanUriSegment(string absolutePath)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4TestData.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4TestData.cs
@@ -5,7 +5,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public static class AspNetMvc4TestData
     {
-        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> Data => new()
+        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> WithoutFeatureFlag => new()
         {
             { "/Admin", "GET /admin", 200, false, null, null, AdminHomeIndexTags },
             { "/Admin/Home", "GET /admin/home", 200, false, null, null, AdminHomeIndexTags },
@@ -20,6 +20,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             { "/Home/OptionalIdentifier", "GET /home/optionalidentifier", 200, false, null, null, OptionalIdentifierTags },
             { "/Home/OptionalIdentifier/123", "GET /home/optionalidentifier/?", 200, false, null, null, OptionalIdentifierTags },
             { "/Home/OptionalIdentifier/BadValue", "GET /home/optionalidentifier/badvalue", 200, false, null, null, OptionalIdentifierTags },
+            { "/Home/StatusCode?value=201", "GET /home/statuscode", 201, false, null, null, StatusCodeTags },
+            { "/Home/StatusCode?value=503", "GET /home/statuscode", 503, true, null, "The HTTP response has status code 503.", StatusCodeTags },
+        };
+
+        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> WithFeatureFlag => new()
+        {
+            { "/Admin", "GET /admin/home/index", 200, false, null, null, AdminHomeIndexTags },
+            { "/Admin/Home", "GET /admin/home/index", 200, false, null, null, AdminHomeIndexTags },
+            { "/Admin/Home/Index", "GET /admin/home/index", 200, false, null, null, AdminHomeIndexTags },
+            { "/", "GET /home/index", 200, false, null, null, HomeIndexTags },
+            { "/Home", "GET /home/index", 200, false, null, null, HomeIndexTags },
+            { "/Home/Index", "GET /home/index", 200, false, null, null, HomeIndexTags },
+            { "/Home/BadRequest", "GET /home/badrequest", 500, true, "System.Exception", "Oops, it broke.", BadRequestTags },
+            { "/Home/identifier", "GET /home/identifier", 500, true, "System.ArgumentException", MissingParameterError, IdentifierTags },
+            { "/Home/identifier/123", "GET /home/identifier/{id}", 200, false, null, null, IdentifierTags },
+            { "/Home/identifier/BadValue", "GET /home/identifier/{id}", 500, true, "System.ArgumentException", MissingParameterError, IdentifierTags },
+            { "/Home/OptionalIdentifier/", "GET /home/optionalidentifier", 200, false, null, null, OptionalIdentifierTags },
+            { "/Home/OptionalIdentifier/123", "GET /home/optionalidentifier/{id}", 200, false, null, null, OptionalIdentifierTags },
+            { "/Home/OptionalIdentifier/BadValue", "GET /home/optionalidentifier/{id}", 200, false, null, null, OptionalIdentifierTags },
             { "/Home/StatusCode?value=201", "GET /home/statuscode", 201, false, null, null, StatusCodeTags },
             { "/Home/StatusCode?value=503", "GET /home/statuscode", 503, true, null, "The HTTP response has status code 503.", StatusCodeTags },
         };

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [MemberData(nameof(AspNetMvc4TestData.Data), MemberType = typeof(AspNetMvc4TestData))]
+        [MemberData(nameof(AspNetMvc4TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc4TestData))]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
@@ -4,6 +4,7 @@
 
 using System.Net;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,41 +12,42 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallsite : AspNetMvc5Tests
+    public class AspNetMvc4WithFeatureFlagTestsCallsite : AspNetMvc4WithFeatureFlagTests
     {
-        public AspNetMvc5TestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc4WithFeatureFlagTestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
             : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
         {
         }
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallTargetNoInlining : AspNetMvc5Tests
+    public class AspNetMvc4WithFeatureFlagTestsCallTargetNoInlining : AspNetMvc4WithFeatureFlagTests
     {
-        public AspNetMvc5TestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc4WithFeatureFlagTestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
             : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
         {
         }
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallTarget : AspNetMvc5Tests
+    public class AspNetMvc4WithFeatureFlagTestsCallTarget : AspNetMvc4WithFeatureFlagTests
     {
-        public AspNetMvc5TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc4WithFeatureFlagTestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
             : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
         {
         }
     }
 
-    public abstract class AspNetMvc5Tests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetMvc4WithFeatureFlagTests : TestHelper, IClassFixture<IisFixture>
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetMvc5Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
-            : base("AspNetMvc5", @"test\test-applications\aspnet", output)
+        public AspNetMvc4WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+            : base("AspNetMvc4", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
             SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled, "true");
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);
@@ -54,15 +56,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [MemberData(nameof(AspNetMvc5TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
-        public async Task SubmitsTraces(
+        [MemberData(nameof(AspNetMvc4TestData.WithFeatureFlag), MemberType = typeof(AspNetMvc4TestData))]
+        public async Task WithNewResourceNames_SubmitsTraces(
             string path,
             string expectedResourceName,
             HttpStatusCode expectedStatusCode,
             bool isError,
             string expectedErrorType,
             string expectedErrorMessage,
-            SerializableDictionary expectedTags)
+            SerializableDictionary tags)
         {
             await AssertWebServerSpan(
                 path,
@@ -76,8 +78,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 "aspnet-mvc.request",
                 expectedResourceName,
                 "1.0.0",
-                expectedTags);
+                tags);
         }
     }
 }
+
 #endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
             SetCallTargetSettings(enableCallTarget, enableInlining);
-            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled, "true");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5TestData.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5TestData.cs
@@ -5,8 +5,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class AspNetMvc5TestData
     {
-        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> Data => new()
+        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> WithoutFeatureFlag => new()
         {
+            { "/DataDog", "GET /datadog", 200, false, null, null, DatadogAreaTags },
             { "/DataDog/DogHouse", "GET /datadog/doghouse", 200, false, null, null, DatadogAreaTags },
             { "/DataDog/DogHouse/Woof", "GET /datadog/doghouse/woof", 200, false, null, null, DatadogAreaWoofTags },
             { "/", "GET /", 200, false, null, null, HomeIndexTags },
@@ -14,6 +15,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             { "/Home/Index", "GET /home/index", 200, false, null, null, HomeIndexTags },
             { "/Home/Get", "GET /home/get", 500, true, "System.ArgumentException", MissingParameterError, HomeGetTags },
             { "/Home/Get/3", "GET /home/get/?", 200, false, null, null, HomeGetTags },
+            { "/delay/0", "GET /delay/{seconds}", 200, false, null, null, DelayTags },
+            { "/delay-async/0", "GET /delay-async/{seconds}", 200, false, null, null, DelayAsyncTags },
+            { "/delay-optional", "GET /delay-optional/{seconds}", 200, false, null, null, DelayOptionalTags },
+            { "/delay-optional/1", "GET /delay-optional/{seconds}", 200, false, null, null, DelayOptionalTags },
+            { "/badrequest", "GET /badrequest", 500, true, "System.Exception", "Oops, it broke.", BadRequestTags },
+            { "/statuscode/201", "GET /statuscode/{value}", 201, false, null, null, StatusCodeTags },
+            { "/statuscode/503", "GET /statuscode/{value}", 503, true, null, "The HTTP response has status code 503.", StatusCodeTags },
+        };
+
+        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> WithFeatureFlag => new()
+        {
+            { "/DataDog/", "GET /datadog/doghouse/index", 200, false, null, null, DatadogAreaTags },
+            { "/DataDog/DogHouse", "GET /datadog/doghouse/index", 200, false, null, null, DatadogAreaTags },
+            { "/DataDog/DogHouse/Woof", "GET /datadog/doghouse/woof", 200, false, null, null, DatadogAreaWoofTags },
+            { "/", "GET /home/index", 200, false, null, null, HomeIndexTags },
+            { "/Home", "GET /home/index", 200, false, null, null, HomeIndexTags },
+            { "/Home/Index", "GET /home/index", 200, false, null, null, HomeIndexTags },
+            { "/Home/Get", "GET /home/get", 500, true, "System.ArgumentException", MissingParameterError, HomeGetTags },
+            { "/Home/Get/3", "GET /home/get/{id}", 200, false, null, null, HomeGetTags },
             { "/delay/0", "GET /delay/{seconds}", 200, false, null, null, DelayTags },
             { "/delay-async/0", "GET /delay-async/{seconds}", 200, false, null, null, DelayAsyncTags },
             { "/delay-optional", "GET /delay-optional/{seconds}", 200, false, null, null, DelayOptionalTags },

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base("AspNetMvc5", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
-            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled, "true");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
             SetCallTargetSettings(enableCallTarget, enableInlining);
 
             _iisFixture = iisFixture;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
@@ -4,6 +4,7 @@
 
 using System.Net;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -11,40 +12,41 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallsite : AspNetMvc5Tests
+    public class AspNetMvc5WithFeatureFlagCallsite : AspNetMvc5WithFeatureFlagTests
     {
-        public AspNetMvc5TestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc5WithFeatureFlagCallsite(IisFixture iisFixture, ITestOutputHelper output)
             : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
         {
         }
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallTargetNoInlining : AspNetMvc5Tests
+    public class AspNetMvc5WithFeatureFlagCallTargetNoInlining : AspNetMvc5WithFeatureFlagTests
     {
-        public AspNetMvc5TestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc5WithFeatureFlagCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
             : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
         {
         }
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallTarget : AspNetMvc5Tests
+    public class AspNetMvc5WithFeatureFlagCallTarget : AspNetMvc5WithFeatureFlagTests
     {
-        public AspNetMvc5TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
+        public AspNetMvc5WithFeatureFlagCallTarget(IisFixture iisFixture, ITestOutputHelper output)
             : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
         {
         }
     }
 
-    public abstract class AspNetMvc5Tests : TestHelper, IClassFixture<IisFixture>
+    public abstract class AspNetMvc5WithFeatureFlagTests : TestHelper, IClassFixture<IisFixture>
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetMvc5Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetMvc5WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
             : base("AspNetMvc5", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled, "true");
             SetCallTargetSettings(enableCallTarget, enableInlining);
 
             _iisFixture = iisFixture;
@@ -54,7 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
-        [MemberData(nameof(AspNetMvc5TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
+        [MemberData(nameof(AspNetMvc5TestData.WithFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,
@@ -80,4 +82,5 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
     }
 }
+
 #endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2TestData.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2TestData.cs
@@ -5,7 +5,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     public class AspNetWebApi2TestData
     {
-        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> Data => new()
+        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> WithoutFeatureFlag => new()
         {
             { "/api/environment", "GET api/environment", 200, false, null, null, EnvironmentTags },
             { "/api/absolute-route", "GET api/absolute-route", 200, false, null, null, AbsoluteRouteTags },
@@ -25,6 +25,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             { "/api2/transientfailure/false", "GET api2/transientfailure/{value}", 500, true, "System.ArgumentException", "Passed in value was not 'true': false", ConventionTransientFailureTags },
             { "/api2/statuscode/201", "GET api2/statuscode/{value}", 201, false, null, null, ConventionStatusCodeTags },
             { "/api2/statuscode/503", "GET api2/statuscode/{value}", 503, true, null, "The HTTP response has status code 503.", ConventionStatusCodeTags },
+        };
+
+        public static TheoryData<string, string, int, bool, string, string, SerializableDictionary> WithFeatureFlag => new()
+        {
+            { "/api/environment", "GET /api/environment", 200, false, null, null, EnvironmentTags },
+            { "/api/absolute-route", "GET /api/absolute-route", 200, false, null, null, AbsoluteRouteTags },
+            { "/api/delay/0", "GET /api/delay/{seconds}", 200, false, null, null, DelayTags },
+            { "/api/delay-optional", "GET /api/delay-optional/{seconds}", 200, false, null, null, DelayOptionalTags },
+            { "/api/delay-optional/1", "GET /api/delay-optional/{seconds}", 200, false, null, null, DelayOptionalTags },
+            { "/api/delay-async/0", "GET /api/delay-async/{seconds}", 200, false, null, null, DelayAsyncTags },
+            { "/api/transient-failure/true", "GET /api/transient-failure/{value}", 200, false, null, null, TransientFailureTags },
+            { "/api/transient-failure/false", "GET /api/transient-failure/{value}", 500, true, "System.ArgumentException", "Passed in value was not 'true': false", TransientFailureTags },
+            { "/api/statuscode/201", "GET /api/statuscode/{value}", 201, false, null, null, StatusCodeTags },
+            { "/api/statuscode/503", "GET /api/statuscode/{value}", 503, true, null, "The HTTP response has status code 503.", StatusCodeTags },
+            { "/api2/delay/0", "GET /api2/delay/{value}", 200, false, null, null, ConventionDelayTags },
+            { "/api2/optional", "GET /api2/optional/{value}", 200, false, null, null, ConventionDelayOptionalTags },
+            { "/api2/optional/1", "GET /api2/optional/{value}", 200, false, null, null, ConventionDelayOptionalTags },
+            { "/api2/delayAsync/0", "GET /api2/delayasync/{value}", 200, false, null, null, ConventionDelayAsyncTags },
+            { "/api2/transientfailure/true", "GET /api2/transientfailure/{value}", 200, false, null, null, ConventionTransientFailureTags },
+            { "/api2/transientfailure/false", "GET /api2/transientfailure/{value}", 500, true, "System.ArgumentException", "Passed in value was not 'true': false", ConventionTransientFailureTags },
+            { "/api2/statuscode/201", "GET /api2/statuscode/{value}", 201, false, null, null, ConventionStatusCodeTags },
+            { "/api2/statuscode/503", "GET /api2/statuscode/{value}", 503, true, null, "The HTTP response has status code 503.", ConventionStatusCodeTags },
         };
 
         private static SerializableDictionary EnvironmentTags => new()

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
-        [MemberData(nameof(AspNetWebApi2TestData.Data), MemberType = typeof(AspNetWebApi2TestData))]
+        [MemberData(nameof(AspNetWebApi2TestData.WithoutFeatureFlag), MemberType = typeof(AspNetWebApi2TestData))]
         public async Task SubmitsTraces(
             string path,
             string expectedResourceName,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
             SetCallTargetSettings(enableCallTarget, enableInlining);
-            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled, "true");
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
@@ -1,0 +1,125 @@
+﻿#if NET461
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+
+using System.Net;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    [Collection("IisTests")]
+    public class AspNetWebApi2WithFeatureFlagCallsite : AspNetWebApi2WithFeatureFlagTests
+    {
+        public AspNetWebApi2WithFeatureFlagCallsite(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetWebApi2WithFeatureFlagCallTargetNoInlining : AspNetWebApi2WithFeatureFlagTests
+    {
+        public AspNetWebApi2WithFeatureFlagCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetWebApi2WithFeatureFlagCallTarget : AspNetWebApi2WithFeatureFlagTests
+    {
+        public AspNetWebApi2WithFeatureFlagCallTarget(IisFixture iisFixture, ITestOutputHelper output)
+            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+        {
+        }
+    }
+
+    public abstract class AspNetWebApi2WithFeatureFlagTests : TestHelper, IClassFixture<IisFixture>
+    {
+        private readonly IisFixture _iisFixture;
+
+        public AspNetWebApi2WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+            : base("AspNetMvc5", @"test\test-applications\aspnet", output)
+        {
+            SetServiceVersion("1.0.0");
+            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.AspnetRouteTemplateResourceNamesEnabled, "true");
+
+            _iisFixture = iisFixture;
+            _iisFixture.TryStartIis(this);
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
+        [MemberData(nameof(AspNetWebApi2TestData.WithFeatureFlag), MemberType = typeof(AspNetWebApi2TestData))]
+        public async Task SubmitsTraces(
+            string path,
+            string expectedResourceName,
+            HttpStatusCode expectedStatusCode,
+            bool isError,
+            string expectedErrorType,
+            string expectedErrorMessage,
+            SerializableDictionary expectedTags)
+        {
+            await AssertWebServerSpan(
+                path,
+                _iisFixture.Agent,
+                _iisFixture.HttpPort,
+                expectedStatusCode,
+                isError,
+                expectedErrorType,
+                expectedErrorMessage,
+                "web",
+                "aspnet-webapi.request",
+                expectedResourceName,
+                "1.0.0",
+                expectedTags);
+        }
+
+        private static SerializableDictionary EnvironmentTags() => new()
+        {
+            { Tags.AspNetRoute, "api/environment" },
+        };
+
+        private static SerializableDictionary AbsoluteRouteTags() => new()
+        {
+            { Tags.AspNetRoute, "api/absolute-route" },
+        };
+
+        private static SerializableDictionary TransientFailureTags() => new()
+        {
+            { Tags.AspNetRoute, "api/transient-failure/{value}" },
+        };
+
+        private static SerializableDictionary DelayHomeTags() => new()
+        {
+            { Tags.AspNetRoute, "delay/{seconds}" },
+        };
+
+        private static SerializableDictionary DelayTags() => new()
+        {
+            { Tags.AspNetRoute, "api/delay/{seconds}" },
+        };
+
+        private static SerializableDictionary DelayOptionalTags() => new()
+        {
+            { Tags.AspNetRoute, "api/delay-optional/{seconds}" },
+        };
+
+        private static SerializableDictionary DelayAsyncTags() => new()
+        {
+            { Tags.AspNetRoute, "api/delay-async/{seconds}" },
+        };
+
+        private static SerializableDictionary StatusCodeTags() => new()
+        {
+            { Tags.AspNetRoute, "api/statuscode/{value}" },
+        };
+    }
+}
+#endif

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("E653C852227B4F0C9E48D30D83C68BF3", Id)]
         public void CleanUriSegment(string segment, string expected)
         {
-            string actual = UriHelpers.CleanUriSegment(segment);
+            string actual = UriHelpers.GetCleanUriPath(segment);
 
             Assert.Equal(expected, actual);
         }

--- a/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
+++ b/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
@@ -28,8 +28,6 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("https://localhost:5040/controller/action/2022", "/controller/action/?")]
         [InlineData("https://example.org/controller/action/2022", "/controller/action/?")]
         [InlineData("ftp://example.org/controller/action/2022", "/controller/action/?")]
-        [InlineData("//example.org/controller/action/2022", "/controller/action/?")]
-        [InlineData("//[::]/controller/action/2022", "/controller/action/?")]
         public void GetCleanUriPath_ShouldExtractThePathAndRemoveIds(string url, string expected)
         {
             Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(new Uri(url)));

--- a/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
+++ b/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
@@ -1,8 +1,9 @@
+using System;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Util
 {
-    public class CleanUriSegmentTests
+    public class UriHelpersTests
     {
         [Theory]
         [InlineData("/", "/")]
@@ -14,9 +15,24 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs", "/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs")]
         [InlineData("/controller/action/2022", "/controller/action/?")]
         [InlineData("/controller/action/", "/controller/action/")]
-        public void CleanUriSegmentTest(string url, string expected)
+        public void CleanUriSegment_ShouldRemoveIdsFromPaths(string url, string expected)
         {
             Assert.Equal(expected, Trace.Util.UriHelpers.CleanUriSegment(url));
+        }
+
+        [Theory]
+        [InlineData("http://localhost:5040", "/")]
+        [InlineData("http://localhost:5040/", "/")]
+        [InlineData("http://localhost:5040/controller/", "/controller/")]
+        [InlineData("http://localhost:5040/controller/action/2022", "/controller/action/?")]
+        [InlineData("https://localhost:5040/controller/action/2022", "/controller/action/?")]
+        [InlineData("https://example.org/controller/action/2022", "/controller/action/?")]
+        [InlineData("ftp://example.org/controller/action/2022", "/controller/action/?")]
+        [InlineData("//example.org/controller/action/2022", "/controller/action/?")]
+        [InlineData("//[::]/controller/action/2022", "/controller/action/?")]
+        public void GetCleanUriPath_ShouldExtractThePathAndRemoveIds(string url, string expected)
+        {
+            Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(new Uri(url)));
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
+++ b/test/Datadog.Trace.Tests/Util/UriHelpersTests.cs
@@ -15,9 +15,9 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs", "/DataDog/dd-trace-dotnet/blob/e2d83dec7d6862d4181937776ddaf72819e291ce/src/Datadog.Trace/Util/UriHelpers.cs")]
         [InlineData("/controller/action/2022", "/controller/action/?")]
         [InlineData("/controller/action/", "/controller/action/")]
-        public void CleanUriSegment_ShouldRemoveIdsFromPaths(string url, string expected)
+        public void GetCleanUriPath_ShouldRemoveIdsFromPaths(string url, string expected)
         {
-            Assert.Equal(expected, Trace.Util.UriHelpers.CleanUriSegment(url));
+            Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(url));
         }
 
         [Theory]
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Tests.Util
         [InlineData("https://localhost:5040/controller/action/2022", "/controller/action/?")]
         [InlineData("https://example.org/controller/action/2022", "/controller/action/?")]
         [InlineData("ftp://example.org/controller/action/2022", "/controller/action/?")]
-        public void GetCleanUriPath_ShouldExtractThePathAndRemoveIds(string url, string expected)
+        public void GetCleanUriPath_ByUri_ShouldExtractThePathAndRemoveIds(string url, string expected)
         {
             Assert.Equal(expected, Trace.Util.UriHelpers.GetCleanUriPath(new Uri(url)));
         }


### PR DESCRIPTION
Currently the resource names for our ASP.NET/WebAPI spans are inconsistently named, and do not make best use of routing information available. This PR makes the naming consistent across MVC/WebAPI2, and moves to using the route information where available.. These changes are currently opt-in, behind a feature flag.

## Current Resource Names

Conventional routed MVC ([e.g. `/Home/Get/0`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs#L28) ) use URL obfuscation for both the "root IIS span" and the "child MVC span", and start with a `/`:

![image](https://user-images.githubusercontent.com/18755388/111495020-df57f780-8736-11eb-92a6-a1b4cc8e79dc.png)

Attribute routed MVC ([e.g. `/delay/10`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs#L33-L34)) uses URL obfuscation for the "root IIS span" and the _route_  for the "child MVC span", prefixing both with a `/`:

![image](https://user-images.githubusercontent.com/18755388/111494966-d23b0880-8736-11eb-9020-69e73c344ac0.png)

Conventional routed WebAPI2 ([e.g. `/api2/delay/3`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/ConventionsController.cs#L12)) uses URL obfuscation for the "root IIS span" and the _route_ for the "child MVC span". Only the root span is prefixed with a `/`:

![image](https://user-images.githubusercontent.com/18755388/111495509-5ab9a900-8737-11eb-9174-c936dc7f9e50.png)

Attribute routed WebApi2 ([e.g. `/api/delay/3`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/ApiController.cs#L13-L14)) is the same as the convential routed WebAPI 2: URL obfuscation for the "root IIS span" and the _route_ for the "child MVC span". Only the root span is prefixed with a `/`:

![image](https://user-images.githubusercontent.com/18755388/111495850-a9ffd980-8737-11eb-87d0-09161567c541.png)

## New Unified Resource Names

If you enable the  feature flag, using `DD_TRACE_ASPNET_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED=true`, then all these approaches give the same span pattern.

* Instead of URL obfuscation, the route template is used where available (i.e. everywhere except 404s)
* All resource names start with `/`
* Both spans have the same resource name
* Where a route is not found (i.e. it's a 404) we fallback to simple URL obfuscation to remove Ids and `Guid`s
* As with the existing WebApi integration, we replace the common tokens `area`, `controller` and `action` in route names. 
* For conventional routing, if a route has unused route parameters, these are removed from the resource name. This means that paths matching the common (default) route `{controller}/{action}/{id?}` (where `id` is optional), e.g. `/home/action` would have resource name `GET /home/action` instead of `GET /home/action/{id}`. 
* The `aspnet.route` tag is set both on the root span and the mvc span

Conventional routed MVC ([e.g. `/Home/Get/0`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs#L28) )

![image](https://user-images.githubusercontent.com/18755388/111498939-56db5600-873a-11eb-95ee-e3ae531e9d8c.png)

Attribute routed MVC ([e.g. `/delay/10`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs#L33-L34)) 

![image](https://user-images.githubusercontent.com/18755388/111498886-4a56fd80-873a-11eb-90af-7014f7a7f869.png)

Conventional routed WebAPI2 ([e.g. `/api2/delay/3`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/ConventionsController.cs#L12))

![image](https://user-images.githubusercontent.com/18755388/111498842-3d3a0e80-873a-11eb-83ad-ed94f7e6cdcf.png)

Attribute routed WebApi2 ([e.g. `/api/delay/3`](https://github.com/DataDog/dd-trace-dotnet/blob/master/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/ApiController.cs#L13-L14))

![image](https://user-images.githubusercontent.com/18755388/111498651-082dbc00-873a-11eb-9943-423f7dc68ce3.png)

Unknown routes with IDs are still obfuscated as before:

![image](https://user-images.githubusercontent.com/18755388/111499130-88542180-873a-11eb-9359-d7401ec903fc.png)

## Testing

As these changes could break customer metrics relying on the old behaviour, the new behaviour is behind an opt-in feature flag. Integration tests confirm both the new behaviour, and the old behaviour when the feature flag is disabled.

@DataDog/apm-dotnet