### PR TITLE
Fix CallTarget resilience on integrations with async continuations

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator.cs
@@ -43,11 +43,32 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception ex)
                 {
-                    _continuation(instance, default, ex, state);
+                    try
+                    {
+                        // *
+                        // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                        // *
+                        _continuation(instance, default, ex, state);
+                    }
+                    catch (Exception contEx)
+                    {
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    }
+
                     throw;
                 }
 
-                _continuation(instance, default, default, state);
+                try
+                {
+                    // *
+                    // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                    // *
+                    _continuation(instance, default, default, state);
+                }
+                catch (Exception contEx)
+                {
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                }
             }
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
@@ -44,11 +44,34 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 }
                 catch (Exception ex)
                 {
-                    _continuation(instance, result, ex, state);
+                    try
+                    {
+                        // *
+                        // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                        // *
+                        _continuation(instance, result, ex, state);
+                    }
+                    catch (Exception contEx)
+                    {
+                        IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                    }
+
                     throw;
                 }
 
-                return _continuation(instance, result, null, state);
+                try
+                {
+                    // *
+                    // Calls the CallTarget integration continuation, exceptions here should never bubble up to the application
+                    // *
+                    return _continuation(instance, result, null, state);
+                }
+                catch (Exception contEx)
+                {
+                    IntegrationOptions<TIntegration, TTarget>.LogException(contEx, "Exception occurred when calling the CallTarget integration continuation.");
+                }
+
+                return result;
             }
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationOptions.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationOptions.cs
@@ -17,10 +17,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         internal static void DisableIntegration() => _disableIntegration = true;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void LogException(Exception exception)
+        internal static void LogException(Exception exception, string message = null)
         {
             // ReSharper disable twice ExplicitCallerInfoArgument
-            Log.Error(exception, exception?.Message);
+            Log.Error(exception, message ?? exception?.Message);
             if (exception is DuckTypeException)
             {
                 Log.Warning($"DuckTypeException has been detected, the integration <{typeof(TIntegration)}, {typeof(TTarget)}> will be disabled.");

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -47,6 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 int beginMethodCount = Regex.Matches(processResult.StandardOutput, beginMethodString).Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
+                int exceptionCount = Regex.Matches(processResult.StandardOutput, "Exception thrown.").Count;
 
                 string[] typeNames = new string[]
                 {
@@ -58,8 +59,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     ".ReturnGenericMethod",
                 };
 
-                Assert.Equal(32, beginMethodCount);
-                Assert.Equal(32, endMethodCount);
+                Assert.Equal(42, beginMethodCount);
+                Assert.Equal(42, endMethodCount);
+                Assert.Equal(10, exceptionCount);
                 foreach (var typeName in typeNames)
                 {
                     Assert.Contains(typeName, processResult.StandardOutput);

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -59,9 +59,21 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     ".ReturnGenericMethod",
                 };
 
-                Assert.Equal(42, beginMethodCount);
-                Assert.Equal(42, endMethodCount);
-                Assert.Equal(10, exceptionCount);
+                if (numberOfArguments == 0)
+                {
+                    // On number of arguments = 0 the throw exception on integrations async continuation runs.
+                    // So we have 1 more case with an exception being reported from the integration.
+                    Assert.Equal(43, beginMethodCount);
+                    Assert.Equal(43, endMethodCount);
+                    Assert.Equal(11, exceptionCount);
+                }
+                else
+                {
+                    Assert.Equal(42, beginMethodCount);
+                    Assert.Equal(42, endMethodCount);
+                    Assert.Equal(10, exceptionCount);
+                }
+
                 foreach (var typeName in typeNames)
                 {
                     Assert.Contains(typeName, processResult.StandardOutput);

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsIntegration.cs
@@ -14,23 +14,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(0)<{typeof(Noop0ArgumentsIntegration)}, {typeof(TTarget)}>({instance})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop0ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop0ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsIntegration.cs
@@ -43,7 +43,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop0ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop0ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(0)<{typeof(Noop0ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop0ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsIntegration.cs
@@ -43,7 +43,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop1ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsIntegration.cs
@@ -14,23 +14,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(1)<{typeof(Noop1ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}>({instance}, {arg1})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop1ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop1ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop1ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(1)<{typeof(Noop1ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}>({instance}, {arg1})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop1ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsIntegration.cs
@@ -14,23 +14,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(2)<{typeof(Noop2ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}>({instance}, {arg1}, {arg2})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop2ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop2ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsIntegration.cs
@@ -43,7 +43,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop2ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop2ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(2)<{typeof(Noop2ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}>({instance}, {arg1}, {arg2})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop2ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop3ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsIntegration.cs
@@ -15,23 +15,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(3)<{typeof(Noop3ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}>({instance}, {arg1}, {arg2}, {arg3})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop3ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop3ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop3ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(3)<{typeof(Noop3ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}>({instance}, {arg1}, {arg2}, {arg3})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop3ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop4ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsIntegration.cs
@@ -15,23 +15,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(4)<{typeof(Noop4ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop4ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop4ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop4ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(4)<{typeof(Noop4ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop4ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsIntegration.cs
@@ -15,23 +15,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(5)<{typeof(Noop5ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop5ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop5ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop5ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop5ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(5)<{typeof(Noop5ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop5ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsIntegration.cs
@@ -15,23 +15,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, instance.Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(6)<{typeof(Noop6ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}, {typeof(TArg6)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5}, {arg6})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop6ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop6ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop6ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop6ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(6)<{typeof(Noop6ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}, {typeof(TArg6)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5}, {arg6})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop6ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsIntegration.cs
@@ -15,23 +15,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, ((IDuckType)instance).Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(7)<{typeof(Noop7ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}, {typeof(TArg6)}, {typeof(TArg7)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5}, {arg6}, {arg7})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop7ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop7ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop7ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop7ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(7)<{typeof(Noop7ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}, {typeof(TArg6)}, {typeof(TArg7)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5}, {arg6}, {arg7})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop7ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsIntegration.cs
@@ -10,28 +10,46 @@ namespace CallTargetNativeTest.NoOp
     public static class Noop8ArgumentsIntegration
     {
         public static CallTargetState OnMethodBegin<TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TArg3 : IArg
         {
             CallTargetState returnValue = new CallTargetState(null, ((IDuckType)instance).Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(8)<{typeof(Noop8ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}, {typeof(TArg6)}, {typeof(TArg7)}, {typeof(TArg8)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5}, {arg6}, {arg7}, {arg8})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop8ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop8ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop8ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop8ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(8)<{typeof(Noop8ArgumentsVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}, {typeof(TArg2)}, {typeof(TArg3)}, {typeof(TArg4)}, {typeof(TArg5)}, {typeof(TArg6)}, {typeof(TArg7)}, {typeof(TArg8)}>({instance}, {arg1}, {arg2}, {arg3}, {arg4}, {arg5}, {arg6}, {arg7}, {arg8})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop8ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsIntegration.cs
@@ -44,7 +44,7 @@ namespace CallTargetNativeTest.NoOp
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop9ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
-            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnAsyncEnd") == true)
             {
                 Console.WriteLine("Exception thrown.");
                 throw new Exception();

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsIntegration.cs
@@ -15,23 +15,41 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = new CallTargetState(null, ((IDuckType)instance).Instance);
             Console.WriteLine($"ProfilerOK: BeginMethod(Array)<{typeof(Noop9ArgumentsIntegration)}, {typeof(TTarget)}>({instance})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             CallTargetReturn<TReturn> rValue = new CallTargetReturn<TReturn>(returnValue);
             Console.WriteLine($"ProfilerOK: EndMethod(1)<{typeof(Noop9ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return rValue;
         }
 
         public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
-            where TTarget : IInstance
+            where TTarget : IInstance, IDuckType
             where TReturn : IReturnValue
         {
             Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(Noop9ArgumentsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsVoidIntegration.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/Noop9ArgumentsVoidIntegration.cs
@@ -12,6 +12,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetState returnValue = CallTargetState.GetDefault();
             Console.WriteLine($"ProfilerOK: BeginMethod(Array)<{typeof(Noop9ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
 
@@ -19,6 +25,12 @@ namespace CallTargetNativeTest.NoOp
         {
             CallTargetReturn returnValue = CallTargetReturn.GetDefault();
             Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(Noop9ArgumentsVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
             return returnValue;
         }
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -174,6 +174,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With0ArgumentsStatic.ReturnGenericMethod<int>());
             Console.WriteLine();
             //
+            var w0TBegin = new With0ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w0TBegin.VoidMethod());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w0TBegin.ReturnValueMethod());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w0TBegin.ReturnReferenceMethod());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w0TBegin.ReturnGenericMethod<string>());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w0TBegin.ReturnGenericMethod<int>());
+            Console.WriteLine();
+            //
+            var w0TEnd = new With0ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w0TEnd.VoidMethod());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w0TEnd.ReturnValueMethod());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w0TEnd.ReturnReferenceMethod());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w0TEnd.ReturnGenericMethod<string>());
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w0TEnd.ReturnGenericMethod<int>());
+            Console.WriteLine();
         }
 
         private static void Argument1()
@@ -262,6 +287,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With1ArgumentsStatic.ReturnGenericMethod<int, string>("Hello World"));
             Console.WriteLine();
             //
+            var w1TBegin = new With1ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w1TBegin.VoidMethod("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w1TBegin.ReturnValueMethod("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w1TBegin.ReturnReferenceMethod("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w1TBegin.ReturnGenericMethod<string, string>("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w1TBegin.ReturnGenericMethod<int, int>(42));
+            Console.WriteLine();
+            //
+            var w1TEnd = new With1ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w1TEnd.VoidMethod("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w1TEnd.ReturnValueMethod("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w1TEnd.ReturnReferenceMethod("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w1TEnd.ReturnGenericMethod<string, string>("Hello world"));
+            Console.WriteLine($"{typeof(With1ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w1TEnd.ReturnGenericMethod<int, int>(42));
+            Console.WriteLine();
         }
 
         private static void Argument2()
@@ -350,6 +400,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With2ArgumentsStatic.ReturnGenericMethod<int, string>("Hello World", 42));
             Console.WriteLine();
             //
+            var w2TBegin = new With2ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w2TBegin.VoidMethod("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w2TBegin.ReturnValueMethod("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w2TBegin.ReturnReferenceMethod("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w2TBegin.ReturnGenericMethod<string, string>("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w2TBegin.ReturnGenericMethod<int, int>(42, 99));
+            Console.WriteLine();
+            //
+            var w2TEnd = new With2ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w2TEnd.VoidMethod("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w2TEnd.ReturnValueMethod("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w2TEnd.ReturnReferenceMethod("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w2TEnd.ReturnGenericMethod<string, string>("Hello world", 42));
+            Console.WriteLine($"{typeof(With2ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w2TEnd.ReturnGenericMethod<int, int>(42, 99));
+            Console.WriteLine();
         }
 
         private static void Argument3()
@@ -438,6 +513,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With3ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>>("Hello World", 42, Tuple.Create(1, 2)));
             Console.WriteLine();
             //
+            var w3TBegin = new With3ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w3TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w3TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w3TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w3TBegin.ReturnGenericMethod<string, string, Tuple<int, int>>("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w3TBegin.ReturnGenericMethod<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2)));
+            Console.WriteLine();
+            //
+            var w3TEnd = new With3ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w3TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w3TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w3TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w3TEnd.ReturnGenericMethod<string, string, Tuple<int, int>>("Hello world", 42, Tuple.Create(1, 2)));
+            Console.WriteLine($"{typeof(With3ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w3TEnd.ReturnGenericMethod<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2)));
+            Console.WriteLine();
         }
 
         private static void Argument4()
@@ -526,6 +626,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With4ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>>("Hello World", 42, Tuple.Create(1, 2), Program.CompletedTask));
             Console.WriteLine();
             //
+            var w4TBegin = new With4ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w4TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w4TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w4TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w4TBegin.ReturnGenericMethod<string, string, Tuple<int, int>>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w4TBegin.ReturnGenericMethod<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine();
+            //
+            var w4TEnd = new With4ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w4TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w4TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w4TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w4TEnd.ReturnGenericMethod<string, string, Tuple<int, int>>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine($"{typeof(With4ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w4TEnd.ReturnGenericMethod<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2), Program.CompletedTask));
+            Console.WriteLine();
         }
 
         private static void Argument5()
@@ -614,6 +739,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With5ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>>("Hello World", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
             Console.WriteLine();
             //
+            var w5TBegin = new With5ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w5TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w5TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w5TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w5TBegin.ReturnGenericMethod<string, string, Tuple<int, int>>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w5TBegin.ReturnGenericMethod<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine();
+            //
+            var w5TEnd = new With5ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w5TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w5TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w5TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w5TEnd.ReturnGenericMethod<string, string, Tuple<int, int>>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine($"{typeof(With5ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w5TEnd.ReturnGenericMethod<int, int, Tuple<int, int>>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None));
+            Console.WriteLine();
         }
 
         private static void Argument6()
@@ -624,7 +774,7 @@ namespace CallTargetNativeTest
             Console.WriteLine($"{typeof(With6Arguments).FullName}.ReturnValueMethod");
             RunMethod(() => w6.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
             Console.WriteLine($"{typeof(With6Arguments).FullName}.ReturnReferenceMethod");
-            RunMethod(() => w6.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987).Wait());
+            RunMethod(() => w6.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
             Console.WriteLine($"{typeof(With6Arguments).FullName}.ReturnGenericMethod<string>");
             RunMethod(() => w6.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
             Console.WriteLine($"{typeof(With6Arguments).FullName}.ReturnGenericMethod<int>");
@@ -702,6 +852,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With6ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>, ulong>("Hello World", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
             Console.WriteLine();
             //
+            var w6TBegin = new With6ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w6TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w6TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w6TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w6TBegin.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w6TBegin.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine();
+            //
+            var w6TEnd = new With6ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w6TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w6TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w6TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w6TEnd.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine($"{typeof(With6ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w6TEnd.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987));
+            Console.WriteLine();
         }
 
         private static void Argument7()
@@ -790,6 +965,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With7ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>, ulong>("Hello World", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
             Console.WriteLine();
             //
+            var w7TBegin = new With7ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w7TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w7TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w7TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w7TBegin.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w7TBegin.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine();
+            //
+            var w7TEnd = new With7ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w7TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w7TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w7TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w7TEnd.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine($"{typeof(With7ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w7TEnd.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value"));
+            Console.WriteLine();
         }
 
         private static void Argument8()
@@ -878,6 +1078,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With8ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>, ulong>("Hello World", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
             Console.WriteLine();
             //
+            var w8TBegin = new With8ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w8TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w8TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w8TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w8TBegin.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w8TBegin.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine();
+            //
+            var w8TEnd = new With8ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w8TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w8TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w8TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w8TEnd.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine($"{typeof(With8ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w8TEnd.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly()));
+            Console.WriteLine();
         }
 
         private static void Argument9()
@@ -966,6 +1191,31 @@ namespace CallTargetNativeTest
             RunMethod(() => With9ArgumentsStatic.ReturnGenericMethod<int, string, Tuple<int, int>, ulong>("Hello World", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
             Console.WriteLine();
             //
+            var w9TBegin = new With9ArgumentsThrowOnBegin();
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnBegin).FullName}.VoidMethod");
+            RunMethod(() => w9TBegin.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnBegin).FullName}.ReturnValueMethod");
+            RunMethod(() => w9TBegin.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnBegin).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w9TBegin.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w9TBegin.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnBegin).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w9TBegin.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine();
+            //
+            var w9TEnd = new With9ArgumentsThrowOnEnd();
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnEnd).FullName}.VoidMethod");
+            RunMethod(() => w9TEnd.VoidMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnEnd).FullName}.ReturnValueMethod");
+            RunMethod(() => w9TEnd.ReturnValueMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnEnd).FullName}.ReturnReferenceMethod");
+            RunMethod(() => w9TEnd.ReturnReferenceMethod("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<string>");
+            RunMethod(() => w9TEnd.ReturnGenericMethod<string, string, Tuple<int, int>, ulong>("Hello world", 42, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine($"{typeof(With9ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
+            RunMethod(() => w9TEnd.ReturnGenericMethod<int, int, Tuple<int, int>, ulong>(42, 99, Tuple.Create(1, 2), Program.CompletedTask, CancellationToken.None, 987, "Arg7-Value", Assembly.GetExecutingAssembly(), null));
+            Console.WriteLine();
         }
 
 

--- a/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -199,6 +199,11 @@ namespace CallTargetNativeTest
             Console.WriteLine($"{typeof(With0ArgumentsThrowOnEnd).FullName}.ReturnGenericMethod<int>");
             RunMethod(() => w0TEnd.ReturnGenericMethod<int>());
             Console.WriteLine();
+            //
+            var w0TAsyncEnd = new With0ArgumentsThrowOnAsyncEnd();
+            Console.WriteLine($"{typeof(With0ArgumentsThrowOnAsyncEnd).FullName}.Wait2Seconds");
+            RunMethod(() => w0TAsyncEnd.Wait2Seconds().Wait());
+            Console.WriteLine();
         }
 
         private static void Argument1()

--- a/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
@@ -4,22 +4,19 @@
       "commandName": "Project",
       "commandLineArgs": "all",
       "environmentVariables": {
-        "COR_ENABLE_PROFILING": "1",
-        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
-
-        "CORECLR_ENABLE_PROFILING": "1",
-        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
-
-        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
-        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)integrations.json",
-        "DD_VERSION": "1.0.0",
-
         "DD_CTARGET_TESTMODE": "True",
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)profiler-lib",
+        "COR_ENABLE_PROFILING": "1",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "DD_DUMP_ILREWRITE_ENABLED": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "DD_TRACE_CALLTARGET_ENABLED": "1",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)integrations.json",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
+        "DD_VERSION": "1.0.0",
         "DD_CLR_ENABLE_INLINING": "1",
-        "DD_DUMP_ILREWRITE_ENABLED": "1"
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
       },
       "nativeDebugging": true
     }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With0Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With0Arguments.cs
@@ -31,5 +31,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod() => "Hello World";
         public static T ReturnGenericMethod<T>() => default;
     }
-
+    class With0ArgumentsThrowOnBegin : With0Arguments { }
+    class With0ArgumentsThrowOnEnd : With0Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With0Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With0Arguments.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace CallTargetNativeTest
 {
     // *** With0Arguments
@@ -33,4 +35,8 @@ namespace CallTargetNativeTest
     }
     class With0ArgumentsThrowOnBegin : With0Arguments { }
     class With0ArgumentsThrowOnEnd : With0Arguments { }
+    class With0ArgumentsThrowOnAsyncEnd
+    {
+        public Task Wait2Seconds() => Task.Delay(2000);
+    }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With1Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With1Arguments.cs
@@ -31,4 +31,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1>(TArg1 arg1) => default;
     }
+    class With1ArgumentsThrowOnBegin : With1Arguments { }
+    class With1ArgumentsThrowOnEnd : With1Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With2Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With2Arguments.cs
@@ -31,4 +31,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1>(TArg1 arg1, int arg2) => default;
     }
+    class With2ArgumentsThrowOnBegin : With2Arguments { }
+    class With2ArgumentsThrowOnEnd : With2Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With3Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With3Arguments.cs
@@ -31,4 +31,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3) => default;
     }
+    class With3ArgumentsThrowOnBegin : With3Arguments { }
+    class With3ArgumentsThrowOnEnd : With3Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With4Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With4Arguments.cs
@@ -33,4 +33,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3, Task arg4) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4) => default;
     }
+    class With4ArgumentsThrowOnBegin : With4Arguments { }
+    class With4ArgumentsThrowOnEnd : With4Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With5Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With5Arguments.cs
@@ -34,4 +34,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4, CancellationToken arg5) => default;
     }
+    class With5ArgumentsThrowOnBegin : With5Arguments { }
+    class With5ArgumentsThrowOnEnd : With5Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With6Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With6Arguments.cs
@@ -8,11 +8,7 @@ namespace CallTargetNativeTest
     {
         public void VoidMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5, ulong arg6) { }
         public int ReturnValueMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5, ulong arg6) => 42;
-        public async Task<string> ReturnReferenceMethod(string arg, int arg21, object arg3, Task arg4, CancellationToken arg5, ulong arg6)
-        {
-            await Task.Delay(4000);
-            return "Hello World";
-        }
+        public string ReturnReferenceMethod(string arg, int arg21, object arg3, Task arg4, CancellationToken arg5, ulong arg6) => "Hello World";
         public T ReturnGenericMethod<T, TArg1, TArg3, TArg6>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4, CancellationToken arg5, TArg6 arg6) => default;
     }
     class With6ArgumentsGeneric<T>
@@ -38,4 +34,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5, ulong arg6) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3, TArg6>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4, CancellationToken arg5, TArg6 arg6) => default;
     }
+    class With6ArgumentsThrowOnBegin : With6Arguments { }
+    class With6ArgumentsThrowOnEnd : With6Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With7Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With7Arguments.cs
@@ -34,4 +34,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5, ulong arg6, string arg7) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3, TArg6>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4, CancellationToken arg5, TArg6 arg6, string arg7) => default;
     }
+    class With7ArgumentsThrowOnBegin : With7Arguments { }
+    class With7ArgumentsThrowOnEnd : With7Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With8Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With8Arguments.cs
@@ -35,4 +35,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5, ulong arg6, string arg7, Assembly arg8) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3, TArg6>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4, CancellationToken arg5, TArg6 arg6, string arg7, Assembly arg8) => default;
     }
+    class With8ArgumentsThrowOnBegin : With8Arguments { }
+    class With8ArgumentsThrowOnEnd : With8Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/With9Arguments.cs
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/With9Arguments.cs
@@ -35,4 +35,6 @@ namespace CallTargetNativeTest
         public static string ReturnReferenceMethod(string arg1, int arg2, object arg3, Task arg4, CancellationToken arg5, ulong arg6, string arg7, Assembly arg8, int? arg9) => "Hello World";
         public static T ReturnGenericMethod<T, TArg1, TArg3, TArg6>(TArg1 arg1, int arg2, TArg3 arg3, Task arg4, CancellationToken arg5, TArg6 arg6, string arg7, Assembly arg8, int? arg9) => default;
     }
+    class With9ArgumentsThrowOnBegin : With9Arguments { }
+    class With9ArgumentsThrowOnEnd : With9Arguments { }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/integrations.json
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/integrations.json
@@ -70,6 +70,22 @@
         "caller": {},
         "target": {
           "assembly": "CallTargetNativeTest",
+          "type": "CallTargetNativeTest.With0ArgumentsThrowOnAsyncEnd",
+          "method": "Wait2Seconds",
+          "signature_types": [
+            "_"
+          ]
+        },
+        "wrapper": {
+          "assembly": "CallTargetNativeTest, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+          "type": "CallTargetNativeTest.NoOp.Noop0ArgumentsIntegration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "CallTargetNativeTest",
           "type": "CallTargetNativeTest.With0ArgumentsGeneric`1",
           "method": "VoidMethod",
           "signature_types": [


### PR DESCRIPTION
This PR includes:

1. Fixes the calltarget resilience on integrations with async continuatinos by wrapping the call inside a `try/catch`.
2. Adds unit test cases over integrations throwing exceptions in `OnMethodBegin`, `OnMethodEnd` and `OnMethodEndAsync` callbacks and not crashing the app.


@DataDog/apm-dotnet