### PR TITLE
Add support for ducktyping in multiple assembly load contexts

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -417,6 +417,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OracleMDA", "test\t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OracleMDA.Core", "test\test-applications\integrations\Samples.OracleMDA.Core\Samples.OracleMDA.Core.csproj", "{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Datadog.Trace.AssemblyLoadContext", "src\Datadog.Trace.AssemblyLoadContext\Datadog.Trace.AssemblyLoadContext.csproj", "{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{047EF15D-F100-4C18-95E8-87A314309F32}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1572,6 +1576,28 @@ Global
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|x64.Build.0 = Release|x64
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|x86.ActiveCfg = Release|x86
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|x86.Build.0 = Release|x86
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Release|x64.Build.0 = Release|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A}.Release|x86.Build.0 = Release|Any CPU
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Debug|x64.ActiveCfg = Debug|x64
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Debug|x64.Build.0 = Debug|x64
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Debug|x86.ActiveCfg = Debug|x86
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Debug|x86.Build.0 = Debug|x86
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Release|Any CPU.ActiveCfg = Release|x86
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Release|x64.ActiveCfg = Release|x64
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Release|x64.Build.0 = Release|x64
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Release|x86.ActiveCfg = Release|x86
+		{047EF15D-F100-4C18-95E8-87A314309F32}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1694,6 +1720,8 @@ Global
 		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{BD46EFCC-177C-466E-81DF-39314B780ADA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{2C50150B-DE9D-46EF-9FE1-5DA84D17F91A} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{047EF15D-F100-4C18-95E8-87A314309F32} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/src/Datadog.Trace.AssemblyLoadContext/AssemblyBuilderHelper.cs
+++ b/src/Datadog.Trace.AssemblyLoadContext/AssemblyBuilderHelper.cs
@@ -1,0 +1,21 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace Datadog.Trace.AssemblyLoadContext
+{
+    /// <summary>
+    /// Assembly Builder Helper
+    /// </summary>
+    public static class AssemblyBuilderHelper
+    {
+        /// <summary>
+        /// Define Dynamic Assembly
+        /// </summary>
+        /// <param name="name">Assembly name</param>
+        /// <returns>AssemblyBuilder instance</returns>
+        public static AssemblyBuilder DefineDynamicAssembly(string name)
+        {
+            return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+        }
+    }
+}

--- a/src/Datadog.Trace.AssemblyLoadContext/Datadog.Trace.AssemblyLoadContext.csproj
+++ b/src/Datadog.Trace.AssemblyLoadContext/Datadog.Trace.AssemblyLoadContext.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 	<PropertyGroup>
 		<IsPackable>false</IsPackable>

--- a/src/Datadog.Trace.AssemblyLoadContext/Datadog.Trace.AssemblyLoadContext.csproj
+++ b/src/Datadog.Trace.AssemblyLoadContext/Datadog.Trace.AssemblyLoadContext.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<GenerateDocumentationFile>false</GenerateDocumentationFile>
+		<LangVersion>9.0</LangVersion>
+
+		<!-- Strong name signature -->
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>..\..\Datadog.Trace.snk</AssemblyOriginatorKeyFile>
+		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+		<DelaySign>false</DelaySign>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+	</ItemGroup>
+
+</Project>

--- a/src/Datadog.Trace.AssemblyLoadContext/Directory.Build.props
+++ b/src/Datadog.Trace.AssemblyLoadContext/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+
+</Project>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- NuGet -->
@@ -76,6 +76,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
+    <ProjectReference Include="..\Datadog.Trace.AssemblyLoadContext\Datadog.Trace.AssemblyLoadContext.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/src/Datadog.Trace/Datadog.Trace.csproj
@@ -50,6 +50,18 @@
     <DefineConstants>$(DefineConstants);ASYNCLOCAL;HASHTABLE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp2')) OR $(TargetFramework.StartsWith('netcoreapp3')) OR $(TargetFramework.StartsWith('net5')) OR $(TargetFramework.StartsWith('net6'))">
+    <DefineConstants>$(DefineConstants);HAVE_ASSEMBLYLOADCONTEXT</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netcoreapp2')) OR $(TargetFramework.StartsWith('netcoreapp3')) OR $(TargetFramework.StartsWith('net5')) OR $(TargetFramework.StartsWith('net6'))">
+    <DefineConstants>$(DefineConstants);HAVE_ASSEMBLYLOADCONTEXT</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('netstandard2'))">
+    <DefineConstants>$(DefineConstants);IS_NETSTANDARD2_X</DefineConstants>
+  </PropertyGroup>
+
   <!-- Remove System.Collections.NonGeneric. This was defined in Serilog 2.8.0 but it is unnecessary -->
   <!--
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Datadog.Trace/DuckTyping/DuckType.AssemblyLoadContext.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.AssemblyLoadContext.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+#if NETCOREAPP2_0_OR_GREATER
+using RuntimeLoader = System.Runtime.Loader;
+#endif
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable SA1214
+#pragma warning disable SA1203 // Constants should appear before fields
+
+namespace Datadog.Trace.DuckTyping
+{
+    /// <summary>
+    /// Duck Type
+    /// </summary>
+    public static partial class DuckType
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static readonly ConditionalWeakTable<object, ModuleBuilder> ModuleBuilders = new ConditionalWeakTable<object, ModuleBuilder>();
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static long _assemblyCount = 0;
+
+#if NETCOREAPP2_2_OR_GREATER || NETSTANDARD2_0
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static readonly ConditionalWeakTable<object, DefineDynamicAssemblyDelegate> DefineDynamicAssemblies = new ConditionalWeakTable<object, DefineDynamicAssemblyDelegate>();
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static object _currentContext;
+
+        private delegate AssemblyBuilder DefineDynamicAssemblyDelegate(string name);
+
+        private static object GetTargetContext(Type targetType)
+        {
+            List<object> contexts = new List<object>();
+            var targetContext = GetAssemblyLoadContext(targetType.Assembly ?? typeof(DuckType).Assembly);
+            contexts.Add(targetContext);
+
+            if (targetType.IsGenericType)
+            {
+                foreach (var type in targetType.GetGenericArguments())
+                {
+                    var context = GetAssemblyLoadContext(type.Assembly);
+                    if (targetContext != context && !contexts.Contains(context))
+                    {
+                        contexts.Add(context);
+                    }
+                }
+
+                if (contexts.Count > 1 && targetType.Assembly == typeof(object).Assembly)
+                {
+                    contexts.Remove(targetContext);
+                }
+            }
+
+            if (contexts.Count > 1)
+            {
+                return CreateAssemblyLoadContext($"DuckType-For:{targetType.Name}");
+            }
+
+            return contexts[0];
+        }
+
+        private static AssemblyBuilder CreateAssemblyBuilder(string name, object targetContext)
+        {
+            if (_currentContext == null)
+            {
+                _currentContext = GetAssemblyLoadContext(typeof(DuckType).Assembly);
+            }
+
+            if (targetContext != _currentContext)
+            {
+                if (!DefineDynamicAssemblies.TryGetValue(targetContext, out var @delegate))
+                {
+                    var loaderAssembly = LoadFromAssemblyPath(targetContext, typeof(AssemblyLoadContext.AssemblyBuilderHelper).Assembly.Location);
+                    var loaderType = loaderAssembly.GetType(typeof(AssemblyLoadContext.AssemblyBuilderHelper).FullName);
+                    var loaderMethod = loaderType.GetMethod(nameof(AssemblyLoadContext.AssemblyBuilderHelper.DefineDynamicAssembly), BindingFlags.Static | BindingFlags.Public);
+                    @delegate = (DefineDynamicAssemblyDelegate)loaderMethod.CreateDelegate(typeof(DefineDynamicAssemblyDelegate));
+                    DefineDynamicAssemblies.Add(targetContext, @delegate);
+                }
+
+                return @delegate(name);
+            }
+
+            return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+        }
+#endif
+
+#if NETCOREAPP2_0_OR_GREATER
+        private static object GetAssemblyLoadContext(Assembly assembly)
+        {
+            return RuntimeLoader.AssemblyLoadContext.GetLoadContext(assembly);
+        }
+
+        private static Assembly LoadFromAssemblyPath(object context, string path)
+        {
+            return ((RuntimeLoader.AssemblyLoadContext)context).LoadFromAssemblyPath(path);
+        }
+
+        private static object CreateAssemblyLoadContext(string name)
+        {
+            return new RuntimeLoader.AssemblyLoadContext(name);
+        }
+
+        private static ModuleBuilder GetModuleBuilder(Type targetType)
+        {
+            object targetContext = GetTargetContext(targetType);
+            if (!ModuleBuilders.TryGetValue(targetContext, out var moduleBuilder))
+            {
+                var assemblyBuilder = CreateAssemblyBuilder($"DuckTypeAssembly_{++_assemblyCount}", targetContext);
+                moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+                ModuleBuilders.Add(targetContext, moduleBuilder);
+            }
+
+            return moduleBuilder;
+        }
+#elif NETSTANDARD2_0
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private const string AssemblyLoadContextTypeName = "System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader";
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static Type _assemblyLoadContextType = null;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static ContextFetcher _contextFetcher = null;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static LoadFromAssemblyPathFetcher _loadFromAssemblyPathFetcher = null;
+
+        private static object GetAssemblyLoadContext(Assembly assembly)
+        {
+            if (_contextFetcher == null)
+            {
+                MethodInfo mInfo = _assemblyLoadContextType.GetMethod("GetLoadContext", BindingFlags.Static | BindingFlags.Public);
+                _contextFetcher = ContextFetcher.GetFetcher(mInfo);
+            }
+
+            return _contextFetcher.Get(assembly);
+        }
+
+        private static Assembly LoadFromAssemblyPath(object context, string path)
+        {
+            if (_loadFromAssemblyPathFetcher == null)
+            {
+                MethodInfo loadFromAssemblyPathMethod = _assemblyLoadContextType.GetMethod("LoadFromAssemblyPath", BindingFlags.Public | BindingFlags.Instance);
+                _loadFromAssemblyPathFetcher = LoadFromAssemblyPathFetcher.GetFetcher(loadFromAssemblyPathMethod, context);
+            }
+
+            return _loadFromAssemblyPathFetcher.Load(context, path);
+        }
+
+        private static object CreateAssemblyLoadContext(string name)
+        {
+            return Activator.CreateInstance(_assemblyLoadContextType, name);
+        }
+
+        private static ModuleBuilder GetModuleBuilder(Type targetType)
+        {
+            ModuleBuilder moduleBuilder;
+
+            if (_assemblyLoadContextType == null)
+            {
+                _assemblyLoadContextType = Type.GetType(AssemblyLoadContextTypeName, throwOnError: false);
+
+                if (_assemblyLoadContextType == null)
+                {
+                    object targetAssembly = targetType.Assembly ?? typeof(DuckType).Assembly;
+                    if (!ModuleBuilders.TryGetValue(targetAssembly, out moduleBuilder))
+                    {
+                        var assemblyBuilder = CreateAssemblyBuilderFallback($"DuckTypeAssembly.{targetType.Assembly?.GetName().Name}_{++_assemblyCount}", targetType);
+                        moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+                        ModuleBuilders.Add(targetAssembly, moduleBuilder);
+                    }
+
+                    return moduleBuilder;
+                }
+            }
+
+            object targetContext = GetTargetContext(targetType);
+            if (!ModuleBuilders.TryGetValue(targetContext, out moduleBuilder))
+            {
+                var assemblyBuilder = CreateAssemblyBuilder($"DuckTypeAssembly.{targetType.Assembly?.GetName().Name}_{++_assemblyCount}", targetContext);
+                moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+                ModuleBuilders.Add(targetContext, moduleBuilder);
+            }
+
+            return moduleBuilder;
+        }
+
+        private static AssemblyBuilder CreateAssemblyBuilderFallback(string name, Type targetType)
+        {
+            return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+        }
+
+        private class ContextFetcher
+        {
+            private delegate TReturn GetAssemblyLoadContextDelegate<TReturn>(Assembly assembly);
+
+            public static ContextFetcher GetFetcher(MethodInfo minfo)
+            {
+                return (ContextFetcher)Activator.CreateInstance(typeof(GenericContextFetcher<>).MakeGenericType(minfo.ReturnType), minfo);
+            }
+
+            public virtual object Get(Assembly assembly)
+            {
+                return null;
+            }
+
+            private class GenericContextFetcher<TReturn> : ContextFetcher
+            {
+                private GetAssemblyLoadContextDelegate<TReturn> _delegate;
+
+                public GenericContextFetcher(MethodInfo mInfo)
+                {
+                    _delegate = (GetAssemblyLoadContextDelegate<TReturn>)mInfo.CreateDelegate(typeof(GetAssemblyLoadContextDelegate<TReturn>));
+                }
+
+                public override object Get(Assembly assembly)
+                {
+                    return _delegate(assembly);
+                }
+            }
+        }
+
+        private class LoadFromAssemblyPathFetcher
+        {
+            private delegate Assembly LoadFromAssemblyPathDelegate<TContext>(TContext context, string path);
+
+            public static LoadFromAssemblyPathFetcher GetFetcher(MethodInfo minfo, object context)
+            {
+                return (LoadFromAssemblyPathFetcher)Activator.CreateInstance(typeof(GenericLoadFromAssemblyPathFetcher<>).MakeGenericType(context.GetType().BaseType), minfo);
+            }
+
+            public virtual Assembly Load(object context, string path)
+            {
+                return null;
+            }
+
+            private class GenericLoadFromAssemblyPathFetcher<TContext> : LoadFromAssemblyPathFetcher
+            {
+                private LoadFromAssemblyPathDelegate<TContext> _delegate;
+
+                public GenericLoadFromAssemblyPathFetcher(MethodInfo mInfo)
+                {
+                    _delegate = (LoadFromAssemblyPathDelegate<TContext>)mInfo.CreateDelegate(typeof(LoadFromAssemblyPathDelegate<TContext>));
+                }
+
+                public override Assembly Load(object context, string path)
+                {
+                    if (context is TContext ctx)
+                    {
+                        return _delegate(ctx, path);
+                    }
+
+                    return null;
+                }
+            }
+        }
+#else
+        private static AssemblyBuilder CreateAssemblyBuilder(string name, Type targetType)
+        {
+            return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
+        }
+
+        private static ModuleBuilder GetModuleBuilder(Type targetType)
+        {
+            object targetAssembly = targetType.Assembly ?? typeof(DuckType).Assembly;
+            if (!ModuleBuilders.TryGetValue(targetAssembly, out var moduleBuilder))
+            {
+                var assemblyBuilder = CreateAssemblyBuilder($"DuckTypeAssembly.{targetType.Assembly?.GetName().Name}_{++_assemblyCount}", targetType);
+                moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+                ModuleBuilders.Add(targetAssembly, moduleBuilder);
+            }
+
+            return moduleBuilder;
+        }
+#endif
+    }
+}

--- a/src/Datadog.Trace/DuckTyping/DuckType.AssemblyLoadContext.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.AssemblyLoadContext.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
-#if NETCOREAPP2_0_OR_GREATER
+#if HAVE_ASSEMBLYLOADCONTEXT
 using RuntimeLoader = System.Runtime.Loader;
 #endif
 
@@ -19,22 +19,52 @@ namespace Datadog.Trace.DuckTyping
     /// </summary>
     public static partial class DuckType
     {
+        /// <summary>
+        /// Contains the current module builders, the key is an object that can be an AssemblyLoadContext (NETCORE) or an Assembly (NETFRAMEWORK) instance.
+        /// The usage of the ConditionalWeakTable is due to the fact that an AssemblyLoadContext can be unloaded.
+        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly ConditionalWeakTable<object, ModuleBuilder> ModuleBuilders = new ConditionalWeakTable<object, ModuleBuilder>();
 
+        /// <summary>
+        /// Count of emmited AssemblyBuilders.
+        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static long _assemblyCount = 0;
 
-#if NETCOREAPP2_2_OR_GREATER || NETSTANDARD2_0
+#if HAVE_ASSEMBLYLOADCONTEXT || IS_NETSTANDARD2_X
+        /// <summary>
+        /// Contains the `DefineDynamicAssemblyDelegate` created on the target context. The key is an AssemblyLoadContext object.
+        /// The usage of the ConditionalWeakTable is due to the fact that an AssemblyLoadContext can be unloaded.
+        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly ConditionalWeakTable<object, DefineDynamicAssemblyDelegate> DefineDynamicAssemblies = new ConditionalWeakTable<object, DefineDynamicAssemblyDelegate>();
+
+        /// <summary>
+        /// Context where the DuckType class is loaded.
+        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static object _currentContext;
 
+        /// <summary>
+        /// Delegate used to call AssemblyBuilder.DefineDynamicAssembly method in a target context.
+        /// </summary>
+        /// <param name="name">Assembly name</param>
+        /// <returns>Assembly builder instance</returns>
         private delegate AssemblyBuilder DefineDynamicAssemblyDelegate(string name);
 
+        /// <summary>
+        /// Gets the target context where the Assembly builder should be defined given a target type
+        /// </summary>
+        /// <param name="targetType">Target type for ducktyping</param>
+        /// <returns>An AssemblyLoadContext object</returns>
         private static object GetTargetContext(Type targetType)
         {
+            // First we get the AssemblyLoadContext of the target type
+            // If the Type is a Generic type, we scan for the contexts of the generics parameters (eg: Task<T>, Dictioanry<TKey, TValue>)
+            // If we get different contexts we remove the target type context if the target type is from System.Private.CoreLib
+            // If only 1 context remains then we use that. (Context of T from Task<T>)
+            // If we still have multiple context, then we play safe and create a new isolated context for that combination (context of TKey being different to context of TValue in a Dictionary<TKey, TValue>)
             List<object> contexts = new List<object>();
             var targetContext = GetAssemblyLoadContext(targetType.Assembly ?? typeof(DuckType).Assembly);
             contexts.Add(targetContext);
@@ -64,6 +94,12 @@ namespace Datadog.Trace.DuckTyping
             return contexts[0];
         }
 
+        /// <summary>
+        /// Creates an Assembly builder with a name in a target context
+        /// </summary>
+        /// <param name="name">Name of the assembly</param>
+        /// <param name="targetContext">AssemblyLoadContext where the assembly is going to be defined.</param>
+        /// <returns>An AssemblyBuilder instance</returns>
         private static AssemblyBuilder CreateAssemblyBuilder(string name, object targetContext)
         {
             if (_currentContext == null)
@@ -73,6 +109,9 @@ namespace Datadog.Trace.DuckTyping
 
             if (targetContext != _currentContext)
             {
+                // if the target context is different from the current context we need to call the `AssemblyBuilder.DefineDynamicAssembly` from
+                // the target context, for that we load the `Datadog.Trace.AssemblyLoadContext` assembly into the target context and create a delegate
+                // to `Datadog.Trace.AssemblyLoadContext.AssemblyBuilderHelper.DefineDynamicAssembly` method and call it.
                 if (!DefineDynamicAssemblies.TryGetValue(targetContext, out var @delegate))
                 {
                     var loaderAssembly = LoadFromAssemblyPath(targetContext, typeof(AssemblyLoadContext.AssemblyBuilderHelper).Assembly.Location);
@@ -85,11 +124,15 @@ namespace Datadog.Trace.DuckTyping
                 return @delegate(name);
             }
 
+            // In the case we are in the same context we just call `AssemblyBuilder.DefineDynamicAssembly` from here.
             return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
         }
 #endif
 
-#if NETCOREAPP2_0_OR_GREATER
+#if HAVE_ASSEMBLYLOADCONTEXT
+        // ***
+        // Indirections to the AssemblyLoadContext methods.
+        // ***
         private static object GetAssemblyLoadContext(Assembly assembly)
         {
             return RuntimeLoader.AssemblyLoadContext.GetLoadContext(assembly);
@@ -105,6 +148,12 @@ namespace Datadog.Trace.DuckTyping
             return new RuntimeLoader.AssemblyLoadContext(name);
         }
 
+        /// <summary>
+        /// Gets the ModuleBuilder instance from a target type.
+        /// By resolving all the AssemblyLoadContext if is required.
+        /// </summary>
+        /// <param name="targetType">Target type for ducktyping</param>
+        /// <returns>ModuleBuilder instance</returns>
         private static ModuleBuilder GetModuleBuilder(Type targetType)
         {
             object targetContext = GetTargetContext(targetType);
@@ -117,7 +166,10 @@ namespace Datadog.Trace.DuckTyping
 
             return moduleBuilder;
         }
-#elif NETSTANDARD2_0
+#elif IS_NETSTANDARD2_X
+        // ***
+        // Proxies to the AssemblyLoadContext methods using delegates and fetchers.
+        // ***
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private const string AssemblyLoadContextTypeName = "System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader";
 
@@ -155,6 +207,12 @@ namespace Datadog.Trace.DuckTyping
             return Activator.CreateInstance(_assemblyLoadContextType, name);
         }
 
+        /// <summary>
+        /// Gets the ModuleBuilder instance from a target type.
+        /// By resolving all the AssemblyLoadContext if is required.
+        /// </summary>
+        /// <param name="targetType">Target type for ducktyping</param>
+        /// <returns>ModuleBuilder instance</returns>
         private static ModuleBuilder GetModuleBuilder(Type targetType)
         {
             ModuleBuilder moduleBuilder;
@@ -188,6 +246,12 @@ namespace Datadog.Trace.DuckTyping
             return moduleBuilder;
         }
 
+        /// <summary>
+        /// Fallback method in case `System.Runtime.Loader.AssemblyLoadContext, System.Runtime.Loader` cannot be loaded.
+        /// </summary>
+        /// <param name="name">Name of the assembly</param>
+        /// <param name="targetType">Target type for ducktyping</param>
+        /// <returns>An AssemblyBuilder instance</returns>
         private static AssemblyBuilder CreateAssemblyBuilderFallback(string name, Type targetType)
         {
             return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
@@ -258,11 +322,22 @@ namespace Datadog.Trace.DuckTyping
             }
         }
 #else
+        /// <summary>
+        /// Creates an assembly builder with a Name. (.NET Framework / Non AssemblyLoadContext version)
+        /// </summary>
+        /// <param name="name">Name of the assembly</param>
+        /// <param name="targetType">Target type for ducktyping</param>
+        /// <returns>An AssemblyBuilder instance</returns>
         private static AssemblyBuilder CreateAssemblyBuilder(string name, Type targetType)
         {
             return AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(name), AssemblyBuilderAccess.Run);
         }
 
+        /// <summary>
+        /// Gets the ModuleBuilder instance from a target type.  (.NET Framework / Non AssemblyLoadContext version)
+        /// </summary>
+        /// <param name="targetType">Target type for ducktyping</param>
+        /// <returns>ModuleBuilder instance</returns>
         private static ModuleBuilder GetModuleBuilder(Type targetType)
         {
             object targetAssembly = targetType.Assembly ?? typeof(DuckType).Assembly;

--- a/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // We create the dynamic method
                 Type[] dynParameters = targetField.IsStatic ? Type.EmptyTypes : new[] { typeof(object) };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, targetType.Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, proxyTypeBuilder.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());
@@ -155,7 +155,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // Create dynamic method
                 Type[] dynParameters = targetField.IsStatic ? new[] { dynValueType } : new[] { typeof(object), dynValueType };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, targetType.Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, proxyTypeBuilder.Module, true);
 
                 // Write the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // We create the dynamic method
                 Type[] dynParameters = targetField.IsStatic ? Type.EmptyTypes : new[] { typeof(object) };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, targetType.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());
@@ -155,7 +155,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // Create dynamic method
                 Type[] dynParameters = targetField.IsStatic ? new[] { dynValueType } : new[] { typeof(object), dynValueType };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, targetType.Module, true);
 
                 // Write the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -357,7 +357,7 @@ namespace Datadog.Trace.DuckTyping
                     Type[] originalTargetParameters = targetMethod.GetParameters().Select(p => p.ParameterType).ToArray();
                     Type[] targetParameters = targetMethod.IsStatic ? originalTargetParameters : (new[] { typeof(object) }).Concat(originalTargetParameters).ToArray();
                     Type[] dynParameters = targetMethod.IsStatic ? targetMethodParametersTypes : (new[] { typeof(object) }).Concat(targetMethodParametersTypes).ToArray();
-                    DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, targetType.Module, true);
+                    DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, proxyTypeBuilder.Module, true);
 
                     // Emit the dynamic method body
                     LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -357,7 +357,7 @@ namespace Datadog.Trace.DuckTyping
                     Type[] originalTargetParameters = targetMethod.GetParameters().Select(p => p.ParameterType).ToArray();
                     Type[] targetParameters = targetMethod.IsStatic ? originalTargetParameters : (new[] { typeof(object) }).Concat(originalTargetParameters).ToArray();
                     Type[] dynParameters = targetMethod.IsStatic ? targetMethodParametersTypes : (new[] { typeof(object) }).Concat(targetMethodParametersTypes).ToArray();
-                    DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
+                    DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, targetType.Module, true);
 
                     // Emit the dynamic method body
                     LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertyGetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, targetType.Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, proxyTypeBuilder.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());
@@ -260,7 +260,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertySetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, targetType.Module, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, proxyTypeBuilder.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertyGetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, targetType.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());
@@ -260,7 +260,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertySetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, targetType.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -31,9 +31,7 @@ namespace Datadog.Trace.DuckTyping
         private static readonly MethodInfo _methodBuilderGetToken = typeof(MethodBuilder).GetMethod("GetToken", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static ModuleBuilder _moduleBuilder = null;
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static AssemblyBuilder _assemblyBuilder = null;
+        private static long _typeCount = 0;
 
         /// <summary>
         /// DynamicMethods delegates cache

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -130,14 +130,8 @@ namespace Datadog.Trace.DuckTyping
                         interfaceTypes = new[] { typeof(IDuckType) };
                     }
 
-                    // Ensures the module builder
-                    if (_moduleBuilder is null)
-                    {
-                        var id = Guid.NewGuid().ToString("N");
-                        AssemblyName aName = new AssemblyName("DuckTypeAssembly._" + id);
-                        _assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(aName, AssemblyBuilderAccess.Run);
-                        _moduleBuilder = _assemblyBuilder.DefineDynamicModule("MainModule");
-                    }
+                    // Gets the module builder
+                    var moduleBuilder = GetModuleBuilder(targetType);
 
                     string assembly = string.Empty;
                     if (targetType.Assembly != null)
@@ -151,10 +145,10 @@ namespace Datadog.Trace.DuckTyping
                     }
 
                     // Create a valid type name that can be used as a member of a class. (BenchmarkDotNet fails if is an invalid name)
-                    string proxyTypeName = $"{assembly}.{targetType.FullName.Replace(".", "_").Replace("+", "__")}.{proxyDefinitionType.FullName.Replace(".", "_").Replace("+", "__")}";
+                    string proxyTypeName = $"{assembly}.{targetType.FullName.Replace(".", "_").Replace("+", "__")}.{proxyDefinitionType.FullName.Replace(".", "_").Replace("+", "__")}_{++_typeCount}";
 
                     // Create Type
-                    TypeBuilder proxyTypeBuilder = _moduleBuilder.DefineType(
+                    TypeBuilder proxyTypeBuilder = moduleBuilder.DefineType(
                         proxyTypeName,
                         typeAttributes,
                         parentType,

--- a/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
+++ b/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+      <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    </ItemGroup>
+  
+  </Project>

--- a/test/test-applications/regression/DuplicateTypeProxy/Program.cs
+++ b/test/test-applications/regression/DuplicateTypeProxy/Program.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace DuplicateTypeProxy
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            await RunAsync(typeof(HttpClient));
+
+            for (int i = 0; i < 5; i++)
+            {
+                var assembly = Assembly.LoadFile(typeof(HttpClient).Assembly.Location);
+                await RunAsync(assembly.GetType("System.Net.Http.HttpClient"));
+            }
+        }
+
+        public static async Task RunAsync(Type httpClientType)
+        {
+            var instance = Activator.CreateInstance(httpClientType);
+            var getAsync = httpClientType.GetMethod("GetAsync", new[] { typeof(string) });
+
+            var task = (Task)getAsync.Invoke(instance, new[] { "http://www.contoso.com" });
+            await task;
+        }
+    }
+}

--- a/test/test-applications/regression/DuplicateTypeProxy/Properties/launchSettings.json
+++ b/test/test-applications/regression/DuplicateTypeProxy/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "DuplicateTypeProxy": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "nativeDebugging": false
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for ducktyping in multiple assembly load contexts.

On netcoreapp and netstandard checks if the target type for ducktyping is in a different AssemblyLoadContext and creates the ducktype proxy in the same context.

The PR doesn't modify the behavior in .NET Framework

@DataDog/apm-dotnet