### PR TITLE
fix misc build warnings

### DIFF
--- a/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Tool.csproj
+++ b/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Tool.csproj
@@ -14,6 +14,9 @@
     <PackageId>dd-trace</PackageId>
     <RootNamespace>Datadog.Trace.Tools.Runner</RootNamespace>
     <OutputPath>bin\$(Configuration)\Tool</OutputPath>
+
+      <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,22 +24,22 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="..\..\build\docker\linux-build.dockerfile" Link="linux-build.dockerfile" />
     <None Include="Datadog.Trace.Tools.Runner.proj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="home\**\*.*" Pack="true" PackagePath="\home">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Content Update="home\**\readme.txt" Pack="false">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>

--- a/test/test-applications/integrations/Samples.FakeKudu/Samples.FakeKudu.csproj
+++ b/test/test-applications/integrations/Samples.FakeKudu/Samples.FakeKudu.csproj
@@ -4,7 +4,7 @@
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 


### PR DESCRIPTION
Small PR to resolve a few build warnings:
- `Datadog.Trace.Tools.Runner.Tool.csproj`: disable warnings about EOL .NET Core targets
- `Samples.FakeKudu.csproj`: only add `System.Net.Http` assembly reference when targeting .NET Framework