### PR TITLE
Optimize log injection with NLog

### DIFF
--- a/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Datadog.Trace.Logging.LogProviders;
+
+namespace Datadog.Trace.Logging
+{
+    internal class CustomNLogLogProvider : NLogLogProvider
+    {
+        public void RegisterLayoutRenderers()
+        {
+            var logEventInfoType = FindType("NLog.LogEventInfo", "NLog");
+            var wrapFunc = (Func<Func<object>, object>)typeof(CustomNLogLogProvider).GetMethod(nameof(WrapFunc), BindingFlags.Static | BindingFlags.NonPublic)
+                .MakeGenericMethod(logEventInfoType)
+                .CreateDelegate(typeof(Func<Func<object>, object>));
+
+            var layoutRendererType = FindType("NLog.LayoutRenderers.LayoutRenderer", "NLog");
+            var register = GetRegisterLayoutRendererMethod(layoutRendererType, logEventInfoType);
+
+            register(CorrelationIdentifier.TraceIdKey, wrapFunc(() => Tracer.Instance?.ActiveScope?.Span.TraceId.ToString()));
+            register(CorrelationIdentifier.SpanIdKey, wrapFunc(() => Tracer.Instance?.ActiveScope?.Span.SpanId.ToString()));
+            register(CorrelationIdentifier.VersionKey, wrapFunc(() => Tracer.Instance?.Settings.ServiceVersion));
+            register(CorrelationIdentifier.EnvKey, wrapFunc(() => Tracer.Instance?.Settings.Environment));
+            register(CorrelationIdentifier.ServiceKey, wrapFunc(() => Tracer.Instance?.DefaultServiceName));
+        }
+
+        private static object WrapFunc<T>(Func<object> action)
+        {
+            return new Func<T, object>(_ => action());
+        }
+
+        private Action<string, object> GetRegisterLayoutRendererMethod(Type layoutRendererType, Type logEventInfoType)
+        {
+            var funcType = typeof(Func<,>).MakeGenericType(logEventInfoType, typeof(object));
+            var registerMethod = layoutRendererType.GetMethod("Register", typeof(string), funcType);
+
+            var nameParam = Expression.Parameter(typeof(string), "name");
+            var funcParam = Expression.Parameter(typeof(object), "func");
+
+            var castFuncParam = Expression.Convert(funcParam, funcType);
+
+            var call = Expression.Call(registerMethod, nameParam, castFuncParam);
+
+            return Expression.Lambda<Action<string, object>>(call, nameParam, funcParam).Compile();
+        }
+    }
+}

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -129,6 +129,10 @@ namespace Datadog.Trace.Logging
                         _serilogEnricher = customSerilogLogProvider.CreateEnricher(tracer);
                     }
                 }
+                else if (_logProvider is CustomNLogLogProvider customNLogLogProvider)
+                {
+                    customNLogLogProvider.RegisterLayoutRenderers();
+                }
                 else
                 {
                     _scopeManager.SpanActivated += MapOnSpanActivated;
@@ -216,6 +220,13 @@ namespace Datadog.Trace.Logging
                 Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
                     CustomSerilogLogProvider.IsLoggerAvailable,
                     () => new CustomSerilogLogProvider()));
+
+            // Register the custom NLog provider
+            LogProvider.LogProviderResolvers.Insert(
+                0,
+                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
+                    CustomNLogLogProvider.IsLoggerAvailable,
+                    () => new CustomNLogLogProvider()));
         }
 
         private void SetDefaultValues()

--- a/src/Datadog.Trace/Logging/NLogEnricher.cs
+++ b/src/Datadog.Trace/Logging/NLogEnricher.cs
@@ -1,0 +1,83 @@
+using System;
+
+namespace Datadog.Trace.Logging
+{
+    internal class NLogEnricher
+    {
+        private readonly object _versionProperty;
+        private readonly object _environmentProperty;
+        private readonly object _serviceProperty;
+        private readonly object _traceIdProperty;
+        private readonly object _spanIdProperty;
+
+        public NLogEnricher(Tracer tracer)
+        {
+            _versionProperty = tracer.Settings.ServiceVersion;
+            _environmentProperty = tracer.Settings.Environment;
+            _serviceProperty = tracer.DefaultServiceName;
+            _traceIdProperty = new TracerProperty(tracer, t => t.ActiveScope?.Span.TraceId.ToString());
+            _spanIdProperty = new TracerProperty(tracer, t => t.ActiveScope?.Span.SpanId.ToString());
+        }
+
+        public IDisposable Register(ILogProvider logProvider)
+        {
+            return new Context(logProvider, this);
+        }
+
+        /// <summary>
+        /// Wraps all the individual context objects in a single instance, that can be stored in an AsyncLocal
+        /// </summary>
+        private class Context : IDisposable
+        {
+            private readonly IDisposable _environment;
+            private readonly IDisposable _version;
+            private readonly IDisposable _service;
+            private readonly IDisposable _traceId;
+            private readonly IDisposable _spanId;
+
+            public Context(ILogProvider logProvider, NLogEnricher enricher)
+            {
+                try
+                {
+                    _environment = logProvider.OpenMappedContext(CorrelationIdentifier.EnvKey, enricher._environmentProperty);
+                    _version = logProvider.OpenMappedContext(CorrelationIdentifier.VersionKey, enricher._versionProperty);
+                    _service = logProvider.OpenMappedContext(CorrelationIdentifier.ServiceKey, enricher._serviceProperty);
+                    _traceId = logProvider.OpenMappedContext(CorrelationIdentifier.TraceIdKey, enricher._traceIdProperty);
+                    _spanId = logProvider.OpenMappedContext(CorrelationIdentifier.SpanIdKey, enricher._spanIdProperty);
+                }
+                catch
+                {
+                    // Clear the properties that are already mapped
+                    Dispose();
+                    throw;
+                }
+            }
+
+            public void Dispose()
+            {
+                _environment?.Dispose();
+                _version?.Dispose();
+                _service?.Dispose();
+                _traceId?.Dispose();
+                _spanId?.Dispose();
+            }
+        }
+
+        private class TracerProperty
+        {
+            private readonly Tracer _tracer;
+            private readonly Func<Tracer, string> _getter;
+
+            public TracerProperty(Tracer tracer, Func<Tracer, string> getter)
+            {
+                _tracer = tracer;
+                _getter = getter;
+            }
+
+            public override string ToString()
+            {
+                return _getter(_tracer);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
+++ b/test/Datadog.Trace.Tests/Logging/LoggingProviderTestHelpers.cs
@@ -1,14 +1,9 @@
 using System;
-using System.Globalization;
-using System.IO;
-using System.Text;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Moq;
-using Serilog.Formatting.Display;
-using Xunit;
 
 namespace Datadog.Trace.Tests.Logging
 {

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Tests.Logging
     {
         private const string NLogExpectedStringFormat = "\"{0}\": \"{1}\"";
 
-        private readonly ILogProvider _logProvider;
+        private readonly CustomNLogLogProvider _logProvider;
         private readonly ILog _logger;
         private readonly MemoryTarget _target;
 
@@ -27,6 +27,11 @@ namespace Datadog.Trace.Tests.Logging
             layout.Attributes.Add(new JsonAttribute("time", Layout.FromString("${longdate}")));
             layout.Attributes.Add(new JsonAttribute("level", Layout.FromString("${level:uppercase=true}")));
             layout.Attributes.Add(new JsonAttribute("message", Layout.FromString("${message}")));
+            layout.Attributes.Add(new JsonAttribute("env", Layout.FromString("${dd.env}")));
+            layout.Attributes.Add(new JsonAttribute("service", Layout.FromString("${dd.service}")));
+            layout.Attributes.Add(new JsonAttribute("version", Layout.FromString("${dd.version}")));
+            layout.Attributes.Add(new JsonAttribute("trace_id", Layout.FromString("${dd.trace_id}")));
+            layout.Attributes.Add(new JsonAttribute("span_id", Layout.FromString("${dd.span_id}")));
             _target = new MemoryTarget
             {
                 Layout = layout
@@ -37,7 +42,7 @@ namespace Datadog.Trace.Tests.Logging
             LogManager.Configuration = config;
             SimpleConfigurator.ConfigureForTargetLogging(_target, NLog.LogLevel.Trace);
 
-            _logProvider = new NLogLogProvider();
+            _logProvider = new CustomNLogLogProvider();
             LogProvider.SetCurrentLogProvider(_logProvider);
             _logger = new LoggerExecutionWrapper(_logProvider.GetLogger("test"));
         }
@@ -46,7 +51,7 @@ namespace Datadog.Trace.Tests.Logging
         public void LogsInjectionEnabledAddsParentCorrelationIdentifiers()
         {
             // Assert that the NLog log provider is correctly being used
-            Assert.IsType<NLogLogProvider>(LogProvider.CurrentLogProvider);
+            Assert.IsType<CustomNLogLogProvider>(LogProvider.CurrentLogProvider);
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
@@ -62,7 +67,7 @@ namespace Datadog.Trace.Tests.Logging
         public void LogsInjectionEnabledAddsChildCorrelationIdentifiers()
         {
             // Assert that the NLog log provider is correctly being used
-            Assert.IsType<NLogLogProvider>(LogProvider.CurrentLogProvider);
+            Assert.IsType<CustomNLogLogProvider>(LogProvider.CurrentLogProvider);
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
@@ -78,7 +83,7 @@ namespace Datadog.Trace.Tests.Logging
         public void LogsInjectionEnabledDoesNotAddCorrelationIdentifiersOutsideSpans()
         {
             // Assert that the NLog log provider is correctly being used
-            Assert.IsType<NLogLogProvider>(LogProvider.CurrentLogProvider);
+            Assert.IsType<CustomNLogLogProvider>(LogProvider.CurrentLogProvider);
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
@@ -94,7 +99,7 @@ namespace Datadog.Trace.Tests.Logging
         public void LogsInjectionEnabledUsesTracerServiceName()
         {
             // Assert that the NLog log provider is correctly being used
-            Assert.IsType<NLogLogProvider>(LogProvider.CurrentLogProvider);
+            Assert.IsType<CustomNLogLogProvider>(LogProvider.CurrentLogProvider);
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: true);
@@ -110,7 +115,7 @@ namespace Datadog.Trace.Tests.Logging
         public void DisabledLibLogSubscriberDoesNotAddCorrelationIdentifiers()
         {
             // Assert that the NLog log provider is correctly being used
-            Assert.IsType<NLogLogProvider>(LogProvider.CurrentLogProvider);
+            Assert.IsType<CustomNLogLogProvider>(LogProvider.CurrentLogProvider);
 
             // Instantiate a tracer for this test with default settings and set LogsInjectionEnabled to TRUE
             var tracer = LoggingProviderTestHelpers.InitializeTracer(enableLogsInjection: false);

--- a/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
+++ b/test/Datadog.Trace.Tests/Logging/NLogLogProviderTests.cs
@@ -27,11 +27,6 @@ namespace Datadog.Trace.Tests.Logging
             layout.Attributes.Add(new JsonAttribute("time", Layout.FromString("${longdate}")));
             layout.Attributes.Add(new JsonAttribute("level", Layout.FromString("${level:uppercase=true}")));
             layout.Attributes.Add(new JsonAttribute("message", Layout.FromString("${message}")));
-            layout.Attributes.Add(new JsonAttribute("env", Layout.FromString("${dd.env}")));
-            layout.Attributes.Add(new JsonAttribute("service", Layout.FromString("${dd.service}")));
-            layout.Attributes.Add(new JsonAttribute("version", Layout.FromString("${dd.version}")));
-            layout.Attributes.Add(new JsonAttribute("trace_id", Layout.FromString("${dd.trace_id}")));
-            layout.Attributes.Add(new JsonAttribute("span_id", Layout.FromString("${dd.span_id}")));
             _target = new MemoryTarget
             {
                 Layout = layout


### PR DESCRIPTION
Instead of registering the values of the properties for each span created, register properties for each trace and have those fetch the active span. 

|      Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
|         Old | 13.736 us | 0.0642 us | 0.0536 us | 0.1831 |     - |     - |  16.74 KB |
|         New |  5.899 us | 0.0828 us | 0.0774 us | 0.0687 |     - |     - |   6.34 KB |

Since Serilog and NLog now use a very similar logic, I think there's some refactoring to do. But I'm going to optimize log4net first so I can refactor them all at once.

