### PR TITLE
Run Postgres tests in Windows integration-test pipelines

### DIFF
--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -294,6 +294,8 @@ jobs:
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
+  - template: steps/install-windows-services.yml
+
   - task: NuGetCommand@2
     displayName: nuget restore
     inputs:

--- a/.azure-pipelines/steps/install-windows-services.yml
+++ b/.azure-pipelines/steps/install-windows-services.yml
@@ -1,0 +1,77 @@
+steps:
+- bash: |
+    # Sourced from https://github.com/npgsql/npgsql/blob/v5.0.4/.github/workflows/build.yml
+    # Some configuration is tweaked for tests in the npgsql/npgsql repo
+
+    # Find EnterpriseDB version number
+    EDB_VERSION=$(pwsh -c "
+        \$global:progressPreference='silentlyContinue';
+        Invoke-WebRequest -URI https://www.postgresql.org/applications-v2.xml |
+            Select-Object -ExpandProperty Content |
+            Select-Xml -XPath '/applications/application[id=\"postgresql_13\" and platform=\"windows-x64\"]/version/text()' |
+            Select-Object -First 1 -ExpandProperty Node |
+            Select-Object -ExpandProperty Value")
+
+    # Install PostgreSQL
+    echo "Installing PostgreSQL (version: ${EDB_VERSION})"
+    curl -o pgsql.zip -L https://get.enterprisedb.com/postgresql/postgresql-${EDB_VERSION}-windows-x64-binaries.zip
+    unzip pgsql.zip -x 'pgsql/include/**' 'pgsql/doc/**' 'pgsql/pgAdmin 4/**' 'pgsql/StackBuilder/**'
+
+    # Match Npgsql CI Docker image and stash one level up
+    # Datadog: Remove usage of server.crt
+    # Datadog: Remove usage of server.key
+
+    # Find OSGEO version number
+    OSGEO_VERSION=$(\
+      curl -Ls https://download.osgeo.org/postgis/windows/pg13 |
+      sed -n 's/.*>postgis-bundle-pg13-\(3.[0-9]*.[0-9]*\)x64.zip<.*/\1/p' |
+      tail -n 1)
+
+    # Install PostGIS
+    echo "Installing PostGIS (version: ${OSGEO_VERSION})"
+    POSTGIS_FILE="postgis-bundle-pg13-${OSGEO_VERSION}x64"
+    curl -o postgis.zip -L https://download.osgeo.org/postgis/windows/pg13/${POSTGIS_FILE}.zip
+    unzip postgis.zip -d postgis
+    cp -a postgis/$POSTGIS_FILE/. pgsql/
+
+    # Start PostgreSQL
+    pgsql/bin/initdb -D pgsql/PGDATA -E UTF8 -U postgres
+    SOCKET_DIR=$(echo "$LOCALAPPDATA\Temp" | sed 's|\\|/|g')
+    sed -i "s|#unix_socket_directories = ''|unix_socket_directories = '$SOCKET_DIR'|" pgsql/PGDATA/postgresql.conf
+    sed -i "s|#wal_level =|wal_level = logical #|" pgsql/PGDATA/postgresql.conf
+    sed -i "s|#max_wal_senders =|max_wal_senders = 50 #|" pgsql/PGDATA/postgresql.conf
+    sed -i "s|#wal_sender_timeout =|wal_sender_timeout = 3s #|" pgsql/PGDATA/postgresql.conf
+    sed -i "s|#synchronous_standby_names =|synchronous_standby_names = 'npgsql_test_sync_standby' #|" pgsql/PGDATA/postgresql.conf
+    sed -i "s|#synchronous_commit =|synchronous_commit = local #|" pgsql/PGDATA/postgresql.conf
+    pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10' start
+
+    # Configure test account
+    pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests SUPERUSER LOGIN PASSWORD 'npgsql_tests'"
+    pgsql/bin/psql -U postgres -c "CREATE DATABASE npgsql_tests OWNER npgsql_tests"
+    pgsql/bin/psql -U postgres -c "CREATE EXTENSION citext" npgsql_tests
+    pgsql/bin/psql -U postgres -c "CREATE EXTENSION hstore" npgsql_tests
+    pgsql/bin/psql -U postgres -c "CREATE EXTENSION ltree" npgsql_tests
+    pgsql/bin/psql -U postgres -c "CREATE EXTENSION postgis" npgsql_tests
+
+    # user 'npgsql_tests_scram' must be created with password encrypted as scram-sha-256 (which only applies after restart)
+    sed -i "s|#password_encryption = md5|password_encryption = scram-sha-256|" pgsql/PGDATA/postgresql.conf
+
+    pgsql/bin/pg_ctl -D pgsql/PGDATA -l logfile -o '-c max_prepared_transactions=10' restart
+
+    pgsql/bin/psql -U postgres -c "CREATE ROLE npgsql_tests_scram SUPERUSER LOGIN PASSWORD 'npgsql_tests_scram'"
+
+    # Disable trust authentication except for unix domain sockets, requiring MD5
+    # passwords - some tests must fail if a password isn't provided.
+    if [ 13 -ge 13 ]; then
+          echo "local all all trust" > pgsql/PGDATA/pg_hba.conf
+          echo "host all npgsql_tests_scram all scram-sha-256" >> pgsql/PGDATA/pg_hba.conf
+    else
+          echo "host all npgsql_tests_scram all scram-sha-256" > pgsql/PGDATA/pg_hba.conf
+    fi
+    echo "host all all all md5" >> pgsql/PGDATA/pg_hba.conf
+    echo "host replication all all md5" >> pgsql/PGDATA/pg_hba.conf
+  displayName: Start PostgreSQL 13 (Windows)
+
+- bash: |
+    echo "##vso[task.setvariable variable=POSTGRES_CONNECTION_STRING]Server=localhost;Username=npgsql_tests;Password=npgsql_tests;Database=npgsql_tests;Timeout=0;Command Timeout=0"
+  displayName: Set POSTGRES_CONNECTION_STRING env variable

--- a/.azure-pipelines/steps/install-windows-services.yml
+++ b/.azure-pipelines/steps/install-windows-services.yml
@@ -2,6 +2,9 @@ steps:
 - bash: |
     # Sourced from https://github.com/npgsql/npgsql/blob/v5.0.4/.github/workflows/build.yml
     # Some configuration is tweaked for tests in the npgsql/npgsql repo
+    # Changes from original source:
+    # - Remove usage of SSL certs
+    # - Remove PostGIS
 
     # Find EnterpriseDB version number
     EDB_VERSION=$(pwsh -c "
@@ -16,23 +19,6 @@ steps:
     echo "Installing PostgreSQL (version: ${EDB_VERSION})"
     curl -o pgsql.zip -L https://get.enterprisedb.com/postgresql/postgresql-${EDB_VERSION}-windows-x64-binaries.zip
     unzip pgsql.zip -x 'pgsql/include/**' 'pgsql/doc/**' 'pgsql/pgAdmin 4/**' 'pgsql/StackBuilder/**'
-
-    # Match Npgsql CI Docker image and stash one level up
-    # Datadog: Remove usage of server.crt
-    # Datadog: Remove usage of server.key
-
-    # Find OSGEO version number
-    OSGEO_VERSION=$(\
-      curl -Ls https://download.osgeo.org/postgis/windows/pg13 |
-      sed -n 's/.*>postgis-bundle-pg13-\(3.[0-9]*.[0-9]*\)x64.zip<.*/\1/p' |
-      tail -n 1)
-
-    # Install PostGIS
-    echo "Installing PostGIS (version: ${OSGEO_VERSION})"
-    POSTGIS_FILE="postgis-bundle-pg13-${OSGEO_VERSION}x64"
-    curl -o postgis.zip -L https://download.osgeo.org/postgis/windows/pg13/${POSTGIS_FILE}.zip
-    unzip postgis.zip -d postgis
-    cp -a postgis/$POSTGIS_FILE/. pgsql/
 
     # Start PostgreSQL
     pgsql/bin/initdb -D pgsql/PGDATA -E UTF8 -U postgres
@@ -51,7 +37,6 @@ steps:
     pgsql/bin/psql -U postgres -c "CREATE EXTENSION citext" npgsql_tests
     pgsql/bin/psql -U postgres -c "CREATE EXTENSION hstore" npgsql_tests
     pgsql/bin/psql -U postgres -c "CREATE EXTENSION ltree" npgsql_tests
-    pgsql/bin/psql -U postgres -c "CREATE EXTENSION postgis" npgsql_tests
 
     # user 'npgsql_tests_scram' must be created with password encrypted as scram-sha-256 (which only applies after restart)
     sed -i "s|#password_encryption = md5|password_encryption = scram-sha-256|" pgsql/PGDATA/postgresql.conf

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -463,6 +463,8 @@ stages:
     - task: NuGetToolInstaller@1
       displayName: install nuget
 
+    - template: steps/install-windows-services.yml
+
     - task: NuGetCommand@2
       displayName: nuget restore
       inputs:

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Theory]
         [MemberData(nameof(GetNpgsql))]
         [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
         public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget, bool enableInlining)
         {
             SetCallTargetSettings(enableCallTarget, enableInlining);
@@ -106,6 +107,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [InlineData(true, false)]
         [InlineData(true, true)]
         [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
         public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
         {
             SetCallTargetSettings(enableCallTarget, enableInlining);


### PR DESCRIPTION
The `Samples.Npgsql` test application was not previously run because there's no postgres container that is a Windows container. After looking through the test code in the `npgsql/npgsql` repo, it turns out there are Windows downloads and it can be reliably installed and run on Windows.

This PR adds the setup code to start up postgres in the Windows VM (this could later be separated into its own Windows container) and runs the integration test.

@DataDog/apm-dotnet