### PR TITLE
Don't listen for the Console_CancelKeyPress

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -145,16 +145,6 @@ namespace Datadog.Trace
                 Log.Warning(ex, "Unable to register a callback to the AppDomain.UnhandledException event.");
             }
 
-            try
-            {
-                // Registering for the cancel key press event requires the System.Security.Permissions.UIPermission
-                Console.CancelKeyPress += Console_CancelKeyPress;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "Unable to register a callback to the Console.CancelKeyPress event.");
-            }
-
             // start the heartbeat loop
             _heartbeatTimer = new Timer(HeartbeatCallback, state: null, dueTime: TimeSpan.Zero, period: TimeSpan.FromMinutes(1));
 
@@ -668,11 +658,6 @@ namespace Datadog.Trace
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             Log.Warning("Application threw an unhandled exception: {Exception}", e.ExceptionObject);
-            RunShutdownTasks();
-        }
-
-        private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
-        {
             RunShutdownTasks();
         }
 


### PR DESCRIPTION
Flushing and closing the tracer on cancel key press can lead to flushing the buffer before the app has finished writing spans. `CurrentDomain_ProcessExit` should always fire and flush, so flushing twice is unnecessary

As an example repro, create a new service worker using `dotnet new worker`, and update _worker.cs_ to:

```csharp
public class Worker : BackgroundService
{
    private readonly ILogger<Worker> _logger;
    public Worker(ILogger<Worker> logger, IHostApplicationLifetime lifetime)
    {
        _logger = logger;
    }

    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
    {
        var client = new HttpClient();
        using (var scope = Tracer.Instance.StartActive("background-service")); // this trace is closed AFTER the tracer is flushed
        {
            while (!stoppingToken.IsCancellationRequested)
            {
                var response = await client.GetStringAsync("https://jsonplaceholder.typicode.com/todos/1");
                _logger.LogInformation("Received Json");
                await Task.Delay(100, stoppingToken);
            }
        }
    }
}
```

Run the app, see the requests being made, and hit `ctrl-c`. The traces are not sent, as the `background-service` operation is closed _after_ the Tracer is close and flushed

@DataDog/apm-dotnet