### PR TITLE
Check agent version only once

### DIFF
--- a/src/Datadog.Trace/Agent/Api.cs
+++ b/src/Datadog.Trace/Agent/Api.cs
@@ -194,11 +194,14 @@ namespace Datadog.Trace.Agent
 
                 try
                 {
-                    var version = response.GetHeader(AgentHttpHeaderNames.AgentVersion);
-
                     var tracer = _tracer ?? Tracer.Instance;
 
-                    tracer.ReportAgentVersion(version);
+                    if (tracer.AgentVersion == null)
+                    {
+                        var version = response.GetHeader(AgentHttpHeaderNames.AgentVersion);
+
+                        tracer.AgentVersion = version ?? string.Empty;
+                    }
 
                     if (response.ContentLength != 0 && Tracer.Instance.Sampler != null)
                     {

--- a/src/Datadog.Trace/IDatadogTracer.cs
+++ b/src/Datadog.Trace/IDatadogTracer.cs
@@ -8,6 +8,8 @@ namespace Datadog.Trace
     {
         string DefaultServiceName { get; }
 
+        string AgentVersion { get; set; }
+
         IScopeManager ScopeManager { get; }
 
         ISampler Sampler { get; }
@@ -19,8 +21,6 @@ namespace Datadog.Trace
         Span StartSpan(string operationName, ISpanContext parent);
 
         Span StartSpan(string operationName, ISpanContext parent, string serviceName, DateTimeOffset? startTime, bool ignoreActiveScope);
-
-        void ReportAgentVersion(string agentVersion);
 
         void Write(Span[] span);
 

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -228,6 +228,27 @@ namespace Datadog.Trace
         public TracerSettings Settings { get; }
 
         /// <summary>
+        /// Gets or sets the detected version of the agent
+        /// </summary>
+        string IDatadogTracer.AgentVersion
+        {
+            get
+            {
+                return _agentVersion;
+            }
+
+            set
+            {
+                if (ShouldLogPartialFlushWarning(value))
+                {
+                    var detectedVersion = string.IsNullOrEmpty(value) ? "{detection failed}" : value;
+
+                    Log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {version})", detectedVersion);
+                }
+            }
+        }
+
+        /// <summary>
         /// Gets the tracer's scope manager, which determines which span is currently active, if any.
         /// </summary>
         IScopeManager IDatadogTracer.ScopeManager => _scopeManager;
@@ -352,18 +373,6 @@ namespace Datadog.Trace
             if (Settings.TraceEnabled)
             {
                 _agentWriter.WriteTrace(trace);
-            }
-        }
-
-        /// <summary>
-        /// Reports the detected version of the agent
-        /// </summary>
-        /// <param name="version">Version of the agent</param>
-        void IDatadogTracer.ReportAgentVersion(string version)
-        {
-            if (ShouldLogPartialFlushWarning(version))
-            {
-                Log.Warning("DATADOG TRACER DIAGNOSTICS - Partial flush should only be enabled with agent 7.26.0+ (detected version: {version})", version ?? "{detection failed}");
             }
         }
 

--- a/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/test/Datadog.Trace.Tests/ApiTests.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Tests
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
-            tracer.Verify(t => t.ReportAgentVersion(agentVersion), Times.Once);
+            tracer.VerifySet(t => t.AgentVersion = agentVersion, Times.Once);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -375,6 +375,26 @@ namespace Datadog.Trace.Tests
             Assert.Equal(secondSpan.Span.Context.Origin, resultContext.Origin);
             Assert.Equal(origin, resultContext.Origin);
         }
+
+        [Theory]
+        [InlineData("7.25.0", true, true)] // Old agent, partial flush enabled
+        [InlineData("7.25.0", false, false)] // Old agent, partial flush disabled
+        [InlineData("7.26.0", true, false)] // New agent, partial flush enabled
+        [InlineData("invalid version", true, true)] // Version check fail, partial flush enabled
+        [InlineData("invalid version", false, false)] // Version check fail, partial flush disabled
+        [InlineData("", true, true)] // Version check fail, partial flush enabled
+        [InlineData("", false, false)] // Version check fail, partial flush disabled
+        public void LogPartialFlushWarning(string agentVersion, bool partialFlushEnabled, bool expectedResult)
+        {
+            _tracer.Settings.PartialFlushEnabled = partialFlushEnabled;
+
+            // First call depends on the parameters of the test
+            _tracer.ShouldLogPartialFlushWarning(agentVersion).Should().Be(expectedResult);
+
+            // Second call should always be false
+            _tracer.ShouldLogPartialFlushWarning(agentVersion).Should().BeFalse();
+        }
+
 #if NET452
 
         // Test that storage in the Logical Call Context does not expire
@@ -451,23 +471,6 @@ namespace Datadog.Trace.Tests
             // Assert
             Assert.True(eventSet);
             Assert.Equal(2, tracker.DisconnectCount);
-        }
-
-        [Theory]
-        [InlineData("7.25.0", true, true)] // Old agent, partial flush enabled
-        [InlineData("7.25.0", false, false)] // Old agent, partial flush disabled
-        [InlineData("7.26.0", true, false)] // New agent, partial flush enabled
-        [InlineData("invalid version", true, true)] // Version check fail, partial flush enabled
-        [InlineData("invalid version", false, false)] // Version check fail, partial flush disabled
-        public void LogPartialFlushWarning(string agentVersion, bool partialFlushEnabled, bool expectedResult)
-        {
-            _tracer.Settings.PartialFlushEnabled = partialFlushEnabled;
-
-            // First call depends on the parameters of the test
-            _tracer.ShouldLogPartialFlushWarning(agentVersion).Should().Be(expectedResult);
-
-            // Second call should always be false
-            _tracer.ShouldLogPartialFlushWarning(agentVersion).Should().BeFalse();
         }
 
         // Static class with static methods that are publicly accessible so new sandbox AppDomain does not need special


### PR DESCRIPTION
Overhead of the version check is not negligible, so do it only once.