### PR TITLE
Adds native callback stats.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -205,6 +205,7 @@
     <ClInclude Include="pal.h" />
     <ClInclude Include="rejit_handler.h" />
     <ClInclude Include="sig_helpers.h" />
+    <ClInclude Include="stats.h" />
     <ClInclude Include="string.h" />
     <ClInclude Include="util.h" />
     <ClInclude Include="version.h" />

--- a/src/Datadog.Trace.ClrProfiler.Native/stats.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/stats.h
@@ -8,22 +8,17 @@
 namespace trace {
 
 class SWStat {
-  std::chrono::nanoseconds* _value;
-  std::mutex* _mutex;
+  std::atomic_ullong* _value;
   std::chrono::steady_clock::time_point _startTime;
 
  public:
-  SWStat(std::chrono::nanoseconds* value, std::mutex* mutex) {
+  SWStat(std::atomic_ullong* value) {
     _value = value;
-    _mutex = mutex;
     _startTime = std::chrono::steady_clock::now();
   }
   ~SWStat() {
-    auto increment = std::chrono::steady_clock::now() - _startTime;
-    {
-      std::lock_guard<std::mutex> guard(*_mutex);
-      *_value += increment;
-    }
+    auto increment = (std::chrono::steady_clock::now() - _startTime).count();
+    _value->fetch_add(increment);
   }
 };
 
@@ -31,14 +26,14 @@ class Stats : public Singleton<Stats> {
   friend class Singleton<Stats>;
 
  private:
-  std::chrono::nanoseconds callTargetRequestRejit;
-  std::chrono::nanoseconds callTargetRewriter;
-  std::chrono::nanoseconds jitInlining;
-  std::chrono::nanoseconds jitCompilationStarted;
-  std::chrono::nanoseconds moduleUnloadStarted;
-  std::chrono::nanoseconds moduleLoadFinished;
-  std::chrono::nanoseconds assemblyLoadFinished;
-  std::chrono::nanoseconds initialize;
+  std::atomic_ullong callTargetRequestRejit = {0};
+  std::atomic_ullong callTargetRewriter = {0};
+  std::atomic_ullong jitInlining = {0};
+  std::atomic_ullong jitCompilationStarted = {0};
+  std::atomic_ullong moduleUnloadStarted = {0};
+  std::atomic_ullong moduleLoadFinished = {0};
+  std::atomic_ullong assemblyLoadFinished = {0};
+  std::atomic_ullong initialize = {0};
 
   //
   std::atomic_uint callTargetRequestRejitCount = {0};
@@ -49,25 +44,15 @@ class Stats : public Singleton<Stats> {
   std::atomic_uint moduleLoadFinishedCount = {0};
   std::atomic_uint assemblyLoadFinishedCount = {0};
 
-  //
-  std::mutex callTargetRequestRejitMutex;
-  std::mutex callTargetRewriterMutex;
-  std::mutex jitInliningMutex;
-  std::mutex jitCompilationStartedMutex;
-  std::mutex moduleUnloadStartedMutex;
-  std::mutex moduleLoadFinishedMutex;
-  std::mutex assemblyLoadFinishedMutex;
-  std::mutex initializeMutex;
-
  public:
   Stats() {
-    callTargetRequestRejit = std::chrono::nanoseconds(0);
-    jitInlining = std::chrono::nanoseconds(0);
-    jitCompilationStarted = std::chrono::nanoseconds(0);
-    moduleUnloadStarted = std::chrono::nanoseconds(0);
-    moduleLoadFinished = std::chrono::nanoseconds(0);
-    assemblyLoadFinished = std::chrono::nanoseconds(0);
-    initialize = std::chrono::nanoseconds(0);
+    callTargetRequestRejit = 0;
+    jitInlining = 0;
+    jitCompilationStarted = 0;
+    moduleUnloadStarted = 0;
+    moduleLoadFinished = 0;
+    assemblyLoadFinished = 0;
+    initialize = 0;
 
     callTargetRequestRejitCount = 0;
     jitInliningCount = 0;
@@ -78,61 +63,60 @@ class Stats : public Singleton<Stats> {
   }
   SWStat CallTargetRequestRejitMeasure() {
     callTargetRequestRejitCount++;
-
-    return SWStat(&callTargetRequestRejit, &callTargetRequestRejitMutex);
+    return SWStat(&callTargetRequestRejit);
   }
   SWStat CallTargetRewriterCallbackMeasure() {
     callTargetRewriterCount++;
-    return SWStat(&callTargetRewriter, &callTargetRewriterMutex);
+    return SWStat(&callTargetRewriter);
   }
   SWStat JITInliningMeasure() {
     jitInliningCount++;
-    return SWStat(&jitInlining, &jitInliningMutex);
+    return SWStat(&jitInlining);
   }
   SWStat JITCompilationStartedMeasure() {
     jitCompilationStartedCount++;
-    return SWStat(&jitCompilationStarted, &jitCompilationStartedMutex);
+    return SWStat(&jitCompilationStarted);
   }
   SWStat ModuleUnloadStartedMeasure() {
     moduleUnloadStartedCount++;
-    return SWStat(&moduleUnloadStarted, &moduleUnloadStartedMutex);
+    return SWStat(&moduleUnloadStarted);
   }
   SWStat ModuleLoadFinishedMeasure() {
     moduleLoadFinishedCount++;
-    return SWStat(&moduleLoadFinished, &moduleLoadFinishedMutex);
+    return SWStat(&moduleLoadFinished);
   }
   SWStat AssemblyLoadFinishedMeasure() {
     assemblyLoadFinishedCount++;
-    return SWStat(&assemblyLoadFinished, &assemblyLoadFinishedMutex);
+    return SWStat(&assemblyLoadFinished);
   }
   SWStat InitializeMeasure() {
-      return SWStat(&initialize, &initializeMutex);
+      return SWStat(&initialize);
   }
   std::string ToString() {
     std::stringstream ss;
     ss << "[Initialize=";
-    ss << initialize.count() / 1000000 << "ms";
+    ss << initialize.load() / 1000000 << "ms";
     ss << ", ModuleLoadFinished=";
-    ss << moduleLoadFinished.count() / 1000000 << "ms"
-       << "/" << moduleLoadFinishedCount;
+    ss << moduleLoadFinished.load() / 1000000 << "ms"
+       << "/" << moduleLoadFinishedCount.load();
     ss << ", CallTargetRequestRejit=";
-    ss << callTargetRequestRejit.count() / 1000000 << "ms"
-       << "/" << callTargetRequestRejitCount;
+    ss << callTargetRequestRejit.load() / 1000000 << "ms"
+       << "/" << callTargetRequestRejitCount.load();
     ss << ", CallTargetRewriter=";
-    ss << callTargetRewriter.count() / 1000000 << "ms"
-       << "/" << callTargetRewriterCount;
+    ss << callTargetRewriter.load() / 1000000 << "ms"
+       << "/" << callTargetRewriterCount.load();
     ss << ", AssemblyLoadFinished=";
-    ss << assemblyLoadFinished.count() / 1000000 << "ms"
-       << "/" << assemblyLoadFinishedCount;
+    ss << assemblyLoadFinished.load() / 1000000 << "ms"
+       << "/" << assemblyLoadFinishedCount.load();
     ss << ", ModuleUnloadStarted=";
-    ss << moduleUnloadStarted.count() / 1000000 << "ms"
-       << "/" << moduleUnloadStartedCount;
+    ss << moduleUnloadStarted.load() / 1000000 << "ms"
+       << "/" << moduleUnloadStartedCount.load();
     ss << ", JitCompilationStarted=";
-    ss << jitCompilationStarted.count() / 1000000 << "ms"
-       << "/" << jitCompilationStartedCount;
+    ss << jitCompilationStarted.load() / 1000000 << "ms"
+       << "/" << jitCompilationStartedCount.load();
     ss << ", JitInlining=";
-    ss << jitInlining.count() / 1000000 << "ms"
-       << "/" << jitInliningCount;
+    ss << jitInlining.load() / 1000000 << "ms"
+       << "/" << jitInliningCount.load();
     ss << "]";
     return ss.str();
   }

--- a/src/Datadog.Trace.ClrProfiler.Native/stats.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/stats.h
@@ -1,0 +1,118 @@
+#ifndef DD_CLR_PROFILER_STATS_H_
+#define DD_CLR_PROFILER_STATS_H_
+
+#include "util.h"
+#include <chrono>
+
+namespace trace {
+
+class SWStat {
+  std::chrono::nanoseconds *_value;
+  std::chrono::steady_clock::time_point _startTime;
+
+ public:
+  SWStat(std::chrono::nanoseconds *value) {
+      _value = value;
+      _startTime = std::chrono::steady_clock::now();
+  }
+  ~SWStat() {
+    *_value += std::chrono::steady_clock::now() - _startTime;
+  }
+};
+
+class Stats : public Singleton<Stats> {
+  friend class Singleton<Stats>;
+
+ private:
+  std::chrono::nanoseconds callTargetRequestRejit;
+  std::chrono::nanoseconds callTargetRewriter;
+  std::chrono::nanoseconds jitInlining;
+  std::chrono::nanoseconds jitCompilationStarted;
+  std::chrono::nanoseconds moduleUnloadStarted;
+  std::chrono::nanoseconds moduleLoadFinished;
+  std::chrono::nanoseconds assemblyLoadFinished;
+  std::chrono::nanoseconds initialize;
+
+  //
+  unsigned int callTargetRequestRejitCount;
+  unsigned int callTargetRewriterCount;
+  unsigned int jitInliningCount;
+  unsigned int jitCompilationStartedCount;
+  unsigned int moduleUnloadStartedCount;
+  unsigned int moduleLoadFinishedCount;
+  unsigned int assemblyLoadFinishedCount;
+
+ public:
+  Stats() {
+    callTargetRequestRejit = std::chrono::nanoseconds(0);
+    jitInlining = std::chrono::nanoseconds(0);
+    jitCompilationStarted = std::chrono::nanoseconds(0);
+    moduleUnloadStarted = std::chrono::nanoseconds(0);
+    moduleLoadFinished = std::chrono::nanoseconds(0);
+    assemblyLoadFinished = std::chrono::nanoseconds(0);
+    initialize = std::chrono::nanoseconds(0);
+
+    callTargetRequestRejitCount = 0;
+    jitInliningCount = 0;
+    jitCompilationStartedCount = 0;
+    moduleUnloadStartedCount = 0;
+    moduleLoadFinishedCount = 0;
+    assemblyLoadFinishedCount = 0;
+  }
+  SWStat CallTargetRequestRejitMeasure() {
+    callTargetRequestRejitCount++;
+    return SWStat(&callTargetRequestRejit);
+  }
+  SWStat CallTargetRewriterCallbackMeasure() {
+    callTargetRewriterCount++;
+    return SWStat(&callTargetRewriter);
+  }
+  SWStat JITInliningMeasure() {
+    jitInliningCount++;
+    return SWStat(&jitInlining);
+  }
+  SWStat JITCompilationStartedMeasure() {
+    jitCompilationStartedCount++;
+    return SWStat(&jitCompilationStarted);
+  }
+  SWStat ModuleUnloadStartedMeasure() {
+    moduleUnloadStartedCount++;
+    return SWStat(&moduleUnloadStarted);
+  }
+  SWStat ModuleLoadFinishedMeasure() {
+    moduleLoadFinishedCount++;
+    return SWStat(&moduleLoadFinished);
+  }
+  SWStat AssemblyLoadFinishedMeasure() {
+    assemblyLoadFinishedCount++;
+    return SWStat(&assemblyLoadFinished);
+  }
+  SWStat InitializeMeasure() {
+    return SWStat(&initialize);
+  }
+  std::string ToString() {
+    std::stringstream ss;
+    ss << "[Initialize=";
+    ss << initialize.count() / 1000000 << "ms";
+    ss << ", ModuleLoadFinished=";
+    ss << moduleLoadFinished.count() / 1000000 << "ms" << "/" << moduleLoadFinishedCount;
+    ss << ", CallTargetRequestRejit=";
+    ss << callTargetRequestRejit.count() / 1000000 << "ms" << "/" << callTargetRequestRejitCount;
+    ss << ", CallTargetRewriter=";
+    ss << callTargetRewriter.count() / 1000000 << "ms" << "/" << callTargetRewriterCount;
+    ss << ", AssemblyLoadFinished=";
+    ss << assemblyLoadFinished.count() / 1000000 << "ms" << "/" << assemblyLoadFinishedCount;
+    ss << ", ModuleUnloadStarted=";
+    ss << moduleUnloadStarted.count() / 1000000 << "ms" << "/" << moduleUnloadStartedCount;
+    ss << ", JitCompilationStarted=";
+    ss << jitCompilationStarted.count() / 1000000 << "ms" << "/" << jitCompilationStartedCount;
+    ss << ", JitInlining=";
+    ss << jitInlining.count() / 1000000 << "ms" << "/" << jitInliningCount;
+    ss << "]";
+    return ss.str();
+  }
+};
+
+}  // namespace trace
+
+#endif  // DD_CLR_PROFILER_STATS_H_


### PR DESCRIPTION
This PR adds lightweight native callback stats to the process exit message.

#### Example:

```
...
04/23/21 04:29:16.018 PM [10736|13008] [info] Exiting ReJIT request thread.
04/23/21 04:29:16.018 PM [10736|14028] [warning] Exiting. Stats: [Initialize=30ms, ModuleLoadFinished=607ms/343, CallTargetRequestRejit=1ms/14, CallTargetRewriter=2ms/4, AssemblyLoadFinished=21ms/343, ModuleUnloadStarted=0ms/0, JitCompilationStarted=523ms/14997, JitInlining=3ms/18398]
```

```
...
04/23/21 04:29:16.539 PM [3860|14456] [info] Exiting ReJIT request thread.
04/23/21 04:29:16.539 PM [3860|15184] [warning] Exiting. Stats: [Initialize=26ms, ModuleLoadFinished=153ms/86, CallTargetRequestRejit=1ms/5, CallTargetRewriter=1ms/2, AssemblyLoadFinished=10ms/86, ModuleUnloadStarted=0ms/0, JitCompilationStarted=711ms/11193, JitInlining=2ms/21933]
```

@DataDog/apm-dotnet