### PR TITLE
Fix Datadog.Trace.ClrProfiler.Native.sh

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
     displayName: docker-compose run Profiler
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
+      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: linux-tracer-home
@@ -174,7 +174,7 @@ jobs:
     displayName: docker-compose run Profiler.Alpine
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler.Alpine
+      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler.Alpine
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: alpine-linux-tracer-home

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -544,7 +544,7 @@ jobs:
     displayName: docker-compose run Profiler
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
+      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/$(buildConfiguration)/x64
     artifact: linux-tracer-home_arm

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -69,7 +69,7 @@ jobs:
     displayName: docker-compose run Profiler
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run Profiler
+      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Release/x64
     displayName: Uploading linux tracer home artifact

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -69,7 +69,7 @@ jobs:
     displayName: docker-compose run Profiler
     inputs:
       containerregistrytype: Container Registry
-      dockerComposeCommand: run -e buildConfiguration=$(buildConfiguration) Profiler
+      dockerComposeCommand: run -e buildConfiguration=Release Profiler
 
   - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin/Release/x64
     displayName: Uploading linux tracer home artifact
@@ -96,7 +96,7 @@ jobs:
     displayName: dotnet build
     inputs:
       command: build
-      configuration: $(buildConfiguration)
+      configuration: Release
       arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -181,7 +181,7 @@ jobs:
     displayName: dotnet build
     inputs:
       command: build
-      configuration: $(buildConfiguration)
+      configuration: Release
       arguments: -l:DatadogLogger,"$(DD_DOTNET_TRACER_MSBUILD)"
       projects: |
         src/**/*.csproj

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
+
 mkdir -p /var/log/datadog/dotnet
 
 #https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
+
 mkdir -p /var/log/datadog/dotnet
 
 #https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash

--- a/build/docker/Datadog.Trace.ClrProfiler.Native.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.Native.sh
@@ -7,16 +7,17 @@ cd "$DIR/../.."
 
 PUBLISH_OUTPUT_NET2="$( pwd )/src/bin/managed-publish/netstandard2.0"
 PUBLISH_OUTPUT_NET31="$( pwd )/src/bin/managed-publish/netcoreapp3.1"
+BUILD_TYPE=${buildConfiguration:-Debug}
 
 cd src/Datadog.Trace.ClrProfiler.Native
 mkdir -p build
-(cd build && cmake ../ -DCMAKE_BUILD_TYPE=Release && make)
+(cd build && cmake ../ -DCMAKE_BUILD_TYPE=${BUILD_TYPE} && make)
 
-mkdir -p bin/Release/x64
-cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/Release/x64/Datadog.Trace.ClrProfiler.Native.so
+mkdir -p bin/${BUILD_TYPE}/x64
+cp -f build/bin/Datadog.Trace.ClrProfiler.Native.so bin/${BUILD_TYPE}/x64/Datadog.Trace.ClrProfiler.Native.so
 
-mkdir -p bin/Release/x64/netstandard2.0
-cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/Release/x64/netstandard2.0/
+mkdir -p bin/${BUILD_TYPE}/x64/netstandard2.0
+cp -f $PUBLISH_OUTPUT_NET2/*.dll bin/${BUILD_TYPE}/x64/netstandard2.0/
 
-mkdir -p bin/Release/x64/netcoreapp3.1
-cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/Release/x64/netcoreapp3.1/
+mkdir -p bin/${BUILD_TYPE}/x64/netcoreapp3.1
+cp -f $PUBLISH_OUTPUT_NET31/*.dll bin/${BUILD_TYPE}/x64/netcoreapp3.1/

--- a/build/docker/build.arm64.sh
+++ b/build/docker/build.arm64.sh
@@ -5,7 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 cd "$DIR/../.."
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
 PUBLISH_OUTPUT="$( pwd )/src/bin/managed-publish"
+
 mkdir -p "$PUBLISH_OUTPUT/netstandard2.0"
 mkdir -p "$PUBLISH_OUTPUT/netcoreapp3.1"
 

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -5,7 +5,10 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
 cd "$DIR/../.."
 
+buildConfiguration=${buildConfiguration:-Debug}
+publishTargetFramework=${publishTargetFramework:-netcoreapp3.1}
 PUBLISH_OUTPUT="$( pwd )/src/bin/managed-publish"
+
 mkdir -p "$PUBLISH_OUTPUT/netstandard2.0"
 mkdir -p "$PUBLISH_OUTPUT/netcoreapp3.1"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,6 +151,8 @@ services:
       context: ./
       dockerfile: ./build/docker/native.dockerfile
     image: datadog-native
+    environment: 
+    - buildConfiguration=${buildConfiguration}
     command: /project/build/docker/Datadog.Trace.ClrProfiler.Native.sh
     volumes:
     - ./:/project
@@ -160,6 +162,8 @@ services:
       context: ./
       dockerfile: ./build/docker/native.alpine.dockerfile
     image: datadog-native-alpine
+    environment: 
+    - buildConfiguration=${buildConfiguration}
     command: /project/build/docker/Datadog.Trace.ClrProfiler.Native.sh
     volumes:
     - ./:/project

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -272,11 +272,6 @@ namespace Datadog.Trace.TestHelpers
                     ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
                     ctx.Response.Close();
                 }
-                catch (InvalidOperationException)
-                {
-                    // this can occur when setting Response.ContentLength64, with the framework claiming that the response has already been submitted
-                    // for now ignore, and we'll see if this introduces downstream issues
-                }
                 catch (HttpListenerException)
                 {
                     // listener was stopped,
@@ -285,6 +280,11 @@ namespace Datadog.Trace.TestHelpers
                 catch (ObjectDisposedException)
                 {
                     // the response has been already disposed.
+                }
+                catch (InvalidOperationException)
+                {
+                    // this can occur when setting Response.ContentLength64, with the framework claiming that the response has already been submitted
+                    // for now ignore, and we'll see if this introduces downstream issues
                 }
                 catch (Exception) when (!_listener.IsListening)
                 {

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -272,6 +272,11 @@ namespace Datadog.Trace.TestHelpers
                     ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
                     ctx.Response.Close();
                 }
+                catch (InvalidOperationException)
+                {
+                    // this can occur when setting Response.ContentLength64, with the framework claiming that the response has already been submitted
+                    // for now ignore, and we'll see if this introduces downstream issues
+                }
                 catch (HttpListenerException)
                 {
                     // listener was stopped,


### PR DESCRIPTION
Port changes from OTEL PR: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/77

Changes proposed in this pull request:
Add `buildConfiguration` and `publishTargetFramework` variables into shell scripts

@DataDog/apm-dotnet