### PR TITLE
Add additional test for ContainerID parsing

### DIFF
--- a/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 3:net_cls,net_prio:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
 2:hugetlb:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
 1:name=systemd:/kubepods/besteffort/pod3d274242-8ee0-11e9-a8a6-1e68d864ef1a/3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1
+1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2d3da189_6407_48e3_9ab6_78188d75e609.slice/docker-3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1.scope
 ";
 
         public const string Ecs = @"


### PR DESCRIPTION
Python recently had an issue with container ID parsing in https://github.com/DataDog/dd-trace-py/issues/2314. This adds the problematic ID to our test suite to ensure we are not affected


@DataDog/apm-dotnet