### PR TITLE
Increase diagnostic observer test timeout

### DIFF
--- a/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -74,17 +74,19 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
                 // The diagnostic observer runs on a separate thread
                 // This gives time for the Stop event to run and to be flushed to the writer
-                var iterations = 10;
-                while (iterations > 0)
+                const int timeoutInMilliseconds = 10000;
+
+                var deadline = DateTime.Now.AddMilliseconds(timeoutInMilliseconds);
+                while (DateTime.Now < deadline)
                 {
                     if (writer.Traces.Count > 0)
                     {
                         break;
                     }
 
-                    Thread.Sleep(10);
-                    iterations--;
+                    Thread.Sleep(200);
                 }
+                
             }
 
             var trace = Assert.Single(writer.Traces);

--- a/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -86,7 +86,6 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
                     Thread.Sleep(200);
                 }
-                
             }
 
             var trace = Assert.Single(writer.Traces);


### PR DESCRIPTION
Try and reduce test flakiness. Would be nice not to have this time based approach but this is the same approach `MockTracerAgent` uses so...

@DataDog/apm-dotnet