### PR TITLE
Compute top-level spans on the tracer side

### DIFF
--- a/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Agent.MessagePack
                 offset += MessagePackBinary.WriteByte(ref bytes, offset, 1);
             }
 
-            offset += value.Tags.SerializeTo(ref bytes, offset);
+            offset += value.Tags.SerializeTo(ref bytes, offset, value);
 
             return offset - originalOffset;
         }

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -39,6 +39,11 @@ namespace Datadog.Trace
         public const string ContainerId = "Datadog-Container-ID";
 
         /// <summary>
+        /// Tells the agent whether top-level spans are computed by the tracer
+        /// </summary>
+        public const string ComputedTopLevel = "Datadog-Client-Computed-Top-Level";
+
+        /// <summary>
         /// Gets the default constant header that should be added to any request to the agent
         /// </summary>
         internal static KeyValuePair<string, string>[] DefaultHeaders { get; } =
@@ -47,7 +52,8 @@ namespace Datadog.Trace
             new(TracerVersion, TracerConstants.AssemblyVersion),
             new(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
             new(LanguageInterpreter, FrameworkDescription.Instance.Name),
-            new(LanguageVersion, FrameworkDescription.Instance.ProductVersion)
+            new(LanguageVersion, FrameworkDescription.Instance.ProductVersion),
+            new(ComputedTopLevel, "1")
         };
     }
 }

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Tells the agent whether top-level spans are computed by the tracer
         /// </summary>
-        public const string ComputedTopLevel = "Datadog-Client-Computed-Top-Level";
+        public const string ComputedTopLevelSpan = "Datadog-Client-Computed-Top-Level";
 
         /// <summary>
         /// Gets the default constant header that should be added to any request to the agent
@@ -53,7 +53,7 @@ namespace Datadog.Trace
             new(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
             new(LanguageInterpreter, FrameworkDescription.Instance.Name),
             new(LanguageVersion, FrameworkDescription.Instance.ProductVersion),
-            new(ComputedTopLevel, "1")
+            new(ComputedTopLevelSpan, "1")
         };
     }
 }

--- a/src/Datadog.Trace/Metrics.cs
+++ b/src/Datadog.Trace/Metrics.cs
@@ -21,5 +21,11 @@ namespace Datadog.Trace
         /// Read: Rate Limiter Priority Sample Rate
         /// </summary>
         public const string SamplingLimitDecision = "_dd.limit_psr";
+
+        /// <summary>
+        /// To be set on top-level spans
+        /// Top-level spans are spans with a different service name from their immediate parent
+        /// </summary>
+        internal const string TopLevelSpan = "_dd.top_level";
     }
 }

--- a/src/Datadog.Trace/Metrics.cs
+++ b/src/Datadog.Trace/Metrics.cs
@@ -23,8 +23,8 @@ namespace Datadog.Trace
         public const string SamplingLimitDecision = "_dd.limit_psr";
 
         /// <summary>
-        /// To be set on top-level spans
-        /// Top-level spans are spans with a different service name from their immediate parent
+        /// Identifies top-level spans.
+        /// Top-level spans have a different service name from their immediate parent or have no parent.
         /// </summary>
         internal const string TopLevelSpan = "_dd.top_level";
     }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -92,7 +92,9 @@ namespace Datadog.Trace
 
         internal bool IsFinished { get; private set; }
 
-        internal bool IsRootSpan => Context?.TraceContext?.RootSpan == this;
+        internal bool IsRootSpan => Context.TraceContext?.RootSpan == this;
+
+        internal bool IsTopLevel => Context.Parent == null || Context.Parent.ServiceName != ServiceName;
 
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.

--- a/src/Datadog.Trace/Tagging/ITags.cs
+++ b/src/Datadog.Trace/Tagging/ITags.cs
@@ -10,6 +10,6 @@ namespace Datadog.Trace.Tagging
 
         void SetMetric(string key, double? value);
 
-        int SerializeTo(ref byte[] buffer, int offset);
+        int SerializeTo(ref byte[] buffer, int offset, Span span);
     }
 }

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
@@ -149,12 +148,6 @@ namespace Datadog.Trace.Tests
             spans.Add((_tracer.StartActive("Child2", serviceName: "child"), true));
             spans.Add((_tracer.StartActive("Child3", serviceName: "child"), false));
             spans.Add((_tracer.StartActive("Child4", serviceName: "root"), true));
-
-            // Dispose the scope to populate the top-level property
-            foreach (var (scope, _) in spans.AsEnumerable().Reverse())
-            {
-                scope.Dispose();
-            }
 
             foreach (var (scope, expectedResult) in spans)
             {

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using FluentAssertions;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -134,6 +137,29 @@ namespace Datadog.Trace.Tests
             Assert.True(
                 stopwatchSpanDiff < maxDifference,
                 $"Span duration difference ({stopwatchSpanDiff}ms) outside of allowed threshold {maxDifference}ms. Expected average: {avgStopwatch}ms, actual average: {avgSpan}ms");
+        }
+
+        [Fact]
+        public void TopLevelSpans()
+        {
+            var spans = new List<(Scope Scope, bool IsTopLevel)>();
+
+            spans.Add((_tracer.StartActive("Root", serviceName: "root"), true));
+            spans.Add((_tracer.StartActive("Child1", serviceName: "root"), false));
+            spans.Add((_tracer.StartActive("Child2", serviceName: "child"), true));
+            spans.Add((_tracer.StartActive("Child3", serviceName: "child"), false));
+            spans.Add((_tracer.StartActive("Child4", serviceName: "root"), true));
+
+            // Dispose the scope to populate the top-level property
+            foreach (var (scope, _) in spans.AsEnumerable().Reverse())
+            {
+                scope.Dispose();
+            }
+
+            foreach (var (scope, expectedResult) in spans)
+            {
+                scope.Span.Should().Match<Span>(s => s.IsTopLevel == expectedResult);
+            }
         }
     }
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
This is a requirement to implement flushing of partial traces.
