### PR TITLE
Listen on localhost instead of 127.0.0.1

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -60,7 +60,6 @@ namespace Datadog.Trace.TestHelpers
                 // seems like we can't reuse a listener if it fails to start,
                 // so create a new listener each time we retry
                 var listener = new HttpListener();
-                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
                 listener.Prefixes.Add($"http://localhost:{port}/");
 
                 try

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace.Tests
             {
                 var settings = new TracerSettings
                 {
-                    AgentUri = new Uri($"http://127.0.0.1:{agent.Port}"),
+                    AgentUri = new Uri($"http://localhost:{agent.Port}"),
                     TracerMetricsEnabled = tracerMetricsEnabled,
                     StartupDiagnosticLogEnabled = false,
                 };


### PR DESCRIPTION
Previously I was seeing `HttpListenerException : The network location cannot be reached` when running the tests locally (on Windows). This seems to fix the issue, though I haven't tested it on Linux/mac

@DataDog/apm-dotnet