### PR TITLE
Optimize aspnetcore when enabling route template resource names

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Web;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
@@ -159,7 +160,7 @@ namespace Datadog.Trace.AspNet
                 if (sender is HttpApplication app &&
                     app.Context.Items[_httpContextScopeKey] is Scope scope)
                 {
-                    scope.Span.SetHeaderTags(app.Context.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags<IHeadersCollection>(app.Context.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                     scope.Span.SetHttpStatusCode(app.Context.Response.StatusCode, isServer: true);
 
                     if (app.Context.Items[SharedConstants.HttpContextPropagatedResourceNameKey] is string resourceName
@@ -195,7 +196,7 @@ namespace Datadog.Trace.AspNet
 
                 if (httpContext.Items[_httpContextScopeKey] is Scope scope)
                 {
-                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
 
                     if (exception != null && !is404)
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.ClrProfiler.Integrations.AspNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
@@ -112,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 var httpContext = HttpContext.Current;
                 if (httpContext != null)
                 {
-                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 }
 
                 scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true);
@@ -124,7 +125,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+            scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -5,6 +5,7 @@ using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
@@ -69,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 }
                 else
                 {
-                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -80,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+            scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.ClrProfiler.Integrations.AspNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
@@ -357,7 +358,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 if (scope != null)
                 {
-                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -389,7 +390,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+            scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -12,6 +12,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
@@ -168,7 +169,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                     var httpContext = System.Web.HttpContext.Current;
                     if (httpContext != null)
                     {
-                        scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                        scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                     }
 
                     scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true);
@@ -347,7 +348,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(System.Web.HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+            scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -65,6 +65,8 @@ namespace Datadog.Trace.DiagnosticListeners
 
         protected override string ListenerName => DiagnosticListenerName;
 
+        private Tracer CurrentTracer => _tracer ?? Tracer.Instance;
+
 #if NETCOREAPP
         protected override void OnNext(string eventName, object arg)
         {
@@ -481,7 +483,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnHostingHttpRequestInStart(object arg)
         {
-            var tracer = _tracer ?? Tracer.Instance;
+            var tracer = CurrentTracer;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
@@ -495,11 +497,15 @@ namespace Datadog.Trace.DiagnosticListeners
                 string host = request.Host.Value;
                 string httpMethod = request.Method?.ToUpperInvariant() ?? "UNKNOWN";
                 string url = GetUrl(request);
-                httpContext.Features.Set(new RequestTrackingFeature
+
+                if (tracer.Settings.RouteTemplateResourceNamesEnabled)
                 {
-                    HttpMethod = httpMethod,
-                    OriginalUrl = url,
-                });
+                    httpContext.Features.Set(new RequestTrackingFeature
+                    {
+                        HttpMethod = httpMethod,
+                        OriginalUrl = url,
+                    });
+                }
 
                 string absolutePath = request.Path.Value;
 
@@ -527,7 +533,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnRoutingEndpointMatched(object arg)
         {
-            var tracer = _tracer ?? Tracer.Instance;
+            var tracer = CurrentTracer;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId) ||
                 !tracer.Settings.RouteTemplateResourceNamesEnabled)
@@ -647,7 +653,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnMvcBeforeAction(object arg)
         {
-            var tracer = _tracer ?? Tracer.Instance;
+            var tracer = CurrentTracer;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
@@ -773,7 +779,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnMvcAfterAction(object arg)
         {
-            var tracer = _tracer ?? Tracer.Instance;
+            var tracer = CurrentTracer;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId) ||
                 !tracer.Settings.RouteTemplateResourceNamesEnabled)
@@ -791,7 +797,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnHostingHttpRequestInStop(object arg)
         {
-            var tracer = _tracer ?? Tracer.Instance;
+            var tracer = CurrentTracer;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
@@ -816,7 +822,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         private void OnHostingUnhandledException(object arg)
         {
-            var tracer = _tracer ?? Tracer.Instance;
+            var tracer = CurrentTracer;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -807,7 +807,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 {
                     HttpContext httpContext = httpRequest.HttpContext;
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
-                    scope.Span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), tracer.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 }
 
                 scope.Dispose();

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -522,7 +522,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 SpanContext propagatedContext = ExtractPropagatedContext(request);
                 var tagsFromHeaders = ExtractHeaderTags(request, tracer);
 
-                var tags = new AspNetCoreTags();
+                var tags = tracer.Settings.RouteTemplateResourceNamesEnabled ? new AspNetCoreEndpointTags() : new AspNetCoreTags();
                 var scope = tracer.StartActiveWithTags(HttpRequestInOperationName, propagatedContext, tags: tags);
 
                 scope.Span.DecorateWebServerSpan(resourceName, httpMethod, host, url, tags, tagsFromHeaders);
@@ -545,7 +545,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
             if (span != null)
             {
-                var tags = span.Tags as AspNetCoreTags;
+                var tags = span.Tags as AspNetCoreEndpointTags;
                 if (tags is null || !arg.TryDuckCast<HttpRequestInEndpointMatchedStruct>(out var typedArg))
                 {
                     // Shouldn't happen in normal execution
@@ -674,7 +674,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 }
 
                 // Create a child span for the MVC action
-                var mvcSpanTags = new AspNetCoreTags();
+                var mvcSpanTags = new AspNetCoreEndpointTags();
                 var mvcScope = tracer.StartActiveWithTags(MvcOperationName, parentSpan.Context, tags: mvcSpanTags);
                 var span = mvcScope.Span;
                 span.Type = SpanTypes.Web;
@@ -767,7 +767,7 @@ namespace Datadog.Trace.DiagnosticListeners
                 {
                     // If we're using endpoint routing or this is a pipeline re-execution,
                     // these will already be set correctly
-                    if (parentSpan.Tags is AspNetCoreTags parentTags)
+                    if (parentSpan.Tags is AspNetCoreEndpointTags parentTags)
                     {
                         parentTags.AspNetCoreRoute = aspNetRoute;
                     }

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -71,6 +71,12 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
+        // Added to avoid a breaking change
+        internal static void SetHeaderTags(this Span span, IHeadersCollection headers, IDictionary<string, string> headerTags, string defaultTagPrefix)
+        {
+            SetHeaderTags<IHeadersCollection>(span, headers, headerTags, defaultTagPrefix);
+        }
+
         internal static void SetHeaderTags<T>(this Span span, T headers, IDictionary<string, string> headerTags, string defaultTagPrefix)
             where T : IHeadersCollection
         {

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -71,7 +71,8 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static void SetHeaderTags(this Span span, IHeadersCollection headers, IDictionary<string, string> headerTags, string defaultTagPrefix)
+        internal static void SetHeaderTags<T>(this Span span, T headers, IDictionary<string, string> headerTags, string defaultTagPrefix)
+            where T : IHeadersCollection
         {
             if (headerTags is not null && !headerTags.IsEmpty())
             {

--- a/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -72,6 +72,7 @@ namespace Datadog.Trace.ExtensionMethods
         }
 
         // Added to avoid a breaking change
+        [Obsolete("Use SetHeaderTags<T> instead")]
         internal static void SetHeaderTags(this Span span, IHeadersCollection headers, IDictionary<string, string> headerTags, string defaultTagPrefix)
         {
             SetHeaderTags<IHeadersCollection>(span, headers, headerTags, defaultTagPrefix);

--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -334,7 +334,8 @@ namespace Datadog.Trace
             return default;
         }
 
-        private static string ParseString(IHeadersCollection headers, string headerName)
+        private static string ParseString<T>(T headers, string headerName)
+            where T : IHeadersCollection
         {
             var headerValues = headers.GetValues(headerName);
 

--- a/src/Datadog.Trace/Tagging/AspNetCoreEndpointTags.cs
+++ b/src/Datadog.Trace/Tagging/AspNetCoreEndpointTags.cs
@@ -1,0 +1,30 @@
+using Datadog.Trace.ExtensionMethods;
+
+namespace Datadog.Trace.Tagging
+{
+    internal class AspNetCoreEndpointTags : AspNetCoreTags
+    {
+        private static readonly IProperty<string>[] AspNetCoreEndpointTagsProperties =
+            AspNetCoreTagsProperties.Concat(
+                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreRoute, t => t.AspNetCoreRoute, (t, v) => t.AspNetCoreRoute = v),
+                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreArea, t => t.AspNetCoreArea, (t, v) => t.AspNetCoreArea = v),
+                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreController, t => t.AspNetCoreController, (t, v) => t.AspNetCoreController = v),
+                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreEndpoint, t => t.AspNetCoreEndpoint, (t, v) => t.AspNetCoreEndpoint = v),
+                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCorePage, t => t.AspNetCorePage, (t, v) => t.AspNetCorePage = v),
+                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreAction, t => t.AspNetCoreAction, (t, v) => t.AspNetCoreAction = v));
+
+        public string AspNetCoreRoute { get; set; }
+
+        public string AspNetCoreController { get; set; }
+
+        public string AspNetCoreAction { get; set; }
+
+        public string AspNetCoreArea { get; set; }
+
+        public string AspNetCorePage { get; set; }
+
+        public string AspNetCoreEndpoint { get; set; }
+
+        protected override IProperty<string>[] GetAdditionalTags() => AspNetCoreEndpointTagsProperties;
+    }
+}

--- a/src/Datadog.Trace/Tagging/AspNetCoreTags.cs
+++ b/src/Datadog.Trace/Tagging/AspNetCoreTags.cs
@@ -4,31 +4,13 @@ namespace Datadog.Trace.Tagging
 {
     internal class AspNetCoreTags : WebTags
     {
+        private protected static readonly IProperty<string>[] AspNetCoreTagsProperties =
+            WebTagsProperties.Concat(
+                new ReadOnlyProperty<AspNetCoreTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName));
+
         private const string ComponentName = "aspnet_core";
 
-        private static readonly IProperty<string>[] AspNetCoreTagsProperties =
-            WebTagsProperties.Concat(
-                new ReadOnlyProperty<AspNetCoreTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName),
-                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCoreRoute, t => t.AspNetCoreRoute, (t, v) => t.AspNetCoreRoute = v),
-                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCoreArea, t => t.AspNetCoreArea, (t, v) => t.AspNetCoreArea = v),
-                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCoreController, t => t.AspNetCoreController, (t, v) => t.AspNetCoreController = v),
-                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCoreEndpoint, t => t.AspNetCoreEndpoint, (t, v) => t.AspNetCoreEndpoint = v),
-                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCorePage, t => t.AspNetCorePage, (t, v) => t.AspNetCorePage = v),
-                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCoreAction, t => t.AspNetCoreAction, (t, v) => t.AspNetCoreAction = v));
-
         public string InstrumentationName => ComponentName;
-
-        public string AspNetCoreRoute { get; set; }
-
-        public string AspNetCoreController { get; set; }
-
-        public string AspNetCoreAction { get; set; }
-
-        public string AspNetCoreArea { get; set; }
-
-        public string AspNetCorePage { get; set; }
-
-        public string AspNetCoreEndpoint { get; set; }
 
         protected override IProperty<string>[] GetAdditionalTags() => AspNetCoreTagsProperties;
     }


### PR DESCRIPTION
- Remove boxing of headers
- Don't register the aspnetcore feature if RouteTemplateResourceNamesEnabled is false
- Use specialized tags object to reduce allocations when the feature is disabled