### PR TITLE
Implement Dependabot Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
-version: 1
+version: 2
 update_configs:
-  - package_manager: "dotnet:nuget"
+  - package_manager: "nuget"
     directory: "/honeypot"
     update_schedule: "daily"
     default_labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
-update_configs:
-  - package_manager: "nuget"
+updates:
+  # Maintain dependencies for vendors
+  - package-ecosystem: "nuget"
     directory: "/honeypot"
-    update_schedule: "daily"
-    default_labels:
+    schedule:
+      interval: "daily"
+    labels:
       - "vendors"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,33 @@
 version: 2
 updates:
-  # Maintain dependencies for vendors
+  # Dependency notifications for vendored libraries
   - package-ecosystem: "nuget"
     directory: "/honeypot"
     schedule:
       interval: "daily"
     labels:
-      - "vendors"
+      - "dependencies"
+      - "area:vendors"
+  # Core tracer libraries
+  - package-ecosystem: "nuget"
+    directory: "/src"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+  # Test area
+  - package-ecosystem: "nuget"
+    directory: "/test"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "area:tests"
+  # Tools area
+  - package-ecosystem: "nuget"
+    directory: "/tools"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "area:tools"


### PR DESCRIPTION
Previous attempt (#1336) used the documentation for the dependabot preview.

https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates

We can also use this to keep samples up to date with the latest libraries.

@DataDog/apm-dotnet