### PR TITLE
Add log rotation for native logger

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -3,7 +3,7 @@
 #include "pal.h"
 
 #include "spdlog/sinks/null_sink.h"
-#include "spdlog/sinks/basic_file_sink.h"
+#include "spdlog/sinks/rotating_file_sink.h"
 
 #ifndef _WIN32
 typedef struct stat Stat;
@@ -64,7 +64,8 @@ Logger::Logger() {
   spdlog::flush_every(std::chrono::seconds(3));
 
   try {
-    m_fileout = spdlog::basic_logger_mt("Logger", GetLogPath());
+    m_fileout = spdlog::rotating_logger_mt(
+        "Logger", GetLogPath(), 1048576 * 5, 10);
   }
   catch (...) {
     std::cerr << "Logger Handler: Error creating native log file." << std::endl;

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -65,8 +65,11 @@ Logger::Logger() {
 
   static auto current_process_name = ToString(GetCurrentProcessName());
   static auto current_process_id= GetPID();
-  static auto file_name_suffix =
-      "-" + current_process_name + "-" + std::to_string(current_process_id);
+  static auto current_process_without_extension =
+      current_process_name.substr(0, current_process_name.find_last_of("."));
+
+  static auto file_name_suffix = "-" + current_process_without_extension + "-" +
+                                 std::to_string(current_process_id);
 
   try {
     m_fileout = spdlog::rotating_logger_mt(

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -26,8 +26,8 @@ std::string getPathName(const std::string& s) {
 }
 #endif
 
-std::string Logger::GetLogPath() {
-  const auto path = ToString(DatadogLogFilePath());
+std::string Logger::GetLogPath(const std::string& file_name_suffix) {
+  const auto path = ToString(DatadogLogFilePath(file_name_suffix));
 
 #ifdef _WIN32
   // on VC++, use std::filesystem (C++ 17) to
@@ -63,9 +63,14 @@ Logger::Logger() {
 
   spdlog::flush_every(std::chrono::seconds(3));
 
+  static auto current_process_name = ToString(GetCurrentProcessName());
+  static auto current_process_id= GetPID();
+  static auto file_name_suffix =
+      "-" + current_process_name + "-" + std::to_string(current_process_id);
+
   try {
     m_fileout = spdlog::rotating_logger_mt(
-        "Logger", GetLogPath(), 1048576 * 5, 10);
+        "Logger", GetLogPath(file_name_suffix), 1048576 * 5, 10);
   }
   catch (...) {
     std::cerr << "Logger Handler: Error creating native log file." << std::endl;
@@ -74,10 +79,7 @@ Logger::Logger() {
 
   m_fileout->set_level(spdlog::level::debug);
 
-  static auto current_process_name = ToString(GetCurrentProcessName());
-
-  m_fileout->set_pattern("%D %I:%M:%S.%e %p [" + current_process_name +
-                         "|%P|%t] [%l] %v");
+  m_fileout->set_pattern("%D %I:%M:%S.%e %p [%P|%t] [%l] %v");
 
   m_fileout->flush_on(spdlog::level::info);
 };

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -17,7 +17,7 @@ class Logger : public Singleton<Logger> {
 
  private:
   std::shared_ptr<spdlog::logger> m_fileout;
-  static std::string GetLogPath();
+  static std::string GetLogPath(const std::string& file_name_suffix);
   Logger();
   ~Logger();
 

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -24,7 +24,7 @@
 
 namespace trace {
 
-inline WSTRING DatadogLogFilePath() {
+inline WSTRING DatadogLogFilePath(const std::string& file_name_suffix) {
   WSTRING directory = GetEnvironmentValue(environment::log_directory);
 
   if (directory.length() > 0) {
@@ -34,7 +34,7 @@ inline WSTRING DatadogLogFilePath() {
 #else
            WStr('/') +
 #endif
-        WStr("dotnet-tracer-native.log");
+           ToWSTRING("dotnet-tracer-native" + file_name_suffix + ".log");
   }
 
   WSTRING path = GetEnvironmentValue(environment::log_path);
@@ -56,9 +56,11 @@ inline WSTRING DatadogLogFilePath() {
   }
 
   return ToWSTRING(program_data +
-                   R"(\Datadog .NET Tracer\logs\dotnet-tracer-native.log)");
+                   R"(\Datadog .NET Tracer\logs\dotnet-tracer-native)" + 
+                   file_name_suffix + ".log");
 #else
-  return WStr("/var/log/datadog/dotnet/dotnet-tracer-native.log");
+  return ToWSTRING("/var/log/datadog/dotnet/dotnet-tracer-native" +
+                   file_name_suffix + ".log");
 #endif
 }
 


### PR DESCRIPTION
- Enable the rotating file sink for the native logger
- Include the pid and process name in the rotating logger to avoid multiple processes locking file, as described in https://github.com/DataDog/dd-trace-dotnet/pull/1044

So instead of a single filename:

```
dotnet-tracer-native.log
```

We will have multiple, one for each process (+ additional for rolled files):

```
dotnet-tracer-native-dotnet-30432.log
dotnet-tracer-native-Samples.AspNetCoreMvc31-31872.log
dotnet-tracer-native-Samples.AspNetCoreRazorPages-31872.log
```

@DataDog/apm-dotnet