### PR TITLE
Add explicit nuget.config to workaround AzDo failures

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Seems to be related to [this issue](https://github.com/actions/virtual-environments/issues/3038) which relates to GitHub actions, but as AzDo runs on the same underlying infrastructure, probably the same problem.

Apparently this is a commonly-reported intermittent issue related to "ambient state" on the builder causing nuget.org to be omitted from the NuGet "Feeds used" (actions/virtual-environments#1090 (comment)). Add the nuget.org packageSource explicitly using nuget.config to avoid the issue, as recommended by:

actions/setup-dotnet#155 (comment)
actions/virtual-environments#3038 (comment)
NuGet/Home#10586 (comment)

@DataDog/apm-dotnet