### PR TITLE
Don't run unit test or runner pipelines on all branch pushes

### DIFF
--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -1,7 +1,8 @@
 trigger:
   branches:
     include:
-      - '*'
+      - master
+      - refs/tags/*
     exclude:
       - refs/pull/*/head
   paths:

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -1,7 +1,8 @@
 trigger:
   branches:
     include:
-      - '*'
+      - master
+      - refs/tags/*
     exclude:
       - refs/pull/*/head
   paths:


### PR DESCRIPTION
There's a lot of duplicated effort caused by these branch-only pushes, and with limited runners available (especially macos), this causes a backlog of runs for PRs.

We can always manually trigger a pipeline for a branch if we want a pre-PR check, so I think this is probably a good option?

@DataDog/apm-dotnet