### PR TITLE
Remove Microsoft.Win32.Registry from Datadog.Trace.BenchmarkDotNet and Benchmarks.Trace

### DIFF
--- a/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -20,14 +20,6 @@
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <!--
-    This reference allows us to build the code without precompiler directives,
-    but the logic at runtime will never try to use the Registry if it's not available
-    -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" PrivateAssets="all" />
-  </ItemGroup>
-
   <Import Project="..\Datadog.Trace.Ci.Shared\Datadog.Trace.Ci.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -44,7 +44,6 @@
     This reference allows us to build the code without precompiler directives,
     but the logic at runtime will never try to use the Registry if it's not available
     -->
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.14" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #1397 

@DataDog/apm-dotnet