### PR TITLE
Remove "CallTarget:True, MethodInlining:False" test runs in integration-tests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -16,12 +16,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesWithNetStandard(bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandard(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
 #if NET452
             var expectedSpanCount = 28;
@@ -58,12 +57,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(true)]
+        [InlineData(false)]
         [Trait("Category", "EndToEnd")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,9 +22,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             foreach (object[] item in PackageVersions.MicrosoftDataSqlClient)
             {
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
@@ -31,9 +31,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [MemberData(nameof(GetMicrosoftDataSqlClient))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             // ALWAYS: 133 spans
             // - SqlCommand: 21 spans (3 groups * 7 spans)
@@ -89,14 +89,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,23 +18,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             SetServiceVersion("1.0.0");
         }
 
-        public static IEnumerable<object[]> GetMicrosoftDataSqlite()
-        {
-            foreach (object[] item in PackageVersions.MicrosoftDataSqlite)
-            {
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
-            }
-        }
-
         [Theory]
-        [MemberData(nameof(GetMicrosoftDataSqlite))]
+        [MemberData(nameof(PackageVersions.MicrosoftDataSqlite), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandard(string packageVersion)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget: true);
 
             var expectedSpanCount = 91;
 
@@ -66,15 +58,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -25,9 +26,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     continue;
                 }
 
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
@@ -40,37 +40,35 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
                     continue;
                 }
 
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetMySql8Data))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesWithNetStandardInMySql8(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandardInMySql8(string packageVersion, bool enableCallTarget)
         {
-            SubmitsTracesWithNetStandard(packageVersion, enableCallTarget, enableInlining);
+            SubmitsTracesWithNetStandard(packageVersion, enableCallTarget);
         }
 
         [Theory]
         [MemberData(nameof(GetOldMySqlData))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTracesWithNetStandardInOldMySql(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandardInOldMySql(string packageVersion, bool enableCallTarget)
         {
-            SubmitsTracesWithNetStandard(packageVersion, enableCallTarget, enableInlining);
+            SubmitsTracesWithNetStandard(packageVersion, enableCallTarget);
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 
@@ -92,9 +90,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             }
         }
 
-        private void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget, bool enableInlining)
+        private void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             // ALWAYS: 75 spans
             // - MySqlCommand: 19 spans (3 groups * 7 spans - 2 missing spans)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,18 +21,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             foreach (object[] item in PackageVersions.Npgsql)
             {
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetNpgsql))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             // ALWAYS: 77 spans
             // - NpgsqlCommand: 21 spans (3 groups * 7 spans)
@@ -102,13 +102,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,14 +22,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces(bool enableCallTarget, bool enableInlining)
+        public void SubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var expectedSpanCount = 21; // 7 queries * 3 groups (The group of generic constraint calls is not currently supported)
 
@@ -63,14 +63,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -3,6 +3,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using Datadog.Core.Tools;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,9 +22,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             foreach (object[] item in PackageVersions.SystemDataSqlClient)
             {
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
@@ -31,9 +31,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [MemberData(nameof(GetSystemDataSqlClient))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandard(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             // ALWAYS: 98 spans
             // - SqlCommand: 21 spans (3 groups * 7 spans)
@@ -99,14 +99,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -18,14 +18,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTracesWithNetStandard(bool enableCallTarget, bool enableInlining)
+        public void SubmitsTracesWithNetStandard(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var expectedSpanCount = 91;
 
@@ -58,15 +57,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget, bool enableInlining)
+        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var totalSpanCount = 21;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -21,16 +21,16 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             for (int i = 0; i < 10; i++)
             {
                 bool fastPath = i < 9;
-                yield return new object[] { i, fastPath, false };
-                yield return new object[] { i, fastPath, true };
+                yield return new object[] { i, fastPath };
+                yield return new object[] { i, fastPath };
             }
         }
 
         [Theory]
         [MemberData(nameof(MethodArgumentsData))]
-        public void MethodArgumentsInstrumentation(int numberOfArguments, bool fastPath, bool inlining)
+        public void MethodArgumentsInstrumentation(int numberOfArguments, bool fastPath)
         {
-            SetCallTargetSettings(true, inlining);
+            SetCallTargetSettings(enableCallTarget: true);
             SetEnvironmentVariable("DD_INTEGRATIONS", Path.Combine(EnvironmentHelper.GetSampleProjectDirectory(), "integrations.json"));
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -22,9 +22,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             foreach (var item in PackageVersions.ElasticSearch5)
             {
-                yield return item.Concat(false, false);
-                yield return item.Concat(true, false);
-                yield return item.Concat(true, true);
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
@@ -32,9 +31,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [MemberData(nameof(GetElasticsearch))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTraces(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTraces(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -23,9 +23,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             foreach (var item in PackageVersions.ElasticSearch6)
             {
-                yield return item.Concat(false, false);
-                yield return item.Concat(true, false);
-                yield return item.Concat(true, true);
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
@@ -33,9 +32,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [MemberData(nameof(GetElasticsearch))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTraces(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTraces(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -65,12 +65,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void SubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int aspNetCorePort = TcpPortProvider.GetOpenPort();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -234,6 +234,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_VERSION", serviceVersion);
         }
 
+        protected void SetCallTargetSettings(bool enableCallTarget)
+        {
+            SetEnvironmentVariable("DD_TRACE_CALLTARGET_ENABLED", enableCallTarget ? "true" : "false");
+        }
+
         protected void SetCallTargetSettings(bool enableCallTarget, bool enableMethodInlining)
         {
             SetEnvironmentVariable("DD_TRACE_CALLTARGET_ENABLED", enableCallTarget ? "true" : "false");

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -25,7 +25,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             new List<InliningOptions>
             {
                 new InliningOptions(enableCallTarget: false, enableInlining: false),
-                new InliningOptions(enableCallTarget: true, enableInlining: false),
                 new InliningOptions(enableCallTarget: true, enableInlining: true),
             };
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -19,18 +19,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             foreach (var item in PackageVersions.MongoDB)
             {
-                yield return item.Concat(false, false);
-                yield return item.Concat(true, false);
-                yield return item.Concat(true, true);
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetMongoDb))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTraces(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -25,18 +25,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             foreach (object[] item in PackageVersions.RabbitMQ)
             {
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(new object[] { false, }).ToArray();
+                yield return item.Concat(new object[] { true }).ToArray();
             }
         }
 
         [Theory]
         [MemberData(nameof(GetRabbitMQVersions))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTraces(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             var expectedSpanCount = 26;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -21,18 +21,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             foreach (object[] item in PackageVersions.ServiceStackRedis)
             {
-                yield return item.Concat(new object[] { false, false, }).ToArray();
-                yield return item.Concat(new object[] { true, false, }).ToArray();
-                yield return item.Concat(new object[] { true, true, }).ToArray();
+                yield return item.Concat(false);
+                yield return item.Concat(true);
             }
         }
 
         [Theory]
         [MemberData(nameof(GetServiceStackRedisData))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion, bool enableCallTarget, bool enableInlining)
+        public void SubmitsTraces(string packageVersion, bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int agentPort = TcpPortProvider.GetOpenPort();
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -22,12 +22,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void SubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             Output.WriteLine("Starting WcfTests.SubmitsTraces. Starting the Samples.Wcf requires ADMIN privileges");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -20,12 +20,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void SubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int expectedSpanCount = 25;
             const string expectedOperationName = "http.request";
@@ -66,12 +65,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void TracingDisabled_DoesNotSubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TracingDisabled_DoesNotSubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             const string expectedOperationName = "http.request";
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -21,12 +21,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void SubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 71 : 27; // .NET Framework automatic instrumentation doesn't cover Async / TaskAsync operations
 
@@ -70,12 +69,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void TracingDisabled_DoesNotSubmitsTraces(bool enableCallTarget, bool enableInlining)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TracingDisabled_DoesNotSubmitsTraces(bool enableCallTarget)
         {
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             const string expectedOperationName = "http.request";
 


### PR DESCRIPTION
Remove this configuration because we expect passing test cases in the "CallTarget:True, MethodInlining:True" scenario to be sufficient and make the MethodInlining:False redundant. This will slightly reduce the duration of the integration-tests test run.

@DataDog/apm-dotnet