### PR TITLE
Ducktype: Adds module isolation by target assembly

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -417,6 +417,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OracleMDA", "test\t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.OracleMDA.Core", "test\test-applications\integrations\Samples.OracleMDA.Core\Samples.OracleMDA.Core.csproj", "{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems*{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}*SharedItemsImports = 5
@@ -1572,6 +1574,16 @@ Global
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|x64.Build.0 = Release|x64
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|x86.ActiveCfg = Release|x86
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1}.Release|x86.Build.0 = Release|x86
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|x64.ActiveCfg = Debug|x64
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|x64.Build.0 = Debug|x64
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|x86.ActiveCfg = Debug|x86
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Debug|x86.Build.0 = Debug|x86
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|Any CPU.ActiveCfg = Release|x86
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|x64.ActiveCfg = Release|x64
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|x64.Build.0 = Release|x64
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|x86.ActiveCfg = Release|x86
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1694,6 +1706,7 @@ Global
 		{69B678F6-51CF-4A5B-8DEC-1F9CEDC5C9E2} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{BD46EFCC-177C-466E-81DF-39314B780ADA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{B0F3148C-1251-4AAA-B6E6-357A8E675EA1} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{34B67004-7249-4EF1-8E12-6E6DA37EA6BE} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -31,7 +31,7 @@ for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStac
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 
-for sample in DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject NetCoreAssemblyLoadFailureOlderNuGet ; do
+for sample in DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject NetCoreAssemblyLoadFailureOlderNuGet DuplicateTypeProxy ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/regression/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -43,7 +43,7 @@ for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStac
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 
-for sample in OrleansCrash DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject NetCoreAssemblyLoadFailureOlderNuGet ; do
+for sample in OrleansCrash DataDogThreadTest HttpMessageHandler.StackOverflowException StackExchange.Redis.StackOverflowException AspNetMvcCorePerformance AssemblyLoad.FileNotFoundException TraceContext.InvalidOperationException AssemblyResolveMscorlibResources.InfiniteRecursionCrash StackExchange.Redis.AssemblyConflict.SdkProject NetCoreAssemblyLoadFailureOlderNuGet DuplicateTypeProxy ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/regression/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // We create the dynamic method
                 Type[] dynParameters = targetField.IsStatic ? Type.EmptyTypes : new[] { typeof(object) };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, proxyTypeBuilder.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());
@@ -155,7 +155,7 @@ namespace Datadog.Trace.DuckTyping
 
                 // Create dynamic method
                 Type[] dynParameters = targetField.IsStatic ? new[] { dynValueType } : new[] { typeof(object), dynValueType };
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, proxyTypeBuilder.Module, true);
 
                 // Write the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -357,7 +357,7 @@ namespace Datadog.Trace.DuckTyping
                     Type[] originalTargetParameters = targetMethod.GetParameters().Select(p => p.ParameterType).ToArray();
                     Type[] targetParameters = targetMethod.IsStatic ? originalTargetParameters : (new[] { typeof(object) }).Concat(originalTargetParameters).ToArray();
                     Type[] dynParameters = targetMethod.IsStatic ? targetMethodParametersTypes : (new[] { typeof(object) }).Concat(targetMethodParametersTypes).ToArray();
-                    DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
+                    DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, proxyTypeBuilder.Module, true);
 
                     // Emit the dynamic method body
                     LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertyGetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, returnType, dynParameters, proxyTypeBuilder.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());
@@ -260,7 +260,7 @@ namespace Datadog.Trace.DuckTyping
                 // We create the dynamic method
                 Type[] targetParameters = GetPropertySetParametersTypes(targetProperty, false, !targetMethod.IsStatic).ToArray();
                 Type[] dynParameters = targetMethod.IsStatic ? targetParametersTypes : (new[] { typeof(object) }).Concat(targetParametersTypes).ToArray();
-                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, _moduleBuilder, true);
+                DynamicMethod dynMethod = new DynamicMethod(dynMethodName, typeof(void), dynParameters, proxyTypeBuilder.Module, true);
 
                 // Emit the dynamic method body
                 LazyILGenerator dynIL = new LazyILGenerator(dynMethod.GetILGenerator());

--- a/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -34,12 +34,8 @@ namespace Datadog.Trace.DuckTyping
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static readonly Dictionary<Assembly, ModuleBuilder> ActiveBuilders = new Dictionary<Assembly, ModuleBuilder>();
 
-        /// <summary>
-        /// Count of emmited AssemblyBuilders.
-        /// </summary>
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static long _assemblyCount = 0;
-
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static long _typeCount = 0;
 

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -130,14 +130,8 @@ namespace Datadog.Trace.DuckTyping
                         interfaceTypes = new[] { typeof(IDuckType) };
                     }
 
-                    // Ensures the module builder
-                    if (_moduleBuilder is null)
-                    {
-                        var id = Guid.NewGuid().ToString("N");
-                        AssemblyName aName = new AssemblyName("DuckTypeAssembly._" + id);
-                        _assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(aName, AssemblyBuilderAccess.Run);
-                        _moduleBuilder = _assemblyBuilder.DefineDynamicModule("MainModule");
-                    }
+                    // Gets the module builder
+                    var moduleBuilder = GetModuleBuilder(targetType);
 
                     string assembly = string.Empty;
                     if (targetType.Assembly != null)
@@ -151,10 +145,10 @@ namespace Datadog.Trace.DuckTyping
                     }
 
                     // Create a valid type name that can be used as a member of a class. (BenchmarkDotNet fails if is an invalid name)
-                    string proxyTypeName = $"{assembly}.{targetType.FullName.Replace(".", "_").Replace("+", "__")}.{proxyDefinitionType.FullName.Replace(".", "_").Replace("+", "__")}";
+                    string proxyTypeName = $"{assembly}.{targetType.FullName.Replace(".", "_").Replace("+", "__")}.{proxyDefinitionType.FullName.Replace(".", "_").Replace("+", "__")}_{++_typeCount}";
 
                     // Create Type
-                    TypeBuilder proxyTypeBuilder = _moduleBuilder.DefineType(
+                    TypeBuilder proxyTypeBuilder = moduleBuilder.DefineType(
                         proxyTypeName,
                         typeAttributes,
                         parentType,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DuplicateTypeProxySmokeTest.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DuplicateTypeProxySmokeTest.cs
@@ -1,0 +1,20 @@
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class DuplicateTypeProxySmokeTest : SmokeTestBase
+    {
+        public DuplicateTypeProxySmokeTest(ITestOutputHelper output)
+            : base(output, "DuplicateTypeProxy")
+        {
+        }
+
+        [Fact]
+        [Trait("Category", "Smoke")]
+        public void NoExceptions()
+        {
+            CheckForSmoke(shouldDeserializeTraces: false);
+        }
+    }
+}

--- a/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
+++ b/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+      <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+      <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    </ItemGroup>
+  
+  </Project>

--- a/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
+++ b/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
-      <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
       <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
     </PropertyGroup>
 

--- a/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
+++ b/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+      <TargetFrameworks>netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
+      <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
       <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
     </PropertyGroup>
 

--- a/test/test-applications/regression/DuplicateTypeProxy/Program.cs
+++ b/test/test-applications/regression/DuplicateTypeProxy/Program.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace DuplicateTypeProxy
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            await RunAsync(typeof(HttpClient));
+
+            for (int i = 0; i < 5; i++)
+            {
+                var assembly = Assembly.LoadFile(typeof(HttpClient).Assembly.Location);
+                await RunAsync(assembly.GetType("System.Net.Http.HttpClient"));
+            }
+        }
+
+        public static async Task RunAsync(Type httpClientType)
+        {
+            var instance = Activator.CreateInstance(httpClientType);
+            var getAsync = httpClientType.GetMethod("GetAsync", new[] { typeof(string) });
+
+            var task = (Task)getAsync.Invoke(instance, new[] { "http://www.contoso.com" });
+            await task;
+        }
+    }
+}

--- a/test/test-applications/regression/DuplicateTypeProxy/Program.cs
+++ b/test/test-applications/regression/DuplicateTypeProxy/Program.cs
@@ -17,6 +17,15 @@ namespace DuplicateTypeProxy
                 var assembly = Assembly.LoadFile(typeof(HttpClient).Assembly.Location);
                 await RunAsync(assembly.GetType("System.Net.Http.HttpClient"));
             }
+
+#if NETCOREAPP3_1 || NET5_0
+            for (int i = 0; i < 5; i++)
+            {
+                var alc = new System.Runtime.Loader.AssemblyLoadContext($"Context: {i}");
+                var assembly = alc.LoadFromAssemblyPath(typeof(HttpClient).Assembly.Location);
+                await RunAsync(assembly.GetType("System.Net.Http.HttpClient"));
+            }
+#endif
         }
 
         public static async Task RunAsync(Type httpClientType)

--- a/test/test-applications/regression/DuplicateTypeProxy/Properties/launchSettings.json
+++ b/test/test-applications/regression/DuplicateTypeProxy/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "DuplicateTypeProxy": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)profiler-lib\\integrations.json"
+      },
+      "nativeDebugging": false
+    }
+  }
+}


### PR DESCRIPTION
This `PR` adds Ducktype module isolation by target assembly.


@DataDog/apm-dotnet