### PR TITLE
CallTarget ADO.NET performance improvements.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteNonQueryAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteNonQueryAsyncIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteNonQueryIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteNonQueryIntegration.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteNonQueryWithBehaviorIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteNonQueryWithBehaviorIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderAsyncIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderIntegration.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorAsyncIntegration.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior, CancellationToken cancellationToken)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorIntegration.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteScalarAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteScalarAsyncIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteScalarIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteScalarIntegration.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(ScopeFactory.CreateDbCommandScope(Tracer.Instance, instance as IDbCommand));
+            return new CallTargetState(ScopeDBFactory<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             if (_dbTypeName == null)
             {
-                // don't create a scope, skip this trace
+                // don't create a scope, skip this span
                 return null;
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Data;
+using Datadog.Trace.ClrProfiler.Integrations.AdoNet;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler
+{
+    internal static class ScopeDBFactory<T>
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ScopeDBFactory<T>));
+
+        private static readonly string _fullName;
+        private static readonly string _dbTypeName;
+        private static readonly string _operationName;
+
+        static ScopeDBFactory()
+        {
+            var type = typeof(T);
+            _fullName = type.FullName;
+            _dbTypeName = ScopeFactory.GetDbType(type.Name);
+            _operationName = $"{_dbTypeName}.query";
+        }
+
+        public static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command)
+        {
+            if (_dbTypeName == null)
+            {
+                // don't create a scope, skip this trace
+                return null;
+            }
+
+            if (!tracer.Settings.IsIntegrationEnabled(AdoNetConstants.IntegrationId))
+            {
+                // integration disabled, don't create a scope, skip this trace
+                return null;
+            }
+
+            if (tracer.Settings.AdoNetExcludedTypes.Count > 0 && tracer.Settings.AdoNetExcludedTypes.Contains(_fullName))
+            {
+                // AdoNet type disabled, don't create a scope, skip this trace
+                return null;
+            }
+
+            Scope scope = null;
+
+            try
+            {
+                Span parent = tracer.ActiveScope?.Span;
+
+                if (parent != null &&
+                    parent.Type == SpanTypes.Sql &&
+                    parent.GetTag(Tags.DbType) == _dbTypeName &&
+                    parent.ResourceName == command.CommandText)
+                {
+                    // we are already instrumenting this,
+                    // don't instrument nested methods that belong to the same stacktrace
+                    // e.g. ExecuteReader() -> ExecuteReader(commandBehavior)
+                    return null;
+                }
+
+                string serviceName = tracer.Settings.GetServiceName(tracer, _dbTypeName);
+
+                var tags = new SqlTags();
+                scope = tracer.StartActiveWithTags(_operationName, tags: tags, serviceName: serviceName);
+                scope.Span.AddTagsFromDbCommand(command);
+
+                tags.DbType = _dbTypeName;
+
+                tags.SetAnalyticsSampleRate(AdoNetConstants.IntegrationId, tracer.Settings, enabledWithGlobalSetting: false);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error creating or populating scope.");
+            }
+
+            return scope;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
@@ -32,13 +32,13 @@ namespace Datadog.Trace.ClrProfiler
 
             if (!tracer.Settings.IsIntegrationEnabled(AdoNetConstants.IntegrationId))
             {
-                // integration disabled, don't create a scope, skip this trace
+                // integration disabled, don't create a scope, skip this span
                 return null;
             }
 
             if (tracer.Settings.AdoNetExcludedTypes.Count > 0 && tracer.Settings.AdoNetExcludedTypes.Contains(_fullName))
             {
-                // AdoNet type disabled, don't create a scope, skip this trace
+                // AdoNet type disabled, don't create a scope, skip this span
                 return null;
             }
 

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Data;
+using System.Data.Common;
+using Datadog.Trace.Configuration;
+using MySql.Data.MySqlClient;
+using Npgsql;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class ScopeDBFactoryTests
+    {
+        public static IEnumerable<object[]> GetDbCommandScopeData()
+        {
+            yield return new object[] { new System.Data.SqlClient.SqlCommand() };
+            yield return new object[] { new MySqlCommand() };
+            yield return new object[] { new NpgsqlCommand() };
+#if !NET452
+            yield return new object[] { new Microsoft.Data.SqlClient.SqlCommand() };
+#endif
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDbCommandScopeData))]
+        public void CreateDbCommandScope_ReturnsNullForExcludedAdoNetTypes(IDbCommand command)
+        {
+            // Set up tracer
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.AdoNetExcludedTypes, command.GetType().FullName }
+            };
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var tracerSettings = new TracerSettings(source);
+            var tracer = new Tracer(tracerSettings);
+
+            // Create scope
+            using (var outerScope = CreateDbCommandScope(tracer, new CustomDbCommand()))
+            {
+                using (var innerScope = CreateDbCommandScope(tracer, command))
+                {
+                    Assert.Null(innerScope);
+                }
+
+                Assert.NotNull(outerScope);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDbCommandScopeData))]
+        public void CreateDbCommandScope_UsesReplacementServiceNameWhenProvided(IDbCommand command)
+        {
+            // Set up tracer
+            var dbType = ScopeFactory.GetDbType(command.GetType().Name);
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.ServiceNameMappings, $"{dbType}:my-custom-type" }
+            };
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var tracerSettings = new TracerSettings(source);
+            var tracer = new Tracer(tracerSettings);
+
+            // Create scope
+            using (var outerScope = CreateDbCommandScope(tracer, command))
+            {
+                Assert.Equal("my-custom-type", outerScope.Span.ServiceName);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDbCommandScopeData))]
+        public void CreateDbCommandScope_IgnoresReplacementServiceNameWhenNotProvided(IDbCommand command)
+        {
+            // Set up tracer
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.ServiceNameMappings, $"something:my-custom-type" }
+            };
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var tracerSettings = new TracerSettings(source);
+            var tracer = new Tracer(tracerSettings);
+
+            // Create scope
+            using (var outerScope = CreateDbCommandScope(tracer, command))
+            {
+                Assert.NotEqual("my-custom-type", outerScope.Span.ServiceName);
+            }
+        }
+
+        private static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command)
+        {
+            return (Scope)typeof(ScopeDBFactory<>)
+                .MakeGenericType(command.GetType())
+                .GetMethod(nameof(CreateDbCommandScope))
+                .Invoke(null, new object[] { tracer, command });
+        }
+
+        private class CustomDbCommand : DbCommand
+        {
+            public override string CommandText { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override int CommandTimeout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override CommandType CommandType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override bool DesignTimeVisible { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override UpdateRowSource UpdatedRowSource { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            protected override DbConnection DbConnection { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            protected override DbParameterCollection DbParameterCollection => throw new NotImplementedException();
+
+            protected override DbTransaction DbTransaction { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public override void Cancel()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override int ExecuteNonQuery()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override object ExecuteScalar()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Prepare()
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override DbParameter CreateDbParameter()
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Improve performance of CallTarget ADO.NET instrumentation in both CPU and Memory.

![image](https://user-images.githubusercontent.com/69803/112317399-4c760a80-8cac-11eb-999e-ab46a07fcdef.png)



@DataDog/apm-dotnet