### PR TITLE
Define benchmark scheduled runs in yaml

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -4,6 +4,15 @@ trigger:
       - master
       - refs/tags/*
 
+schedules:
+- cron: "0 3 * * *"
+  displayName: Daily 3am (UTC) build
+  branches:
+    include:
+    - master
+    - benchmarks/*
+  always: true
+
 variables:
   buildConfiguration: release
   dotnetCoreSdkVersion: 5.0.103


### PR DESCRIPTION
Currently this is defined via the "classic" editor in the UI. 
The new schedule won't take effect until we merge this branch and delete the classic UI entries


@DataDog/apm-dotnet