### PR TITLE
Move constant agent headers to a central place, to avoid duplication

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -59,8 +59,6 @@ namespace Datadog.Trace.Agent
 
                 // Set additional headers
                 request.AddHeader(AgentHttpHeaderNames.TraceCount, numberOfTraces.ToString());
-                request.AddHeader(AgentHttpHeaderNames.LanguageInterpreter, FrameworkDescription.Instance.Name);
-                request.AddHeader(AgentHttpHeaderNames.LanguageVersion, FrameworkDescription.Instance.ProductVersion);
 
                 if (_containerId != null)
                 {

--- a/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -13,11 +13,10 @@ namespace Datadog.Trace.Agent.Transports
             _request = request;
 
             // Default headers
-            _request.Headers.Add(AgentHttpHeaderNames.Language, ".NET");
-            _request.Headers.Add(AgentHttpHeaderNames.TracerVersion, TracerConstants.AssemblyVersion);
-
-            // don't add automatic instrumentation to requests from this HttpClient
-            _request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+            foreach (var pair in AgentHttpHeaderNames.DefaultHeaders)
+            {
+                _request.Headers.Add(pair.Key, pair.Value);
+            }
         }
 
         public void AddHeader(string name, string value)

--- a/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -12,12 +12,10 @@ namespace Datadog.Trace.Agent.Transports
         {
             _client = handler == null ? new HttpClient() : new HttpClient(handler);
 
-            // Default headers
-            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.Language, ".NET");
-            _client.DefaultRequestHeaders.Add(AgentHttpHeaderNames.TracerVersion, TracerConstants.AssemblyVersion);
-
-            // don't add automatic instrumentation to requests from this HttpClient
-            _client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+            foreach (var pair in AgentHttpHeaderNames.DefaultHeaders)
+            {
+                _client.DefaultRequestHeaders.Add(pair.Key, pair.Value);
+            }
         }
 
         public string Info(Uri endpoint)

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -1,4 +1,4 @@
-using System.Runtime.InteropServices;
+using System.Collections.Generic;
 
 namespace Datadog.Trace
 {
@@ -37,5 +37,17 @@ namespace Datadog.Trace
         /// The id of the container where the traced application is running.
         /// </summary>
         public const string ContainerId = "Datadog-Container-ID";
+
+        /// <summary>
+        /// Gets the default constant header that should be added to any request to the agent
+        /// </summary>
+        internal static KeyValuePair<string, string>[] DefaultHeaders { get; } =
+        {
+            new(Language, ".NET"),
+            new(TracerVersion, TracerConstants.AssemblyVersion),
+            new(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
+            new(LanguageInterpreter, FrameworkDescription.Instance.Name),
+            new(LanguageVersion, FrameworkDescription.Instance.ProductVersion)
+        };
     }
 }

--- a/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
+++ b/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.HttpOverStreams
@@ -13,8 +14,8 @@ namespace Datadog.Trace.HttpOverStreams
             {
                 if (_metadataHeaders == null)
                 {
-                    _metadataHeaders =
-                        $"{AgentHttpHeaderNames.Language}: .NET{DatadogHttpValues.CrLf}{AgentHttpHeaderNames.TracerVersion}: {TracerConstants.AssemblyVersion}{DatadogHttpValues.CrLf}{HttpHeaderNames.TracingEnabled}: false{DatadogHttpValues.CrLf}";
+                    var headers = AgentHttpHeaderNames.DefaultHeaders.Select(kvp => $"{kvp.Key}: {kvp.Value}{DatadogHttpValues.CrLf}");
+                    _metadataHeaders = string.Concat(headers);
                 }
 
                 return _metadataHeaders;


### PR DESCRIPTION
Also move LanguageInterpreter and LanguageVersion to the constant headers
