### PR TITLE
Include the job attempt number in integration test log uploads

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -117,7 +117,7 @@ jobs:
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) -e publishTargetFramework=$(publishTargetFramework) IntegrationTests
 
   - publish: build_data
-    artifact: $(Agent.JobName)_profiler-logs
+    artifact: $(Agent.JobName)_profiler-logs-$(System.JobAttempt)
     condition: succeededOrFailed()
 
   - task: PublishTestResults@2
@@ -240,7 +240,7 @@ jobs:
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.Alpine.Core50
 
   - publish: build_data
-    artifact: $(Agent.JobName)_profiler-logs
+    artifact: $(Agent.JobName)_profiler-logs-$(System.JobAttempt)
     condition: succeededOrFailed()
 
   - task: PublishTestResults@2
@@ -582,7 +582,7 @@ jobs:
       dockerComposeCommand: run -e TestAllPackageVersions=true -e buildConfiguration=$(buildConfiguration) IntegrationTests.ARM64.Core50
 
   - publish: build_data
-    artifact: $(Agent.JobName)_profiler-logs
+    artifact: $(Agent.JobName)_profiler-logs-$(System.JobAttempt)
     condition: succeededOrFailed()
 
   - task: PublishTestResults@2


### PR DESCRIPTION
This is the only pipeline that publishes whether the pipeline succeeds or fails, so it's the only job vulnerable to duplicate artefacts

@DataDog/apm-dotnet