### PR TITLE
Robert/dotnet 445 wrong service name for db command

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             _type = typeof(T);
             _fullName = _type.FullName;
-            _dbTypeName = ScopeFactory.GetDbType(_type.Name);
+            _dbTypeName = ScopeFactory.GetDbType(_type.Namespace, _type.Name);
             _operationName = $"{_dbTypeName}.query";
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Data;
-using System.Linq;
 using Datadog.Trace.ClrProfiler.Integrations.AdoNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
@@ -206,10 +205,11 @@ namespace Datadog.Trace.ClrProfiler
                     "SQLiteCommand" => "sqlite",
                     "InterceptableDbCommand" => null,
                     "ProfiledDbCommand" => null,
-                    _ when namespaceName.Length == 0 && commandTypeName == commandSuffix =>
-                        commandTypeName.ToLowerInvariant(),
+                    _ when namespaceName.Length == 0 && commandTypeName == commandSuffix => "command",
+                    _ when namespaceName.Contains('.') && commandTypeName == commandSuffix =>
+                        namespaceName.Substring(namespaceName.LastIndexOf('.')).ToLowerInvariant(),
                     _ when commandTypeName == commandSuffix =>
-                        namespaceName.Split('.').Last().ToLowerInvariant(),
+                        namespaceName.ToLowerInvariant(),
                     _ when commandTypeName.EndsWith(commandSuffix) =>
                         commandTypeName.Substring(0, commandTypeName.Length - commandSuffix.Length).ToLowerInvariant(),
                     _ => commandTypeName.ToLowerInvariant()

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Linq;
 using Datadog.Trace.ClrProfiler.Integrations.AdoNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
@@ -203,8 +204,17 @@ namespace Datadog.Trace.ClrProfiler
                     "MySqlCommand" => "mysql",
                     "SqliteCommand" => "sqlite",
                     "SQLiteCommand" => "sqlite",
-                    "InterceptableDbCommand" => null,
-                    "ProfiledDbCommand" => null,
+                    _ => null,
+                };
+
+            if (result != null || result == "InterceptableDbCommand" || result == "ProfiledDbCommand")
+            {
+                return result;
+            }
+
+            return
+                commandTypeName switch
+                {
                     _ when namespaceName.Length == 0 && commandTypeName == commandSuffix => "command",
                     _ when namespaceName.Contains('.') && commandTypeName == commandSuffix =>
                         namespaceName.Substring(namespaceName.LastIndexOf('.')).ToLowerInvariant(),
@@ -214,8 +224,6 @@ namespace Datadog.Trace.ClrProfiler
                         commandTypeName.Substring(0, commandTypeName.Length - commandSuffix.Length).ToLowerInvariant(),
                     _ => commandTypeName.ToLowerInvariant()
                 };
-
-            return result;
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeFactory.cs
@@ -206,6 +206,8 @@ namespace Datadog.Trace.ClrProfiler
                     "SQLiteCommand" => "sqlite",
                     "InterceptableDbCommand" => null,
                     "ProfiledDbCommand" => null,
+                    _ when namespaceName.Length == 0 && commandTypeName == commandSuffix =>
+                        commandTypeName.ToLowerInvariant(),
                     _ when commandTypeName == commandSuffix =>
                         namespaceName.Split('.').Last().ToLowerInvariant(),
                     _ when commandTypeName.EndsWith(commandSuffix) =>

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
@@ -52,7 +52,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void CreateDbCommandScope_UsesReplacementServiceNameWhenProvided(IDbCommand command)
         {
             // Set up tracer
-            var dbType = ScopeFactory.GetDbType(command.GetType().Name);
+            var t = command.GetType();
+            var dbType = ScopeFactory.GetDbType(t.Namespace, t.Name);
             var collection = new NameValueCollection
             {
                 { ConfigurationKeys.ServiceNameMappings, $"{dbType}:my-custom-type" }
@@ -86,6 +87,20 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             {
                 Assert.NotEqual("my-custom-type", outerScope.Span.ServiceName);
             }
+        }
+
+        [Theory]
+        [InlineData("System.Data.SqlClient", "SqlCommand", "sql-server")]
+        [InlineData("MySql.Data.MySqlClient", "MySqlCommand", "mysql")]
+        [InlineData("Npgsql", "NpgsqlCommand", "postgres")]
+        [InlineData("", "ProfiledDbCommand", null)]
+        [InlineData("", "ExampleCommand", "example")]
+        [InlineData("", "Example", "example")]
+        [InlineData("Custom.DB", "Command", "db")]
+        public void GetDbType_IgnoresReplacementServiceNameWhenNotProvided(string namespaceName, string commandTypeName, string expected)
+        {
+            var dbType = ScopeFactory.GetDbType(namespaceName, commandTypeName);
+            Assert.Equal(expected, dbType);
         }
 
         private static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command)

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeDBFactoryTests.cs
@@ -96,8 +96,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("", "ProfiledDbCommand", null)]
         [InlineData("", "ExampleCommand", "example")]
         [InlineData("", "Example", "example")]
+        [InlineData("", "Command", "command")]
         [InlineData("Custom.DB", "Command", "db")]
-        public void GetDbType_IgnoresReplacementServiceNameWhenNotProvided(string namespaceName, string commandTypeName, string expected)
+        public void GetDbType_CorrectNameGenerated(string namespaceName, string commandTypeName, string expected)
         {
             var dbType = ScopeFactory.GetDbType(namespaceName, commandTypeName);
             Assert.Equal(expected, dbType);

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -167,7 +167,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void CreateDbCommandScope_UsesReplacementServiceNameWhenProvided(IDbCommand command)
         {
             // Set up tracer
-            var dbType = ScopeFactory.GetDbType(command.GetType().Name);
+            var t = command.GetType();
+            var dbType = ScopeFactory.GetDbType(t.Namespace, t.Name);
             var collection = new NameValueCollection
             {
                 { ConfigurationKeys.ServiceNameMappings, $"{dbType}:my-custom-type" }


### PR DESCRIPTION
Fixes #
https://github.com/DataDog/dd-trace-dotnet/issues/1282

Changes proposed in this pull request:

Special cases for when the DbCommand name is command.



@DataDog/apm-dotnet