### PR TITLE
Support propagation of B3 headers

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -291,6 +291,13 @@ namespace Datadog.Trace.Configuration
         public const string TracesTransport = "DD_TRACE_TRANSPORT";
 
         /// <summary>
+        /// Configuration key for overriding the style to use for communicating span context.
+        /// Default value is <c>Datadog</c>.
+        /// Override options available: <c>B3</c>, <c>DataDog</c>
+        /// </summary>
+        public const string PropagationStyle = "DD_PROPAGATION_STYLE_INJECT";
+
+        /// <summary>
         /// Configuration key for the application's server http statuses to set spans as errors by.
         /// </summary>
         /// <seealso cref="TracerSettings.HttpServerErrorStatusCodes"/>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -51,6 +51,8 @@ namespace Datadog.Trace.Configuration
                            // default value
                            true;
 
+            PropagationStyles = source?.GetString(ConfigurationKeys.PropagationStyle)?.Split(',') ?? new[] { "Datadog" };
+
             if (AzureAppServices.Metadata.IsRelevant && AzureAppServices.Metadata.IsUnsafeToTrace)
             {
                 TraceEnabled = false;
@@ -209,6 +211,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
         public bool TraceEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default PropagationStyle
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.PropagationStyle"/>
+        public string[] PropagationStyles { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether debug is enabled for a tracer.

--- a/src/Datadog.Trace/HttpHeaderNames.cs
+++ b/src/Datadog.Trace/HttpHeaderNames.cs
@@ -30,5 +30,30 @@ namespace Datadog.Trace
         /// Origin of the distributed trace.
         /// </summary>
         public const string Origin = "x-datadog-origin";
+
+        /// <summary>
+        /// TraceId used for B3 propagation. Per specification, the TraceId is 64 or 128-bit in length and indicates the overall ID of the trace.
+        /// </summary>
+        public const string B3TraceId = "x-b3-traceid";
+
+        /// <summary>
+        /// The parent span id for B3 propagation. Per specification, the ParentSpanId is 64-bit in length and indicates the position of the parent operation in the trace tree
+        /// </summary>
+        public const string B3ParentId = "x-b3-parentspanid";
+
+        /// <summary>
+        /// The span id for B3 propagation. Per specification, The SpanId is 64-bit in length and indicates the position of the current operation in the trace tree.
+        /// </summary>
+        public const string B3SpanId = "x-b3-spanid";
+
+        /// <summary>
+        /// The sampling state for B3 propagation. 0 for a negative sampling decision, 1 for a positive sampling decision. Empty for no decision.
+        /// </summary>
+        public const string B3Sampled = "x-b3-sampled";
+
+        /// <summary>
+        /// The flags for B3 propagation. Currently, this is only used for indicating a debug trace when the first bit is set.
+        /// </summary>
+        public const string B3Flags = "x-b3-flags";
     }
 }


### PR DESCRIPTION
Fixes #1328 

Changes proposed in this pull request:
- Add support for DD_PROPAGATION_STYLE_INJECT, similar to the Java SDK, to support B3 trace context propagation using the DD tracer. 



@DataDog/apm-dotnet