### PR TITLE
Fixes the CMake version to 3.19.8 in CMakeLists

### DIFF
--- a/.azure-pipelines/crank.yml
+++ b/.azure-pipelines/crank.yml
@@ -103,10 +103,13 @@ jobs:
       arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-  
+
   - script: |
       sudo apt-get update
       sudo apt-get install -y llvm clang
+      sudo apt-get remove -y cmake
+      curl -L -o /tmp/cmake.sh https://github.com/Kitware/CMake/releases/download/v3.19.8/cmake-3.19.8-Linux-x86_64.sh
+      sudo sh /tmp/cmake.sh --prefix=/usr/local --exclude-subdir --skip-license
     displayName: install_dependencies
 
   - script: |

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required (VERSION 3.8..3.19)
 cmake_policy(SET CMP0015 NEW)
 
 # ******************************************************


### PR DESCRIPTION
Currently the build artifact when using a CMake >= 3.20 version, fails to embed the managed loader.
This PR fixes the crank pipeline to force the usage of 3.19.8 version.

@DataDog/apm-dotnet