### PR TITLE
remove obsolete OS checks and reference assemblies dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,6 @@
     <!-- Strong name signature -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Datadog.Trace.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
 

--- a/build/docker/build.sh
+++ b/build/docker/build.sh
@@ -42,7 +42,7 @@ fi
 
 dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 
-for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics Samples.FakeDbCommand Samples.Microsoft.Data.Sqlite Samples.SQLite.Core Samples.OracleMDA Samples.OracleMDA.Core ; do
+for sample in Samples.Elasticsearch Samples.Elasticsearch.V5 Samples.ServiceStack.Redis Samples.StackExchange.Redis Samples.SqlServer Samples.Microsoft.Data.SqlClient Samples.MongoDB Samples.HttpMessageHandler Samples.WebRequest Samples.Npgsql Samples.MySql Samples.GraphQL Samples.FakeKudu Samples.Dapper Samples.NoMultiLoader Samples.RabbitMQ Samples.RuntimeMetrics Samples.FakeDbCommand Samples.Microsoft.Data.Sqlite Samples.SQLite.Core Samples.OracleMDA.Core ; do
     dotnet publish -f $publishTargetFramework -c $buildConfiguration test/test-applications/integrations/$sample/$sample.csproj -p:Configuration=$buildConfiguration -p:ManagedProfilerOutputDirectory="$PUBLISH_OUTPUT"
 done
 

--- a/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Datadog.Trace.ClrProfiler.Managed.Loader</RootNamespace>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp2.0</TargetFrameworks>
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -27,8 +27,5 @@
 
     <!-- StyleCop -->
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.src.cs" />
-
-    <!-- reference assemblies let us target .NET Framework without the SDK (for example, on non-Windows) -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Platforms>x64;x86</Platforms>
+    <PlatformTarget>$(Platform)</PlatformTarget>
 
     <!--These should be consolidated in a file that can be shared for the tests and samples directories -->
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)'=='true' or '$(TestAllPackageVersions)'!='true'">$(DefineConstants);DEFAULT_SAMPLES</DefineConstants>
@@ -31,7 +32,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-  
+
   <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild">
     <ItemGroup>
       <!-- Subfolders of the output directory should each be a target framework -->

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Sinks.Observable" Version="2.0.1" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
-    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
 
+    <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -2,9 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -22,10 +22,5 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.test.cs" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <!-- reference assemblies let us target .NET Framework without the SDK (for example, on non-Windows) -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
 
 </Project>

--- a/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp3.1;net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <!-- benchmarkdotnet only support numberic values, not "latest"-->
@@ -13,12 +12,11 @@
     <!-- Strong name signature -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\Datadog.Trace.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DelaySign>false</DelaySign>
     <NoWarn>1591</NoWarn>
-    
+
      <!-- Tell Visual Studio to not create a new launchSettings.json file, even though we have AspNetCore assets -->
-    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>   
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/Directory.Build.props
+++ b/test/test-applications/Directory.Build.props
@@ -1,9 +1,7 @@
 <Project>
   <PropertyGroup>
     <OutputType Condition="'$(OutputType)' == ''">Exe</OutputType>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == '' and '$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TargetFrameworks)' == ''">netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net452;net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <LangVersion>latest</LangVersion>
@@ -40,7 +38,7 @@
              Link="profiler-lib\integrations.json" />
   </ItemGroup>
 
-  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild" 
+  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild"
           Condition=" '$(ExcludeManagedProfiler)' != 'true' AND '$(LoadManagedProfilerFromProfilerDirectory)' == 'true'">
     <ItemGroup>
       <!-- Subfolders of the output directory should each be a target framework -->

--- a/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\Directory.Build.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/test-applications/integrations/Directory.Build.props
+++ b/test/test-applications/integrations/Directory.Build.props
@@ -1,3 +1,0 @@
-<Project>
-  <Import Project="..\Directory.Build.props" />
-</Project>

--- a/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Samples.AspNetCoreRazorPages.csproj
+++ b/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Samples.AspNetCoreRazorPages.csproj
@@ -10,14 +10,13 @@
     <!-- Strong name signature -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(ProjectDir)../../../../Datadog.Trace.snk</AssemblyOriginatorKeyFile>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Compile Include="..\..\..\Datadog.Trace.IntegrationTests\DiagnosticListeners\ErrorHandlingHelper.cs" Link="ErrorHandlingHelper.cs" />
   </ItemGroup>

--- a/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Samples.AspNetCoreRazorPages.csproj
+++ b/test/test-applications/integrations/Samples.AspNetCoreRazorPages/Samples.AspNetCoreRazorPages.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
       <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
-      <Configurations>Debug;Release</Configurations>
-      <Platforms>x64;x86;AnyCPU</Platforms>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/test-applications/integrations/Samples.Dapper/Samples.Dapper.csproj
+++ b/test/test-applications/integrations/Samples.Dapper/Samples.Dapper.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
      <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <ApiVersion Condition="'$(ApiVersion)' == ''">5.3.0</ApiVersion>
 
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->

--- a/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <ApiVersion Condition="'$(ApiVersion)' == ''">6.1.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'>='6.1.0'">$(DefineConstants);ELASTICSEARCH_6_1</DefineConstants>

--- a/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Samples.Microsoft.Data.SqlClient.csproj
+++ b/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Samples.Microsoft.Data.SqlClient.csproj
@@ -4,8 +4,7 @@
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.0.1</ApiVersion>
 
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Samples.Microsoft.Data.Sqlite.csproj
+++ b/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Samples.Microsoft.Data.Sqlite.csproj
@@ -4,8 +4,7 @@
     <ApiVersion Condition="'$(ApiVersion)' == ''">5.0.2</ApiVersion>
 
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -25,5 +24,5 @@
     <!-- this referenced project only targets netstandard2.0 -->
     <ProjectReference Condition="'$(TargetFramework)' != 'net452'" Include="..\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/test-applications/integrations/Samples.OracleMDA.Core/Samples.OracleMDA.Core.csproj
+++ b/test/test-applications/integrations/Samples.OracleMDA.Core/Samples.OracleMDA.Core.csproj
@@ -4,8 +4,7 @@
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.19.101</ApiVersion>
 
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -16,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="$(ApiVersion)" />
-    
+
     <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
     <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+  <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />

--- a/test/test-applications/integrations/Samples.OracleMDA/Samples.OracleMDA.csproj
+++ b/test/test-applications/integrations/Samples.OracleMDA/Samples.OracleMDA.csproj
@@ -2,10 +2,7 @@
 
   <PropertyGroup>
     <ApiVersion Condition="'$(ApiVersion)' == ''">19.10.1</ApiVersion>
-
-    <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461</TargetFrameworks>
-    <TargetFrameworks Condition="$(MSBuildVersion) &gt;= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -20,13 +17,13 @@
     <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper\Samples.DatabaseHelper.csproj" />
     <ProjectReference Include="..\dependency-libs\Samples.DatabaseHelper.netstandard\Samples.DatabaseHelper.netstandard.csproj" />
   </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
+
+  <ItemGroup>
     <PackageReference Include="System.Security.Permissions" Version="5.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Management" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/test-applications/integrations/Samples.RabbitMQ/Samples.RabbitMQ.csproj
+++ b/test/test-applications/integrations/Samples.RabbitMQ/Samples.RabbitMQ.csproj
@@ -5,9 +5,7 @@
     <DefineConstants Condition="$(ApiVersion) >= 6.0.0">$(DefineConstants);RABBITMQ_6_0</DefineConstants>
 
     <!-- override to remove net452 -->
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
-    <!-- <TargetFrameworks Condition="'$(OS)' == 'Windows_NT' AND $(ApiVersion) &lt; 6.0.0">$(TargetFrameworks);net452</TargetFrameworks> -->
-    <TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0 AND !$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks);net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <DefineConstants Condition="$(ApiVersion) >= 6.0.0">$(DefineConstants);RABBITMQ_6_0</DefineConstants>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
@@ -18,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="RabbitMQ.Client" Version="$(ApiVersion)" />
   </ItemGroup>

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/Samples.DatabaseHelper.NetFramework20.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20/Samples.DatabaseHelper.NetFramework20.csproj
@@ -5,8 +5,4 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
-
 </Project>

--- a/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/Samples.DatabaseHelper.csproj
@@ -10,11 +10,6 @@
     <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- reference assemblies let us target .NET Framework without the SDK (for example, on non-Windows) -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
     <PackageReference Include="Dapper" Version="2.0.30" />
 

--- a/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/Samples.NoMultiLoader.Deps.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.NoMultiLoader.Deps/Samples.NoMultiLoader.Deps.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Data" />
   </ItemGroup>

--- a/test/test-applications/integrations/dependency-libs/Samples.Shared/Samples.Shared.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.Shared/Samples.Shared.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
     <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netstandard2.0;netcoreapp3.1;net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1;net45</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/Samples.SqlServer.Vb.vbproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb/Samples.SqlServer.Vb.vbproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netstandard2.0;netcoreapp3.1</TargetFrameworks>
-
+    <TargetFrameworks>net45;net461;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <ApiVersion Condition="'$(ApiVersion)' == ''">4.1.0</ApiVersion>
   </PropertyGroup>
 

--- a/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20/Samples.WebRequestHelper.NetFramework20.csproj
+++ b/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20/Samples.WebRequestHelper.NetFramework20.csproj
@@ -5,8 +5,4 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
-  
 </Project>

--- a/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/EntityFramework6x.MdTokenLookupFailure.csproj
+++ b/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/EntityFramework6x.MdTokenLookupFailure.csproj
@@ -14,6 +14,8 @@
     <Deterministic>true</Deterministic>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -145,11 +147,4 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets" Condition="Exists('..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net452.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net452.targets'))" />
-  </Target>
 </Project>

--- a/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/packages.config
+++ b/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.2.0" targetFramework="net452" />
-  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.0" targetFramework="net452" developmentDependency="true" />
-  <package id="Microsoft.NETFramework.ReferenceAssemblies.net452" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/test/test-applications/regression/Log4Net.SerializationException/Log4Net.SerializationException.csproj
+++ b/test/test-applications/regression/Log4Net.SerializationException/Log4Net.SerializationException.csproj
@@ -11,10 +11,6 @@
     <ProjectReference Include="..\dependency-libs\ApplicationWithLog4Net\ApplicationWithLog4Net.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-  </ItemGroup>
-
   <Target Name="AfterBuildMoveApplicationWithLog4Net" AfterTargets="AfterBuild">
     <ItemGroup>
       <!-- Subfolders of the output directory should each be a target framework -->

--- a/test/test-applications/regression/NLog10LogsInjection.NullReferenceException/NLog10LogsInjection.NullReferenceException.csproj
+++ b/test/test-applications/regression/NLog10LogsInjection.NullReferenceException/NLog10LogsInjection.NullReferenceException.csproj
@@ -1,8 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461</TargetFrameworks>
-    <IsPackable>false</IsPackable>
     <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
   </PropertyGroup>
 

--- a/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
+++ b/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
@@ -15,6 +15,8 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -117,7 +119,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -141,13 +142,6 @@
     <Resource Include="Watermark.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net472.targets" Condition="Exists('..\..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net472.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net472.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net472.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net472.targets'))" />
-  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/packages.config
+++ b/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.0" targetFramework="net472" developmentDependency="true" />
-  <package id="Microsoft.NETFramework.ReferenceAssemblies.net472" version="1.0.0" targetFramework="net472" developmentDependency="true" />
-</packages>

--- a/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
+++ b/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj
@@ -13,6 +13,8 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -87,7 +89,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\dependency-libs\Datadog.StackExchange.Redis.Abstractions\Datadog.StackExchange.Redis.Abstractions.csproj">
@@ -104,11 +105,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets" Condition="Exists('..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.NETFramework.ReferenceAssemblies.net45.1.0.0\build\Microsoft.NETFramework.ReferenceAssemblies.net45.targets'))" />
-  </Target>
 </Project>

--- a/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/packages.config
+++ b/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.NETFramework.ReferenceAssemblies" version="1.0.0" targetFramework="net45" developmentDependency="true" />
-  <package id="Microsoft.NETFramework.ReferenceAssemblies.net45" version="1.0.0" targetFramework="net45" developmentDependency="true" />
-</packages>

--- a/test/test-applications/regression/dependency-libs/ApplicationWithLog4Net/ApplicationWithLog4Net.csproj
+++ b/test/test-applications/regression/dependency-libs/ApplicationWithLog4Net/ApplicationWithLog4Net.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net45</TargetFrameworks>
-    <Platforms>x64;x86</Platforms>
-    <PlatformTarget>$(Platform)</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/test-applications/regression/dependency-libs/Directory.Build.props
+++ b/test/test-applications/regression/dependency-libs/Directory.Build.props
@@ -1,9 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net452;net461;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp2.1</TargetFrameworks>
-    <RuntimeIdentifiers Condition="'$(TargetFramework)' == 'netcoreapp2.1'">win-x64;win-x86;linux-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' != 'netcoreapp2.1'">win-$(Platform)</RuntimeIdentifier>
+    <TargetFrameworks>net452;net461;netcoreapp2.1</TargetFrameworks>
 
     <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
   </PropertyGroup>

--- a/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
+++ b/tools/Datadog.Core.Tools/Datadog.Core.Tools.csproj
@@ -10,9 +10,4 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- reference assemblies let us target .NET Framework without the SDK (for example, on non-Windows) -->
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
-  </ItemGroup>
-  
 </Project>


### PR DESCRIPTION
## Clean up in project files

The checks for `'$(OS)' == 'Windows_NT'` have been redundant since we added references to `Microsoft.NETFramework.ReferenceAssemblies`. These references assemblies allows the new .NET SDK to target .NET Framework (`net45`, `net461`, etc) even if the .NET Framework SDK is not installed (including on Linux and macOS).
- remove `<TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">`

.NET SDK 5.0 automatically includes the .NET Framework reference assemblies (see above) if needed, so we no longer need the explicit reference to `Microsoft.NETFramework.ReferenceAssemblies`.
- remove `<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies">`

.NET SDK 3.0 added support for signing assemblies on non-Windows OS. This [public signing](https://github.com/dotnet/runtime/blob/main/docs/project/public-signing.md) workaround is a holdover from the 2.x era.
- remove `<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>`

.NET SDK 3.0 and above can set `RuntimeIdentifiers` automatically in many cases.
- remove `<RuntimeIdentifiers>` and `<RuntimeIdentifier>` where not needed.

We now fully support .NET 5 everywhere. No need to check for MSBuild version anymore.
- remove `<TargetFrameworks Condition="$(MSBuildVersion) >= 16.8.0">$(TargetFrameworks);net5.0</TargetFrameworks>`

All managed library projects (`<OutputType>Library</OutputType>`) can target platform "Any CPU".
- remove `<Platforms>` and `<PlatformTarget>` from library projects
