### PR TITLE
Port OTEL refactor

### DIFF
--- a/src/Datadog.Trace/Abstractions/IMetrics.cs
+++ b/src/Datadog.Trace/Abstractions/IMetrics.cs
@@ -1,0 +1,14 @@
+namespace Datadog.Trace.Abstractions
+{
+    internal interface IMetrics
+    {
+        /// <summary>
+        /// Increments the specified counter.
+        /// </summary>
+        /// <param name="statName">The name of the metric.</param>
+        /// <param name="value">The amount of increment.</param>
+        /// <param name="sampleRate">Percentage of metric to be sent.</param>
+        /// <param name="tags">Array of tags to be added to the data.</param>
+        void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null);
+    }
+}

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -10,7 +10,7 @@ using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.Agent
 {
-    internal class AgentWriter : IAgentWriter
+    internal class AgentWriter : ITraceWriter
     {
 #if NET45
         private const TaskCreationOptions TaskOptions = TaskCreationOptions.None;

--- a/src/Datadog.Trace/Agent/DogStatsdMetrics.cs
+++ b/src/Datadog.Trace/Agent/DogStatsdMetrics.cs
@@ -1,0 +1,20 @@
+using Datadog.Trace.Abstractions;
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.Agent
+{
+    internal class DogStatsdMetrics : IMetrics
+    {
+        private readonly IDogStatsd _dogStatsd;
+
+        public DogStatsdMetrics(IDogStatsd dogStatsd)
+        {
+            _dogStatsd = dogStatsd;
+        }
+
+        public void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null)
+        {
+            _dogStatsd.Increment(statName, value, sampleRate, tags);
+        }
+    }
+}

--- a/src/Datadog.Trace/Agent/ITraceWriter.cs
+++ b/src/Datadog.Trace/Agent/ITraceWriter.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
-    internal interface IAgentWriter
+    internal interface ITraceWriter
     {
         void WriteTrace(Span[] trace);
 

--- a/src/Datadog.Trace/Agent/NullMetrics.cs
+++ b/src/Datadog.Trace/Agent/NullMetrics.cs
@@ -1,0 +1,11 @@
+using Datadog.Trace.Abstractions;
+
+namespace Datadog.Trace.Agent
+{
+    internal class NullMetrics : IMetrics
+    {
+        public void Increment(string statName, int value = 1, double sampleRate = 1, string[] tags = null)
+        {
+        }
+    }
+}

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Abstractions;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DiagnosticListeners;
@@ -95,10 +96,11 @@ namespace Datadog.Trace
                 Statsd = statsd ?? CreateDogStatsdClient(Settings, DefaultServiceName, Settings.DogStatsdPort);
             }
 
+            IMetrics metrics = Statsd != null ? new DogStatsdMetrics(Statsd) : new NullMetrics();
             if (traceWriter == null)
             {
                 Log.Warning("Using eager agent writer");
-                _traceWriter = new AgentWriter(new Api(Settings.AgentUri, TransportStrategy.Get(Settings), Statsd), Statsd, maxBufferSize: Settings.TraceBufferSize);
+                _traceWriter = new AgentWriter(new Api(Settings.AgentUri, TransportStrategy.Get(Settings), Statsd), metrics, maxBufferSize: Settings.TraceBufferSize);
             }
             else
             {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 
@@ -111,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
 

--- a/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -108,16 +108,16 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             }
         }
 
-        private static Tracer GetTracer(IAgentWriter writer = null)
+        private static Tracer GetTracer(ITraceWriter writer = null)
         {
             var settings = new TracerSettings();
-            var agentWriter = writer ?? new Mock<IAgentWriter>().Object;
+            var agentWriter = writer ?? new Mock<ITraceWriter>().Object;
             var samplerMock = new Mock<ISampler>();
 
             return new Tracer(settings, agentWriter, samplerMock.Object, scopeManager: null, statsd: null);
         }
 
-        private class AgentWriterStub : IAgentWriter
+        private class AgentWriterStub : ITraceWriter
         {
             public List<Span[]> Traces { get; } = new();
 

--- a/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
+++ b/test/Datadog.Trace.IntegrationTests/SendTracesToAgent.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.IntegrationTests
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
             var api = new Api(endpoint, apiRequestFactory: null, statsd: null);
-            var agentWriter = new AgentWriter(api, statsd: null);
+            var agentWriter = new AgentWriter(api, new NullMetrics());
 
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/OpenTracingSendTracesToAgent.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.OpenTracing.IntegrationTests
             var endpoint = new Uri("http://localhost:8126");
             _httpRecorder = new RecordHttpHandler();
             var api = new Api(endpoint, apiRequestFactory: null, statsd: null);
-            var agentWriter = new AgentWriter(api, statsd: null);
+            var agentWriter = new AgentWriter(api, new NullMetrics());
 
             var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
             _tracer = new OpenTracingTracer(tracer);

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.OpenTracing.Tests
                 ServiceName = DefaultServiceName
             };
 
-            var writerMock = new Mock<IAgentWriter>(MockBehavior.Strict);
+            var writerMock = new Mock<ITraceWriter>(MockBehavior.Strict);
             var samplerMock = new Mock<ISampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         public OpenTracingSpanTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         public OpenTracingTracerTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             var datadogTracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Abstractions;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
@@ -22,7 +23,7 @@ namespace Datadog.Trace.Tests
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");
 
             _api = new Mock<IApi>();
-            _agentWriter = new AgentWriter(_api.Object, statsd: null);
+            _agentWriter = new AgentWriter(_api.Object, new NullMetrics());
         }
 
         [Fact]
@@ -52,7 +53,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task FlushTwice()
         {
-            var w = new AgentWriter(_api.Object, statsd: null);
+            var w = new AgentWriter(_api.Object, new NullMetrics());
             await w.FlushAndCloseAsync();
             await w.FlushAndCloseAsync();
         }
@@ -63,7 +64,7 @@ namespace Datadog.Trace.Tests
             // The flush thread should be able to recover from an error when calling the API
             // Also, it should free the faulty buffer
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, statsd: null);
+            var agent = new AgentWriter(api.Object, new NullMetrics());
 
             var mutex = new ManualResetEventSlim();
 
@@ -91,7 +92,7 @@ namespace Datadog.Trace.Tests
         {
             // Make sure that the agent is able to switch to the secondary buffer when the primary is full/busy
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, statsd: null);
+            var agent = new AgentWriter(api.Object, new NullMetrics());
 
             var barrier = new Barrier(2);
 
@@ -151,7 +152,7 @@ namespace Datadog.Trace.Tests
             var sizeOfTrace = ComputeSizeOfTrace(CreateTrace(1));
 
             // Make the buffer size big enough for a single trace
-            var agent = new AgentWriter(api.Object, statsd: null, automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
+            var agent = new AgentWriter(api.Object, new NullMetrics(), automaticFlush: false, maxBufferSize: (sizeOfTrace * 2) + SpanBuffer.HeaderSize - 1);
 
             agent.WriteTrace(CreateTrace(1));
             agent.WriteTrace(CreateTrace(1));
@@ -174,7 +175,7 @@ namespace Datadog.Trace.Tests
         public void DropTraces()
         {
             // Traces should be dropped when both buffers are full
-            var statsd = new Mock<IDogStatsd>();
+            var statsd = new Mock<IMetrics>();
 
             var sizeOfTrace = ComputeSizeOfTrace(CreateTrace(1));
 
@@ -227,7 +228,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public Task WakeUpSerializationTask()
         {
-            var agent = new AgentWriter(Mock.Of<IApi>(), statsd: null, batchInterval: 0);
+            var agent = new AgentWriter(Mock.Of<IApi>(), new NullMetrics(), batchInterval: 0);
 
             // To reduce flackyness, first we make sure the serialization thread is started
             WaitForDequeue(agent);

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Tests
         public ApiTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
         private static Tracer GetTracer()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             return new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.Tests
                     StartupDiagnosticLogEnabled = false,
                 };
 
-                var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd);
+                var tracer = new Tracer(settings, traceWriter: null, sampler: null, scopeManager: null, statsd);
 
                 using (var scope = tracer.StartActive("root"))
                 {

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tests.Logging
         internal static Tracer InitializeTracer(bool enableLogsInjection)
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             settings.LogsInjectionEnabled = enableLogsInjection;

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Tests
     public class SpanTests
     {
         private readonly ITestOutputHelper _output;
-        private readonly Mock<IAgentWriter> _writerMock;
+        private readonly Mock<ITraceWriter> _writerMock;
         private readonly Tracer _tracer;
 
         public SpanTests(ITestOutputHelper output)
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Tests
             _output = output;
 
             var settings = new TracerSettings();
-            _writerMock = new Mock<IAgentWriter>();
+            _writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             _tracer = new Tracer(settings, _writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -12,12 +12,12 @@ namespace Datadog.Trace.Tests
 {
     public class TracerSettingsTests
     {
-        private readonly Mock<IAgentWriter> _writerMock;
+        private readonly Mock<ITraceWriter> _writerMock;
         private readonly Mock<ISampler> _samplerMock;
 
         public TracerSettingsTests()
         {
-            _writerMock = new Mock<IAgentWriter>();
+            _writerMock = new Mock<ITraceWriter>();
             _samplerMock = new Mock<ISampler>();
         }
 

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests
         public TracerTests()
         {
             var settings = new TracerSettings();
-            var writerMock = new Mock<IAgentWriter>();
+            var writerMock = new Mock<ITraceWriter>();
             var samplerMock = new Mock<ISampler>();
 
             _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -16,7 +16,7 @@ namespace Benchmarks.Trace
     {
         private const int SpanCount = 1000;
 
-        private static readonly IAgentWriter AgentWriter;
+        private static readonly ITraceWriter AgentWriter;
         private static readonly Span[] Spans;
         private static readonly Span[] EnrichedSpans;
 

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -29,7 +29,7 @@ namespace Benchmarks.Trace
 
             var api = new Api(settings.AgentUri, new FakeApiRequestFactory(), statsd: null);
 
-            AgentWriter = new AgentWriter(api, statsd: null, automaticFlush: false);
+            AgentWriter = new AgentWriter(api, new NullMetrics(), automaticFlush: false);
 
             Spans = new Span[SpanCount];
             EnrichedSpans = new Span[SpanCount];

--- a/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -5,7 +5,7 @@ using Datadog.Trace.Agent;
 
 namespace Benchmarks.Trace
 {
-    class DummyAgentWriter : IAgentWriter
+    class DummyAgentWriter : ITraceWriter
     {
         private static readonly Task<bool> PingTask = Task.FromResult(true);
 


### PR DESCRIPTION
Port changes from OTEL PR's:
- open-telemetry/opentelemetry-dotnet-instrumentation#74
- open-telemetry/opentelemetry-dotnet-instrumentation#78

PR 74 introduces the following refactorings, with 78 adding small changes. The refactorings include:
1. Renaming `IAgentWriter` to `ITraceWriter`
2. Refactoring `AgentWriter` to use an `IMetrics` object with a default `NullMetric` implementation, which helps remove null checks everywhere it's used

@DataDog/apm-dotnet