### PR TITLE
Remove AgentWriter log

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -99,7 +99,6 @@ namespace Datadog.Trace
 
             if (agentWriter == null)
             {
-                Log.Warning("Using eager agent writer");
                 _agentWriter = new AgentWriter(new Api(Settings.AgentUri, TransportStrategy.Get(Settings), Statsd), Statsd, maxBufferSize: Settings.TraceBufferSize);
             }
             else


### PR DESCRIPTION
This log serves no purpose today. It's a remnant from when there was a configuration key to enable eager serialization.