### PR TITLE
Log a warning if partial flush is enabled with an old agent

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.Agent
         {
         }
 
+        // Internal constructor used for tests
         internal Api(Uri baseEndpoint, IApiRequestFactory apiRequestFactory, IDogStatsd statsd, IDatadogTracer tracer)
         {
             Log.Debug("Creating new Api");

--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
@@ -20,14 +19,20 @@ namespace Datadog.Trace.Agent
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly IDogStatsd _statsd;
-        private readonly FormatterResolverWrapper _formatterResolver = new FormatterResolverWrapper(SpanFormatterResolver.Instance);
         private readonly string _containerId;
         private readonly Uri _tracesEndpoint;
+        private readonly IDatadogTracer _tracer;
         private string _cachedResponse;
 
         public Api(Uri baseEndpoint, IApiRequestFactory apiRequestFactory, IDogStatsd statsd)
+            : this(baseEndpoint, apiRequestFactory, statsd, tracer: null)
+        {
+        }
+
+        internal Api(Uri baseEndpoint, IApiRequestFactory apiRequestFactory, IDogStatsd statsd, IDatadogTracer tracer)
         {
             Log.Debug("Creating new Api");
+            _tracer = tracer;
             _tracesEndpoint = new Uri(baseEndpoint, TracesPath);
             _statsd = statsd;
             _containerId = ContainerMetadata.GetContainerId();
@@ -188,6 +193,12 @@ namespace Datadog.Trace.Agent
 
                 try
                 {
+                    var version = response.GetHeader(AgentHttpHeaderNames.AgentVersion);
+
+                    var tracer = _tracer ?? Tracer.Instance;
+
+                    tracer.ReportAgentVersion(version);
+
                     if (response.ContentLength != 0 && Tracer.Instance.Sampler != null)
                     {
                         var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
@@ -196,7 +207,7 @@ namespace Datadog.Trace.Agent
                         {
                             var apiResponse = JsonConvert.DeserializeObject<ApiResponse>(responseContent);
 
-                            Tracer.Instance.Sampler.SetDefaultSampleRates(apiResponse?.RateByService);
+                            tracer.Sampler.SetDefaultSampleRates(apiResponse?.RateByService);
 
                             _cachedResponse = responseContent;
                         }

--- a/src/Datadog.Trace/Agent/IApiResponse.cs
+++ b/src/Datadog.Trace/Agent/IApiResponse.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.Agent
 
         long ContentLength { get; }
 
+        string GetHeader(string headerName);
+
         Task<string> ReadAsStringAsync();
     }
 }

--- a/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
+++ b/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
@@ -18,6 +18,8 @@ namespace Datadog.Trace.Agent.Transports
 
         public long ContentLength => _response.ContentLength;
 
+        public string GetHeader(string headerName) => _response.Headers[headerName];
+
         public async Task<string> ReadAsStringAsync()
         {
             using (var responseStream = _response.GetResponseStream())

--- a/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
@@ -1,4 +1,5 @@
 #if NETCOREAPP
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -20,6 +21,26 @@ namespace Datadog.Trace.Agent.Transports
         public void Dispose()
         {
             _response.Dispose();
+        }
+
+        public string GetHeader(string headerName)
+        {
+            if (_response.Headers.TryGetValues(headerName, out var headers))
+            {
+                if (headers is string[] headersArray)
+                {
+                    if (headersArray.Length > 0)
+                    {
+                        return headersArray[0];
+                    }
+                }
+                else
+                {
+                    return headers.FirstOrDefault();
+                }
+            }
+
+            return null;
         }
 
         public Task<string> ReadAsStringAsync()

--- a/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Agent.Transports
                 await response.Content.CopyToAsync(buffer).ConfigureAwait(false);
                 responseContentStream.Position = 0;
 
-                return new HttpStreamResponse(response.StatusCode, responseContentStream.Length, response.GetContentEncoding(), responseContentStream);
+                return new HttpStreamResponse(response.StatusCode, responseContentStream.Length, response.GetContentEncoding(), responseContentStream, response.Headers);
             }
         }
     }

--- a/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
@@ -1,19 +1,22 @@
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using Datadog.Trace.HttpOverStreams;
 
 namespace Datadog.Trace.Agent.Transports
 {
     internal class HttpStreamResponse : IApiResponse
     {
+        private readonly HttpHeaders _headers;
         private string _responseCache;
 
-        public HttpStreamResponse(int statusCode, long contentLength, Encoding encoding, Stream responseStream)
+        public HttpStreamResponse(int statusCode, long contentLength, Encoding encoding, Stream responseStream, HttpHeaders headers)
         {
             StatusCode = statusCode;
             ContentLength = contentLength;
             Encoding = encoding;
             ResponseStream = responseStream;
+            _headers = headers;
         }
 
         public int StatusCode { get; }
@@ -27,6 +30,8 @@ namespace Datadog.Trace.Agent.Transports
         public void Dispose()
         {
         }
+
+        public string GetHeader(string headerName) => _headers.GetValue(headerName);
 
         public async Task<string> ReadAsStringAsync()
         {

--- a/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -44,6 +44,11 @@ namespace Datadog.Trace
         public const string ComputedTopLevelSpan = "Datadog-Client-Computed-Top-Level";
 
         /// <summary>
+        /// Version reported by the Datadog agent
+        /// </summary>
+        public const string AgentVersion = "Datadog-Agent-Version";
+
+        /// <summary>
         /// Gets the default constant header that should be added to any request to the agent
         /// </summary>
         internal static KeyValuePair<string, string>[] DefaultHeaders { get; } =

--- a/src/Datadog.Trace/IDatadogTracer.cs
+++ b/src/Datadog.Trace/IDatadogTracer.cs
@@ -20,6 +20,8 @@ namespace Datadog.Trace
 
         Span StartSpan(string operationName, ISpanContext parent, string serviceName, DateTimeOffset? startTime, bool ignoreActiveScope);
 
+        void ReportAgentVersion(string agentVersion);
+
         void Write(Span[] span);
 
         /// <summary>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -363,7 +363,7 @@ namespace Datadog.Trace
         {
             if (ShouldLogPartialFlushWarning(version))
             {
-                Log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {version})", version);
+                Log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {version})", version ?? "{detection failed}");
             }
         }
 

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -50,6 +50,8 @@ namespace Datadog.Trace
 
         private readonly IAgentWriter _agentWriter;
 
+        private string _agentVersion;
+
         static Tracer()
         {
             TracingProcessManager.Initialize();
@@ -353,6 +355,18 @@ namespace Datadog.Trace
             }
         }
 
+        /// <summary>
+        /// Reports the detected version of the agent
+        /// </summary>
+        /// <param name="version">Version of the agent</param>
+        void IDatadogTracer.ReportAgentVersion(string version)
+        {
+            if (ShouldLogPartialFlushWarning(version))
+            {
+                Log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {version})", version);
+            }
+        }
+
         internal SpanContext CreateSpanContext(ISpanContext parent = null, string serviceName = null, bool ignoreActiveScope = false, ulong? spanId = null)
         {
             if (parent == null && !ignoreActiveScope)
@@ -561,6 +575,24 @@ namespace Datadog.Trace
             {
                 Log.Warning(ex, "DATADOG TRACER DIAGNOSTICS - Error fetching configuration");
             }
+        }
+
+        internal bool ShouldLogPartialFlushWarning(string agentVersion)
+        {
+            if (agentVersion != _agentVersion)
+            {
+                _agentVersion = agentVersion;
+
+                if (Settings.PartialFlushEnabled)
+                {
+                    if (!Version.TryParse(agentVersion, out var parsedVersion) || parsedVersion < new Version(7, 26, 0))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -120,6 +120,11 @@ namespace Benchmarks.Trace
 
             public long ContentLength => 0;
 
+            public string GetHeader(string headerName)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task<string> ReadAsStringAsync()
             {
                 throw new NotImplementedException();


### PR DESCRIPTION
Partial flush requires agent version 7.26.0+.

Note that 7.26.0 does not report the version (this feature is added in 7.27.0), so there is a window of time during which customers may get the warning even though they run with a supported agent.