### PR TITLE
don't throw or log exceptions in TryDuckCast methods

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
@@ -41,17 +41,14 @@ namespace Datadog.Trace.DuckTyping
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryDuckCast<T>(this object instance, out T value)
         {
-            try
+            if (DuckType.CanCreate<T>(instance))
             {
                 value = DuckType.Create<T>(instance);
                 return true;
             }
-            catch (Exception ex)
-            {
-                Log.Error(ex, ex.Message);
-                value = default;
-                return false;
-            }
+
+            value = default;
+            return false;
         }
 
         /// <summary>
@@ -64,17 +61,14 @@ namespace Datadog.Trace.DuckTyping
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryDuckCast(this object instance, Type targetType, out object value)
         {
-            try
+            if (DuckType.CanCreate(targetType, instance))
             {
                 value = DuckType.Create(targetType, instance);
                 return true;
             }
-            catch (Exception ex)
-            {
-                Log.Error(ex, ex.Message);
-                value = default;
-                return false;
-            }
+
+            value = default;
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
Rewrite the `TryDuckCast` methods to use the same logic as `DuckAs`. Don't throw exceptions and don't write to the log.

In some cases we use these methods to find out if an object can be cast or not. A failure here is expected and was spamming the logs.

This is a short-term fix for now. We will come back and consider performance implications of the two separate `CanCreate` and `Create` calls.