### PR TITLE
Re-enable AspNet integration tests in CI

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -340,20 +340,6 @@ jobs:
         !test/test-applications/integrations/dependency-libs/**/*.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
-  - task: NuGetCommand@2
-    displayName: nuget restore IIS samples
-    inputs:
-      restoreSolution: test/test-applications/aspnet/samples-iis.sln
-      verbosityRestore: Normal
-
-  - task: MSBuild@1
-    displayName: Publish IIS samples
-    inputs:
-      solution: test/test-applications/aspnet/samples-iis.sln
-      configuration: '$(buildConfiguration)'
-      msbuildArguments: '/p:DeployOnBuild=true /p:PublishProfile=$(System.DefaultWorkingDirectory)/test/test-applications/aspnet/PublishProfiles/FolderProfile.pubxml'
-      maximumCpuCount: true
-
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -376,7 +376,11 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: down
     condition: succeededOrFailed()
-    
+
+  - publish: $(System.DefaultWorkingDirectory)/test
+    artifact: windows-$(buildPlatform)-artifacts
+    condition: succeededOrFailed()
+
 - job: Windows_IIS
   timeoutInMinutes: 100
   strategy:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -376,11 +376,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: down
     condition: succeededOrFailed()
-
-  - publish: $(System.DefaultWorkingDirectory)/test
-    artifact: windows-$(buildPlatform)-artifacts
-    condition: succeededOrFailed()
-
+    
 - job: Windows_IIS
   timeoutInMinutes: 100
   strategy:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -340,6 +340,20 @@ jobs:
         !test/test-applications/integrations/dependency-libs/**/*.csproj
       arguments: --configuration $(buildConfiguration) -p:Platform=$(buildPlatform) -p:ManagedProfilerOutputDirectory=$(publishOutput) -p:BuildInParallel=false /nowarn:netsdk1138 -p:ExcludeManagedProfiler=true -p:ExcludeNativeProfiler=true -p:LoadManagedProfilerFromProfilerDirectory=false
 
+  - task: NuGetCommand@2
+    displayName: nuget restore IIS samples
+    inputs:
+      restoreSolution: test/test-applications/aspnet/samples-iis.sln
+      verbosityRestore: Normal
+
+  - task: MSBuild@1
+    displayName: Publish IIS samples
+    inputs:
+      solution: test/test-applications/aspnet/samples-iis.sln
+      configuration: '$(buildConfiguration)'
+      msbuildArguments: '/p:DeployOnBuild=true /p:PublishProfile=$(System.DefaultWorkingDirectory)/test/test-applications/aspnet/PublishProfiles/FolderProfile.pubxml'
+      maximumCpuCount: true
+
   - task: DotNetCoreCLI@2
     displayName: dotnet test
     inputs:
@@ -464,7 +478,7 @@ jobs:
     inputs:
       solution: test/test-applications/aspnet/samples-iis.sln
       configuration: '$(buildConfiguration)'
-      msbuildArguments: '/p:DeployOnBuild=true /p:PublishProfile=FolderProfile.pubxml'
+      msbuildArguments: '/p:DeployOnBuild=true /p:PublishProfile=$(System.DefaultWorkingDirectory)/test/test-applications/aspnet/PublishProfiles/FolderProfile.pubxml'
       maximumCpuCount: true
 
   - task: DockerCompose@0

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
+        [Trait("RunOnWindows", "True")]
         [MemberData(nameof(AspNetMvc4TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc4TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(AspNetMvc4TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc4TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(AspNetMvc4TestData.WithFeatureFlag), MemberType = typeof(AspNetMvc4TestData))]
         public async Task WithNewResourceNames_SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
+        [Trait("RunOnWindows", "True")]
         [MemberData(nameof(AspNetMvc4TestData.WithFeatureFlag), MemberType = typeof(AspNetMvc4TestData))]
         public async Task WithNewResourceNames_SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -54,6 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(AspNetMvc5TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
+        [Trait("RunOnWindows", "True")]
         [MemberData(nameof(AspNetMvc5TestData.WithoutFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(Integrations.AspNetMvcIntegration))]
+        [Trait("RunOnWindows", "True")]
         [MemberData(nameof(AspNetMvc5TestData.WithFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(AspNetMvc5TestData.WithFeatureFlag), MemberType = typeof(AspNetMvc5TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -54,6 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(AspNetWebApi2TestData.WithoutFeatureFlag), MemberType = typeof(AspNetWebApi2TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
+        [Trait("RunOnWindows", "True")]
         [MemberData(nameof(AspNetWebApi2TestData.WithoutFeatureFlag), MemberType = typeof(AspNetWebApi2TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(Integrations.AspNetWebApi2Integration))]
+        [Trait("RunOnWindows", "True")]
         [MemberData(nameof(AspNetWebApi2TestData.WithFeatureFlag), MemberType = typeof(AspNetWebApi2TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [MemberData(nameof(AspNetWebApi2TestData.WithFeatureFlag), MemberType = typeof(AspNetWebApi2TestData))]
         public async Task SubmitsTraces(
             string path,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _iisFixture.TryStartIis(this);
         }
 
-        [Fact(Skip = "This example does not use MVC or WebApi, so we will not generate traces until AspNet is invoked via automatic instrumentation.")]
+        [Theory(Skip = "This example does not use MVC or WebApi, so we will not generate traces until AspNet is invoked via automatic instrumentation.")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [Theory]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(AspNetWebFormsTests))]
+        [Trait("RunOnWindows", "True")]
         [InlineData("/Account/Login", "GET /account/login", false)]
         public async Task SubmitsTraces(
             string path,
@@ -49,9 +49,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 "1.0.0");
         }
 
-        [Fact]
+        [Fact(Skip = "This test requires Elasticsearch to be running on the host, which is not currently enabled in CI.")]
         [Trait("Category", "EndToEnd")]
-        [Trait("Integration", nameof(AspNetWebFormsTests))]
+        [Trait("RunOnWindows", "True")]
         public async Task NestedAsyncElasticCallSubmitsTrace()
         {
             var testStart = DateTime.UtcNow;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         [InlineData("/Account/Login", "GET /account/login", false)]
         public async Task SubmitsTraces(
             string path,
@@ -52,6 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Fact(Skip = "This test requires Elasticsearch to be running on the host, which is not currently enabled in CI.")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
+        [Trait("LoadFromGAC", "True")]
         public async Task NestedAsyncElasticCallSubmitsTrace()
         {
             var testStart = DateTime.UtcNow;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _iisFixture.TryStartIis(this);
         }
 
-        [Theory]
+        [Fact(Skip = "This example does not use MVC or WebApi, so we will not generate traces until AspNet is invoked via automatic instrumentation.")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]

--- a/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+++ b/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
+
+    <!-- Tell Visual Studio to not create a new launchSettings.json file, even though we have AspNetCore assets -->
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -378,7 +378,10 @@ namespace Datadog.Trace.TestHelpers
 
             if (_samplesDirectory.Contains("aspnet"))
             {
-                outputDir = binDir;
+                outputDir = Path.Combine(
+                    binDir,
+                    EnvironmentTools.GetBuildConfiguration(),
+                    "publish");
             }
             else if (EnvironmentTools.GetOS() == "win")
             {

--- a/test/test-applications/aspnet/PublishProfiles/FolderProfile.pubxml
+++ b/test/test-applications/aspnet/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <PublishProvider>FileSystem</PublishProvider>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <publishUrl>bin\Release\publish</publishUrl>
+    <DeleteExistingFiles>True</DeleteExistingFiles>
+  </PropertyGroup>
+</Project>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Samples.AspNetMvc4.csproj
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Samples.AspNetMvc4.csproj
@@ -191,16 +191,6 @@
     <Content Include="Scripts\jquery-3.3.1.slim.min.map" />
     <Content Include="Scripts\jquery-3.3.1.min.map" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-      <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
-      <Name>Datadog.Trace.ClrProfiler.Managed</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Views/Home/Index.cshtml
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Views/Home/Index.cshtml
@@ -1,8 +1,14 @@
 ﻿@model List<KeyValuePair<string, string>>
 @using System.Linq
+@using System.Reflection;
 
 @{
     ViewBag.Title = "Index";
+
+    var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace.ClrProfiler.Managed");
+    var profilerAttached = instrumentationType?.GetProperty("ProfilerAttached", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) ?? false;
+    var tracerAssemblyLocation = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace")?.Assembly.Location ?? "(none)";
+    var clrProfilerAssemblyLocation = instrumentationType?.Assembly.Location ?? "(none)";
 }
 
 <div class="container">
@@ -14,15 +20,15 @@
             </tr>
             <tr>
                 <th scope="row">Profiler attached</th>
-                <td>@Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached</td>
+                <td>@profilerAttached</td>
             </tr>
             <tr>
                 <th scope="row">Datadog.Trace.dll path</th>
-                <td>@typeof(Datadog.Trace.Tracer).Assembly.Location</td>
+                <td>@tracerAssemblyLocation</td>
             </tr>
             <tr>
                 <th scope="row">Datadog.Trace.ClrProfiler.Managed.dll</th>
-                <td>@typeof(Datadog.Trace.ClrProfiler.Instrumentation).Assembly.Location</td>
+                <td>@clrProfilerAssemblyLocation</td>
             </tr>
         </tbody>
     </table>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Views/Home/Index.cshtml
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Views/Home/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@model List<KeyValuePair<string, string>>
 @using System.Linq
-@using System.Reflection;
+@using System.Reflection
 
 @{
     ViewBag.Title = "Index";

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Areas/Datadog/DatadogAreaRegistration.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Areas/Datadog/DatadogAreaRegistration.cs
@@ -17,7 +17,8 @@ namespace Samples.AspNetMvc5.Areas.Datadog
             context.MapRoute(
                 "Datadog_default",
                 "Datadog/{controller}/{action}/{id}",
-                new { area = AreaName, action = "Index", id = UrlParameter.Optional }
+                //new { area = AreaName, action = "Index", id = UrlParameter.Optional }
+                new { area = AreaName, controller = "DogHouse", action = "Index", id = UrlParameter.Optional }
             );
         }
     }

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Samples.AspNetMvc5.csproj
@@ -143,17 +143,13 @@
     <Folder Include="Models\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
+      <Project>{8e1baa6a-47cc-47f0-a7d6-74741118eb7c}</Project>
+      <Name>Datadog.Trace</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\integrations\dependency-libs\Samples.Shared\Samples.Shared.csproj">
       <Project>{b4ae8b0f-c2b2-41df-88bb-d97e267d8964}</Project>
       <Name>Samples.Shared</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-      <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
-      <Name>Datadog.Trace.ClrProfiler.Managed</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Views/Home/Index.cshtml
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Views/Home/Index.cshtml
@@ -2,6 +2,11 @@
 
 @{
     ViewBag.Title = "Index";
+
+    var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace.ClrProfiler.Managed");
+    var profilerAttached = instrumentationType?.GetProperty("ProfilerAttached", BindingFlags.Public | BindingFlags.Static)?.GetValue(null) ?? false;
+    var tracerAssemblyLocation = Type.GetType("Datadog.Trace.Tracer, Datadog.Trace")?.Assembly.Location ?? "(none)";
+    var clrProfilerAssemblyLocation = instrumentationType?.Assembly.Location ?? "(none)";
 }
 
 <div class="container">
@@ -13,7 +18,7 @@
             </tr>
             <tr>
                 <th scope="row">Profiler attached</th>
-                <td>@Datadog.Trace.ClrProfiler.Instrumentation.ProfilerAttached</td>
+                <td>@profilerAttached</td>
             </tr>
             <tr>
                 <th scope="row">Current directory</th>
@@ -25,11 +30,11 @@
             </tr>
             <tr>
                 <th scope="row">Datadog.Trace.dll path</th>
-                <td>@typeof(Datadog.Trace.Tracer).Assembly.Location</td>
+                <td>@tracerAssemblyLocation</td>
             </tr>
             <tr>
                 <th scope="row">Datadog.Trace.ClrProfiler.Managed.dll</th>
-                <td>@typeof(Datadog.Trace.ClrProfiler.Instrumentation).Assembly.Location</td>
+                <td>@clrProfilerAssemblyLocation</td>
             </tr>
         </tbody>
     </table>

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Views/Home/Index.cshtml
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Views/Home/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@model List<KeyValuePair<string, string>>
+@using System.Reflection
 
 @{
     ViewBag.Title = "Index";

--- a/test/test-applications/aspnet/Samples.WebForms/Samples.WebForms.csproj
+++ b/test/test-applications/aspnet/Samples.WebForms/Samples.WebForms.csproj
@@ -195,7 +195,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
+      <Project>{8e1baa6a-47cc-47f0-a7d6-74741118eb7c}</Project>
       <Name>Datadog.Trace</Name>
     </ProjectReference>
   </ItemGroup>

--- a/test/test-applications/aspnet/samples-iis.sln
+++ b/test/test-applications/aspnet/samples-iis.sln
@@ -3,26 +3,114 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNet472.LoaderOptimizationRegKey", "Samples.AspNet472.LoaderOptimizationRegKey\Samples.AspNet472.LoaderOptimizationRegKey.csproj", "{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CB2BB1C3-36DF-4368-A925-74C0E4FDB5EE}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNetMvc5", "Samples.AspNetMvc5\Samples.AspNetMvc5.csproj", "{3C6DD42E-9214-4747-92BA-78DE29AACE59}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNetMvc4", "Samples.AspNetMvc4\Samples.AspNetMvc4.csproj", "{6D86109F-B7C9-477D-86D7-45735A3A0818}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.WebForms", "Samples.WebForms\Samples.WebForms.csproj", "{99A62CCF-8E7F-4D57-8383-D38C371C8087}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dependency-libs", "dependency-libs", "{A7843DE3-5647-4354-8443-EF22BDEEB450}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Shared", "..\integrations\dependency-libs\Samples.Shared\Samples.Shared.csproj", "{539BE627-E17E-47BD-BB5F-71788E36B962}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace", "..\..\..\src\Datadog.Trace\Datadog.Trace.csproj", "{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNet472.LoaderOptimizationRegKey", "Samples.AspNet472.LoaderOptimizationRegKey\Samples.AspNet472.LoaderOptimizationRegKey.csproj", "{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Debug|x64.ActiveCfg = Debug|x64
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Debug|x64.Build.0 = Debug|x64
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Debug|x86.ActiveCfg = Debug|x86
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Debug|x86.Build.0 = Debug|x86
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Release|x64.ActiveCfg = Release|x64
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Release|x64.Build.0 = Release|x64
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Release|x86.ActiveCfg = Release|x86
+		{3C6DD42E-9214-4747-92BA-78DE29AACE59}.Release|x86.Build.0 = Release|x86
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Debug|x64.ActiveCfg = Debug|x64
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Debug|x64.Build.0 = Debug|x64
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Debug|x86.ActiveCfg = Debug|x86
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Debug|x86.Build.0 = Debug|x86
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Release|x64.ActiveCfg = Release|x64
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Release|x64.Build.0 = Release|x64
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Release|x86.ActiveCfg = Release|x86
+		{6D86109F-B7C9-477D-86D7-45735A3A0818}.Release|x86.Build.0 = Release|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x64.Build.0 = Debug|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x86.Build.0 = Debug|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x64.ActiveCfg = Release|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x64.Build.0 = Release|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x86.ActiveCfg = Release|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x86.Build.0 = Release|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Debug|x64.Build.0 = Debug|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Debug|x86.Build.0 = Debug|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Release|Any CPU.Build.0 = Release|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Release|x64.ActiveCfg = Release|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Release|x64.Build.0 = Release|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Release|x86.ActiveCfg = Release|Any CPU
+		{539BE627-E17E-47BD-BB5F-71788E36B962}.Release|x86.Build.0 = Release|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Debug|x86.Build.0 = Debug|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Release|x64.Build.0 = Release|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C}.Release|x86.Build.0 = Release|Any CPU
 		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Debug|x64.Build.0 = Debug|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Debug|x86.Build.0 = Debug|Any CPU
 		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Release|x64.ActiveCfg = Release|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Release|x64.Build.0 = Release|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Release|x86.ActiveCfg = Release|Any CPU
+		{BBB60B0F-BF01-4499-936A-4A299A9ACFD4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{539BE627-E17E-47BD-BB5F-71788E36B962} = {A7843DE3-5647-4354-8443-EF22BDEEB450}
+		{8E1BAA6A-47CC-47F0-A7D6-74741118EB7C} = {A7843DE3-5647-4354-8443-EF22BDEEB450}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {81EC8DA4-0E99-483E-AAF2-B1184DF6E2B5}


### PR DESCRIPTION
### Summary
Runs the AspNet tests added by https://github.com/DataDog/dd-trace-dotnet/pull/1288 . Currently, this only tests the `AspNetMvc` and `AspNetWebApi2` integrations because the `AspNet` integration is not yet enabled via automatic instrumentation. That will be completed in https://github.com/DataDog/dd-trace-dotnet/pull/1280

The tests are run in the Windows IIS runs for the following reasons:
- Restoring the projects and publishing can be grouped into the existing `samples-iis.sln` solution
- Instrumenting IIS and IIS Express requires the Datadog.Trace assemblies to be in the GAC

### Changes
- Adding the AspNet CI applications to `samples-iis.sln`, which we are already properly restoring and publishing in the Windows IIS jobs
- Removing some compile-time references to `Datadog.Trace.dll` and `Datadog.Trace.ClrProfiler.Managed.dll` with lookups via reflection. This is used so the site can give us a clear indicator whether automatic instrumentation is running
- Miscellaneous change: Stop Visual Studio from auto-generating a `launchSetings.json` for the Datadog.Trace.IntegrationTests project

@DataDog/apm-dotnet