### PR TITLE
Add benchmarks for log4net and nlog

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -80,7 +80,7 @@ stages:
       inputs:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
-        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
+        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 1500'
       env:
         DD_ENV: CI
         DD_SERVICE: dd-trace-dotnet

--- a/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -32,6 +32,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     <PackageReference Include="JetBrains.Profiler.Api" Version="1.1.7" />
+    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>


### PR DESCRIPTION
Initial results:

log4net:
```
|      Method |     Mean |   Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|--------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|         Log | 183.1 us | 4.02 us | 11.48 us |  1.00 |    0.00 |      - |     - |     - |      4 KB |
| EnrichedLog | 204.2 us | 4.06 us |  3.98 us |  1.20 |    0.06 | 0.2441 |     - |     - |  28.17 KB |
```

nlog:
```
|      Method |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|         Log |  2.357 us | 0.0465 us | 0.0681 us |  1.00 |    0.00 | 0.0229 |     - |     - |   1.98 KB |
| EnrichedLog | 14.132 us | 0.2751 us | 0.3168 us |  5.97 |    0.22 | 0.1831 |     - |     - |  16.74 KB |
```