### PR TITLE
ProcessExit event handler improvements

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -671,7 +671,39 @@ namespace Datadog.Trace
 
         private void CurrentDomain_ProcessExit(object sender, EventArgs e)
         {
-            RunShutdownTasks();
+            // This handles a grateful shutdown or a SIGTERM
+            // Multiple delegates can be registered to this event. (eg. IHostApplicationLifetime instances)
+            // So we must be sure we are the last handler of the event to ensure we are flushing all the
+            // possible traces we are generating.
+
+            // For this, we try to get the internal ProcessExit delegate from the event.
+            var processExitDelegate = DelegatesHelper.GetInternalProcessExitDelegate();
+            if (processExitDelegate != null)
+            {
+                // With the internal MulticastDelegate we first create the delegate instance
+                // we want to run at last of the event handler.
+
+                // Sets the final delegate to be executed by the ProcessExit event.
+                var lastDelegate = new EventHandler((s, earg) =>
+                {
+                    RunShutdownTasks();
+                });
+
+                // Try to modify the MulticastDelegate invocation list and set the last delegate.
+                if (!DelegatesHelper.TrySetLastDelegate(processExitDelegate, lastDelegate))
+                {
+                    // This means we are in the last delegate already
+                    // or we were unable to set the last delegate, in
+                    // any case we fallback by running the delegate now.
+                    lastDelegate(sender, e);
+                }
+            }
+            else
+            {
+                // If we were unable to extract the internal delegate of the event then
+                // we just fallback and run the code here.
+                RunShutdownTasks();
+            }
         }
 
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
@@ -682,7 +714,17 @@ namespace Datadog.Trace
 
         private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
         {
-            RunShutdownTasks();
+            // Console Cancel KeyPress is raised on SIGINT and SIGQUIT signal,
+            // here we ensure we flush and not close the writer.
+            // There's a possibility of a graceful shutdown handled by ProcessExit.
+            try
+            {
+                _agentWriter.FlushTracesAsync().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error flushing traces on shutdown.");
+            }
         }
 
         private void CurrentDomain_DomainUnload(object sender, EventArgs e)

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -695,7 +695,7 @@ namespace Datadog.Trace
                     // This means we are in the last delegate already
                     // or we were unable to set the last delegate, in
                     // any case we fallback by running the delegate now.
-                    lastDelegate(sender, e);
+                    RunShutdownTasks();
                 }
             }
             else

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -671,7 +671,7 @@ namespace Datadog.Trace
 
         private void CurrentDomain_ProcessExit(object sender, EventArgs e)
         {
-            // This handles a grateful shutdown or a SIGTERM
+            // This handles a graceful shutdown or a SIGTERM
             // Multiple delegates can be registered to this event. (eg. IHostApplicationLifetime instances)
             // So we must be sure we are the last handler of the event to ensure we are flushing all the
             // possible traces we are generating.

--- a/src/Datadog.Trace/Util/DelegatesHelper.cs
+++ b/src/Datadog.Trace/Util/DelegatesHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Util
         {
             // This methods tries to get the internal delegte for the process exit event.
 
-#if NETCOREAPP || NET5_0_OR_GREATER
+#if NETSTANDARD2_0 || NETCOREAPP || NETCOREAPP3_1_OR_GREATER
             // code for netcoreapp2.1, netcoreapp3.1, net5.0
             var appContextProcessExit = typeof(AppContext).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Static);
             if (appContextProcessExit != null)

--- a/src/Datadog.Trace/Util/DelegatesHelper.cs
+++ b/src/Datadog.Trace/Util/DelegatesHelper.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace Datadog.Trace.Util
+{
+    /// <summary>
+    /// Delegates helper class
+    /// </summary>
+    internal static class DelegatesHelper
+    {
+        /// <summary>
+        /// Tries to get the internal ProcessExit delegate from the event using reflection.
+        /// </summary>
+        /// <returns>MulticastDelegate instance or null</returns>
+        public static MulticastDelegate GetInternalProcessExitDelegate()
+        {
+            // This methods tries to get the internal delegte for the process exit event.
+
+#if NETCOREAPP || NET5_0_OR_GREATER
+            // code for netcoreapp2.1, netcoreapp3.1, net5.0
+            var appContextProcessExit = typeof(AppContext).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Static);
+            if (appContextProcessExit != null)
+            {
+                return appContextProcessExit.GetValue(null) as MulticastDelegate;
+            }
+#endif
+            // code for .NET Framework
+            var appDomainProcessExit = typeof(AppDomain).GetField("_processExit", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (appDomainProcessExit != null)
+            {
+                return appDomainProcessExit.GetValue(AppDomain.CurrentDomain) as MulticastDelegate;
+            }
+
+            // code for Mono
+            appDomainProcessExit = typeof(AppDomain).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (appDomainProcessExit != null)
+            {
+                return appDomainProcessExit.GetValue(AppDomain.CurrentDomain) as MulticastDelegate;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Try to set a delegate as the last one from a MulticastDelegate invocation list.
+        /// </summary>
+        /// <param name="targetDelegate">MulticastDelegate instance target were the invocation list will be modified</param>
+        /// <param name="lastDelegate">Last delegate to run on the MulticastDelegate</param>
+        /// <returns>true if the modification was made; otherwise, false.</returns>
+        public static bool TrySetLastDelegate(MulticastDelegate targetDelegate, Delegate lastDelegate)
+        {
+            // The MulticastDelegate class has two inner fields with the invocation list and the count
+            // (the invocation list is an array but the resize is handled similar to a list in a 2x factor)
+            // Mono behaves different to .NET Framework and .NETCore, using a single `delegates` array.
+
+            Type multicastType = typeof(MulticastDelegate);
+            BindingFlags bindingFlags = BindingFlags.NonPublic | BindingFlags.Instance;
+            FieldInfo invocationListField = multicastType.GetField("_invocationList", bindingFlags);
+            FieldInfo invocationCountField = multicastType.GetField("_invocationCount", bindingFlags);
+
+            if (invocationListField is null || invocationCountField is null)
+            {
+                // We try the mono approach
+                FieldInfo delegatesField = multicastType.GetField("delegates", bindingFlags);
+                if (delegatesField.GetValue(targetDelegate) is Delegate[] delegates && delegates.Length > 1)
+                {
+                    Delegate oldDelegate = delegates[delegates.Length - 1];
+                    // Here we assume the caller of this method is the one is handling the event,
+                    // so we check if we are not already the last delegate before trying to combine new delegates.
+                    var frame = new StackFrame(1);
+                    if (oldDelegate.Method != frame.GetMethod())
+                    {
+                        // Combine the last delegate in the invocation list with the one we want to be the last.
+                        delegates[delegates.Length - 1] = Delegate.Combine(oldDelegate, lastDelegate);
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            if (invocationListField.GetValue(targetDelegate) is object[] invocationList)
+            {
+                if (invocationCountField.GetValue(targetDelegate) is IntPtr invocationCountPtr)
+                {
+                    // The internal count is saved as a IntPtr but contains an int value, so we cast.
+                    int invocationCount = (int)invocationCountPtr;
+
+                    if (invocationCount > 1)
+                    {
+                        Delegate oldDelegate = (Delegate)invocationList[invocationCount - 1];
+                        // Here we assume the caller of this method is the one is handling the event,
+                        // so we check if we are not already the last delegate before trying to combine new delegates.
+                        StackFrame frame = new StackFrame(1);
+                        if (oldDelegate.Method != frame.GetMethod())
+                        {
+                            // Combine the last delegate in the invocation list with the one we want to be the last.
+                            invocationList[invocationCount - 1] = Delegate.Combine(oldDelegate, lastDelegate);
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Datadog.Trace/Util/DelegatesHelper.cs
+++ b/src/Datadog.Trace/Util/DelegatesHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Util
         {
             // This methods tries to get the internal delegte for the process exit event.
 
-#if NETSTANDARD2_0 || NETCOREAPP || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_0 || NETCOREAPP
             // code for netcoreapp2.1, netcoreapp3.1, net5.0
             var appContextProcessExit = typeof(AppContext).GetField("ProcessExit", BindingFlags.NonPublic | BindingFlags.Static);
             if (appContextProcessExit != null)

--- a/src/Datadog.Trace/Util/DelegatesHelper.cs
+++ b/src/Datadog.Trace/Util/DelegatesHelper.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Util
                     // The internal count is saved as a IntPtr but contains an int value, so we cast.
                     int invocationCount = (int)invocationCountPtr;
 
-                    if (invocationCount > 1)
+                    if (invocationCount > 1 && invocationCount <= invocationList.Length)
                     {
                         Delegate oldDelegate = (Delegate)invocationList[invocationCount - 1];
                         // Here we assume the caller of this method is the one is handling the event,

--- a/src/Datadog.Trace/Util/DelegatesHelper.cs
+++ b/src/Datadog.Trace/Util/DelegatesHelper.cs
@@ -43,6 +43,26 @@ namespace Datadog.Trace.Util
         }
 
         /// <summary>
+        /// Tries to get the internal Console.CancelKeyPress delegate from the event using reflection.
+        /// </summary>
+        /// <returns>MulticastDelegate instance or null</returns>
+        public static MulticastDelegate GetInternalCancelKeyPressDelegate()
+        {
+            // This methods tries to get the internal delegte for the Console.CancelKeyPress event.
+
+            FieldInfo consoleCancelCallbacks =
+                typeof(Console).GetField("s_cancelCallbacks", BindingFlags.NonPublic | BindingFlags.Static) ??
+                typeof(Console).GetField("_cancelCallbacks", BindingFlags.NonPublic | BindingFlags.Static);
+
+            if (consoleCancelCallbacks != null)
+            {
+                return consoleCancelCallbacks.GetValue(null) as MulticastDelegate;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Try to set a delegate as the last one from a MulticastDelegate invocation list.
         /// </summary>
         /// <param name="targetDelegate">MulticastDelegate instance target were the invocation list will be modified</param>

--- a/test/Datadog.Trace.Tests/DelegatesHelperTests.cs
+++ b/test/Datadog.Trace.Tests/DelegatesHelperTests.cs
@@ -10,8 +10,15 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void GetProcessExitDelegateTest()
         {
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
             var @delegate = DelegatesHelper.GetInternalProcessExitDelegate();
+            AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
             Assert.NotNull(@delegate);
+
+            void CurrentDomain_ProcessExit(object sender, EventArgs e)
+            {
+                throw new NotImplementedException();
+            }
         }
 
         [Fact]
@@ -19,8 +26,8 @@ namespace Datadog.Trace.Tests
         {
             Console.CancelKeyPress += Console_CancelKeyPress;
             var @delegate = DelegatesHelper.GetInternalCancelKeyPressDelegate();
-            Assert.NotNull(@delegate);
             Console.CancelKeyPress -= Console_CancelKeyPress;
+            Assert.NotNull(@delegate);
 
             void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
             {

--- a/test/Datadog.Trace.Tests/DelegatesHelperTests.cs
+++ b/test/Datadog.Trace.Tests/DelegatesHelperTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Util;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class DelegatesHelperTests
+    {
+        [Fact]
+        public void GetProcessExitDelegateTest()
+        {
+            var @delegate = DelegatesHelper.GetInternalProcessExitDelegate();
+            Assert.NotNull(@delegate);
+        }
+
+        [Fact]
+        public void SetLastDelegateTest()
+        {
+            var lstEvents = new List<int>();
+
+            TargetObject.MyEvent += TargetObject_MyEvent;
+            TargetObject.MyEvent += TargetObject_MyEvent2;
+            TargetObject.FireEvent();
+            TargetObject.MyEvent -= TargetObject_MyEvent;
+            TargetObject.MyEvent -= TargetObject_MyEvent2;
+
+            Assert.Equal(1, lstEvents[0]);
+            Assert.Equal(2, lstEvents[1]);
+            Assert.Equal(3, lstEvents[2]);
+
+            void TargetObject_MyEvent(object sender, EventArgs e)
+            {
+                lstEvents.Add(1);
+
+                var targetDelegate = TargetObject.GetDelegate();
+
+                var lastDelegate = new EventHandler((s, eArgs) =>
+                {
+                    lstEvents.Add(3);
+                });
+
+                if (!DelegatesHelper.TrySetLastDelegate(targetDelegate, lastDelegate))
+                {
+                    lastDelegate(sender, e);
+                }
+            }
+
+            void TargetObject_MyEvent2(object sender, EventArgs e) => lstEvents.Add(2);
+        }
+
+        [Fact]
+        public void SetLastDelegateInversedTest()
+        {
+            var lstEvents = new List<int>();
+
+            TargetObject.MyEvent += TargetObject_MyEvent2;
+            TargetObject.MyEvent += TargetObject_MyEvent;
+            TargetObject.FireEvent();
+            TargetObject.MyEvent -= TargetObject_MyEvent2;
+            TargetObject.MyEvent -= TargetObject_MyEvent;
+
+            Assert.Equal(2, lstEvents[0]);
+            Assert.Equal(1, lstEvents[1]);
+            Assert.Equal(3, lstEvents[2]);
+
+            void TargetObject_MyEvent(object sender, EventArgs e)
+            {
+                lstEvents.Add(1);
+
+                var targetDelegate = TargetObject.GetDelegate();
+
+                var lastDelegate = new EventHandler((s, eArgs) =>
+                {
+                    lstEvents.Add(3);
+                });
+
+                if (!DelegatesHelper.TrySetLastDelegate(targetDelegate, lastDelegate))
+                {
+                    lastDelegate(sender, e);
+                }
+            }
+
+            void TargetObject_MyEvent2(object sender, EventArgs e) => lstEvents.Add(2);
+        }
+
+        [Fact]
+        public void SetLastDelegaten3HandlersTest()
+        {
+            var lstEvents = new List<int>();
+
+            TargetObject.MyEvent += TargetObject_MyEvent2;
+            TargetObject.MyEvent += TargetObject_MyEvent;
+            TargetObject.MyEvent += TargetObject_MyEvent2;
+            TargetObject.FireEvent();
+            TargetObject.MyEvent -= TargetObject_MyEvent2;
+            TargetObject.MyEvent -= TargetObject_MyEvent;
+            TargetObject.MyEvent -= TargetObject_MyEvent2;
+
+            Assert.Equal(2, lstEvents[0]);
+            Assert.Equal(1, lstEvents[1]);
+            Assert.Equal(2, lstEvents[2]);
+            Assert.Equal(3, lstEvents[3]);
+
+            void TargetObject_MyEvent(object sender, EventArgs e)
+            {
+                lstEvents.Add(1);
+
+                var targetDelegate = TargetObject.GetDelegate();
+
+                var lastDelegate = new EventHandler((s, eArgs) =>
+                {
+                    lstEvents.Add(3);
+                });
+
+                if (!DelegatesHelper.TrySetLastDelegate(targetDelegate, lastDelegate))
+                {
+                    lastDelegate(sender, e);
+                }
+            }
+
+            void TargetObject_MyEvent2(object sender, EventArgs e) => lstEvents.Add(2);
+        }
+
+        internal static class TargetObject
+        {
+            public static event EventHandler MyEvent;
+
+            public static EventHandler GetDelegate() => MyEvent;
+
+            public static void FireEvent()
+            {
+                MyEvent?.Invoke(null, EventArgs.Empty);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/DelegatesHelperTests.cs
+++ b/test/Datadog.Trace.Tests/DelegatesHelperTests.cs
@@ -15,6 +15,20 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
+        public void GetCancelKeyPressDelegateTest()
+        {
+            Console.CancelKeyPress += Console_CancelKeyPress;
+            var @delegate = DelegatesHelper.GetInternalCancelKeyPressDelegate();
+            Assert.NotNull(@delegate);
+            Console.CancelKeyPress -= Console_CancelKeyPress;
+
+            void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
         public void SetLastDelegateTest()
         {
             var lstEvents = new List<int>();


### PR DESCRIPTION
This PR improves the way we handle the ProcessExit event by ensuring that the tracer handler is the last one to be executed from the event.

#### The background:
The process signals received on the CLR are handled this way:

1. `SIGTERM` is handled by `AppDomain.CurrentDomain.ProcessExit`
2. `SIGINT` and `SIGQUIT` is handled by `Console.CancelKeyPress`
3. `SIGKILL` can't be caught or ignored.

https://github.com/DataDog/dd-trace-dotnet/pull/1323#issuecomment-810232442

In scenarios where `IHostApplicationLifetime` is being used we can face the case where the tracer handles the `ProcessExit` event where the traces are flushed and the writer is closed but the actual application can still be creating new spans. As @andrewlock describes in the discussion here: https://github.com/DataDog/dd-trace-dotnet/pull/1323#issuecomment-810379331

This PR solves the issue by ensuring the tracer handler for ProcessExit will be the last one of the event, to send all the spans generated on previous handlers.

Also on `SIGINT` and `SIGQUIT` signals changes the actual behavior to only flush and not close due we can receive a `SIGTERM` later.

@DataDog/apm-dotnet