### PR TITLE
OTel Port: Fix double parsing

### DIFF
--- a/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
+++ b/src/Datadog.Trace/Configuration/StringConfigurationSource.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Configuration
@@ -89,7 +90,7 @@ namespace Datadog.Trace.Configuration
         {
             string value = GetString(key);
 
-            return double.TryParse(value, out double result)
+            return double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out double result)
                        ? result
                        : (double?)null;
         }


### PR DESCRIPTION
Source: https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/96

@DataDog/apm-dotnet