### PR TITLE
DuckType extensions optimisation

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -666,6 +666,16 @@ namespace Datadog.Trace.DuckTyping
         /// <typeparam name="T">Type of proxy definition</typeparam>
         public static class CreateCache<T>
         {
+            /// <summary>
+            /// Gets the type of T
+            /// </summary>
+            public static readonly Type Type = typeof(T);
+
+            /// <summary>
+            /// Gets if the T type is visible
+            /// </summary>
+            public static readonly bool IsVisible = Type.IsPublic || Type.IsNestedPublic;
+
             private static CreateTypeResult _fastPath = default;
 
             /// <summary>
@@ -729,14 +739,13 @@ namespace Datadog.Trace.DuckTyping
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private static CreateTypeResult GetProxySlow(Type targetType)
             {
-                Type proxyTypeDefinition = typeof(T);
 #if NET45
-                if (!proxyTypeDefinition.IsValueType && !UseDirectAccessTo(proxyTypeDefinition))
+                if (!Type.IsValueType && !IsVisible)
                 {
-                    DuckTypeTypeIsNotPublicException.Throw(proxyTypeDefinition, nameof(proxyTypeDefinition));
+                    DuckTypeTypeIsNotPublicException.Throw(Type, nameof(Type));
                 }
 #endif
-                return GetOrCreateProxyType(proxyTypeDefinition, targetType);
+                return GetOrCreateProxyType(Type, targetType);
             }
         }
     }

--- a/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (typeof(T).IsPublic || typeof(T).IsNestedPublic)
+            if (DuckType.CreateCache<T>.IsVisible)
             {
                 DuckType.CreateTypeResult proxyResult = DuckType.CreateCache<T>.GetProxy(instance.GetType());
                 if (proxyResult.Success)
@@ -104,7 +104,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (typeof(T).IsPublic || typeof(T).IsNestedPublic)
+            if (DuckType.CreateCache<T>.IsVisible)
             {
                 DuckType.CreateTypeResult proxyResult = DuckType.CreateCache<T>.GetProxy(instance.GetType());
                 if (proxyResult.Success)
@@ -156,7 +156,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (typeof(T).IsPublic || typeof(T).IsNestedPublic)
+            if (DuckType.CreateCache<T>.IsVisible)
             {
                 return DuckType.CanCreate<T>(instance);
             }


### PR DESCRIPTION
This PR adds a cache layer for `Type.IsPublic` and `Type.IsNestedPublic` to avoid the extern call on `TryDuckCast`, `DuckAs` and `DuckIs` extension methods.

### Benchmarks:

#### Current:
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.928 (2004/?/20H1)
Intel Core i7-1068NG7 CPU 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=5.0.202
  [Host]     : .NET Core 3.1.14 (CoreCLR 4.700.21.16201, CoreFX 4.700.21.16208), X64 RyuJIT
  DefaultJob : .NET Core 3.1.14 (CoreCLR 4.700.21.16201, CoreFX 4.700.21.16208), X64 RyuJIT


|      Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|---------:|---------:|-------:|------:|------:|----------:|
| TryDuckCast | 29.93 ns | 0.254 ns | 0.225 ns | 0.0025 |     - |     - |      24 B |
|    DuckCast | 22.92 ns | 0.406 ns | 0.380 ns | 0.0025 |     - |     - |      24 B |
|      DuckAs | 30.03 ns | 0.169 ns | 0.158 ns | 0.0024 |     - |     - |      24 B |
|      DuckIs | 18.91 ns | 0.147 ns | 0.123 ns |      - |     - |     - |         - |
```

#### PR:
```

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.928 (2004/?/20H1)
Intel Core i7-1068NG7 CPU 2.30GHz, 1 CPU, 2 logical and 2 physical cores
.NET Core SDK=5.0.202
  [Host]     : .NET Core 3.1.14 (CoreCLR 4.700.21.16201, CoreFX 4.700.21.16208), X64 RyuJIT
  DefaultJob : .NET Core 3.1.14 (CoreCLR 4.700.21.16201, CoreFX 4.700.21.16208), X64 RyuJIT


|      Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|---------:|---------:|-------:|------:|------:|----------:|
| TryDuckCast | 20.64 ns | 0.303 ns | 0.253 ns | 0.0025 |     - |     - |      24 B |
|    DuckCast | 23.05 ns | 0.486 ns | 0.681 ns | 0.0025 |     - |     - |      24 B |
|      DuckAs | 23.52 ns | 0.379 ns | 0.601 ns | 0.0025 |     - |     - |      24 B |
|      DuckIs | 11.05 ns | 0.028 ns | 0.023 ns |      - |     - |     - |         - |
```


@DataDog/apm-dotnet