### PR TITLE
Allow CallTarget instrumentation of nested classes

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -1586,7 +1586,7 @@ bool FindTypeDefByName(
     }
     instrumentedMethodTypeName = nameParts[1];
 
-  } else if (nameParts.size() > 1) {
+  } else if (nameParts.size() > 2) {
     Warn("Invalid TypeDef-only one layer of nested classes are supported: ",
          instrumentationTargetMethodTypeName, ", Module: ", assemblyName);
     return false;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -1603,5 +1603,7 @@ bool FindTypeDefByName(
           ", Module: ", assemblyName);
     return false;
   }
+
+  return true;
 }
 }  // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -486,6 +486,11 @@ bool ReturnTypeIsValueTypeOrGeneric(const ComPtr<IMetaDataImport2>& metadata_imp
                       const mdToken targetFunctionToken,
                       const MethodSignature targetFunctionSignature,
                       mdToken* ret_type_token);
+
+bool FindTypeDefByName(const trace::WSTRING instrumentationTargetMethodTypeName,
+                       const trace::WSTRING assemblyName,
+                       const ComPtr<IMetaDataImport2>& metadata_import,
+                       mdTypeDef& typeDef);
 }  // namespace trace
 
 #endif  // DD_CLR_PROFILER_CLR_HELPERS_H_

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -297,6 +297,7 @@ struct TypeInfo {
   const TypeInfo* extend_from;
   const bool valueType;
   const bool isGeneric;
+  const TypeInfo* parent_type;
 
   TypeInfo()
       : id(0),
@@ -305,16 +306,19 @@ struct TypeInfo {
         token_type(0),
         extend_from(nullptr),
         valueType(false),
-        isGeneric(false) {}
+        isGeneric(false),
+        parent_type(nullptr) {}
   TypeInfo(mdToken id, WSTRING name, mdTypeSpec type_spec, ULONG32 token_type,
-           const TypeInfo* extend_from, bool valueType, bool isGeneric) 
+           const TypeInfo* extend_from, bool valueType, bool isGeneric,
+           const TypeInfo* parent_type)
       : id(id),
         name(name),
         type_spec(type_spec),
         token_type(token_type),
         extend_from(extend_from),
         valueType(valueType),
-        isGeneric(isGeneric) {}
+        isGeneric(isGeneric),
+        parent_type(parent_type) {}
 
   bool IsValid() const { return id != 0; }
 };
@@ -382,7 +386,7 @@ struct FunctionInfo {
 
   FunctionInfo(mdToken id, WSTRING name, TypeInfo type,
                MethodSignature signature,
-               MethodSignature function_spec_signature, 
+               MethodSignature function_spec_signature,
                mdToken method_def_id,
                FunctionMethodSignature method_signature)
       : id(id),

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -16,10 +16,12 @@ TEST_F(CLRHelperTest, EnumeratesTypeDefs) {
       L"Samples.ExampleLibrary.GenericTests.StructContainer`1",
       L"Samples.ExampleLibrary.FakeClient.Biscuit`1",
       L"Samples.ExampleLibrary.FakeClient.Biscuit",
+      L"Samples.ExampleLibrary.FakeClient.StructBiscuit",
       L"Samples.ExampleLibrary.FakeClient.DogClient`2",
       L"Samples.ExampleLibrary.FakeClient.DogTrick`1",
       L"Samples.ExampleLibrary.FakeClient.DogTrick",
       L"<>c",
+      L"Cookie",
       L"Cookie",
       L"<StayAndLayDown>d__4`2",
       L"Raisin"};
@@ -210,6 +212,7 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromTypeDefs) {
       L"Samples.ExampleLibrary.FakeClient.DogClient`2",
       L"Samples.ExampleLibrary.FakeClient.DogTrick",
       L"Samples.ExampleLibrary.FakeClient.DogTrick`1",
+      L"Samples.ExampleLibrary.FakeClient.StructBiscuit",
       L"Samples.ExampleLibrary.GenericTests.ComprehensiveCaller`2",
       L"Samples.ExampleLibrary.GenericTests.GenericTarget`2",
       L"Samples.ExampleLibrary.GenericTests.PointStruct",
@@ -303,6 +306,7 @@ TEST_F(CLRHelperTest, GetsTypeInfoFromMethods) {
       L"Samples.ExampleLibrary.FakeClient.DogClient`2",
       L"Samples.ExampleLibrary.FakeClient.DogTrick",
       L"Samples.ExampleLibrary.FakeClient.DogTrick`1",
+      L"Samples.ExampleLibrary.FakeClient.StructBiscuit",
       L"Samples.ExampleLibrary.GenericTests.ComprehensiveCaller`2",
       L"Samples.ExampleLibrary.GenericTests.GenericTarget`2",
       L"Samples.ExampleLibrary.GenericTests.PointStruct",
@@ -444,4 +448,53 @@ TEST_F(CLRHelperTest,
     }
   }
   EXPECT_EQ(actual, expected);
+}
+
+TEST_F(CLRHelperTest, FindTypeDefsByName) {
+  std::vector<std::wstring> expected_types = {
+      L"Samples.ExampleLibrary.Class1",
+      L"Samples.ExampleLibrary.GenericTests.ComprehensiveCaller`2",
+      L"Samples.ExampleLibrary.GenericTests.GenericTarget`2",
+      L"Samples.ExampleLibrary.GenericTests.PointStruct",
+      L"Samples.ExampleLibrary.GenericTests.StructContainer`1",
+      L"Samples.ExampleLibrary.FakeClient.Biscuit`1",
+      L"Samples.ExampleLibrary.FakeClient.Biscuit",
+      L"Samples.ExampleLibrary.FakeClient.DogClient`2",
+      L"Samples.ExampleLibrary.FakeClient.DogTrick`1",
+      L"Samples.ExampleLibrary.FakeClient.DogTrick"};
+
+  for (auto& def : expected_types) {
+    mdTypeDef typeDef = mdTypeDefNil;
+    auto found = FindTypeDefByName(def, L"Samples.ExampleLibrary",
+                                   metadata_import_, typeDef);
+    EXPECT_TRUE(found) << "Failed type is : " << def << std::endl;
+    EXPECT_NE(typeDef, mdTypeDefNil) << "Failed type is : " << def << std::endl;
+  }
+}
+
+TEST_F(CLRHelperTest, FindNestedTypeDefsByName) {
+  std::vector<std::wstring> expected_types = {
+      L"Samples.ExampleLibrary.FakeClient.Biscuit+Cookie",
+      L"Samples.ExampleLibrary.FakeClient.StructBiscuit+Cookie"};
+
+  for (auto& def : expected_types) {
+    mdTypeDef typeDef = mdTypeDefNil;
+    auto found = FindTypeDefByName(def, L"Samples.ExampleLibrary",
+                                   metadata_import_, typeDef);
+    EXPECT_TRUE(found) << "Failed type is : " << def << std::endl;
+    EXPECT_NE(typeDef, mdTypeDefNil) << "Failed type is : " << def << std::endl;
+  }
+}
+
+TEST_F(CLRHelperTest, DoesNotFindDoubleNestedTypeDefsByName) {
+  std::vector<std::wstring> expected_types = {
+      L"Samples.ExampleLibrary.FakeClient.Biscuit+Cookie+Raisin"};
+
+  for (auto& def : expected_types) {
+    mdTypeDef typeDef = mdTypeDefNil;
+    auto found = FindTypeDefByName(def, L"Samples.ExampleLibrary",
+                                   metadata_import_, typeDef);
+    EXPECT_FALSE(found) << "Failed type is : " << def << std::endl;
+    EXPECT_EQ(typeDef, mdTypeDefNil) << "Failed type is : " << def << std::endl;
+  }
 }

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -488,6 +488,7 @@ TEST_F(CLRHelperTest, FindNestedTypeDefsByName) {
 
 TEST_F(CLRHelperTest, DoesNotFindDoubleNestedTypeDefsByName) {
   std::vector<std::wstring> expected_types = {
+      L"Samples.ExampleLibrary.NotARealClass",
       L"Samples.ExampleLibrary.FakeClient.Biscuit+Cookie+Raisin"};
 
   for (auto& def : expected_types) {

--- a/test/test-applications/integrations/dependency-libs/Samples.ExampleLibrary/FakeClient/Biscuit.cs
+++ b/test/test-applications/integrations/dependency-libs/Samples.ExampleLibrary/FakeClient/Biscuit.cs
@@ -24,4 +24,13 @@ namespace Samples.ExampleLibrary.FakeClient
             }
         }
     }
+
+    public struct StructBiscuit
+    {
+        public Guid Id { get; set; }
+        public struct Cookie
+        {
+            public bool IsYummy { get; set; }
+        }
+    }
 }


### PR DESCRIPTION
Allows specifying the nested type to instrument using the pattern "Fully.Qualified.Parent+Nested"
Only supports one level of nesting

@DataDog/apm-dotnet