### PR TITLE
Fix git parser on really big pack files (>2GB)

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/GitInfo.cs
+++ b/src/Datadog.Trace.Ci.Shared/GitInfo.cs
@@ -454,6 +454,7 @@ namespace Datadog.Trace.Ci
                             fs.Seek(packageOffset.Offset, SeekOrigin.Begin);
                             byte[] packData = br.ReadBytes(2);
 
+                            // Extract the object size
                             int objectSize = (int)(packData[0] & 0x0F);
 
                             if (packData[0] > 128)
@@ -491,9 +492,8 @@ namespace Datadog.Trace.Ci
                         }
                     }
                 }
-                catch (Exception ex)
+                catch
                 {
-                    _ = ex;
                 }
 
                 return false;

--- a/src/Datadog.Trace.Ci.Shared/GitInfo.cs
+++ b/src/Datadog.Trace.Ci.Shared/GitInfo.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Ci
 {
@@ -13,6 +14,8 @@ namespace Datadog.Trace.Ci
     /// </summary>
     internal class GitInfo
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(GitInfo));
+
         private GitInfo()
         {
         }
@@ -219,8 +222,9 @@ namespace Datadog.Trace.Ci
                     }
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Log.Error(ex, ex.Message);
             }
 
             return gitInfo;
@@ -413,24 +417,31 @@ namespace Datadog.Trace.Ci
             public static bool TryGetFromObjectFile(string filePath, out GitCommitObject commitObject)
             {
                 commitObject = default;
-                using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                try
                 {
-                    // We skip the 2 bytes zlib header magic number.
-                    fs.Seek(2, SeekOrigin.Begin);
-                    using (var defStream = new DeflateStream(fs, CompressionMode.Decompress))
+                    using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
-                        byte[] buffer = new byte[8192];
-                        int readBytes = defStream.Read(buffer, 0, buffer.Length);
-                        defStream.Close();
-
-                        if (_commitByteArray.SequenceEqual(buffer.Take(_commitByteArray.Length)))
+                        // We skip the 2 bytes zlib header magic number.
+                        fs.Seek(2, SeekOrigin.Begin);
+                        using (var defStream = new DeflateStream(fs, CompressionMode.Decompress))
                         {
-                            string strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
-                            string dataContent = strContent.Substring(strContent.IndexOf('\0') + 1);
-                            commitObject = new GitCommitObject(dataContent);
-                            return true;
+                            byte[] buffer = new byte[8192];
+                            int readBytes = defStream.Read(buffer, 0, buffer.Length);
+                            defStream.Close();
+
+                            if (_commitByteArray.SequenceEqual(buffer.Take(_commitByteArray.Length)))
+                            {
+                                string strContent = Encoding.UTF8.GetString(buffer, 0, readBytes);
+                                string dataContent = strContent.Substring(strContent.IndexOf('\0') + 1);
+                                commitObject = new GitCommitObject(dataContent);
+                                return true;
+                            }
                         }
                     }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, ex.Message);
                 }
 
                 return false;
@@ -454,18 +465,18 @@ namespace Datadog.Trace.Ci
                             fs.Seek(packageOffset.Offset, SeekOrigin.Begin);
                             byte[] packData = br.ReadBytes(2);
 
-                            // Extract the object size
+                            // Extract the object size (https://codewords.recurse.com/images/three/varint.svg)
                             int objectSize = (int)(packData[0] & 0x0F);
 
-                            if (packData[0] > 128)
+                            if (packData[0] >= 128)
                             {
                                 objectSize += (packData[1] & 0x7F) * 16;
-                                if (packData[1] > 128)
+                                if (packData[1] >= 128)
                                 {
                                     int multiplier = 128;
                                     byte pData = br.ReadByte();
                                     objectSize += (pData & 0x7F) * multiplier;
-                                    while (pData > 128)
+                                    while (pData >= 128)
                                     {
                                         multiplier *= 128;
                                         pData = br.ReadByte();
@@ -492,8 +503,9 @@ namespace Datadog.Trace.Ci
                         }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Log.Error(ex, ex.Message);
                 }
 
                 return false;
@@ -522,79 +534,86 @@ namespace Datadog.Trace.Ci
                 int folderIndex = int.Parse(index, System.Globalization.NumberStyles.HexNumber);
                 int previousIndex = folderIndex > 0 ? folderIndex - 1 : folderIndex;
 
-                using (var fs = new FileStream(idxFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                using (var br = new BigEndianBinaryReader(fs))
+                try
                 {
-                    // Skip header and version
-                    fs.Seek(8, SeekOrigin.Begin);
-
-                    // First layer: 256 4-byte elements, with number of elements per folder
-                    uint numberOfObjectsInPreviousIndex = 0;
-                    if (previousIndex > -1)
+                    using (var fs = new FileStream(idxFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                    using (var br = new BigEndianBinaryReader(fs))
                     {
-                        // Seek to previous index position and read the number of objects
-                        fs.Seek(previousIndex * 4, SeekOrigin.Current);
-                        numberOfObjectsInPreviousIndex = br.ReadUInt32();
-                    }
+                        // Skip header and version
+                        fs.Seek(8, SeekOrigin.Begin);
 
-                    // In the fanout table, every index has its objects + the previous ones.
-                    // We need to subtract the previous index objects to know the correct
-                    // actual number of objects for this specific index.
-                    uint numberOfObjectsInIndex = br.ReadUInt32() - numberOfObjectsInPreviousIndex;
-
-                    // Seek to last position. The last position contains the number of all objects.
-                    fs.Seek((255 - (folderIndex + 1)) * 4, SeekOrigin.Current);
-                    uint totalNumberOfObjects = br.ReadUInt32();
-
-                    // Second layer: 20-byte elements with the names in order
-                    // Search the sha index in the second layer: the SHA listing.
-                    uint? indexOfCommit = null;
-                    fs.Seek(20 * (int)numberOfObjectsInPreviousIndex, SeekOrigin.Current);
-                    for (uint i = 0; i < numberOfObjectsInIndex; i++)
-                    {
-                        string str = BitConverter.ToString(br.ReadBytes(20)).Replace("-", string.Empty);
-                        if (str.Equals(commitSha, StringComparison.OrdinalIgnoreCase))
+                        // First layer: 256 4-byte elements, with number of elements per folder
+                        uint numberOfObjectsInPreviousIndex = 0;
+                        if (previousIndex > -1)
                         {
-                            indexOfCommit = numberOfObjectsInPreviousIndex + i;
-
-                            // If we find the SHA, we skip all SHA listing table.
-                            fs.Seek(20 * (totalNumberOfObjects - (indexOfCommit.Value + 1)), SeekOrigin.Current);
-                            break;
-                        }
-                    }
-
-                    if (indexOfCommit.HasValue)
-                    {
-                        // Third layer: 4 byte CRC for each object. We skip it
-                        fs.Seek(4 * totalNumberOfObjects, SeekOrigin.Current);
-
-                        uint indexOfCommitValue = indexOfCommit.Value;
-
-                        // Fourth layer: 4 byte per object of offset in pack file
-                        fs.Seek(4 * indexOfCommitValue, SeekOrigin.Current);
-                        uint offset = br.ReadUInt32();
-
-                        ulong packOffset;
-                        if (((offset >> 31) & 1) == 0)
-                        {
-                            // offset is in the layer
-                            packOffset = (ulong)offset;
-                        }
-                        else
-                        {
-                            // offset is not in this layer, clear first bit and look at it at the 5th layer
-                            offset &= 0x7FFFFFFF;
-                            // Skip complete fourth layer.
-                            fs.Seek(4 * (totalNumberOfObjects - (indexOfCommitValue + 1)), SeekOrigin.Current);
-                            // Use the offset from fourth layer, to find the actual pack file offset in the fifth layer.
-                            // In this case, the offset is 8 bytes long.
-                            fs.Seek(8 * offset, SeekOrigin.Current);
-                            packOffset = br.ReadUInt64();
+                            // Seek to previous index position and read the number of objects
+                            fs.Seek(previousIndex * 4, SeekOrigin.Current);
+                            numberOfObjectsInPreviousIndex = br.ReadUInt32();
                         }
 
-                        packageOffset = new GitPackageOffset(idxFilePath, (long)packOffset);
-                        return true;
+                        // In the fanout table, every index has its objects + the previous ones.
+                        // We need to subtract the previous index objects to know the correct
+                        // actual number of objects for this specific index.
+                        uint numberOfObjectsInIndex = br.ReadUInt32() - numberOfObjectsInPreviousIndex;
+
+                        // Seek to last position. The last position contains the number of all objects.
+                        fs.Seek((255 - (folderIndex + 1)) * 4, SeekOrigin.Current);
+                        uint totalNumberOfObjects = br.ReadUInt32();
+
+                        // Second layer: 20-byte elements with the names in order
+                        // Search the sha index in the second layer: the SHA listing.
+                        uint? indexOfCommit = null;
+                        fs.Seek(20 * (int)numberOfObjectsInPreviousIndex, SeekOrigin.Current);
+                        for (uint i = 0; i < numberOfObjectsInIndex; i++)
+                        {
+                            string str = BitConverter.ToString(br.ReadBytes(20)).Replace("-", string.Empty);
+                            if (str.Equals(commitSha, StringComparison.OrdinalIgnoreCase))
+                            {
+                                indexOfCommit = numberOfObjectsInPreviousIndex + i;
+
+                                // If we find the SHA, we skip all SHA listing table.
+                                fs.Seek(20 * (totalNumberOfObjects - (indexOfCommit.Value + 1)), SeekOrigin.Current);
+                                break;
+                            }
+                        }
+
+                        if (indexOfCommit.HasValue)
+                        {
+                            // Third layer: 4 byte CRC for each object. We skip it
+                            fs.Seek(4 * totalNumberOfObjects, SeekOrigin.Current);
+
+                            uint indexOfCommitValue = indexOfCommit.Value;
+
+                            // Fourth layer: 4 byte per object of offset in pack file
+                            fs.Seek(4 * indexOfCommitValue, SeekOrigin.Current);
+                            uint offset = br.ReadUInt32();
+
+                            ulong packOffset;
+                            if (((offset >> 31) & 1) == 0)
+                            {
+                                // offset is in the layer
+                                packOffset = (ulong)offset;
+                            }
+                            else
+                            {
+                                // offset is not in this layer, clear first bit and look at it at the 5th layer
+                                offset &= 0x7FFFFFFF;
+                                // Skip complete fourth layer.
+                                fs.Seek(4 * (totalNumberOfObjects - (indexOfCommitValue + 1)), SeekOrigin.Current);
+                                // Use the offset from fourth layer, to find the actual pack file offset in the fifth layer.
+                                // In this case, the offset is 8 bytes long.
+                                fs.Seek(8 * offset, SeekOrigin.Current);
+                                packOffset = br.ReadUInt64();
+                            }
+
+                            packageOffset = new GitPackageOffset(idxFilePath, (long)packOffset);
+                            return true;
+                        }
                     }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, ex.Message);
                 }
 
                 return false;

--- a/src/Datadog.Trace.Ci.Shared/GitInfo.cs
+++ b/src/Datadog.Trace.Ci.Shared/GitInfo.cs
@@ -224,7 +224,7 @@ namespace Datadog.Trace.Ci
             }
             catch (Exception ex)
             {
-                Log.Error(ex, ex.Message);
+                Log.Error(ex, "Error loading git information from directory");
             }
 
             return gitInfo;
@@ -441,7 +441,7 @@ namespace Datadog.Trace.Ci
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, ex.Message);
+                    Log.Error(ex, "Error getting commit object from object file");
                 }
 
                 return false;
@@ -516,7 +516,7 @@ namespace Datadog.Trace.Ci
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, ex.Message);
+                    Log.Error(ex, "Error loading commit information from package offset");
                 }
 
                 return false;
@@ -624,7 +624,7 @@ namespace Datadog.Trace.Ci
                 }
                 catch (Exception ex)
                 {
-                    Log.Error(ex, ex.Message);
+                    Log.Error(ex, "Error getting package offset");
                 }
 
                 return false;


### PR DESCRIPTION
This PR fixes an issue detected in very large pack files where the git metadata couldn't be loaded.

The problem was before we were loading the object size using only 2 bytes, the PR changes to multiple bytes.

The PR has been tested loading data from the linux kernel git repo.

@DataDog/apm-dotnet