### PR TITLE
Inject additional tags/metrics during serialization

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -67,7 +66,7 @@ namespace Datadog.Trace.Agent
             _batchInterval = batchInterval;
             _traceKeepRateCalculator = traceKeepRateCalculator;
 
-            var formatterResolver = SpanFormatterResolver.Instance;
+            var formatterResolver = new SpanFormatterResolver(traceKeepRateCalculator);
 
             _forceFlush = new TaskCompletionSource<bool>(TaskOptions);
 
@@ -322,24 +321,6 @@ namespace Datadog.Trace.Agent
                 }
 
                 return null;
-            }
-
-            // Add the current keep rate to the root span
-            var rootSpan = trace[0].Context.TraceContext?.RootSpan;
-            if (rootSpan is not null)
-            {
-                _ = _traceKeepRateCalculator.GetKeepRate();
-
-                /*
-                if (rootSpan.Tags is CommonTags commonTags)
-                {
-                    commonTags.TracesKeepRate = currentKeepRate;
-                }
-                else
-                {
-                    rootSpan.Tags.SetMetric(Metrics.TracesKeepRate, currentKeepRate);
-                }
-                */
             }
 
             // We use a double-buffering mechanism

--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -328,7 +328,9 @@ namespace Datadog.Trace.Agent
             var rootSpan = trace[0].Context.TraceContext?.RootSpan;
             if (rootSpan is not null)
             {
-                var currentKeepRate = _traceKeepRateCalculator.GetKeepRate();
+                _ = _traceKeepRateCalculator.GetKeepRate();
+
+                /*
                 if (rootSpan.Tags is CommonTags commonTags)
                 {
                     commonTags.TracesKeepRate = currentKeepRate;
@@ -337,6 +339,7 @@ namespace Datadog.Trace.Agent
                 {
                     rootSpan.Tags.SetMetric(Metrics.TracesKeepRate, currentKeepRate);
                 }
+                */
             }
 
             // We use a double-buffering mechanism

--- a/src/Datadog.Trace/Agent/MessagePack/SpanFormatterResolver.cs
+++ b/src/Datadog.Trace/Agent/MessagePack/SpanFormatterResolver.cs
@@ -6,19 +6,18 @@ namespace Datadog.Trace.Agent.MessagePack
 {
     internal class SpanFormatterResolver : IFormatterResolver
     {
-        public static readonly IFormatterResolver Instance = new SpanFormatterResolver();
+        private readonly IMessagePackFormatter<Span> _formatter;
 
-        private static readonly IMessagePackFormatter<Span> Formatter = new SpanMessagePackFormatter();
-
-        private SpanFormatterResolver()
+        internal SpanFormatterResolver(IKeepRateCalculator keepRateCalculator)
         {
+            _formatter = new SpanMessagePackFormatter(keepRateCalculator);
         }
 
         public IMessagePackFormatter<T> GetFormatter<T>()
         {
             if (typeof(T) == typeof(Span))
             {
-                return (IMessagePackFormatter<T>)Formatter;
+                return (IMessagePackFormatter<T>)_formatter;
             }
 
             return StandardResolver.Instance.GetFormatter<T>();

--- a/src/Datadog.Trace/Tagging/CommonTags.cs
+++ b/src/Datadog.Trace/Tagging/CommonTags.cs
@@ -5,8 +5,7 @@ namespace Datadog.Trace.Tagging
         protected static readonly IProperty<double?>[] CommonMetricsProperties =
         {
             new Property<CommonTags, double?>(Trace.Metrics.SamplingLimitDecision, t => t.SamplingLimitDecision, (t, v) => t.SamplingLimitDecision = v),
-            new Property<CommonTags, double?>(Trace.Metrics.SamplingPriority, t => t.SamplingPriority, (t, v) => t.SamplingPriority = v),
-            new Property<CommonTags, double?>(Trace.Metrics.TracesKeepRate, t => t.TracesKeepRate, (t, v) => t.TracesKeepRate = v)
+            new Property<CommonTags, double?>(Trace.Metrics.SamplingPriority, t => t.SamplingPriority, (t, v) => t.SamplingPriority = v)
         };
 
         protected static readonly IProperty<string>[] CommonTagsProperties =
@@ -22,8 +21,6 @@ namespace Datadog.Trace.Tagging
         public double? SamplingPriority { get; set; }
 
         public double? SamplingLimitDecision { get; set; }
-
-        public double? TracesKeepRate { get; set; }
 
         protected override IProperty<double?>[] GetAdditionalMetrics() => CommonMetricsProperties;
 

--- a/src/Datadog.Trace/Tagging/ITags.cs
+++ b/src/Datadog.Trace/Tagging/ITags.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Datadog.Trace.Tagging
 {
     internal interface ITags
@@ -10,6 +13,6 @@ namespace Datadog.Trace.Tagging
 
         void SetMetric(string key, double? value);
 
-        int SerializeTo(ref byte[] buffer, int offset, Span span);
+        int SerializeTo(ref byte[] buffer, int offset, Span span, Func<Span, KeyValuePair<string, string>>[] tagFactories, Func<Span, KeyValuePair<string, double?>>[] metricsFactories);
     }
 }

--- a/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
+++ b/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
+using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Agent
@@ -16,7 +17,7 @@ namespace Datadog.Trace.Tests.Agent
         [InlineData(50, 50, true)]
         public void SerializeSpans(int traceCount, int spanCount, bool resizeExpected)
         {
-            var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
+            var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanFormatterResolver(Mock.Of<IKeepRateCalculator>()));
 
             var traces = new List<Span[]>();
 
@@ -59,7 +60,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public void Overflow()
         {
-            var buffer = new SpanBuffer(10, SpanFormatterResolver.Instance);
+            var buffer = new SpanBuffer(10, new SpanFormatterResolver(Mock.Of<IKeepRateCalculator>()));
 
             Assert.False(buffer.IsFull);
 
@@ -85,7 +86,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public void LockingBuffer()
         {
-            var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
+            var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanFormatterResolver(Mock.Of<IKeepRateCalculator>()));
 
             var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
 
@@ -103,7 +104,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public void ClearingBuffer()
         {
-            var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
+            var buffer = new SpanBuffer(10 * 1024 * 1024, new SpanFormatterResolver(Mock.Of<IKeepRateCalculator>()));
 
             var trace = new[]
             {
@@ -131,7 +132,7 @@ namespace Datadog.Trace.Tests.Agent
         [Fact]
         public void InvalidSize()
         {
-            Assert.Throws<ArgumentException>(() => new SpanBuffer(4, SpanFormatterResolver.Instance));
+            Assert.Throws<ArgumentException>(() => new SpanBuffer(4, new SpanFormatterResolver(Mock.Of<IKeepRateCalculator>())));
         }
 
         [MessagePack.MessagePackObject]

--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.ClrProfiler.Integrations.AdoNet;
 using Datadog.Trace.Tagging;
@@ -115,15 +116,15 @@ namespace Datadog.Trace.Tests.Tagging
 
             var buffer = new byte[0];
 
-            var resolver = new FormatterResolverWrapper(SpanFormatterResolver.Instance);
+            var resolver = new FormatterResolverWrapper(new SpanFormatterResolver(Mock.Of<IKeepRateCalculator>()));
             MessagePackSerializer.Serialize(ref buffer, 0, span, resolver);
 
             var deserializedSpan = MessagePack.MessagePackSerializer.Deserialize<FakeSpan>(buffer);
 
             Assert.Equal(16, deserializedSpan.Tags.Count);
 
-            // For top-level spans, there is one metric added during serialization
-            Assert.Equal(topLevelSpan ? 17 : 16, deserializedSpan.Metrics.Count);
+            // For top-level spans, there are two metrics added during serialization
+            Assert.Equal(topLevelSpan ? 18 : 16, deserializedSpan.Metrics.Count);
 
             Assert.Equal("Overridden Environment", deserializedSpan.Tags[Tags.Env]);
             Assert.Equal(0.75, deserializedSpan.Metrics[Metrics.SamplingLimitDecision]);


### PR DESCRIPTION
Add a global mechanism to inject tags/metrics at serialization time without having to store them on the tags object.

Unfortunately this is a breaking change since it touches the ITags interface.