### PR TITLE
Remove more "CallTarget:True, MethodInlining:False" test runs in integration-tests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc4TestsCallsite : AspNetMvc4Tests
     {
         public AspNetMvc4TestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+            : base(iisFixture, output, enableCallTarget: false)
         {
         }
     }
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc4TestsCallTarget : AspNetMvc4Tests
     {
         public AspNetMvc4TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+            : base(iisFixture, output, enableCallTarget: true)
         {
         }
     }
@@ -33,11 +33,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetMvc4Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetMvc4Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget)
             : base("AspNetMvc4", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -21,15 +21,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc4TestsCallTargetNoInlining : AspNetMvc4Tests
-    {
-        public AspNetMvc4TestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
-        {
-        }
-    }
-
-    [Collection("IisTests")]
     public class AspNetMvc4TestsCallTarget : AspNetMvc4Tests
     {
         public AspNetMvc4TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc4WithFeatureFlagTestsCallsite : AspNetMvc4WithFeatureFlagTests
     {
         public AspNetMvc4WithFeatureFlagTestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+            : base(iisFixture, output, enableCallTarget: false)
         {
         }
     }
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc4WithFeatureFlagTestsCallTarget : AspNetMvc4WithFeatureFlagTests
     {
         public AspNetMvc4WithFeatureFlagTestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+            : base(iisFixture, output, enableCallTarget: true)
         {
         }
     }
@@ -33,11 +33,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetMvc4WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetMvc4WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget)
             : base("AspNetMvc4", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
             SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
 
             _iisFixture = iisFixture;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4WithFeatureFlagTests.cs
@@ -21,15 +21,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc4WithFeatureFlagTestsCallTargetNoInlining : AspNetMvc4WithFeatureFlagTests
-    {
-        public AspNetMvc4WithFeatureFlagTestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
-        {
-        }
-    }
-
-    [Collection("IisTests")]
     public class AspNetMvc4WithFeatureFlagTestsCallTarget : AspNetMvc4WithFeatureFlagTests
     {
         public AspNetMvc4WithFeatureFlagTestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -20,15 +20,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc5TestsCallTargetNoInlining : AspNetMvc5Tests
-    {
-        public AspNetMvc5TestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
-        {
-        }
-    }
-
-    [Collection("IisTests")]
     public class AspNetMvc5TestsCallTarget : AspNetMvc5Tests
     {
         public AspNetMvc5TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc5TestsCallsite : AspNetMvc5Tests
     {
         public AspNetMvc5TestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+            : base(iisFixture, output, enableCallTarget: false)
         {
         }
     }
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc5TestsCallTarget : AspNetMvc5Tests
     {
         public AspNetMvc5TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+            : base(iisFixture, output, enableCallTarget: true)
         {
         }
     }
@@ -32,11 +32,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetMvc5Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetMvc5Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget)
             : base("AspNetMvc5", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
@@ -21,15 +21,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [Collection("IisTests")]
-    public class AspNetMvc5WithFeatureFlagCallTargetNoInlining : AspNetMvc5WithFeatureFlagTests
-    {
-        public AspNetMvc5WithFeatureFlagCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
-        {
-        }
-    }
-
-    [Collection("IisTests")]
     public class AspNetMvc5WithFeatureFlagCallTarget : AspNetMvc5WithFeatureFlagTests
     {
         public AspNetMvc5WithFeatureFlagCallTarget(IisFixture iisFixture, ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5WithFeatureFlagTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc5WithFeatureFlagCallsite : AspNetMvc5WithFeatureFlagTests
     {
         public AspNetMvc5WithFeatureFlagCallsite(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+            : base(iisFixture, output, enableCallTarget: false)
         {
         }
     }
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetMvc5WithFeatureFlagCallTarget : AspNetMvc5WithFeatureFlagTests
     {
         public AspNetMvc5WithFeatureFlagCallTarget(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+            : base(iisFixture, output, enableCallTarget: true)
         {
         }
     }
@@ -33,12 +33,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetMvc5WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetMvc5WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget)
             : base("AspNetMvc5", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
             SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -20,15 +20,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [Collection("IisTests")]
-    public class AspNetWebApi2TestsCallTargetNoInlining : AspNetWebApi2Tests
-    {
-        public AspNetWebApi2TestsCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
-        {
-        }
-    }
-
-    [Collection("IisTests")]
     public class AspNetWebApi2TestsCallTarget : AspNetWebApi2Tests
     {
         public AspNetWebApi2TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetWebApi2TestsCallsite : AspNetWebApi2Tests
     {
         public AspNetWebApi2TestsCallsite(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+            : base(iisFixture, output, enableCallTarget: false)
         {
         }
     }
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetWebApi2TestsCallTarget : AspNetWebApi2Tests
     {
         public AspNetWebApi2TestsCallTarget(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+            : base(iisFixture, output, enableCallTarget: true)
         {
         }
     }
@@ -32,11 +32,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetWebApi2Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetWebApi2Tests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget)
             : base("AspNetMvc5", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
 
             _iisFixture = iisFixture;
             _iisFixture.TryStartIis(this);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
@@ -21,15 +21,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [Collection("IisTests")]
-    public class AspNetWebApi2WithFeatureFlagCallTargetNoInlining : AspNetWebApi2WithFeatureFlagTests
-    {
-        public AspNetWebApi2WithFeatureFlagCallTargetNoInlining(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: false)
-        {
-        }
-    }
-
-    [Collection("IisTests")]
     public class AspNetWebApi2WithFeatureFlagCallTarget : AspNetWebApi2WithFeatureFlagTests
     {
         public AspNetWebApi2WithFeatureFlagCallTarget(IisFixture iisFixture, ITestOutputHelper output)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2WithFeatureFlagTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetWebApi2WithFeatureFlagCallsite : AspNetWebApi2WithFeatureFlagTests
     {
         public AspNetWebApi2WithFeatureFlagCallsite(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: false, enableInlining: false)
+            : base(iisFixture, output, enableCallTarget: false)
         {
         }
     }
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     public class AspNetWebApi2WithFeatureFlagCallTarget : AspNetWebApi2WithFeatureFlagTests
     {
         public AspNetWebApi2WithFeatureFlagCallTarget(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, enableCallTarget: true, enableInlining: true)
+            : base(iisFixture, output, enableCallTarget: true)
         {
         }
     }
@@ -33,11 +33,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     {
         private readonly IisFixture _iisFixture;
 
-        public AspNetWebApi2WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget, bool enableInlining)
+        public AspNetWebApi2WithFeatureFlagTests(IisFixture iisFixture, ITestOutputHelper output, bool enableCallTarget)
             : base("AspNetMvc5", @"test\test-applications\aspnet", output)
         {
             SetServiceVersion("1.0.0");
-            SetCallTargetSettings(enableCallTarget, enableInlining);
+            SetCallTargetSettings(enableCallTarget);
             SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
 
             _iisFixture = iisFixture;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -242,12 +242,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_TRACE_CALLTARGET_ENABLED", enableCallTarget ? "true" : "false");
         }
 
-        protected void SetCallTargetSettings(bool enableCallTarget, bool enableMethodInlining)
-        {
-            SetEnvironmentVariable("DD_TRACE_CALLTARGET_ENABLED", enableCallTarget ? "true" : "false");
-            SetEnvironmentVariable("DD_CLR_ENABLE_INLINING", enableMethodInlining ? "true" : "false");
-        }
-
         protected async Task AssertWebServerSpan(
             string path,
             MockTracerAgent agent,


### PR DESCRIPTION
Follows on from work done in https://github.com/DataDog/dd-trace-dotnet/pull/1439. The AspNet integration tests were still testing the case where CallTarget:True, MethodInlining:False. Also removed the test helper that allows setting the inlining explicitly as no longer used in any paths. 🤞 should give a slight speed up to integration tests

@DataDog/apm-dotnet