### PR TITLE
Enable endpoint routing in aspnetcore benchmark

### DIFF
--- a/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -69,7 +69,13 @@ namespace Benchmarks.Trace
 
             public void Configure(IApplicationBuilder builder)
             {
-                builder.UseMvcWithDefaultRoute();
+                builder.UseRouting();
+                builder.UseEndpoints(endpoints =>
+                {
+                    endpoints.MapControllerRoute(
+                        name: "default",
+                        pattern: "{controller=Home}/{action=Index}/{id?}");
+                });
             }
         }
     }

--- a/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -45,9 +45,7 @@
     but the logic at runtime will never try to use the Registry if it's not available
     -->
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.14" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The impact of changes introduced in https://github.com/DataDog/dd-trace-dotnet/pull/1289 can only be measured with endpoint routing enabled.

It also means upgrading the benchmark from aspnetcore 2.x to 3.x, but it's probably more representative of what customers use.