### PR TITLE
Add abstraction for Outbound HTTP span names and attributes

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -278,6 +278,14 @@ namespace Datadog.Trace.Configuration
         public const string DiagnosticSourceEnabled = "DD_DIAGNOSTIC_SOURCE_ENABLED";
 
         /// <summary>
+        /// Configuration key for the semantic convention to be used.
+        /// The Tracer uses it to define operation names, span tags, statuses etc.
+        /// Default is <c>"Default"</c>.
+        /// <seealso cref="TracerSettings.Convention"/>
+        /// </summary>
+        public const string Convention = "DD_CONVENTION";
+
+        /// <summary>
         /// Configuration key for setting the API key, used by the Agent.
         /// This key is here for troubleshooting purposes.
         /// </summary>

--- a/src/Datadog.Trace/Configuration/ConventionType.cs
+++ b/src/Datadog.Trace/Configuration/ConventionType.cs
@@ -1,0 +1,23 @@
+namespace Datadog.Trace.Configuration
+{
+    /// <summary>
+    /// Semantic convention used to when defining operation names, span tags, statuses etc.
+    /// </summary>
+    public enum ConventionType
+    {
+        /// <summary>
+        /// The default convention. Currently it is Datadog (sic!).
+        /// </summary>
+        Default,
+
+        /// <summary>
+        /// The OpenTelemetry convention.
+        /// </summary>
+        OpenTelemetry,
+
+        /// <summary>
+        /// The Datadog convention. Current default.
+        /// </summary>
+        Datadog,
+    }
+}

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -170,6 +170,9 @@ namespace Datadog.Trace.Configuration
                                            "500-599";
             HttpServerErrorStatusCodes = ParseHttpCodesToArray(httpServerErrorStatusCodes);
 
+            Enum.TryParse(source?.GetString(ConfigurationKeys.Convention) ?? "default", ignoreCase: true, out ConventionType conventionType);
+            Convention = conventionType;
+
             var httpClientErrorStatusCodes = source?.GetString(ConfigurationKeys.HttpClientErrorStatusCodes) ??
                                         // Default value
                                         "400-499";
@@ -327,6 +330,14 @@ namespace Datadog.Trace.Configuration
         /// are enabled and sent to DogStatsd.
         /// </summary>
         public bool TracerMetricsEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the semantic convention to be used.
+        /// The Tracer uses it to define operation names, span tags, statuses etc.
+        /// Default is <c>"Default"</c>.
+        /// <seealso cref="ConfigurationKeys.Convention"/>
+        /// </summary>
+        public ConventionType Convention { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether runtime metrics

--- a/src/Datadog.Trace/Conventions/DatadogHttpTags.cs
+++ b/src/Datadog.Trace/Conventions/DatadogHttpTags.cs
@@ -1,0 +1,20 @@
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Conventions
+{
+    internal class DatadogHttpTags : HttpTags
+    {
+        protected static readonly IProperty<string>[] HttpTagsProperties =
+            InstrumentationTagsProperties.Concat(
+                new Property<HttpTags, string>(Trace.Tags.HttpStatusCode, t => t.HttpStatusCode, (t, v) => t.HttpStatusCode = v),
+                new Property<HttpTags, string>(HttpClientHandlerTypeKey, t => t.HttpClientHandlerType, (t, v) => t.HttpClientHandlerType = v),
+                new Property<HttpTags, string>(Trace.Tags.HttpMethod, t => t.HttpMethod, (t, v) => t.HttpMethod = v),
+                new Property<HttpTags, string>(Trace.Tags.HttpUrl, t => t.HttpUrl, (t, v) => t.HttpUrl = v),
+                new Property<HttpTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName, (t, v) => t.InstrumentationName = v));
+
+        private const string HttpClientHandlerTypeKey = "http-client-handler-type";
+
+        protected override IProperty<string>[] GetAdditionalTags() => HttpTagsProperties;
+    }
+}

--- a/src/Datadog.Trace/Conventions/DatadogOutboundHttpConvention.cs
+++ b/src/Datadog.Trace/Conventions/DatadogOutboundHttpConvention.cs
@@ -1,0 +1,38 @@
+
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Tagging;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Conventions
+{
+    internal class DatadogOutboundHttpConvention : IOutboundHttpConvention
+    {
+        private readonly Tracer _tracer;
+
+        public DatadogOutboundHttpConvention(Tracer tracer)
+        {
+            _tracer = tracer;
+        }
+
+        public Scope CreateScope(OutboundHttpArgs args, out HttpTags tags)
+        {
+            tags = new DatadogHttpTags();
+            var requestUri = args.RequestUri;
+            var httpMethod = args.HttpMethod;
+
+            string serviceName = _tracer.Settings.GetServiceName(_tracer, "http-client");
+            var scope = _tracer.StartActiveWithTags("http.request", tags: tags, serviceName: serviceName, spanId: args.SpanId);
+            scope.Span.Type = SpanTypes.Http;
+
+            tags.HttpMethod = httpMethod;
+            tags.HttpUrl = UriHelpers.CleanUri(requestUri, removeScheme: false, tryRemoveIds: false);
+            string resourceUrl = UriHelpers.CleanUri(requestUri, removeScheme: true, tryRemoveIds: true);
+            scope.Span.ResourceName = $"{httpMethod} {resourceUrl}";
+
+            var integrationId = args.IntegrationInfo;
+            tags.InstrumentationName = IntegrationRegistry.GetName(integrationId);
+            tags.SetAnalyticsSampleRate(integrationId, _tracer.Settings, enabledWithGlobalSetting: false);
+            return scope;
+        }
+    }
+}

--- a/src/Datadog.Trace/Conventions/IOutboundHttpConvention.cs
+++ b/src/Datadog.Trace/Conventions/IOutboundHttpConvention.cs
@@ -1,0 +1,12 @@
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Conventions
+{
+    /// <summary>
+    /// Semantic convention used when defining operation names, span tags, statuses for outbound HTTP requests.
+    /// </summary>
+    internal interface IOutboundHttpConvention
+    {
+        Scope CreateScope(OutboundHttpArgs args, out HttpTags tags);
+    }
+}

--- a/src/Datadog.Trace/Conventions/OtelHttpTags.cs
+++ b/src/Datadog.Trace/Conventions/OtelHttpTags.cs
@@ -1,0 +1,18 @@
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Conventions
+{
+    internal class OtelHttpTags : HttpTags
+    {
+        protected static readonly IProperty<string>[] HttpTagsProperties =
+            InstrumentationTagsProperties.Concat(
+                new Property<HttpTags, string>(Trace.Tags.HttpStatusCode, t => t.HttpStatusCode, (t, v) => t.HttpStatusCode = v),
+                new Property<HttpTags, string>("http.client.type", t => t.HttpClientHandlerType, (t, v) => t.HttpClientHandlerType = v),
+                new Property<HttpTags, string>(Trace.Tags.HttpMethod, t => t.HttpMethod, (t, v) => t.HttpMethod = v),
+                new Property<HttpTags, string>(Trace.Tags.HttpUrl, t => t.HttpUrl, (t, v) => t.HttpUrl = v),
+                new Property<HttpTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName, (t, v) => t.InstrumentationName = v));
+
+        protected override IProperty<string>[] GetAdditionalTags() => HttpTagsProperties;
+    }
+}

--- a/src/Datadog.Trace/Conventions/OtelOutboundHttpConvention.cs
+++ b/src/Datadog.Trace/Conventions/OtelOutboundHttpConvention.cs
@@ -1,0 +1,33 @@
+using System;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Conventions
+{
+    internal class OtelOutboundHttpConvention : IOutboundHttpConvention
+    {
+        private readonly Tracer _tracer;
+
+        public OtelOutboundHttpConvention(Tracer tracer)
+        {
+            _tracer = tracer;
+        }
+
+        public Scope CreateScope(OutboundHttpArgs args, out HttpTags tags)
+        {
+            var otelTags = new OtelHttpTags();
+            tags = otelTags;
+
+            string operationName = "HTTP " + args.HttpMethod;
+            string serviceName = _tracer.Settings.GetServiceName(_tracer, "http-client");
+            var scope = _tracer.StartActiveWithTags(operationName, tags: tags, serviceName: serviceName, spanId: args.SpanId);
+            scope.Span.Type = SpanTypes.Http;
+
+            var uri = args.RequestUri;
+            otelTags.HttpMethod = args.HttpMethod;
+            otelTags.HttpUrl = string.Concat(uri.Scheme, Uri.SchemeDelimiter, uri.Authority, uri.PathAndQuery, uri.Fragment);
+            otelTags.InstrumentationName = IntegrationRegistry.GetName(args.IntegrationInfo);
+            return scope;
+        }
+    }
+}

--- a/src/Datadog.Trace/Conventions/OutboundHttpArgs.cs
+++ b/src/Datadog.Trace/Conventions/OutboundHttpArgs.cs
@@ -1,0 +1,40 @@
+using System;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Tagging;
+
+namespace Datadog.Trace.Conventions
+{
+    /// <summary>
+    /// Arguments used by <c>"IOutboundHttpConvention"</c>.
+    /// </summary>
+    internal readonly struct OutboundHttpArgs
+    {
+        /// <summary>
+        /// Optional span ID.
+        /// </summary>
+        public readonly ulong? SpanId;
+
+        /// <summary>
+        /// Request's HTTP method.
+        /// </summary>
+        public readonly string HttpMethod;
+
+        /// <summary>
+        /// Request's URI.
+        /// </summary>
+        public readonly Uri RequestUri;
+
+        /// <summary>
+        /// Request's URI.
+        /// </summary>
+        public readonly IntegrationInfo IntegrationInfo;
+
+        public OutboundHttpArgs(ulong? spanId, string httpMethod, Uri requestUri, IntegrationInfo integrationInfo)
+        {
+            SpanId = spanId;
+            HttpMethod = httpMethod;
+            RequestUri = requestUri;
+            IntegrationInfo = integrationInfo;
+        }
+    }
+}

--- a/src/Datadog.Trace/Tagging/HttpTags.cs
+++ b/src/Datadog.Trace/Tagging/HttpTags.cs
@@ -1,19 +1,7 @@
-using Datadog.Trace.ExtensionMethods;
-
 namespace Datadog.Trace.Tagging
 {
-    internal class HttpTags : InstrumentationTags, IHasStatusCode
+    internal abstract class HttpTags : InstrumentationTags, IHasStatusCode
     {
-        protected static readonly IProperty<string>[] HttpTagsProperties =
-            InstrumentationTagsProperties.Concat(
-                new Property<HttpTags, string>(Trace.Tags.HttpStatusCode, t => t.HttpStatusCode, (t, v) => t.HttpStatusCode = v),
-                new Property<HttpTags, string>(HttpClientHandlerTypeKey, t => t.HttpClientHandlerType, (t, v) => t.HttpClientHandlerType = v),
-                new Property<HttpTags, string>(Trace.Tags.HttpMethod, t => t.HttpMethod, (t, v) => t.HttpMethod = v),
-                new Property<HttpTags, string>(Trace.Tags.HttpUrl, t => t.HttpUrl, (t, v) => t.HttpUrl = v),
-                new Property<HttpTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName, (t, v) => t.InstrumentationName = v));
-
-        private const string HttpClientHandlerTypeKey = "http-client-handler-type";
-
         public override string SpanKind => SpanKinds.Client;
 
         public string InstrumentationName { get; set; }
@@ -25,7 +13,5 @@ namespace Datadog.Trace.Tagging
         public string HttpClientHandlerType { get; set; }
 
         public string HttpStatusCode { get; set; }
-
-        protected override IProperty<string>[] GetAdditionalTags() => HttpTagsProperties;
     }
 }

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Conventions;
 using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
@@ -103,6 +104,17 @@ namespace Datadog.Trace
             else
             {
                 _agentWriter = agentWriter;
+            }
+
+            switch (Settings.Convention)
+            {
+                case ConventionType.OpenTelemetry:
+                    OutboundHttpConvention = new OtelOutboundHttpConvention(this);
+                    break;
+                case ConventionType.Datadog:
+                default:
+                    OutboundHttpConvention = new DatadogOutboundHttpConvention(this);
+                    break;
             }
 
             _scopeManager = scopeManager ?? new AsyncLocalScopeManager();
@@ -240,6 +252,8 @@ namespace Datadog.Trace
         internal ISampler Sampler { get; }
 
         internal IDogStatsd Statsd { get; private set; }
+
+        internal IOutboundHttpConvention OutboundHttpConvention { get; }
 
         /// <summary>
         /// Create a new Tracer with the given parameters

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/OtelScopeFactoryTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Text;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Sampling;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class OtelScopeFactoryTests
+    {
+        [Theory]
+        [ClassData(typeof(TestData))]
+        public void OutboundHttp(Input input, Result expected)
+        {
+            var settings = new TracerSettings();
+            settings.Convention = ConventionType.OpenTelemetry;
+            var tracer = new Tracer(settings, Mock.Of<IAgentWriter>(), Mock.Of<ISampler>(), scopeManager: null, statsd: null);
+
+            using (var scope = ScopeFactory.CreateOutboundHttpScope(tracer, input.Method, new Uri(input.Uri), new IntegrationInfo((int)IntegrationIds.HttpMessageHandler), out var tags))
+            {
+                var span = scope.Span;
+                var actual = new Result
+                {
+                    OperationName = span.OperationName,
+                    HttpMethodTag = span.GetTag("http.method"),
+                    HttpUrlTag = span.GetTag("http.url"),
+                };
+
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        public struct Input
+        {
+            public string Method;
+            public string Uri;
+        }
+
+        public struct Result
+        {
+            public string OperationName;
+            public string HttpMethodTag;
+            public string HttpUrlTag;
+
+            public override string ToString()
+            {
+                var sb = new StringBuilder();
+                sb.Append(Environment.NewLine);
+                foreach (var field in GetType().GetFields())
+                {
+                    sb.Append($"{field.Name}: {field.GetValue(this)}{Environment.NewLine}");
+                }
+
+                return sb.ToString();
+            }
+        }
+
+        public class TestData : TheoryData<Input, Result>
+        {
+#pragma warning disable SA1118 // The parameter spans multiple lines
+            public TestData()
+            {
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://username:password@example.com:8080/path/to/file.aspx?query=1#fragment",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com:8080/path/to/file.aspx?query=1#fragment",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://username:password@example.com/path/to/file.aspx?query=1#fragment",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/to/file.aspx?query=1#fragment",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://username@example.com/path/to/file.aspx",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/to/file.aspx",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/to/file.aspx?query=1",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/to/file.aspx?query=1",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/to/file.aspx#fragment",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/to/file.aspx#fragment",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/to/file.aspx",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/to/file.aspx",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/123/file.aspx",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/123/file.aspx",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/123/",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/123/",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/123",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/123",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/E653C852-227B-4F0C-9E48-D30D83C68BF3",
+                    });
+                Add(
+                    new Input
+                    {
+                        Method = "GET",
+                        Uri = "https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3",
+                    },
+                    new Result
+                    {
+                        OperationName = "HTTP GET",
+                        HttpMethodTag = "GET",
+                        HttpUrlTag = "https://example.com/path/E653C852227B4F0C9E48D30D83C68BF3",
+                    });
+            }
+#pragma warning restore SA1118
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -90,6 +90,12 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,:tagonly,headeronly:,:,nocolon", CreateFunc(s => s.HeaderTags), HeaderTags };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:tag1", CreateFunc(s => s.HeaderTags), HeaderTagsSameTag };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header1:tag2", CreateFunc(s => s.HeaderTags.Count), 1 };
+
+            yield return new object[] { ConfigurationKeys.Convention, null, CreateFunc(s => s.Convention), ConventionType.Default };
+            yield return new object[] { ConfigurationKeys.Convention, string.Empty, CreateFunc(s => s.Convention), ConventionType.Default };
+            yield return new object[] { ConfigurationKeys.Convention, "opentelemetry", CreateFunc(s => s.Convention), ConventionType.OpenTelemetry };
+            yield return new object[] { ConfigurationKeys.Convention, "Datadog", CreateFunc(s => s.Convention), ConventionType.Datadog };
+            yield return new object[] { ConfigurationKeys.Convention, "unknown", CreateFunc(s => s.Convention), ConventionType.Default };
         }
 
         // JsonConfigurationSource needs to be tested with JSON data, which cannot be used with the other IConfigurationSource implementations.

--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Tests.Tagging
 
         private void ValidateProperties<T>(Type type, string methodName, Func<T> valueGenerator)
         {
-            var instance = (ITags)Activator.CreateInstance(type);
+            var instance = (ITags)Activator.CreateInstance(type, nonPublic: true);
 
             var allTags = (IProperty<T>[])type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic)
                 .Invoke(instance, null);


### PR DESCRIPTION
Port changes from OTEL PR: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/63

Changes proposed in this pull request:
This PR adds an abstraction layer `IOutboundHttpConvention` to allow the Tracer to configure tags based on the runtime configuration.

This change currently keeps the OTEL-semantics for decorating HTTP client spans.

@DataDog/apm-dotnet