### PR TITLE
Report Trace Drop/Keep Rate to the Agent

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -326,7 +327,14 @@ namespace Datadog.Trace.Agent
             if (rootSpan is not null)
             {
                 var currentKeepRate = _traceKeepRateCalculator.GetKeepRate();
-                rootSpan.Tags.SetMetric(Metrics.TracesKeepRate, currentKeepRate);
+                if (rootSpan.Tags is CommonTags commonTags)
+                {
+                    commonTags.TracesKeepRate = currentKeepRate;
+                }
+                else
+                {
+                    rootSpan.Tags.SetMetric(Metrics.TracesKeepRate, currentKeepRate);
+                }
             }
 
             // We use a double-buffering mechanism

--- a/src/Datadog.Trace/Agent/IKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/IKeepRateCalculator.cs
@@ -1,0 +1,25 @@
+﻿namespace Datadog.Trace.Agent
+{
+    internal interface IKeepRateCalculator
+    {
+        /// <summary>
+        /// Increment the number of kept traces
+        /// </summary>
+        void IncrementKeeps(int count);
+
+        /// <summary>
+        /// Increment the number of dropped traces
+        /// </summary>
+        void IncrementDrops(int count);
+
+        /// <summary>
+        /// Get the current keep rate for traces
+        /// </summary>
+        double GetKeepRate();
+
+        /// <summary>
+        /// Stop updating the buckets. The current Keep rate can continue to be read.
+        /// </summary>
+        void CancelUpdates();
+    }
+}

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Agent
+{
+    /// <summary>
+    /// Used to calculate the Trace Keep Rate, tracking the number of
+    /// traces kept and dropped that should have been sent to the backend.
+    /// Traces ignored due to sampling are not included in these rates.
+    /// </summary>
+    internal class MovingAverageKeepRateCalculator : IKeepRateCalculator
+    {
+        private const int DefaultKeepRate = 10;
+        private static readonly TimeSpan DefaultBucketDuration = TimeSpan.FromSeconds(1);
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<MovingAverageKeepRateCalculator>();
+
+        private readonly int _windowSize;
+        private readonly TimeSpan _bucketDuration;
+        private readonly uint[] _dropped;
+        private readonly uint[] _created;
+
+        private readonly CancellationTokenSource _cts = new();
+
+        private int _index = 0;
+        private long _totals = 0;
+
+        private long _latestDrops = 0;
+        private long _latestKeeps = 0;
+
+        internal MovingAverageKeepRateCalculator(int size, TimeSpan bucketDuration)
+        {
+            if (size < 0 || size > 100)
+            {
+                throw new ArgumentOutOfRangeException(nameof(size), "Must be a value between 1 and 100");
+            }
+
+            _windowSize = size;
+            _bucketDuration = bucketDuration;
+            _dropped = new uint[size];
+            _created = new uint[size];
+
+            if (bucketDuration != Timeout.InfiniteTimeSpan)
+            {
+                Task.Run(UpdateBucketTaskLoopAsync)
+                    .ContinueWith(t => Log.Error(t.Exception, "Error in "), TaskContinuationOptions.OnlyOnFaulted);
+            }
+        }
+
+        public static MovingAverageKeepRateCalculator CreateDefaultKeepRateCalculator()
+            => new MovingAverageKeepRateCalculator(DefaultKeepRate, DefaultBucketDuration);
+
+        /// <summary>
+        /// Increment the number of kept traces
+        /// </summary>
+        public void IncrementKeeps(int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            Interlocked.Add(ref _latestKeeps, count);
+        }
+
+        /// <summary>
+        /// Increment the number of dropped traces
+        /// </summary>
+        public void IncrementDrops(int count)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            Interlocked.Add(ref _latestDrops, count);
+        }
+
+        /// <summary>
+        /// Get the current keep rate for traces
+        /// </summary>
+        public double GetKeepRate()
+        {
+            var totals = Interlocked.Read(ref _totals);
+            UnpackBits(totals, out var totalDropped, out var totalCreated);
+            if (totalCreated == 0)
+            {
+                return 0;
+            }
+
+            return 1 - ((double)totalDropped / totalCreated);
+        }
+
+        /// <summary>
+        /// Stop updating the buckets. The current Keep rate can continue to be read.
+        /// </summary>
+        public void CancelUpdates()
+        {
+            _cts.Cancel();
+        }
+
+        /// <summary>
+        /// Update the current rate. Internal for testing only. Should not be called in normal usage.
+        /// </summary>
+        internal void UpdateBucket()
+        {
+            var index = _index;
+            var previousDropped = _dropped[_index];
+            var previousCreated = _created[_index];
+
+            var latestDropped = Math.Min(Interlocked.Exchange(ref _latestDrops, 0), uint.MaxValue);
+            var latestCreated = Math.Min(Interlocked.Exchange(ref _latestKeeps, 0) + latestDropped, uint.MaxValue);
+
+            UnpackBits(_totals, out var previousTotalDropped, out var previousTotalCreated);
+
+            var newTotalDropped = (uint)Math.Min(((long)previousTotalDropped) - previousDropped + latestDropped, uint.MaxValue);
+            var newTotalCreated = (uint)Math.Min(((long)previousTotalCreated) - previousCreated + latestCreated, uint.MaxValue);
+
+            // Pack the totals into a single value we can read and write atomically
+            var packedTotal = PackBits(newTotalDropped, newTotalCreated);
+            Interlocked.Exchange(ref _totals, packedTotal);
+
+            _dropped[_index] = (uint)latestDropped;
+            _created[_index] = (uint)latestCreated;
+            _index = (index + 1) % _windowSize;
+        }
+
+        private async Task UpdateBucketTaskLoopAsync()
+        {
+            while (true)
+            {
+                if (_cts.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                UpdateBucket();
+
+                await Task.Delay(_bucketDuration, _cts.Token).ConfigureAwait(false);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private long PackBits(uint hits, uint total)
+        {
+            long result = hits;
+            result = result << 32;
+            return result | (long)total;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void UnpackBits(long bits, out uint hits, out uint total)
+        {
+            hits = (uint)(bits >> 32);
+            total = (uint)(bits & 0xffffffffL);
+        }
+    }
+}

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -23,7 +23,6 @@ namespace Datadog.Trace.Agent
         private readonly uint[] _dropped;
         private readonly uint[] _created;
 
-        private readonly CancellationTokenSource _cts = new();
         private readonly TaskCompletionSource<bool> _processExit = new TaskCompletionSource<bool>();
 
         private int _index = 0;

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -114,6 +114,7 @@ namespace Datadog.Trace.Agent
             var latestDropped = Math.Min(Interlocked.Exchange(ref _latestDrops, 0), uint.MaxValue);
             var latestCreated = Math.Min(Interlocked.Exchange(ref _latestKeeps, 0) + latestDropped, uint.MaxValue);
 
+            var totals = _totals;
             UnpackBits(totals, out var previousTotalDropped, out var previousTotalCreated);
 
             var newTotalDropped = (uint)Math.Min(((long)previousTotalDropped) - previousDropped + latestDropped, uint.MaxValue);

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -8,8 +8,9 @@ namespace Datadog.Trace.Agent
 {
     /// <summary>
     /// Used to calculate the Trace Keep Rate, tracking the number of
-    /// traces kept and dropped that should have been sent to the backend.
-    /// Traces ignored due to sampling are not included in these rates.
+    /// traces kept and dropped that should have been sent to the agent.
+    /// Traces that are subsequently dropped by the agent due to sampling
+    /// will not count as dropped in this rate.
     /// </summary>
     internal class MovingAverageKeepRateCalculator : IKeepRateCalculator
     {

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -108,13 +108,13 @@ namespace Datadog.Trace.Agent
         internal void UpdateBucket()
         {
             var index = _index;
-            var previousDropped = _dropped[_index];
-            var previousCreated = _created[_index];
+            var previousDropped = _dropped[index];
+            var previousCreated = _created[index];
 
             var latestDropped = Math.Min(Interlocked.Exchange(ref _latestDrops, 0), uint.MaxValue);
             var latestCreated = Math.Min(Interlocked.Exchange(ref _latestKeeps, 0) + latestDropped, uint.MaxValue);
 
-            UnpackBits(_totals, out var previousTotalDropped, out var previousTotalCreated);
+            UnpackBits(totals, out var previousTotalDropped, out var previousTotalCreated);
 
             var newTotalDropped = (uint)Math.Min(((long)previousTotalDropped) - previousDropped + latestDropped, uint.MaxValue);
             var newTotalCreated = (uint)Math.Min(((long)previousTotalCreated) - previousCreated + latestCreated, uint.MaxValue);
@@ -123,8 +123,8 @@ namespace Datadog.Trace.Agent
             var packedTotal = PackBits(newTotalDropped, newTotalCreated);
             Interlocked.Exchange(ref _totals, packedTotal);
 
-            _dropped[_index] = (uint)latestDropped;
-            _created[_index] = (uint)latestCreated;
+            _dropped[index] = (uint)latestDropped;
+            _created[index] = (uint)latestCreated;
             _index = (index + 1) % _windowSize;
         }
 

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Agent
             if (bucketDuration != Timeout.InfiniteTimeSpan)
             {
                 Task.Run(UpdateBucketTaskLoopAsync)
-                    .ContinueWith(t => Log.Error(t.Exception, "Error in "), TaskContinuationOptions.OnlyOnFaulted);
+                    .ContinueWith(t => Log.Error(t.Exception, $"Error in {nameof(MovingAverageKeepRateCalculator)} {nameof(UpdateBucketTaskLoopAsync)} "), TaskContinuationOptions.OnlyOnFaulted);
             }
         }
 

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -31,17 +31,17 @@ namespace Datadog.Trace.Agent
         private long _latestDrops = 0;
         private long _latestKeeps = 0;
 
-        internal MovingAverageKeepRateCalculator(int size, TimeSpan bucketDuration)
+        internal MovingAverageKeepRateCalculator(int windowSize, TimeSpan bucketDuration)
         {
-            if (size < 0 || size > 100)
+            if (windowSize < 0 || windowSize > 100)
             {
-                throw new ArgumentOutOfRangeException(nameof(size), "Must be a value between 1 and 100");
+                throw new ArgumentOutOfRangeException(nameof(windowSize), windowSize, "Must be a value between 1 and 100");
             }
 
-            _windowSize = size;
+            _windowSize = windowSize;
             _bucketDuration = bucketDuration;
-            _dropped = new uint[size];
-            _created = new uint[size];
+            _dropped = new uint[windowSize];
+            _created = new uint[windowSize];
 
             if (bucketDuration != Timeout.InfiniteTimeSpan)
             {

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Agent
     /// </summary>
     internal class MovingAverageKeepRateCalculator : IKeepRateCalculator
     {
-        private const int DefaultKeepRate = 10;
+        private const int DefaultWindowSize = 10;
         private static readonly TimeSpan DefaultBucketDuration = TimeSpan.FromSeconds(1);
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<MovingAverageKeepRateCalculator>();
 
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Agent
         }
 
         public static MovingAverageKeepRateCalculator CreateDefaultKeepRateCalculator()
-            => new MovingAverageKeepRateCalculator(DefaultKeepRate, DefaultBucketDuration);
+            => new MovingAverageKeepRateCalculator(DefaultWindowSize, DefaultBucketDuration);
 
         /// <summary>
         /// Increment the number of kept traces

--- a/src/Datadog.Trace/Metrics.cs
+++ b/src/Datadog.Trace/Metrics.cs
@@ -31,6 +31,6 @@ namespace Datadog.Trace
         /// <summary>
         /// Records the keep rate of spans in the tracer, independent of sampling rate
         /// </summary>
-        public const string TracesKeepRate = "_dd.tracer_kr";
+        internal const string TracesKeepRate = "_dd.tracer_kr";
     }
 }

--- a/src/Datadog.Trace/Metrics.cs
+++ b/src/Datadog.Trace/Metrics.cs
@@ -27,5 +27,10 @@ namespace Datadog.Trace
         /// Top-level spans have a different service name from their immediate parent or have no parent.
         /// </summary>
         internal const string TopLevelSpan = "_dd.top_level";
+
+        /// <summary>
+        /// Records the keep rate of spans in the tracer, independent of sampling rate
+        /// </summary>
+        public const string TracesKeepRate = "_dd.tracer_kr";
     }
 }

--- a/src/Datadog.Trace/Tagging/CommonTags.cs
+++ b/src/Datadog.Trace/Tagging/CommonTags.cs
@@ -5,7 +5,8 @@ namespace Datadog.Trace.Tagging
         protected static readonly IProperty<double?>[] CommonMetricsProperties =
         {
             new Property<CommonTags, double?>(Trace.Metrics.SamplingLimitDecision, t => t.SamplingLimitDecision, (t, v) => t.SamplingLimitDecision = v),
-            new Property<CommonTags, double?>(Trace.Metrics.SamplingPriority, t => t.SamplingPriority, (t, v) => t.SamplingPriority = v)
+            new Property<CommonTags, double?>(Trace.Metrics.SamplingPriority, t => t.SamplingPriority, (t, v) => t.SamplingPriority = v),
+            new Property<CommonTags, double?>(Trace.Metrics.TracesKeepRate, t => t.TracesKeepRate, (t, v) => t.TracesKeepRate = v)
         };
 
         protected static readonly IProperty<string>[] CommonTagsProperties =
@@ -21,6 +22,8 @@ namespace Datadog.Trace.Tagging
         public double? SamplingPriority { get; set; }
 
         public double? SamplingLimitDecision { get; set; }
+
+        public double? TracesKeepRate { get; set; }
 
         protected override IProperty<double?>[] GetAdditionalMetrics() => CommonMetricsProperties;
 

--- a/test/Datadog.Trace.Tests/Agent/MovingAverageKeepRateCalculatorTests.cs
+++ b/test/Datadog.Trace.Tests/Agent/MovingAverageKeepRateCalculatorTests.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Agent
+{
+    public class MovingAverageKeepRateCalculatorTests
+    {
+        [Theory]
+        [InlineData(0, 10, 0)]
+        [InlineData(6, 4, 0.6)]
+        [InlineData(9, 1, 0.9)]
+        [InlineData(1, 9, 0.1)]
+        [InlineData(10, 0, 1)]
+        [InlineData(100, 1, 0.99)]
+        public void Calculator_ShouldCalculateKeepRateCorrectly(int keep, int drop, double expected)
+        {
+            const int size = 5;
+
+            var calc = new MovingAverageKeepRateCalculator(size, Timeout.InfiniteTimeSpan);
+
+            calc.IncrementKeeps(keep);
+            calc.IncrementDrops(drop);
+            calc.UpdateBucket();
+
+            var actualRate = calc.GetKeepRate();
+
+            Assert.Equal(expected, actualRate, precision: 2);
+        }
+
+        [Theory]
+        [InlineData(1, 0.1, 0.2, 0.3, 0.4, 0.5)]
+        [InlineData(2, 0.1, 0.15, 0.25, 0.35, 0.45)]
+        [InlineData(3, 0.1, 0.15, 0.2, 0.3, 0.4)]
+        [InlineData(4, 0.1, 0.15, 0.2, 0.25, 0.35)]
+        [InlineData(5, 0.1, 0.15, 0.2, 0.25, 0.3)]
+        public void Calculator_ShouldUpdateRates_BasedOnBucketSize(
+            int size, double rate1, double rate2, double rate3, double rate4, double rate5)
+        {
+            var values = new[]
+            {
+                (keep: 1, drop: 9, expectedRate: rate1),
+                (keep: 2, drop: 8, expectedRate: rate2),
+                (keep: 3, drop: 7, expectedRate: rate3),
+                (keep: 4, drop: 6, expectedRate: rate4),
+                (keep: 5, drop: 5, expectedRate: rate5),
+            };
+
+            var calc = new MovingAverageKeepRateCalculator(size, Timeout.InfiniteTimeSpan);
+
+            foreach (var value in values)
+            {
+                calc.IncrementKeeps(value.keep);
+                calc.IncrementDrops(value.drop);
+
+                calc.UpdateBucket();
+
+                var actualRate = calc.GetKeepRate();
+
+                Assert.Equal(value.expectedRate, actualRate, precision: 2);
+            }
+        }
+
+        [Fact]
+        public async Task Calculator_ShouldAutomaticallyIncrementBuckets()
+        {
+            var bucketSize = 10;
+            const int milliseconds = 50;
+            var timespanIncrements = TimeSpan.FromMilliseconds(milliseconds);
+
+            var calc = new MovingAverageKeepRateCalculator(bucketSize, timespanIncrements);
+
+            // keep rate should be 0 before we add anything
+            Assert.Equal(expected: 0, actual: calc.GetKeepRate());
+
+            calc.IncrementKeeps(10);
+
+            await Task.Delay(milliseconds * 2);
+
+            Assert.Equal(expected: 1, actual: calc.GetKeepRate());
+
+            calc.IncrementDrops(2);
+            calc.IncrementKeeps(8);
+
+            await Task.Delay(milliseconds * 2);
+
+            Assert.Equal(expected: 0.9, calc.GetKeepRate(), precision: 2);
+
+            // the initial "keeps" should drop off the end at some point
+            var hitExpectedRate = false;
+            for (int i = 0; i < bucketSize; i++)
+            {
+                await Task.Delay(milliseconds);
+                var rate = calc.GetKeepRate();
+
+                // Should hit 0.8 at some point
+                if (Math.Abs(rate - 0.8) < 0.01)
+                {
+                    hitExpectedRate = true;
+                }
+            }
+
+            calc.CancelUpdates();
+
+            Assert.True(hitExpectedRate, "Should have seen a hit rate of 0.8");
+
+            var finalRate = calc.GetKeepRate();
+
+            Assert.Equal(expected: 0, finalRate);
+        }
+
+        [Fact]
+        public void Calculator_ShouldHandleOverflows()
+        {
+            const int size = 5;
+
+            var calc = new MovingAverageKeepRateCalculator(size, Timeout.InfiniteTimeSpan);
+
+            calc.IncrementKeeps(int.MaxValue);
+            calc.IncrementKeeps(1);
+            calc.UpdateBucket();
+
+            var actualRate = calc.GetKeepRate();
+
+            // should not be negative!
+            Assert.Equal(expected: 1, actualRate);
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Agent/MovingAverageKeepRateCalculatorTests.cs
+++ b/test/Datadog.Trace.Tests/Agent/MovingAverageKeepRateCalculatorTests.cs
@@ -9,6 +9,7 @@ namespace Datadog.Trace.Tests.Agent
     public class MovingAverageKeepRateCalculatorTests
     {
         [Theory]
+        [InlineData(0, 0, 0)]
         [InlineData(0, 10, 0)]
         [InlineData(6, 4, 0.6)]
         [InlineData(9, 1, 0.9)]

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -248,6 +248,56 @@ namespace Datadog.Trace.Tests
             return agent.FlushAndCloseAsync();
         }
 
+        [Fact]
+        public async Task AddsTraceKeepRateMetricToRootSpan()
+        {
+            // Traces should be dropped when both buffers are full
+            var calculator = new MovingAverageKeepRateCalculator(size: 10, Timeout.InfiniteTimeSpan);
+
+            var tracer = new Mock<IDatadogTracer>();
+            tracer.Setup(x => x.DefaultServiceName).Returns("Default");
+            var traceContext = new TraceContext(tracer.Object);
+            var rootSpanContext = new SpanContext(null, traceContext, null);
+            var rootSpan = new Span(rootSpanContext, DateTimeOffset.UtcNow);
+            var childSpan = new Span(new SpanContext(rootSpanContext, traceContext, null), DateTimeOffset.UtcNow);
+            traceContext.AddSpan(rootSpan);
+            traceContext.AddSpan(childSpan);
+            var trace = new[] { rootSpan, childSpan };
+            var sizeOfTrace = ComputeSizeOfTrace(trace);
+
+            // Make the buffer size big enough for a single trace
+            var api = new Mock<IApi>();
+            api.Setup(x => x.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>()))
+               .ReturnsAsync(() => true);
+            var agent = new AgentWriter(api.Object, statsd: null, calculator, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1, batchInterval: 100);
+
+            // Fill both buffers
+            agent.WriteTrace(trace);
+            agent.WriteTrace(trace);
+
+            // Drop one
+            agent.WriteTrace(trace);
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            // Write another one
+            agent.WriteTrace(trace);
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+            api.Verify();
+            api.Invocations.Clear();
+
+            // Write trace and update keep rate
+            calculator.UpdateBucket();
+            agent.WriteTrace(trace);
+            await agent.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
+
+            const double expectedTraceKeepRate = 0.75;
+            rootSpan.SetMetric(Metrics.TracesKeepRate, expectedTraceKeepRate);
+            var expectedData = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, new FormatterResolverWrapper(SpanFormatterResolver.Instance));
+            await agent.FlushAndCloseAsync();
+
+            api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData)), It.Is<int>(i => i == 1)), Times.Once);
+        }
+
         private static bool WaitForDequeue(AgentWriter agent, bool wakeUpThread = true, int delay = -1)
         {
             var mutex = new ManualResetEventSlim();

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -252,7 +252,7 @@ namespace Datadog.Trace.Tests
         public async Task AddsTraceKeepRateMetricToRootSpan()
         {
             // Traces should be dropped when both buffers are full
-            var calculator = new MovingAverageKeepRateCalculator(size: 10, Timeout.InfiniteTimeSpan);
+            var calculator = new MovingAverageKeepRateCalculator(windowSize: 10, Timeout.InfiniteTimeSpan);
 
             var tracer = new Mock<IDatadogTracer>();
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");


### PR DESCRIPTION
This adds the `_dd.trace_kr` tag to root spans in a trace. The keep rate is calculated as:

```csharp
var keepRate = 1 - droppedTraceCount/createdTraceCount
```

This excludes sampling, so traces excluded due to sampling do not count towards the drop or keep rate. 

The rate is calculated as a moving average over `n` time buckets of length `t`. So we count the number of dropped and created traces in time `t` (by default, `t` is 1s long), and then average those bucket values across the previous `n` buckets (by default, `n` is 10)

I believe we only drop traces in two places: where the API rejects a trace, or where the buffer is full and so we have to drop a trace. 

@DataDog/apm-dotnet