### PR TITLE
CallTargetState and CallTargetReturn micro-optimizations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetReturn.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetReturn.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetReturn<T> GetDefault()
         {
-            return new CallTargetReturn<T>(default);
+            return default;
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/CallTargetState.cs
@@ -52,12 +52,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _startTime = startTime;
         }
 
-        private CallTargetState(Scope previousScope, Scope scope, object state)
+        internal CallTargetState(Scope previousScope, CallTargetState state)
         {
             _previousScope = previousScope;
-            _scope = scope;
-            _state = state;
-            _startTime = null;
+            _scope = state._scope;
+            _state = state._state;
+            _startTime = state._startTime;
         }
 
         /// <summary>
@@ -70,9 +70,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// </summary>
         public object State => _state;
 
-        internal Scope PreviousScope => _previousScope;
+        /// <summary>
+        /// Gets the CallTarget state StartTime
+        /// </summary>
+        public DateTimeOffset? StartTime => _startTime;
 
-        internal DateTimeOffset? StartTime => _startTime;
+        internal Scope PreviousScope => _previousScope;
 
         /// <summary>
         /// Gets the default call target state (used by the native side to initialize the locals)
@@ -81,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetState GetDefault()
         {
-            return new CallTargetState(null);
+            return default;
         }
 
         /// <summary>
@@ -91,11 +94,6 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         public override string ToString()
         {
             return $"{typeof(CallTargetState).FullName}({_previousScope}, {_scope}, {_state})";
-        }
-
-        internal static CallTargetState WithPreviousScope(Scope previousScope, CallTargetState state)
-        {
-            return new CallTargetState(previousScope, state._scope, state._state);
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, object[] arguments)
         {
-            return CallTargetState.WithPreviousScope(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arguments));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arguments));
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationOptions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationOptions.cs
@@ -17,10 +17,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         internal static void DisableIntegration() => _disableIntegration = true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void LogException(Exception exception, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        internal static void LogException(Exception exception)
         {
             // ReSharper disable twice ExplicitCallerInfoArgument
-            Log.Error(exception, exception?.Message, sourceLine, sourceFile);
+            Log.Error(exception, exception?.Message);
             if (exception is DuckTypeException)
             {
                 Log.Warning($"DuckTypeException has been detected, the integration <{typeof(TIntegration)}, {typeof(TTarget)}> will be disabled.");


### PR DESCRIPTION
This PR include some micro-optimizations due `CallTargetState` being used in the hotpath.

### CallTargetState.GetDefault()

#### Old:
```
    L0000: push rdi
    L0001: push rsi
    L0002: push rbx
    L0003: sub rsp, 0x50
    L0007: vzeroupper
    L000a: mov rsi, rcx
    L000d: lea rdi, [rsp+0x20]
    L0012: mov ecx, 0xc
    L0017: xor eax, eax
    L0019: rep stosd
    L001b: mov rcx, rsi
    L001e: mov rbx, rcx
    L0021: lea rcx, [rsp+0x20]
    L0026: vxorps xmm0, xmm0, xmm0
    L002b: vmovdqu [rcx], xmm0
    L0030: vmovdqu [rcx+0x10], xmm0
    L0036: vmovdqu [rcx+0x20], xmm0
    L003c: lea rcx, [rsp+0x20]
    L0041: xor edx, edx
    L0043: call CallTargetState..ctor(System.Object)
    L0048: mov rdi, rbx
    L004b: lea rsi, [rsp+0x20]
    L0050: call 0x7ff81e8b40c0
    L0055: call 0x7ff81e8b40c0
    L005a: call 0x7ff81e8b40c0
    L005f: movsq
    L0061: movsq
    L0063: movsq
    L0065: mov rax, rbx
    L0068: add rsp, 0x50
    L006c: pop rbx
    L006d: pop rsi
    L006e: pop rdi
    L006f: ret
```
#### New:
```
    L0000: vzeroupper
    L0003: vxorps xmm0, xmm0, xmm0
    L0008: vmovdqu [rcx], xmm0
    L000d: vmovdqu [rcx+0x10], xmm0
    L0013: vmovdqu [rcx+0x20], xmm0
    L0019: mov rax, rcx
    L001c: ret
```

### CallTargetState.WithPreviousScope(System.Object, CallTargetState)

#### Old: (Also runs `CallTargetState..ctor(System.Object, System.Object, System.Object)`)
```
    L0000: push rdi
    L0001: push rsi
    L0002: push rbx
    L0003: sub rsp, 0x50
    L0007: vzeroupper
    L000a: mov rsi, rcx
    L000d: lea rdi, [rsp+0x20]
    L0012: mov ecx, 0xc
    L0017: xor eax, eax
    L0019: rep stosd
    L001b: mov rcx, rsi
    L001e: mov rbx, rcx
    L0021: lea r9, [rsp+0x20]
    L0026: vxorps xmm0, xmm0, xmm0
    L002b: vmovdqu [r9], xmm0
    L0030: vmovdqu [r9+0x10], xmm0
    L0036: vmovdqu [r9+0x20], xmm0
    L003c: mov r9, [r8+0x10]
    L0040: mov r8, [r8+0x8]
    L0044: lea rcx, [rsp+0x20]
    L0049: call CallTargetState..ctor(System.Object, System.Object, System.Object)
    L004e: mov rdi, rbx
    L0051: lea rsi, [rsp+0x20]
    L0056: call 0x7ff81e8b40c0
    L005b: call 0x7ff81e8b40c0
    L0060: call 0x7ff81e8b40c0
    L0065: movsq
    L0067: movsq
    L0069: movsq
    L006b: mov rax, rbx
    L006e: add rsp, 0x50
    L0072: pop rbx
    L0073: pop rsi
    L0074: pop rdi
    L0075: ret
```

#### New: (Removed and now using a custom .ctor)
```
CallTargetState..ctor(System.Object, CallTargetState)
    L0000: push rdi
    L0001: push rsi
    L0002: vzeroupper
    L0005: mov rdi, rcx
    L0008: mov rsi, r8
    L000b: mov rcx, rdi
    L000e: call 0x7ff81e8b3f80
    L0013: mov rdx, [rsi+0x8]
    L0017: lea rcx, [rdi+0x8]
    L001b: call 0x7ff81e8b3f80
    L0020: mov rdx, [rsi+0x10]
    L0024: lea rcx, [rdi+0x10]
    L0028: call 0x7ff81e8b3f80
    L002d: add rsi, 0x18
    L0031: add rdi, 0x18
    L0035: vmovdqu xmm0, [rsi]
    L003a: vmovdqu [rdi], xmm0
    L003f: mov rax, [rsi+0x10]
    L0043: mov [rdi+0x10], rax
    L0047: pop rsi
    L0048: pop rdi
    L0049: ret
```


@DataDog/apm-dotnet