### PR TITLE
Add TryConvertToNormalizedTagName method and apply to DD_TRACE_HEADER_TAGS

### DIFF
--- a/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 
 namespace Datadog.Trace.ExtensionMethods
 {
@@ -68,6 +69,51 @@ namespace Datadog.Trace.ExtensionMethods
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Datadog tag requirements:
+        /// 1. Tag must start with a letter
+        /// 2. Tag cannot exceed 200 characters
+        /// 3. If the first two requirements are met, then valid characters will be retained while all other characters will be converted to underscores. Valid characters include:
+        ///    - Alphanumerics
+        ///    - Underscores
+        ///    - Minuses
+        ///    - Colons
+        ///    - Periods
+        ///    - Slashes
+        ///
+        /// Note: This method will trim leading/trailing whitespace before checking the requirements.
+        /// </summary>
+        /// <param name="value">Input string to convert into tag name</param>
+        /// <param name="result">If the method returns true, the</param>
+        /// <param name="convertPeriodsToUnderscores">A flag determining whether periods should also be converted to underscores</param>
+        /// <returns>Returns whether the conversion was successful</returns>
+        public static bool TryConvertToNormalizedTagName(this string value, out string result, bool convertPeriodsToUnderscores = false)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                result = null;
+                return false;
+            }
+
+            string trimmedValue = value?.Trim();
+            if (!char.IsLetter(trimmedValue[0]) || trimmedValue.Length > 200)
+            {
+                result = null;
+                return false;
+            }
+
+            if (convertPeriodsToUnderscores)
+            {
+                result = Regex.Replace(input: trimmedValue, pattern: "[^a-zA-Z0-9_:/-]", replacement: "_").ToLowerInvariant();
+                return true;
+            }
+            else
+            {
+                result = Regex.Replace(input: trimmedValue, pattern: "[^a-zA-Z0-9_:./-]", replacement: "_").ToLowerInvariant();
+                return true;
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Tests.Configuration
     {
         private static readonly Dictionary<string, string> TagsK1V1K2V2 = new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" } };
         private static readonly Dictionary<string, string> TagsK2V2 = new Dictionary<string, string> { { "k2", "v2" } };
-        private static readonly Dictionary<string, string> HeaderTags = new Dictionary<string, string> { { "header1", "tag1" } };
+        private static readonly Dictionary<string, string> HeaderTagsWithMappings = new Dictionary<string, string> { { "header1", "tag1" }, { "header2", "content-type" }, { "header3", "content-type" }, { "header4", "c___ont_____ent----typ_/_e" }, { "header5", "some_header" } };
         private static readonly Dictionary<string, string> HeaderTagsSameTag = new Dictionary<string, string> { { "header1", "tag1" }, { "header2", "tag1" } };
 
         public static IEnumerable<object[]> GetGlobalDefaultTestData()
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "true", CreateFunc(s => s.AnalyticsEnabled), true };
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "false", CreateFunc(s => s.AnalyticsEnabled), false };
 
-            yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,:tagonly,headeronly:,:,nocolon", CreateFunc(s => s.HeaderTags), HeaderTags };
+            yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:Content-Type,header3: Content-Type ,header4:C!!!ont_____ent----tYp!/!e,header5:Some.Header,:invalidtagonly,invalidheaderonly:,:", CreateFunc(s => s.HeaderTags), HeaderTagsWithMappings };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:tag1", CreateFunc(s => s.HeaderTags), HeaderTagsSameTag };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header1:tag2", CreateFunc(s => s.HeaderTags.Count), 1 };
         }


### PR DESCRIPTION
Add new extension method string.TryConvertToNormalizedTagName. This follows the tag requirements specified by https://docs.datadoghq.com/getting_started/tagging/#defining-tags

Additionally, use the new method in the DD_TRACE_HEADER_TAGS feature to convert user-specified tag names to valid tag names. Invalid tag names will be ignored by the feature instead of being allowed through.

Note: This is a breaking behavior difference if the user was submitting invalid tags.

@DataDog/apm-dotnet