### PR TITLE
Fix the package build pipeline

### DIFF
--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -117,13 +117,13 @@ stages:
         arguments: --configuration $(buildConfiguration) --framework netcoreapp3.1 --output $(tracerHome)/netcoreapp3.1
 
     - task: DockerCompose@0
-      displayName: docker-compose run Profiler
+      displayName: docker-compose run -e buildConfiguration=$(buildConfiguration) Profiler
       inputs:
         containerregistrytype: Container Registry
         dockerComposeCommand: run Profiler
 
     - task: DockerCompose@0
-      displayName: docker-compose run package
+      displayName: docker-compose run -e buildConfiguration=$(buildConfiguration) package
       inputs:
         containerregistrytype: Container Registry
         dockerComposeCommand: run package
@@ -171,13 +171,13 @@ stages:
         arguments: --configuration $(buildConfiguration) --framework netcoreapp3.1 --output $(tracerHome)/netcoreapp3.1
 
     - task: DockerCompose@0
-      displayName: docker-compose run Profiler.Alpine
+      displayName: docker-compose run -e buildConfiguration=$(buildConfiguration) Profiler.Alpine
       inputs:
         containerregistrytype: Container Registry
         dockerComposeCommand: run Profiler.Alpine
 
     - task: DockerCompose@0
-      displayName: docker-compose run package.alpine
+      displayName: docker-compose run -e buildConfiguration=$(buildConfiguration) package.alpine
       inputs:
         containerregistrytype: Container Registry
         dockerComposeCommand: run package.alpine

--- a/build/docker/package.sh
+++ b/build/docker/package.sh
@@ -3,10 +3,11 @@ set -euxo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 VERSION=1.25.2
+BUILD_TYPE=${buildConfiguration:-Debug}
 
 mkdir -p $DIR/../../deploy/linux
-cp $DIR/../../integrations.json $DIR/../../src/Datadog.Trace.ClrProfiler.Native/bin/Release/x64/
-cp $DIR/../../build/artifacts/createLogPath.sh $DIR/../../src/Datadog.Trace.ClrProfiler.Native/bin/Release/x64/
+cp $DIR/../../integrations.json $DIR/../../src/Datadog.Trace.ClrProfiler.Native/bin/${BUILD_TYPE}/x64/
+cp $DIR/../../build/artifacts/createLogPath.sh $DIR/../../src/Datadog.Trace.ClrProfiler.Native/bin/${BUILD_TYPE}/x64/
 
 cd $DIR/../../deploy/linux
 for pkgtype in $PKGTYPES ; do
@@ -17,7 +18,7 @@ for pkgtype in $PKGTYPES ; do
         -n datadog-dotnet-apm \
         -v $VERSION \
         $(if [ $pkgtype != 'tar' ] ; then echo --prefix /opt/datadog ; fi) \
-        --chdir $DIR/../../src/Datadog.Trace.ClrProfiler.Native/bin/Release/x64 \
+        --chdir $DIR/../../src/Datadog.Trace.ClrProfiler.Native/bin/${BUILD_TYPE}/x64 \
         netstandard2.0/ \
         netcoreapp3.1/ \
         Datadog.Trace.ClrProfiler.Native.so \


### PR DESCRIPTION
This was inadvertently introduced in https://github.com/DataDog/dd-trace-dotnet/pull/1309 because the build configuration was not tweaked appropriately for the package scripts and pipeline.

@DataDog/apm-dotnet