### PR TITLE
Add support for flushing partial traces

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -305,12 +305,14 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key to enable sending partial traces to the agent
         /// </summary>
-        public const string PartialFlushEnabled = "DD_TRACER_PARTIAL_FLUSH_ENABLED";
+        /// <seealso cref="TracerSettings.PartialFlushEnabled"/>
+        public const string PartialFlushEnabled = "DD_TRACE_PARTIAL_FLUSH_ENABLED";
 
         /// <summary>
         /// Configuration key to set the minimum number of closed spans in a trace before it's partially flushed
         /// </summary>
-        public const string PartialFlushMinSpans = "DD_TRACER_PARTIAL_FLUSH_MIN_SPANS";
+        /// <seealso cref="TracerSettings.PartialFlushMinSpans"/>
+        public const string PartialFlushMinSpans = "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS";
 
         /// <summary>
         /// String format patterns used to match integration-specific configuration keys.

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -303,6 +303,16 @@ namespace Datadog.Trace.Configuration
         public const string HttpClientErrorStatusCodes = "DD_HTTP_CLIENT_ERROR_STATUSES";
 
         /// <summary>
+        /// Configuration key to enable sending partial traces to the agent
+        /// </summary>
+        public const string PartialFlushEnabled = "DD_TRACER_PARTIAL_FLUSH_ENABLED";
+
+        /// <summary>
+        /// Configuration key to set the minimum number of closed spans in a trace before it's partially flushed
+        /// </summary>
+        public const string PartialFlushMinSpans = "DD_TRACER_PARTIAL_FLUSH_MIN_SPANS";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -190,9 +190,12 @@ namespace Datadog.Trace.Configuration
                 // default value
                 ?? false;
 
-            PartialFlushMinSpans = source?.GetInt32(ConfigurationKeys.PartialFlushMinSpans)
-                // default value
-                ?? 500;
+            var partialFlushMinSpans = source?.GetInt32(ConfigurationKeys.PartialFlushMinSpans);
+
+            if ((partialFlushMinSpans ?? 0) <= 0)
+            {
+                PartialFlushMinSpans = 500;
+            }
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -24,6 +24,8 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         public const int DefaultAgentPort = 8126;
 
+        private int _partialFlushMinSpans;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
         /// </summary>
@@ -183,6 +185,14 @@ namespace Datadog.Trace.Configuration
 
             RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
                                                    ?? false;
+
+            PartialFlushEnabled = source?.GetBool(ConfigurationKeys.PartialFlushEnabled)
+                // default value
+                ?? false;
+
+            PartialFlushMinSpans = source?.GetInt32(ConfigurationKeys.PartialFlushMinSpans)
+                // default value
+                ?? 500;
         }
 
         /// <summary>
@@ -351,6 +361,28 @@ namespace Datadog.Trace.Configuration
         {
             get => GlobalSettings.Source.DiagnosticSourceEnabled;
             set { }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether partial flush is enabled
+        /// </summary>
+        public bool PartialFlushEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum number of closed spans in a trace before it's partially flushed
+        /// </summary>
+        public int PartialFlushMinSpans
+        {
+            get => _partialFlushMinSpans;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentException("The value must be strictly greater than 0", nameof(PartialFlushMinSpans));
+                }
+
+                _partialFlushMinSpans = value;
+            }
         }
 
         /// <summary>

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace
 
         private readonly DateTimeOffset _utcStart = DateTimeOffset.UtcNow;
         private readonly long _timestamp = Stopwatch.GetTimestamp();
-        private List<Span> _spans = new List<Span>();
+        private readonly List<Span> _spans = new List<Span>();
 
         private int _openSpans;
         private SamplingPriority? _samplingPriority;

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -540,6 +540,12 @@ namespace Datadog.Trace
                     writer.WritePropertyName("routetemplate_resourcenames_enabled");
                     writer.WriteValue(Settings.RouteTemplateResourceNamesEnabled);
 
+                    writer.WritePropertyName("partialflush_enabled");
+                    writer.WriteValue(Settings.PartialFlushEnabled);
+
+                    writer.WritePropertyName("partialflush_minspans");
+                    writer.WriteValue(Settings.PartialFlushMinSpans);
+
                     writer.WritePropertyName("agent_reachable");
                     writer.WriteValue(agentError == null);
 

--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -290,7 +290,7 @@ namespace Datadog.Trace.TestHelpers
 
         [MessagePackObject]
         [DebuggerDisplay("TraceId={TraceId}, SpanId={SpanId}, Service={Service}, Name={Name}, Resource={Resource}")]
-        public struct Span
+        public class Span
         {
             [Key("trace_id")]
             public ulong TraceId { get; set; }

--- a/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Datadog.Trace.Util;
 using Moq;
 using Xunit;
 
@@ -28,6 +29,66 @@ namespace Datadog.Trace.Tests
             var t2 = traceContext.UtcNow;
 
             Assert.True(t2.Subtract(t1) > TimeSpan.Zero);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void FlushPartialTraces(bool partialFlush)
+        {
+            var tracer = new Mock<IDatadogTracer>();
+
+            tracer.Setup(t => t.Settings).Returns(new Trace.Configuration.TracerSettings
+            {
+                PartialFlushEnabled = partialFlush,
+                PartialFlushMinSpans = 5
+            });
+
+            var traceContext = new TraceContext(tracer.Object);
+
+            void AddAndCloseSpan()
+            {
+                var span = new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+                traceContext.AddSpan(span);
+                traceContext.CloseSpan(span);
+            }
+
+            var rootSpan = new Span(new SpanContext(42, SpanIdGenerator.ThreadInstance.CreateNew()), DateTimeOffset.UtcNow);
+
+            traceContext.AddSpan(rootSpan);
+
+            for (int i = 0; i < 4; i++)
+            {
+                AddAndCloseSpan();
+            }
+
+            // At this point in time, we have 4 closed spans in the trace
+            tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
+
+            AddAndCloseSpan();
+
+            // Now we have 5 closed spans, partial flush should kick-in if activated
+            if (partialFlush)
+            {
+                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 5)), Times.Once);
+            }
+            else
+            {
+                tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
+            }
+
+            traceContext.CloseSpan(rootSpan);
+
+            // Now the remaining spans are flushed
+            if (partialFlush)
+            {
+                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 1)), Times.Once);
+            }
+            else
+            {
+                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 6)), Times.Once);
+            }
         }
     }
 }

--- a/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -78,6 +78,21 @@ namespace Datadog.Trace.Tests
                 tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
             }
 
+            for (int i = 0; i < 5; i++)
+            {
+                AddAndCloseSpan();
+            }
+
+            // We have 5 more closed spans, partial flush should kick-in a second time if activated
+            if (partialFlush)
+            {
+                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 5)), Times.Exactly(2));
+            }
+            else
+            {
+                tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
+            }
+
             traceContext.CloseSpan(rootSpan);
 
             // Now the remaining spans are flushed
@@ -87,7 +102,7 @@ namespace Datadog.Trace.Tests
             }
             else
             {
-                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 6)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 11)), Times.Once);
             }
         }
     }


### PR DESCRIPTION
Add a way to partially flush large traces. The partial flush is opt-in, and triggered when the number of closed spans in a trace gets above a given threshold.

New configuration keys:
 - `DD_TRACER_PARTIAL_FLUSH_ENABLED`: enables the partial flush
 - `DD_TRACER_PARTIAL_FLUSH_MIN_SPANS`: changes the threshold (default is 500 closed spans in a trace)