### PR TITLE
Try fix scheduled benchmark/throughput runs

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -10,7 +10,7 @@ schedules:
   branches:
     include:
     - master
-    - benchmarks/*
+    - /benchmarks/*
   always: true
 
 variables:

--- a/.azure-pipelines/crank.yml
+++ b/.azure-pipelines/crank.yml
@@ -22,7 +22,7 @@ schedules:
   branches:
     include:
     - master
-    - benchmarks/*
+    - /benchmarks/*
   always: true
 
 jobs:


### PR DESCRIPTION
The `master` branch is running as expected, but the `benchmarks/*` aren't for some reason. There's conflicting formats in [the documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers), so trying the other one...

@DataDog/apm-dotnet