### PR TITLE
Update dependabot to ignore libraries in Datadog.Trace.ClrProfiler.Managed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,16 @@ updates:
     labels:
       - "dependencies"
       - "area:integrations"
+    ignore:
+      # AspNetCore reference libraries are kept at the lowest supported version for compatibility on netstandard2.0
+      - dependency-name: "Microsoft.AspNetCore.Hosting.Abstractions"
+      - dependency-name: "Microsoft.AspNetCore.Mvc.Abstractions"
+      - dependency-name: "Microsoft.AspNetCore.Routing"
+
+      # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
+      - dependency-name: "System.Reflection.Emit"
+      - dependency-name: "System.Reflection.Emit.Lightweight"
+
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.OpenTracing"
     schedule:


### PR DESCRIPTION
Resolves #1367
Resolves #1372
Resolves #1375
Resolves #1378
Resolves #1383

@DataDog/apm-dotnet