### PR TITLE
Don't set the service name in the span constructor

### DIFF
--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -31,7 +31,6 @@ namespace Datadog.Trace
         {
             Tags = tags ?? new CommonTags();
             Context = context;
-            ServiceName = context.ServiceName;
             StartTime = start ?? Context.TraceContext.UtcNow;
 
             Log.Debug(


### PR DESCRIPTION
The service name property is bound to the context, so we're setting the context service name to the value of the context service name.
