### PR TITLE
Add debug logs for partial flush

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -273,6 +273,8 @@ namespace Datadog.Trace.Agent
 
                 if (buffer.TraceCount > 0)
                 {
+                    Log.Debug<int, int>("Flushing {spans} spans across {traces} traces", buffer.SpanCount, buffer.TraceCount);
+
                     var success = await _api.SendTracesAsync(buffer.Data, buffer.TraceCount).ConfigureAwait(false);
 
                     if (success)

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -108,7 +108,19 @@ namespace Datadog.Trace
                 _spans.Add(span);
                 _openSpans--;
 
-                if (_openSpans == 0 || ShouldTriggerPartialFlush())
+                bool shouldFlush = _openSpans == 0;
+
+                if (!shouldFlush && ShouldTriggerPartialFlush())
+                {
+                    shouldFlush = true;
+                    Log.Debug<ulong, ulong, int>(
+                        "Closing span {spanId} triggered a partial flush of trace {traceId} with {spanCount} pending spans",
+                        span.SpanId,
+                        span.TraceId,
+                        _spans.Count);
+                }
+
+                if (shouldFlush)
                 {
                     spansToWrite = _spans.ToArray();
                     _spans.Clear();


### PR DESCRIPTION
The current logs only indicate the number of traces. To properly diagnose partial flush issues, we also need the number of spans.