### PR TITLE
Increase buffer size to avoid edge cases of span dropping

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -1,4 +1,5 @@
 using Datadog.Trace.Ci;
+using Datadog.Trace.Configuration;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
 {
@@ -6,7 +7,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
     {
         static Common()
         {
-            TestTracer = Tracer.Instance;
+            var settings = TracerSettings.FromDefaultSources();
+            settings.TraceBufferSize = 1024 * 1024 * 45; // slightly lower than the 50mb payload agent limit.
+
+            TestTracer = new Tracer(settings);
             ServiceName = TestTracer.DefaultServiceName;
 
             // Preload environment variables.

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
@@ -1,4 +1,5 @@
 using Datadog.Trace.Ci;
+using Datadog.Trace.Configuration;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.Testing
 {
@@ -6,7 +7,10 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
     {
         static Common()
         {
-            TestTracer = Tracer.Instance;
+            var settings = TracerSettings.FromDefaultSources();
+            settings.TraceBufferSize = 1024 * 1024 * 45; // slightly lower than the 50mb payload agent limit.
+
+            TestTracer = new Tracer(settings);
             ServiceName = TestTracer.DefaultServiceName;
 
             // Preload environment variables.

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -373,14 +373,14 @@ namespace Datadog.Trace.Configuration
         internal ServiceNames ServiceNameMappings { get; }
 
         /// <summary>
-        /// Gets a value indicating the size in bytes of the trace buffer
+        /// Gets or sets a value indicating the size in bytes of the trace buffer
         /// </summary>
-        internal int TraceBufferSize { get; }
+        internal int TraceBufferSize { get; set; }
 
         /// <summary>
-        /// Gets a value indicating the batch interval for the serialization queue, in milliseconds
+        /// Gets or sets a value indicating the batch interval for the serialization queue, in milliseconds
         /// </summary>
-        internal int TraceBatchInterval { get; }
+        internal int TraceBatchInterval { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources


### PR DESCRIPTION
Currently the `AgentWriter` uses a maximum of 10mb as default value in both front and back buffer. This PR increases both maximum value to 45mb in both buffers only when running in the test runner to avoid edge cases when both buffers are full without flushing and a test span can be dropped.


@DataDog/apm-dotnet