### PR TITLE
Simplify moving average calculator

### DIFF
--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Agent
             var previousDropped = _dropped[index];
             var previousCreated = _created[index];
 
-            // Cap at unit.MaxValue events. Very unlikely to reach this value!
+            // Cap at uint.MaxValue events. Very unlikely to reach this value!
             var latestDropped = (uint)Math.Min(Interlocked.Exchange(ref _latestDrops, 0), uint.MaxValue);
             var latestCreated = (uint)Math.Min(Interlocked.Exchange(ref _latestKeeps, 0) + latestDropped, uint.MaxValue);
 

--- a/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
+++ b/src/Datadog.Trace/Agent/MovingAverageKeepRateCalculator.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Agent
         public double GetKeepRate()
         {
             // Essentially Interlock.Read(double)
-            return Interlocked.CompareExchange(ref _keepRate, 0, 0);
+            return Volatile.Read(ref _keepRate);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Agent
                                ? 0
                                : 1 - ((double)newSumDropped / newSumCreated);
 
-            Interlocked.Exchange(ref _keepRate, keepRate);
+            Volatile.Write(ref _keepRate, keepRate);
 
             _sumDrops = newSumDropped;
             _sumCreated = newSumCreated;


### PR DESCRIPTION
Was previously going a bit overboard with keeping things atomic, when in reality we only need the current buckets and keep rate to be atomic.

@DataDog/apm-dotnet