### PR TITLE
Fix Call opcode in DuckTyping on struct targets.

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -366,7 +366,7 @@ namespace Datadog.Trace.DuckTyping
                     if (targetMethod.IsPublic)
                     {
                         // We can emit a normal call if we have a public instance with a public target method.
-                        il.EmitCall(targetMethod.IsStatic ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
+                        il.EmitCall(targetMethod.IsStatic || targetMethod.DeclaringType.IsValueType ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
                     }
                     else
                     {
@@ -411,7 +411,7 @@ namespace Datadog.Trace.DuckTyping
                     // Check if we can emit a normal Call/CallVirt to the target method
                     if (!targetMethod.ContainsGenericParameters)
                     {
-                        dynIL.EmitCall(targetMethod.IsStatic ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
+                        dynIL.EmitCall(targetMethod.IsStatic || targetMethod.DeclaringType.IsValueType ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
                     }
                     else
                     {

--- a/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -92,7 +92,7 @@ namespace Datadog.Trace.DuckTyping
                 if (targetMethod.IsPublic)
                 {
                     // We can emit a normal call if we have a public instance with a public property method.
-                    il.EmitCall(targetMethod.IsStatic ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
+                    il.EmitCall(targetMethod.IsStatic || instanceField.FieldType.IsValueType ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
                 }
                 else
                 {
@@ -127,7 +127,7 @@ namespace Datadog.Trace.DuckTyping
                     dynIL.WriteTypeConversion(dynParameters[idx], targetParameters[idx]);
                 }
 
-                dynIL.EmitCall(targetMethod.IsStatic ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
+                dynIL.EmitCall(targetMethod.IsStatic || instanceField.FieldType.IsValueType ? OpCodes.Call : OpCodes.Callvirt, targetMethod, null);
                 dynIL.WriteTypeConversion(targetProperty.PropertyType, returnType);
                 dynIL.Emit(OpCodes.Ret);
                 dynIL.Flush();

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckIgnoreTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckIgnoreTests.cs
@@ -37,6 +37,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             Assert.Equal((int)instance.Value, (int)proxy.Value);
             Assert.Equal(ValuesDuckType.Third.ToString(), proxy.GetValue());
             Assert.Equal(ValuesDuckType.Third.ToString(), ((IGetValue)proxy).GetValueProp);
+            Assert.Equal(42, proxy.GetAnswerToMeaningOfLife());
         }
 
         [Fact]
@@ -47,6 +48,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             Assert.Equal((int)instance.Value, (int)proxy.Value);
             Assert.Equal(ValuesDuckType.Third.ToString(), proxy.GetValue());
             Assert.Equal(ValuesDuckType.Third.ToString(), ((IGetValue)proxy).GetValueProp);
+            Assert.Equal(42, proxy.GetAnswerToMeaningOfLife());
         }
 
         [DuckCopy]
@@ -82,6 +84,8 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             [DuckIgnore]
             public string GetValue() => Value.ToString();
+
+            public abstract int GetAnswerToMeaningOfLife();
         }
 
         public class VirtualPrivateProxy : IGetValue
@@ -93,11 +97,15 @@ namespace Datadog.Trace.DuckTyping.Tests
 
             [DuckIgnore]
             public string GetValue() => Value.ToString();
+
+            public virtual int GetAnswerToMeaningOfLife() => default;
         }
 
         private readonly struct PrivateStruct
         {
             public readonly Values Value => Values.Third;
+
+            public int GetAnswerToMeaningOfLife() => 42;
         }
 
         public interface IGetValue


### PR DESCRIPTION
This PR fixes methods and properties calls on DuckTyping over struct targets by changing the `CallVirt` to a `Call` opcode.

A strange behavior was observed on net461 in Release mode when using `CallVirt` opcode. With this fix the DuckType test suite passes in both `Debug` and `Release`.

This PR has been tested in all 8 pipelines available.

@DataDog/apm-dotnet