### PR TITLE
Fix references to dotnet-tracer-native.log

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -116,7 +116,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) IntegrationTests
 
-  - publish: dotnet-tracer-native.log
+  - publish: logs
     artifact: $(Agent.JobName)_profiler-logs
     condition: succeededOrFailed()
 
@@ -239,7 +239,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core50
 
-  - publish: dotnet-tracer-native.log
+  - publish: logs
     artifact: $(Agent.JobName)_profiler-logs
     condition: succeededOrFailed()
 
@@ -581,7 +581,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core50
 
-  - publish: dotnet-tracer-native.log
+  - publish: logs
     artifact: $(Agent.JobName)_profiler-logs
     condition: succeededOrFailed()
 

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -116,7 +116,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) IntegrationTests
 
-  - publish: logs
+  - publish: build_data
     artifact: $(Agent.JobName)_profiler-logs
     condition: succeededOrFailed()
 
@@ -239,7 +239,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core50
 
-  - publish: logs
+  - publish: build_data
     artifact: $(Agent.JobName)_profiler-logs
     condition: succeededOrFailed()
 
@@ -581,7 +581,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core50
 
-  - publish: logs
+  - publish: build_data
     artifact: $(Agent.JobName)_profiler-logs
     condition: succeededOrFailed()
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -692,7 +692,7 @@ stages:
         containerregistrytype: Container Registry
         dockerComposeCommand: run -e TestAllPackageVersions=$(TestAllPackageVersions) -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) IntegrationTests
 
-    - publish: dotnet-tracer-native.log
+    - publish: logs
       artifact: $(Agent.JobName)_profiler-logs
       condition: succeededOrFailed()
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -692,7 +692,7 @@ stages:
         containerregistrytype: Container Registry
         dockerComposeCommand: run -e TestAllPackageVersions=$(TestAllPackageVersions) -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) IntegrationTests
 
-    - publish: logs
+    - publish: build_data
       artifact: $(Agent.JobName)_profiler-logs
       condition: succeededOrFailed()
 
@@ -776,7 +776,7 @@ stages:
         containerregistrytype: Container Registry
         dockerComposeCommand: run -e TestAllPackageVersions=$(TestAllPackageVersions) -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core50
 
-    - publish: dotnet-tracer-native.log
+    - publish: build_data
       artifact: $(Agent.JobName)_profiler-logs
       condition: succeededOrFailed()
 
@@ -831,7 +831,7 @@ stages:
         containerregistrytype: Container Registry
         dockerComposeCommand: run -e TestAllPackageVersions=$(TestAllPackageVersions) -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core50
 
-    - publish: dotnet-tracer-native.log
+    - publish: build_data
       artifact: $(Agent.JobName)_profiler-logs
       condition: succeededOrFailed()
 

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -18,4 +18,5 @@ wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
 dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results --TestCaseFilter:Category!=ArmUnsupported
 
-cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/
+mkdir /project/logs
+cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/logs

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -4,7 +4,6 @@ set -euxo pipefail
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
 mkdir -p /var/log/datadog/dotnet
-touch /var/log/datadog/dotnet/dotnet-tracer-native.log
 
 dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
 

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -18,4 +18,4 @@ wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
 dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results --TestCaseFilter:Category!=ArmUnsupported
 
-cp /var/log/datadog/dotnet/dotnet-tracer-native.log /project/
+cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.arm64.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
-set -euxo pipefail
+set -uxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
 mkdir -p /var/log/datadog/dotnet
+touch /var/log/datadog/dotnet/dotnet-tracer-native.log
+
+#https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash
+export COMPlus_DbgEnableMiniDump=1
+export COMPlus_DbgMiniDumpType=4
 
 dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
+st01=$?
 
 dotnet vstest test/Datadog.Trace.OpenTracing.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.OpenTracing.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.OpenTracing.IntegrationTests/results
+st02=$?
 
 wait-for-it servicestackredis:6379 -- \
 wait-for-it stackexchangeredis:6379 -- \
@@ -16,6 +23,14 @@ wait-for-it sqledge:1433 -- \
 wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
 dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results --TestCaseFilter:Category!=ArmUnsupported
+st03=$?
 
-mkdir /project/logs
-cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/logs
+# Collect run data
+mkdir /project/build_data
+
+cp /var/log/datadog/dotnet/* /project/build_data/
+cp /tmp/coredump* /project/build_data/ 2>/dev/null || :
+
+if [ $st01 -eq 1 ] || [ $st02 -eq 1 ] || [ $st03 -eq 1 ]; then
+    exit 1
+fi

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -19,4 +19,5 @@ wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
 dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results
 
-cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/
+mkdir /project/logs
+cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/logs

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -4,7 +4,6 @@ set -euxo pipefail
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
 mkdir -p /var/log/datadog/dotnet
-touch /var/log/datadog/dotnet/dotnet-tracer-native.log
 
 dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
 

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
-set -euxo pipefail
+set -uxo pipefail
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../../
 
 mkdir -p /var/log/datadog/dotnet
 
+#https://docs.microsoft.com/en-us/dotnet/core/diagnostics/dumps#collecting-dumps-on-crash
+export COMPlus_DbgEnableMiniDump=1
+export COMPlus_DbgMiniDumpType=4
+
 dotnet vstest test/Datadog.Trace.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.IntegrationTests/results
+st01=$?
 
 dotnet vstest test/Datadog.Trace.OpenTracing.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.OpenTracing.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.OpenTracing.IntegrationTests/results
+st02=$?
 
 wait-for-it servicestackredis:6379 -- \
 wait-for-it stackexchangeredis:6379 -- \
@@ -17,6 +23,14 @@ wait-for-it sqlserver:1433 -- \
 wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
 dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results
+st03=$?
 
-mkdir /project/logs
-cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/logs
+# Collect run data
+mkdir /project/build_data
+
+cp /var/log/datadog/dotnet/* /project/build_data/
+cp /tmp/coredump* /project/build_data/ 2>/dev/null || :
+
+if [ $st01 -eq 1 ] || [ $st02 -eq 1 ] || [ $st03 -eq 1 ]; then
+    exit 1
+fi

--- a/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
+++ b/build/docker/Datadog.Trace.ClrProfiler.IntegrationTests.sh
@@ -19,4 +19,4 @@ wait-for-it mongo:27017 -- \
 wait-for-it postgres:5432 -- \
 dotnet vstest test/Datadog.Trace.ClrProfiler.IntegrationTests/bin/$buildConfiguration/$publishTargetFramework/publish/Datadog.Trace.ClrProfiler.IntegrationTests.dll --logger:trx --ResultsDirectory:test/Datadog.Trace.ClrProfiler.IntegrationTests/results
 
-cp /var/log/datadog/dotnet/dotnet-tracer-native.log /project/
+cp /var/log/datadog/dotnet/dotnet-tracer-native*.log /project/

--- a/build/docker/linux-build.dockerfile
+++ b/build/docker/linux-build.dockerfile
@@ -68,7 +68,6 @@ COPY --from=build-managed ${WORKSPACE} ${WORKSPACE}
 WORKDIR ${WORKSPACE}/src/Datadog.Trace.ClrProfiler.Native/build
 RUN cmake .. && make && cp -f ./bin/Datadog.Trace.ClrProfiler.Native.so ${PUBLISH_FOLDER}/
 RUN mkdir -p /var/log/datadog/dotnet
-RUN touch /var/log/datadog/dotnet/dotnet-tracer-native.log
 WORKDIR ${PUBLISH_FOLDER}
 RUN echo "#!/bin/bash\n set -euxo pipefail\n export CORECLR_ENABLE_PROFILING=\"1\"\n export CORECLR_PROFILER=\"{846F5F1C-F9AE-4B07-969E-05C26BC060D8}\"\n export DD_DOTNET_TRACER_HOME=\"${TRACER_HOME}\"\n export CORECLR_PROFILER_PATH=\"\${DD_DOTNET_TRACER_HOME}/Datadog.Trace.ClrProfiler.Native.so\"\n export DD_INTEGRATIONS=\"\${DD_DOTNET_TRACER_HOME}/integrations.json\"\n eval \"\$@\"\n" > dd-trace.bash
 RUN chmod +x dd-trace.bash

--- a/build/docker/with-profiler-logs.bash
+++ b/build/docker/with-profiler-logs.bash
@@ -2,10 +2,11 @@
 set -euxo pipefail
 
 mkdir -p /var/log/datadog/dotnet
-touch /var/log/datadog/dotnet/dotnet-tracer-native.log
-tail -f /var/log/datadog/dotnet/dotnet-tracer-native.log | awk '
-  /info/ {print "\033[32m" $0 "\033[39m"}
-  /warn/ {print "\033[31m" $0 "\033[39m"}
-' &
 
 eval "$@"
+
+cat /var/log/datadog/dotnet/dotnet-tracer-native* \
+| awk '
+  /info/ {print "\033[32m" $0 "\033[39m"}
+  /warn/ {print "\033[31m" $0 "\033[39m"}
+'

--- a/build/docker/with-profiler-logs.bash
+++ b/build/docker/with-profiler-logs.bash
@@ -1,12 +1,14 @@
 #!/bin/bash
-set -euxo pipefail
+set -uxo pipefail
 
 mkdir -p /var/log/datadog/dotnet
 
 eval "$@"
+exitVal=$?
 
 cat /var/log/datadog/dotnet/dotnet-tracer-native* \
 | awk '
   /info/ {print "\033[32m" $0 "\033[39m"}
   /warn/ {print "\033[31m" $0 "\033[39m"}
 '
+exit $exitVal

--- a/samples/ServiceFabricRemoting/DatadogInstall.ps1
+++ b/samples/ServiceFabricRemoting/DatadogInstall.ps1
@@ -37,7 +37,7 @@ function Set-MachineEnvironmentVariable {
 
 Set-MachineEnvironmentVariable 'DD_DOTNET_TRACER_HOME' $DD_DOTNET_TRACER_HOME
 Set-MachineEnvironmentVariable 'DD_INTEGRATIONS' "$DD_DOTNET_TRACER_HOME\integrations.json"
-Set-MachineEnvironmentVariable 'DD_TRACE_LOG_PATH' "$LOGS_PATH\dotnet-tracer-native.log"
+Set-MachineEnvironmentVariable 'DD_TRACE_LOG_DIRECTORY ' "$LOGS_PATH"
 
 # Set-MachineEnvironmentVariable'COR_ENABLE_PROFILING' '0' # Enable per app
 Set-MachineEnvironmentVariable 'COR_PROFILER' '{846F5F1C-F9AE-4B07-969E-05C26BC060D8}'


### PR DESCRIPTION
In #1296 we added rotation for the native log file, which means the "bare" dotnet-tracer-native.log file isn't used.

This PR updates the build scripts to account for that, so that we still publish the log results for viewing in the ci pipelines

@DataDog/apm-dotnet