### PR TITLE
Ducktype reverse proxy

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckReverseMethodAttribute.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckReverseMethodAttribute.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Datadog.Trace.DuckTyping
+{
+    /// <summary>
+    /// Duck reverse method attribute
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class DuckReverseMethodAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DuckReverseMethodAttribute"/> class.
+        /// </summary>
+        public DuckReverseMethodAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DuckReverseMethodAttribute"/> class.
+        /// </summary>
+        /// <param name="arguments">Methods arguments</param>
+        public DuckReverseMethodAttribute(params string[] arguments)
+        {
+            Arguments = arguments;
+        }
+
+        /// <summary>
+        /// Gets the methods arguments
+        /// </summary>
+        public string[] Arguments { get; private set; }
+    }
+}

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -324,14 +324,14 @@ namespace Datadog.Trace.DuckTyping
                         {
                             if (NeedsDuckChaining(proxyParamType, targetParamType))
                             {
-                                // Load the argument and cast it as Duck type
+                                // Load the argument (our proxy type) and cast it as Duck type (the original type)
                                 il.WriteLoadArgument(idx, false);
                                 if (UseDirectAccessTo(proxyTypeBuilder, proxyParamType) && proxyParamType.IsValueType)
                                 {
                                     il.Emit(OpCodes.Box, proxyParamType);
                                 }
 
-                                // We call DuckType.CreateCache<>.Create()
+                                // We call DuckType.CreateCache<>.Create(object instance)
                                 MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
                                     .MakeGenericType(targetParamType).GetMethod("Create");
 

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -14,38 +14,42 @@ namespace Datadog.Trace.DuckTyping
         private static List<MethodInfo> GetMethods(Type baseType)
         {
             List<MethodInfo> selectedMethods = new List<MethodInfo>(GetBaseMethods(baseType));
-            Type[] implementedInterfaces = baseType.GetInterfaces();
-            foreach (Type imInterface in implementedInterfaces)
+            // If the base type is an interface we must make sure we implement all methods, including from other interfaces
+            if (baseType.IsInterface)
             {
-                if (imInterface == typeof(IDuckType))
+                Type[] implementedInterfaces = baseType.GetInterfaces();
+                foreach (Type imInterface in implementedInterfaces)
                 {
-                    continue;
-                }
-
-                foreach (MethodInfo interfaceMethod in imInterface.GetMethods())
-                {
-                    if (interfaceMethod.IsSpecialName)
+                    if (imInterface == typeof(IDuckType))
                     {
                         continue;
                     }
 
-                    string interfaceMethodName = interfaceMethod.ToString();
-                    bool methodAlreadySelected = false;
-                    foreach (MethodInfo currentMethod in selectedMethods)
+                    foreach (MethodInfo interfaceMethod in imInterface.GetMethods())
                     {
-                        if (currentMethod.ToString() == interfaceMethodName)
+                        if (interfaceMethod.IsSpecialName)
                         {
-                            methodAlreadySelected = true;
-                            break;
+                            continue;
                         }
-                    }
 
-                    if (!methodAlreadySelected)
-                    {
-                        MethodInfo prevMethod = baseType.GetMethod(interfaceMethod.Name, DuckAttribute.DefaultFlags, null, interfaceMethod.GetParameters().Select(p => p.ParameterType).ToArray(), null);
-                        if (prevMethod == null || prevMethod.GetCustomAttribute<DuckIgnoreAttribute>() is null)
+                        string interfaceMethodName = interfaceMethod.ToString();
+                        bool methodAlreadySelected = false;
+                        foreach (MethodInfo currentMethod in selectedMethods)
                         {
-                            selectedMethods.Add(interfaceMethod);
+                            if (currentMethod.ToString() == interfaceMethodName)
+                            {
+                                methodAlreadySelected = true;
+                                break;
+                            }
+                        }
+
+                        if (!methodAlreadySelected)
+                        {
+                            MethodInfo prevMethod = baseType.GetMethod(interfaceMethod.Name, DuckAttribute.DefaultFlags, null, interfaceMethod.GetParameters().Select(p => p.ParameterType).ToArray(), null);
+                            if (prevMethod == null || prevMethod.GetCustomAttribute<DuckIgnoreAttribute>() is null)
+                            {
+                                selectedMethods.Add(interfaceMethod);
+                            }
                         }
                     }
                 }
@@ -101,6 +105,9 @@ namespace Datadog.Trace.DuckTyping
                 {
                     DuckTypeTargetMethodNotFoundException.Throw(proxyMethodDefinition);
                 }
+
+                // Check if target method is a reverse method
+                bool isReverse = targetMethod.GetCustomAttribute<DuckReverseMethodAttribute>(true) is not null;
 
                 // Gets the proxy method definition generic arguments
                 Type[] proxyMethodDefinitionGenericArguments = proxyMethodDefinition.GetGenericArguments();
@@ -233,7 +240,7 @@ namespace Datadog.Trace.DuckTyping
                                 Type proxyParamTypeElementType = proxyParamType.GetElementType();
                                 Type targetParamTypeElementType = targetParamType.GetElementType();
 
-                                if (!UseDirectAccessTo(targetParamTypeElementType))
+                                if (!UseDirectAccessTo(proxyTypeBuilder, targetParamTypeElementType))
                                 {
                                     targetParamType = typeof(object).MakeByRefType();
                                     targetParamTypeElementType = typeof(object);
@@ -290,7 +297,7 @@ namespace Datadog.Trace.DuckTyping
                                 il.WriteLoadArgument(idx, false);
                             }
                         }
-                        else
+                        else if (!isReverse)
                         {
                             // Check if the type can be converted of if we need to enable duck chaining
                             if (NeedsDuckChaining(targetParamType, proxyParamType))
@@ -308,7 +315,35 @@ namespace Datadog.Trace.DuckTyping
                             }
 
                             // If the target parameter type is public or if it's by ref we have to actually use the original target type.
-                            targetParamType = UseDirectAccessTo(targetParamType) ? targetParamType : typeof(object);
+                            targetParamType = UseDirectAccessTo(proxyTypeBuilder, targetParamType) ? targetParamType : typeof(object);
+                            il.WriteSafeTypeConversion(proxyParamType, targetParamType);
+
+                            targetMethodParametersTypes[idx] = targetParamType;
+                        }
+                        else
+                        {
+                            if (NeedsDuckChaining(proxyParamType, targetParamType))
+                            {
+                                // Load the argument and cast it as Duck type
+                                il.WriteLoadArgument(idx, false);
+                                if (UseDirectAccessTo(proxyTypeBuilder, proxyParamType) && proxyParamType.IsValueType)
+                                {
+                                    il.Emit(OpCodes.Box, proxyParamType);
+                                }
+
+                                // We call DuckType.CreateCache<>.Create()
+                                MethodInfo getProxyMethodInfo = typeof(CreateCache<>)
+                                    .MakeGenericType(targetParamType).GetMethod("Create");
+
+                                il.Emit(OpCodes.Call, getProxyMethodInfo);
+                            }
+                            else
+                            {
+                                il.WriteLoadArgument(idx, false);
+                            }
+
+                            // If the target parameter type is public or if it's by ref we have to actually use the original target type.
+                            targetParamType = UseDirectAccessTo(proxyTypeBuilder, targetParamType) ? targetParamType : typeof(object);
                             il.WriteSafeTypeConversion(proxyParamType, targetParamType);
 
                             targetMethodParametersTypes[idx] = targetParamType;
@@ -317,7 +352,7 @@ namespace Datadog.Trace.DuckTyping
                 }
 
                 // Call the target method
-                if (UseDirectAccessTo(targetType))
+                if (UseDirectAccessTo(proxyTypeBuilder, targetType))
                 {
                     // If the instance is public we can emit directly without any dynamic method
 
@@ -351,7 +386,7 @@ namespace Datadog.Trace.DuckTyping
                     // we can't access non public types so we have to cast to object type (in the instance object and the return type).
 
                     string dynMethodName = $"_callMethod_{targetMethod.DeclaringType.Name}_{targetMethod.Name}";
-                    returnType = UseDirectAccessTo(targetMethod.ReturnType) && !targetMethod.ReturnType.IsGenericParameter ? targetMethod.ReturnType : typeof(object);
+                    returnType = UseDirectAccessTo(proxyTypeBuilder, targetMethod.ReturnType) && !targetMethod.ReturnType.IsGenericParameter ? targetMethod.ReturnType : typeof(object);
 
                     // We create the dynamic method
                     Type[] originalTargetParameters = targetMethod.GetParameters().Select(p => p.ParameterType).ToArray();
@@ -438,7 +473,7 @@ namespace Datadog.Trace.DuckTyping
                     // Check if the type can be converted or if we need to enable duck chaining
                     if (NeedsDuckChaining(targetMethod.ReturnType, proxyMethodDefinition.ReturnType))
                     {
-                        if (UseDirectAccessTo(targetMethod.ReturnType) && targetMethod.ReturnType.IsValueType)
+                        if (UseDirectAccessTo(proxyTypeBuilder, targetMethod.ReturnType) && targetMethod.ReturnType.IsValueType)
                         {
                             il.Emit(OpCodes.Box, targetMethod.ReturnType);
                         }
@@ -502,6 +537,32 @@ namespace Datadog.Trace.DuckTyping
                 if (candidateMethod.Name != proxyMethodDuckAttribute.Name)
                 {
                     continue;
+                }
+
+                // Check if the candidate method is a reverse mapped method
+                DuckReverseMethodAttribute reverseMethodAttribute = candidateMethod.GetCustomAttribute<DuckReverseMethodAttribute>(true);
+                if (reverseMethodAttribute?.Arguments is not null)
+                {
+                    string[] arguments = reverseMethodAttribute.Arguments;
+                    if (arguments.Length != proxyMethodParametersTypes.Length)
+                    {
+                        continue;
+                    }
+
+                    bool match = true;
+                    for (var i = 0; i < arguments.Length; i++)
+                    {
+                        if (arguments[i] != proxyMethodParametersTypes[i].FullName && arguments[i] != proxyMethodParametersTypes[i].Name)
+                        {
+                            match = false;
+                            break;
+                        }
+                    }
+
+                    if (match)
+                    {
+                        return candidateMethod;
+                    }
                 }
 
                 ParameterInfo[] candidateParameters = candidateMethod.GetParameters();

--- a/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -40,6 +40,12 @@ namespace Datadog.Trace.DuckTyping
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private static long _typeCount = 0;
 
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static ConstructorInfo _ignoresAccessChecksToAttributeCtor = typeof(IgnoresAccessChecksToAttribute).GetConstructor(new Type[] { typeof(string) });
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static HashSet<string> _ignoresAccessChecksToAssembliesSet = new HashSet<string>();
+
         internal static long AssemblyCount => _assemblyCount;
 
         internal static long TypeCount => _typeCount;

--- a/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -54,10 +54,19 @@ namespace Datadog.Trace.DuckTyping
         /// Gets the ModuleBuilder instance from a target type.  (.NET Framework / Non AssemblyLoadContext version)
         /// </summary>
         /// <param name="targetType">Target type for ducktyping</param>
+        /// <param name="isVisible">Is visible boolean</param>
         /// <returns>ModuleBuilder instance</returns>
-        private static ModuleBuilder GetModuleBuilder(Type targetType)
+        private static ModuleBuilder GetModuleBuilder(Type targetType, bool isVisible)
         {
             Assembly targetAssembly = targetType.Assembly ?? typeof(DuckType).Assembly;
+
+            if (!isVisible)
+            {
+                // If the target type is not visible then we create a new module builder.
+                // This is the only way to IgnoresAccessChecksToAttribute to work.
+                // We can't reuse the module builder if the attributes collection changes.
+                return CreateModuleBuilder($"DuckTypeNotVisibleAssembly.{targetType.Name}", targetAssembly);
+            }
 
             if (targetType.IsGenericType)
             {

--- a/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Statics.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.DuckTyping
         private static ConstructorInfo _ignoresAccessChecksToAttributeCtor = typeof(IgnoresAccessChecksToAttribute).GetConstructor(new Type[] { typeof(string) });
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private static HashSet<string> _ignoresAccessChecksToAssembliesSet = new HashSet<string>();
+        private static Dictionary<ModuleBuilder, HashSet<string>> _ignoresAccessChecksToAssembliesSetDictionary = new Dictionary<ModuleBuilder, HashSet<string>>();
 
         internal static long AssemblyCount => _assemblyCount;
 

--- a/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.DuckTyping
             }
 
 #if NET45
-            if (!proxyType.IsPublic && !proxyType.IsNestedPublic)
+            if (!proxyType.IsVisible)
             {
                 DuckTypeTypeIsNotPublicException.Throw(proxyType, nameof(proxyType));
             }
@@ -85,11 +85,11 @@ namespace Datadog.Trace.DuckTyping
         private static bool UseDirectAccessTo(ModuleBuilder builder, Type targetType)
         {
 #if NET45
-            return targetType.IsPublic || targetType.IsNestedPublic;
+            return targetType.IsVisible;
 #else
             if (builder == null)
             {
-                return targetType.IsPublic || targetType.IsNestedPublic;
+                return targetType.IsVisible;
             }
 
             EnsureTypeVisibility(builder, targetType);

--- a/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.DuckTyping
         /// <returns>true for direct method; otherwise, false.</returns>
         private static bool UseDirectAccessTo(TypeBuilder builder, Type targetType)
         {
-            return UseDirectAccessTo(builder is null ? null : (ModuleBuilder)builder.Module, targetType);
+            return UseDirectAccessTo((ModuleBuilder)builder?.Module, targetType);
         }
 
         /// <summary>

--- a/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
@@ -27,9 +27,28 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
+#if NET45
             if (!proxyType.IsPublic && !proxyType.IsNestedPublic)
             {
                 DuckTypeTypeIsNotPublicException.Throw(proxyType, nameof(proxyType));
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Ensures the visibility access to the type
+        /// </summary>
+        /// <param name="builder">Module builder</param>
+        /// <param name="type">Type to gain internals visibility</param>
+        private static void EnsureTypeVisibility(ModuleBuilder builder, Type type)
+        {
+            string name = type.Assembly.GetName().Name;
+            lock (_ignoresAccessChecksToAssembliesSet)
+            {
+                if (_ignoresAccessChecksToAssembliesSet.Add(name))
+                {
+                    ((AssemblyBuilder)builder.Assembly).SetCustomAttribute(new CustomAttributeBuilder(_ignoresAccessChecksToAttributeCtor, new object[] { name }));
+                }
             }
         }
 
@@ -53,11 +72,43 @@ namespace Datadog.Trace.DuckTyping
         /// <summary>
         /// Gets if the direct access method should be used or the inderect method (dynamic method)
         /// </summary>
+        /// <param name="builder">Module builder</param>
+        /// <param name="targetType">Target type</param>
+        /// <returns>true for direct method; otherwise, false.</returns>
+        private static bool UseDirectAccessTo(ModuleBuilder builder, Type targetType)
+        {
+#if NET45
+            return targetType.IsPublic || targetType.IsNestedPublic;
+#else
+            if (builder == null)
+            {
+                return targetType.IsPublic || targetType.IsNestedPublic;
+            }
+
+            EnsureTypeVisibility(builder, targetType);
+            return true;
+#endif
+        }
+
+        /// <summary>
+        /// Gets if the direct access method should be used or the inderect method (dynamic method)
+        /// </summary>
+        /// <param name="builder">Type builder</param>
+        /// <param name="targetType">Target type</param>
+        /// <returns>true for direct method; otherwise, false.</returns>
+        private static bool UseDirectAccessTo(TypeBuilder builder, Type targetType)
+        {
+            return UseDirectAccessTo(builder is null ? null : (ModuleBuilder)builder.Module, targetType);
+        }
+
+        /// <summary>
+        /// Gets if the direct access method should be used or the inderect method (dynamic method)
+        /// </summary>
         /// <param name="targetType">Target type</param>
         /// <returns>true for direct method; otherwise, false.</returns>
         private static bool UseDirectAccessTo(Type targetType)
         {
-            return targetType.IsPublic || targetType.IsNestedPublic;
+            return UseDirectAccessTo((ModuleBuilder)null, targetType);
         }
     }
 }

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.DuckTyping
                     }
 
                     // Gets the module builder
-                    var moduleBuilder = GetModuleBuilder(targetType);
+                    var moduleBuilder = GetModuleBuilder(targetType, targetType.IsVisible && proxyDefinitionType.IsVisible);
 
                     // Ensure visibility
                     EnsureTypeVisibility(moduleBuilder, targetType);

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -133,6 +133,10 @@ namespace Datadog.Trace.DuckTyping
                     // Gets the module builder
                     var moduleBuilder = GetModuleBuilder(targetType);
 
+                    // Ensure visibility
+                    EnsureTypeVisibility(moduleBuilder, targetType);
+                    EnsureTypeVisibility(moduleBuilder, proxyDefinitionType);
+
                     string assembly = string.Empty;
                     if (targetType.Assembly != null)
                     {
@@ -200,7 +204,7 @@ namespace Datadog.Trace.DuckTyping
         private static FieldInfo CreateIDuckTypeImplementation(TypeBuilder proxyTypeBuilder, Type targetType)
         {
             Type instanceType = targetType;
-            if (!UseDirectAccessTo(targetType))
+            if (!UseDirectAccessTo(proxyTypeBuilder, targetType))
             {
                 instanceType = typeof(object);
             }
@@ -726,11 +730,12 @@ namespace Datadog.Trace.DuckTyping
             private static CreateTypeResult GetProxySlow(Type targetType)
             {
                 Type proxyTypeDefinition = typeof(T);
+#if NET45
                 if (!proxyTypeDefinition.IsValueType && !UseDirectAccessTo(proxyTypeDefinition))
                 {
                     DuckTypeTypeIsNotPublicException.Throw(proxyTypeDefinition, nameof(proxyTypeDefinition));
                 }
-
+#endif
                 return GetOrCreateProxyType(proxyTypeDefinition, targetType);
             }
         }

--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -179,7 +179,7 @@ namespace Datadog.Trace.DuckTyping
 
                         // Create Type
                         Type proxyType = proxyTypeBuilder.CreateTypeInfo().AsType();
-                        return new CreateTypeResult(proxyDefinitionType, proxyType, targetType, CreateStructCopyMethod(proxyDefinitionType, proxyType, targetType), null);
+                        return new CreateTypeResult(proxyDefinitionType, proxyType, targetType, CreateStructCopyMethod(moduleBuilder, proxyDefinitionType, proxyType, targetType), null);
                     }
                     else
                     {
@@ -191,7 +191,7 @@ namespace Datadog.Trace.DuckTyping
 
                         // Create Type
                         Type proxyType = proxyTypeBuilder.CreateTypeInfo().AsType();
-                        return new CreateTypeResult(proxyDefinitionType, proxyType, targetType, GetCreateProxyInstanceDelegate(proxyDefinitionType, proxyType, targetType), null);
+                        return new CreateTypeResult(proxyDefinitionType, proxyType, targetType, GetCreateProxyInstanceDelegate(moduleBuilder, proxyDefinitionType, proxyType, targetType), null);
                     }
                 }
                 catch (Exception ex)
@@ -463,7 +463,7 @@ namespace Datadog.Trace.DuckTyping
             }
         }
 
-        private static Delegate GetCreateProxyInstanceDelegate(Type proxyDefinitionType, Type proxyType, Type targetType)
+        private static Delegate GetCreateProxyInstanceDelegate(ModuleBuilder moduleBuilder, Type proxyDefinitionType, Type proxyType, Type targetType)
         {
             ConstructorInfo ctor = proxyType.GetConstructors()[0];
 
@@ -475,7 +475,7 @@ namespace Datadog.Trace.DuckTyping
                 true);
             ILGenerator il = createProxyMethod.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
-            if (UseDirectAccessTo(targetType))
+            if (UseDirectAccessTo(moduleBuilder, targetType))
             {
                 if (targetType.IsValueType)
                 {
@@ -499,7 +499,7 @@ namespace Datadog.Trace.DuckTyping
             return createProxyMethod.CreateDelegate(delegateType);
         }
 
-        private static Delegate CreateStructCopyMethod(Type proxyDefinitionType, Type proxyType, Type targetType)
+        private static Delegate CreateStructCopyMethod(ModuleBuilder moduleBuilder, Type proxyDefinitionType, Type proxyType, Type targetType)
         {
             ConstructorInfo ctor = proxyType.GetConstructors()[0];
 
@@ -518,7 +518,7 @@ namespace Datadog.Trace.DuckTyping
             // We create an instance of the proxy type
             il.Emit(OpCodes.Ldloca_S, proxyLocal.LocalIndex);
             il.Emit(OpCodes.Ldarg_0);
-            if (UseDirectAccessTo(targetType))
+            if (UseDirectAccessTo(moduleBuilder, targetType))
             {
                 if (targetType.IsValueType)
                 {

--- a/src/Datadog.Trace/DuckTyping/IgnoresAccessChecksToAttribute.cs
+++ b/src/Datadog.Trace/DuckTyping/IgnoresAccessChecksToAttribute.cs
@@ -1,0 +1,23 @@
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// This attribute is recognized by the CLR and allow us to disable visibility checks for certain assemblies (only from 4.6+)
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class IgnoresAccessChecksToAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IgnoresAccessChecksToAttribute"/> class.
+        /// </summary>
+        /// <param name="assemblyName">Assembly name</param>
+        public IgnoresAccessChecksToAttribute(string assemblyName)
+        {
+            AssemblyName = assemblyName;
+        }
+
+        /// <summary>
+        /// Gets the assembly name
+        /// </summary>
+        public string AssemblyName { get; }
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>

--- a/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
@@ -214,6 +214,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
         }
 
+#if NET452
         // *
         [Fact]
         public void TypeIsNotPublicException()
@@ -240,7 +241,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
             public string Name { get; set; }
         }
-
+#endif
         // *
 
         [Fact]
@@ -405,6 +406,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             }
         }
 
+#if NET452
         // *
         [Fact]
         public void ProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException()
@@ -428,7 +430,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             {
             }
         }
-
+#endif
         // *
 
         [Fact]

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -281,6 +281,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
         [MemberData(nameof(Data))]
         public void DefaultGenericsMethods(object obscureObject)
         {
+#if NET452
             if (!obscureObject.GetType().IsPublic && !obscureObject.GetType().IsNestedPublic)
             {
                 Assert.Throws<DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException>(
@@ -300,6 +301,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
                     });
                 return;
             }
+#endif
 
             var duckInterface = obscureObject.DuckCast<IDefaultGenericMethodDuckType>();
             var duckAbstract = obscureObject.DuckCast<DefaultGenericMethodDuckTypeAbstractClass>();

--- a/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.IO;
+using System.Threading;
+using Xunit;
+
+#pragma warning disable SA1201 // Elements should appear in the correct order
+#pragma warning disable SA1602 // Enumeration items should be documented
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class ReverseProxyTests
+    {
+        [Fact]
+        public void InterfaceReverseProxyTest()
+        {
+            Type iLogEventEnricherType = typeof(Datadog.Trace.Vendors.Serilog.Core.ILogEventEnricher);
+
+            var resetEvent = new ManualResetEventSlim();
+
+            var instance = new LogEventEnricherImpl(resetEvent);
+
+            var proxy = instance.DuckCast(iLogEventEnricherType);
+
+            var log = new Vendors.Serilog.LoggerConfiguration()
+                .Enrich.With((Vendors.Serilog.Core.ILogEventEnricher)proxy)
+                .MinimumLevel.Debug()
+                .WriteTo.Sink(new Vendors.Serilog.Sinks.File.NullSink())
+                .CreateLogger();
+
+            log.Information("Hello world");
+
+            Assert.True(resetEvent.Wait(10_000));
+        }
+
+        // ************************************************************************************
+        // Types for InterfaceReverseProxyTest
+        // ***
+
+        public class LogEventEnricherImpl
+        {
+            private ManualResetEventSlim _manualResetEventSlim;
+
+            public LogEventEnricherImpl(ManualResetEventSlim manualResetEventSlim)
+            {
+                _manualResetEventSlim = manualResetEventSlim;
+            }
+
+            [DuckReverseMethod("Datadog.Trace.Vendors.Serilog.Events.LogEvent", "Datadog.Trace.Vendors.Serilog.Core.ILogEventPropertyFactory")]
+            public void Enrich(ILogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+            {
+                Assert.NotNull(logEvent);
+                Assert.NotNull(propertyFactory);
+
+                Assert.Equal(LogEventLevel.Information, logEvent.Level);
+                Assert.NotEqual(DateTimeOffset.MinValue, logEvent.Timestamp);
+                Assert.Null(logEvent.Exception);
+                Assert.Equal("Hello world", logEvent.MessageTemplate.Text);
+
+                _manualResetEventSlim.Set();
+            }
+        }
+
+        public interface ILogEvent
+        {
+            public DateTimeOffset Timestamp { get; }
+
+            public LogEventLevel Level { get; }
+
+            public IMessageTemplate MessageTemplate { get; }
+
+            public Exception Exception { get; }
+        }
+
+        public enum LogEventLevel
+        {
+            Verbose,
+            Debug,
+            Information,
+            Warning,
+            Error,
+            Fatal
+        }
+
+        public interface IMessageTemplate
+        {
+            public string Text { get; }
+        }
+
+        public interface ILogEventPropertyFactory
+        {
+            object CreateProperty(string name, object value, bool destructureObjects = false);
+        }
+
+        // ************************************************************************************
+
+        [Fact]
+        public void AbstractClassReverseProxyTest()
+        {
+            var resetEvent = new ManualResetEventSlim();
+
+            var eventInstance = new LogEventPropertyValueImpl(resetEvent);
+
+            var type = typeof(Datadog.Trace.Vendors.Serilog.Events.LogEventPropertyValue);
+
+            var proxy2 = eventInstance.DuckCast(type);
+            eventInstance.SetBaseInstance(proxy2);
+
+            ((Datadog.Trace.Vendors.Serilog.Events.LogEventPropertyValue)proxy2).ToString("Hello world", null);
+
+            Assert.True(resetEvent.Wait(10_000));
+        }
+
+        public class LogEventPropertyValueImpl
+        {
+            private IBaseClass _base;
+            private ManualResetEventSlim _manualResetEventSlim;
+
+            public LogEventPropertyValueImpl(ManualResetEventSlim manualResetEventSlim)
+            {
+                _manualResetEventSlim = manualResetEventSlim;
+            }
+
+            public void SetBaseInstance(object baseObject)
+            {
+                _base = baseObject.DuckCast<IBaseClass>();
+            }
+
+            [DuckReverseMethod]
+            public void Render(TextWriter output, string format = null, IFormatProvider formatProvider = null)
+            {
+                output.WriteLine(format);
+
+                Assert.NotNull(output);
+                Assert.Equal("Hello world", format);
+
+                _manualResetEventSlim.Set();
+            }
+
+            public interface IBaseClass
+            {
+                public string ToString();
+
+                public string ToString(string format, IFormatProvider formatProvider);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
@@ -89,7 +89,14 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface ILogEventPropertyFactory
         {
-            object CreateProperty(string name, object value, bool destructureObjects = false);
+            ILogEventProperty CreateProperty(string name, object value, bool destructureObjects = false);
+        }
+
+        public interface ILogEventProperty
+        {
+            public string Name { get; }
+
+            public object Value { get; }
         }
 
         // ************************************************************************************
@@ -110,6 +117,10 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             Assert.True(resetEvent.Wait(5_000));
         }
+
+        // ************************************************************************************
+        // Types for AbstractClassReverseProxyTest
+        // ***
 
         public class LogEventPropertyValueImpl
         {
@@ -144,6 +155,8 @@ namespace Datadog.Trace.DuckTyping.Tests
                 public string ToString(string format, IFormatProvider formatProvider);
             }
         }
+
+        // ************************************************************************************
     }
 }
 #endif

--- a/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             log.Information("Hello world");
 
-            Assert.True(resetEvent.Wait(10_000));
+            Assert.True(resetEvent.Wait(5_000));
         }
 
         // ************************************************************************************
@@ -108,7 +108,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             ((Datadog.Trace.Vendors.Serilog.Events.LogEventPropertyValue)proxy2).ToString("Hello world", null);
 
-            Assert.True(resetEvent.Wait(10_000));
+            Assert.True(resetEvent.Wait(5_000));
         }
 
         public class LogEventPropertyValueImpl

--- a/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.DuckTyping.Tests
     public class ReverseProxyTests
     {
         [Fact]
-        public void InterfaceReverseProxyTest()
+        public void PrivateInterfaceReverseProxyTest()
         {
             Type iLogEventEnricherType = typeof(Datadog.Trace.Vendors.Serilog.Core.ILogEventEnricher);
 
@@ -107,7 +107,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         // ************************************************************************************
 
         [Fact]
-        public void AbstractClassReverseProxyTest()
+        public void PrivateAbstractClassReverseProxyTest()
         {
             var resetEvent = new ManualResetEventSlim();
 
@@ -170,7 +170,7 @@ namespace Datadog.Trace.DuckTyping.Tests
         // ************************************************************************************
 
         [Fact]
-        public void PublicInterfaceReverProxyTest()
+        public void PublicInterfaceReverseProxyTest()
         {
             var instance = new PublicBaseInterface();
             var proxyInstance = instance.DuckCast(typeof(IPublicBaseInterface));

--- a/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ReverseProxyTests.cs
@@ -1,3 +1,4 @@
+#if !NET452
 using System;
 using System.IO;
 using System.Threading;
@@ -145,3 +146,4 @@ namespace Datadog.Trace.DuckTyping.Tests
         }
     }
 }
+#endif


### PR DESCRIPTION
This `PR` adds the support for reverse proxy in the DuckTyping mechanism. 

This means instead of defining an interface to create a proxy over an obscure class, in this scenario is the opposite, the interface is obscure and we create a class that implement it.

For example: This will help on scenarios like implementing a serilog sink (`ILogEventSink`) without a compile time dependency to serilog.

The PR also includes the `IgnoresAccessChecksToAttribute` that allows to create proxy types to non public types (Although this feature is not supported for .NET Framework 4.5), overpassing the limitations on #990 caused not by the partial trust problem but by adding the attribute to an AssemblyBuilder after we emit a type from the same assembly builder. 

@DataDog/apm-dotnet