### PR TITLE
Fix native unit tests running in Release mode

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -234,10 +234,14 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromTypeRefs) {
       L"System.Collections.Generic.IList`1",
       L"System.Collections.Generic.List`1",
       L"System.Diagnostics.DebuggableAttribute",
+#ifdef _DEBUG
       L"System.Diagnostics.DebuggerBrowsableAttribute",
       L"System.Diagnostics.DebuggerBrowsableState",
+#endif
       L"System.Diagnostics.DebuggerHiddenAttribute",
+#ifdef _DEBUG
       L"System.Diagnostics.DebuggerStepThroughAttribute",
+#endif
       L"System.Exception",
       L"System.Func`3",
       L"System.Guid",


### PR DESCRIPTION
The current implementation assumes builds are made in Debug mode, so expects some debugger attributes that aren't there in release builds. The current build pipelines are running the native unit tests in debug mode, which is why this hasn't shown up before.

This PR fixes the tests so they should pass in both Release and Debug mode

@DataDog/apm-dotnet