### PR TITLE
Update dependabot all in one go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,15 @@ updates:
     labels:
       - "dependencies"
       - "area:tracer"
+    ignore:
+      # AspNetCore reference libraries are kept at the lowest supported version for compatibility on netstandard2.0
+      - dependency-name: "Microsoft.AspNetCore.Hosting.Abstractions"
+      - dependency-name: "Microsoft.AspNetCore.Mvc.Abstractions"
+      - dependency-name: "Microsoft.AspNetCore.Routing"
+
+      # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
+      - dependency-name: "System.Reflection.Emit"
+      - dependency-name: "System.Reflection.Emit.Lightweight"
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.ClrProfiler.Managed"
     schedule:
@@ -23,6 +32,13 @@ updates:
     labels:
       - "dependencies"
       - "area:integrations"
+    allow:
+      # Allow only updates for explicitly defined dependencies
+      - dependency-type: "direct"
+    ignore:
+      # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
+      - dependency-name: "System.Reflection.Emit"
+      - dependency-name: "System.Reflection.Emit.Lightweight"
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.OpenTracing"
     schedule:
@@ -30,6 +46,9 @@ updates:
     labels:
       - "dependencies"
       - "area:opentracing"
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "direct"
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.BenchmarkDotNet"
     schedule:
@@ -37,3 +56,6 @@ updates:
     labels:
       - "dependencies"
       - "area:benchmarks"
+    allow:
+      # Allow only direct updates for all packages
+      - dependency-type: "direct"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,7 +47,7 @@ updates:
       - "dependencies"
       - "area:opentracing"
     allow:
-      # Allow both direct and indirect updates for all packages
+      # Allow only updates for explicitly defined dependencies
       - dependency-type: "direct"
   - package-ecosystem: "nuget"
     directory: "/src/Datadog.Trace.BenchmarkDotNet"
@@ -57,5 +57,5 @@ updates:
       - "dependencies"
       - "area:benchmarks"
     allow:
-      # Allow only direct updates for all packages
+      # Allow only updates for explicitly defined dependencies
       - dependency-type: "direct"


### PR DESCRIPTION
- For Datadog.Trace, allow all dependencies. For other projects, only allow direct dependencies. This cuts down on noise since all other projects go through Datadog.Trace
- For Datadog.Trace and Datadog.Trace.ClrProfiler.Managed, add packages that should be ignored

Replaces #1386

Impacted PR's:
- Resolves #1366
- Resolves #1367
- Resolves #1370
- Resolves #1371
- Resolves #1372
- Resolves #1374
- Resolves #1375
- Resolves #1376
- Resolves #1377
- Resolves #1378
- Resolves #1379
- Resolves #1380
- Resolves #1381
- Resolves #1382
- Resolves #1383
- Resolves #1384

@DataDog/apm-dotnet