### PR TITLE
Use the property to get the tag/metrics value

### DIFF
--- a/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Tagging;
 
 namespace Datadog.Trace.Sampling
 {
@@ -31,7 +32,17 @@ namespace Datadog.Trace.Sampling
                 return 1;
             }
 
-            var env = span.GetTag(Tags.Env);
+            string env;
+
+            if (span.Tags is CommonTags tags)
+            {
+                env = tags.Environment;
+            }
+            else
+            {
+                env = span.GetTag(Tags.Env);
+            }
+
             var service = span.ServiceName;
 
             var key = new SampleRateKey(service, env);

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using Datadog.Trace.Logging;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace
@@ -97,7 +98,14 @@ namespace Datadog.Trace
                 }
                 else
                 {
-                    span.SetMetric(Metrics.SamplingPriority, (int)_samplingPriority);
+                    if (span.Tags is CommonTags tags)
+                    {
+                        tags.SamplingPriority = (int)_samplingPriority;
+                    }
+                    else
+                    {
+                        span.SetMetric(Metrics.SamplingPriority, (int)_samplingPriority);
+                    }
                 }
             }
 


### PR DESCRIPTION
It doesn't make a big difference, but free optimization is free.

|               Method |     Mean |    Error |  StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|--------:|------:|--------:|-------:|------:|------:|----------:|
|  StartFinishSpan_Old | 593.9 ns | 10.99 ns | 9.74 ns |  1.00 |    0.00 | 0.0048 |     - |     - |     488 B |
|  StartFinishSpan_New | 564.3 ns | 10.70 ns | 9.48 ns |  0.95 |    0.02 | 0.0048 |     - |     - |     488 B |
|                      |          |          |         |       |         |        |       |       |           |
| StartFinishScope_Old | 687.6 ns | 10.35 ns | 9.18 ns |  1.00 |    0.00 | 0.0067 |     - |     - |     632 B |
| StartFinishScope_New | 664.9 ns |  9.49 ns | 8.41 ns |  0.97 |    0.02 | 0.0067 |     - |     - |     632 B |
