### PR TITLE
Enable JetBrains Tools in the Benchmarks projects

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -15,3 +15,4 @@ Datadog.Trace.ClrProfiler.Native,https://github.com/fmtlib/fmt,MIT,"Copyright (c
 Datadog.Trace.OpenTracing,https://github.com/opentracing/opentracing-csharp,MIT,Copyright 2016-2017 The OpenTracing Authors
 Datadog.Trace.OpenTracing,https://github.com/opentracing-contrib/csharp-netcore,Apache-2.0,
 (all),https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation,Apache-2.0,
+JetBrains.Profiler.Api,https://github.com/JetBrains/profiler-api,Apache-2.0,"Copyright (c) 2019-2020 JetBrains s.r.o."

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,4 +1,5 @@
 Component,Origin,License,Copyright
+Benchmarks.Trace,https://github.com/JetBrains/profiler-api,Apache-2.0,"Copyright (c) 2019-2020 JetBrains s.r.o."
 Datadog.Trace,https://github.com/neuecc/MessagePack-CSharp,MIT,Copyright (c) 2017 Yoshifumi Kawai and contributors
 Datadog.Trace,https://github.com/damianh/LibLog,MIT,Copyright (C) 2011-2017 Damian Hickey
 Datadog.Trace,https://github.com/serilog/serilog,Apache-2.0,Copyright (c) 2013-2018 Serilog Contributors
@@ -15,4 +16,3 @@ Datadog.Trace.ClrProfiler.Native,https://github.com/fmtlib/fmt,MIT,"Copyright (c
 Datadog.Trace.OpenTracing,https://github.com/opentracing/opentracing-csharp,MIT,Copyright 2016-2017 The OpenTracing Authors
 Datadog.Trace.OpenTracing,https://github.com/opentracing-contrib/csharp-netcore,Apache-2.0,
 (all),https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation,Apache-2.0,
-JetBrains.Profiler.Api,https://github.com/JetBrains/profiler-api,Apache-2.0,"Copyright (c) 2019-2020 JetBrains s.r.o."

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,5 +1,4 @@
 Component,Origin,License,Copyright
-Benchmarks.Trace,https://github.com/JetBrains/profiler-api,Apache-2.0,"Copyright (c) 2019-2020 JetBrains s.r.o."
 Datadog.Trace,https://github.com/neuecc/MessagePack-CSharp,MIT,Copyright (c) 2017 Yoshifumi Kawai and contributors
 Datadog.Trace,https://github.com/damianh/LibLog,MIT,Copyright (C) 2011-2017 Damian Hickey
 Datadog.Trace,https://github.com/serilog/serilog,Apache-2.0,Copyright (c) 2013-2018 Serilog Contributors

--- a/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="JetBrains.Profiler.Api" Version="1.1.7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/test/benchmarks/Benchmarks.Trace/Program.cs
+++ b/test/benchmarks/Benchmarks.Trace/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
@@ -43,7 +44,7 @@ namespace Benchmarks.Trace
                         GC.Collect();
                         GC.WaitForPendingFinalizers();
 
-                        if (JetBrains.Profiler.Api.MeasureProfiler.GetFeatures().HasFlag(JetBrains.Profiler.Api.MeasureFeatures.Ready))
+                        if ((JetBrains.Profiler.Api.MeasureProfiler.GetFeatures() & JetBrains.Profiler.Api.MeasureFeatures.Ready) != 0)
                         {
                             Console.WriteLine("  Collecting Data...");
                             JetBrains.Profiler.Api.MeasureProfiler.StartCollectingData(groupName);
@@ -57,7 +58,7 @@ namespace Benchmarks.Trace
                             GC.WaitForPendingFinalizers();
                         }
 
-                        if (JetBrains.Profiler.Api.MemoryProfiler.GetFeatures().HasFlag(JetBrains.Profiler.Api.MeasureFeatures.Ready))
+                        if ((JetBrains.Profiler.Api.MemoryProfiler.GetFeatures() & JetBrains.Profiler.Api.MemoryFeatures.Ready) != 0)
                         {
                             Console.WriteLine("  Getting memory snapshot...");
                             JetBrains.Profiler.Api.MemoryProfiler.ForceGc();

--- a/test/benchmarks/Benchmarks.Trace/Program.cs
+++ b/test/benchmarks/Benchmarks.Trace/Program.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using Datadog.Trace.BenchmarkDotNet;
@@ -8,9 +12,67 @@ namespace Benchmarks.Trace
     {
         private static void Main(string[] args)
         {
-            var config = DefaultConfig.Instance.AddExporter(DatadogExporter.Default);
+            if (args?.Any(a => a == "-jetbrains") == true)
+            {
+                ExecuteWithJetbrainsTools(args);
+            }
+            else
+            {
+                var config = DefaultConfig.Instance.AddExporter(DatadogExporter.Default);
+                BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+            }
+        }
 
-            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        private static void ExecuteWithJetbrainsTools(string[] args)
+        {
+            HashSet<string> hashSet = new HashSet<string>(args.Where(a => a != "-jetbrains").Select(a => a.ToLowerInvariant()));
+            var benchmarkTypes = typeof(Program).Assembly.GetTypes().Where(t => hashSet.Contains(t.Name.ToLowerInvariant()));
+            foreach (var benchmarkType in benchmarkTypes)
+            {
+                foreach (var method in benchmarkType.GetMethods())
+                {
+                    if (method.GetCustomAttributes(false).Any(att => att is BenchmarkAttribute))
+                    {
+                        var benchmarkInstance = Activator.CreateInstance(benchmarkType);
+                        var groupName = string.Format("{0}.{1}", benchmarkType.FullName, method.Name);
+                        Console.WriteLine("Running: " + groupName);
+                        for (var i = 0; i < 1000; i++)
+                        {
+                            method.Invoke(benchmarkInstance, null);
+                        }
+                        GC.Collect();
+                        GC.WaitForPendingFinalizers();
+
+                        if (JetBrains.Profiler.Api.MeasureProfiler.GetFeatures().HasFlag(JetBrains.Profiler.Api.MeasureFeatures.Ready))
+                        {
+                            Console.WriteLine("  Collecting Data...");
+                            JetBrains.Profiler.Api.MeasureProfiler.StartCollectingData(groupName);
+                            for (var i = 0; i < 100_000; i++)
+                            {
+                                method.Invoke(benchmarkInstance, null);
+                            }
+                            JetBrains.Profiler.Api.MeasureProfiler.StopCollectingData();
+                            JetBrains.Profiler.Api.MeasureProfiler.SaveData(groupName);
+                            GC.Collect();
+                            GC.WaitForPendingFinalizers();
+                        }
+
+                        if (JetBrains.Profiler.Api.MemoryProfiler.GetFeatures().HasFlag(JetBrains.Profiler.Api.MeasureFeatures.Ready))
+                        {
+                            Console.WriteLine("  Getting memory snapshot...");
+                            JetBrains.Profiler.Api.MemoryProfiler.ForceGc();
+                            JetBrains.Profiler.Api.MemoryProfiler.CollectAllocations(true);
+                            for (var i = 0; i < 100_000; i++)
+                            {
+                                method.Invoke(benchmarkInstance, null);
+                            }
+                            JetBrains.Profiler.Api.MemoryProfiler.GetSnapshot(groupName);
+                            JetBrains.Profiler.Api.MemoryProfiler.CollectAllocations(false);
+                        }
+                    }
+                }
+                Console.WriteLine("Done.");
+            }
         }
     }
 }


### PR DESCRIPTION
This PR enables the JetBrains dotTrace and dotMemory tools for the benchmark tests.
@DataDog/apm-dotnet