### PR TITLE
_dd.origin tag improvements.

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/TestTags.cs
+++ b/src/Datadog.Trace.Ci.Shared/TestTags.cs
@@ -87,5 +87,10 @@ namespace Datadog.Trace.Ci
         /// Parameters metadata TestName
         /// </summary>
         public const string MetadataTestName = "test_name";
+
+        /// <summary>
+        /// Origin value for CIApp Test
+        /// </summary>
+        public const string CIAppTestOriginName = "ciapp-test";
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             span.Type = SpanTypes.Test;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
             span.ResourceName = $"{testSuite}.{testName}";
+            span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             span.Type = SpanTypes.Test;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
             span.ResourceName = $"{testSuite}.{testName}";
-            span.SetOrigin(TestTags.CIAppTestOriginName);
+            span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -44,6 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             span.Type = SpanTypes.Test;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
             span.ResourceName = $"{testSuite}.{testName}";
+            span.SetOrigin(TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             span.Type = SpanTypes.Test;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
             span.ResourceName = $"{testSuite}.{testName}";
+            span.SetOrigin(TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             span.Type = SpanTypes.Test;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
             span.ResourceName = $"{testSuite}.{testName}";
-            span.SetOrigin(TestTags.CIAppTestOriginName);
+            span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -409,7 +409,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 span.Type = SpanTypes.Test;
                 span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                 span.ResourceName = $"{testSuite}.{testName}";
-                span.SetOrigin(TestTags.CIAppTestOriginName);
+                span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
                 span.SetTag(TestTags.Suite, testSuite);
                 span.SetTag(TestTags.Name, testName);
                 span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -409,6 +409,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 span.Type = SpanTypes.Test;
                 span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                 span.ResourceName = $"{testSuite}.{testName}";
+                span.SetOrigin(TestTags.CIAppTestOriginName);
                 span.SetTag(TestTags.Suite, testSuite);
                 span.SetTag(TestTags.Name, testName);
                 span.SetTag(TestTags.Framework, testFramework);

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -112,6 +112,7 @@ namespace Datadog.Trace
             sb.AppendLine($"TraceId: {Context.TraceId}");
             sb.AppendLine($"ParentId: {Context.ParentId}");
             sb.AppendLine($"SpanId: {Context.SpanId}");
+            sb.AppendLine($"Origin: {Context.Origin}");
             sb.AppendLine($"ServiceName: {ServiceName}");
             sb.AppendLine($"OperationName: {OperationName}");
             sb.AppendLine($"Resource: {ResourceName}");
@@ -366,6 +367,11 @@ namespace Datadog.Trace
         internal void ResetStartTime()
         {
             StartTime = Context.TraceContext.UtcNow;
+        }
+
+        internal void SetOrigin(string origin)
+        {
+            Context.Origin = origin;
         }
     }
 }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -314,6 +314,8 @@ namespace Datadog.Trace
             {
                 case Trace.Tags.SamplingPriority:
                     return ((int?)(Context.TraceContext?.SamplingPriority ?? Context.SamplingPriority))?.ToString();
+                case Trace.Tags.Origin:
+                    return Tags.GetTag(key) ?? Context.Origin;
                 default:
                     return Tags.GetTag(key);
             }

--- a/src/Datadog.Trace/Span.cs
+++ b/src/Datadog.Trace/Span.cs
@@ -142,6 +142,9 @@ namespace Datadog.Trace
             // some tags have special meaning
             switch (key)
             {
+                case Trace.Tags.Origin:
+                    Context.Origin = value;
+                    break;
                 case Trace.Tags.SamplingPriority:
                     if (Enum.TryParse(value, out SamplingPriority samplingPriority) &&
                         Enum.IsDefined(typeof(SamplingPriority), samplingPriority))
@@ -315,7 +318,7 @@ namespace Datadog.Trace
                 case Trace.Tags.SamplingPriority:
                     return ((int?)(Context.TraceContext?.SamplingPriority ?? Context.SamplingPriority))?.ToString();
                 case Trace.Tags.Origin:
-                    return Tags.GetTag(key) ?? Context.Origin;
+                    return Context.Origin;
                 default:
                     return Tags.GetTag(key);
             }
@@ -369,11 +372,6 @@ namespace Datadog.Trace
         internal void ResetStartTime()
         {
             StartTime = Context.TraceContext.UtcNow;
-        }
-
-        internal void SetOrigin(string origin)
-        {
-            Context.Origin = origin;
         }
     }
 }

--- a/src/Datadog.Trace/SpanContext.cs
+++ b/src/Datadog.Trace/SpanContext.cs
@@ -105,9 +105,9 @@ namespace Datadog.Trace
         public string ServiceName { get; set; }
 
         /// <summary>
-        /// Gets the origin of the trace
+        /// Gets or sets the origin of the trace
         /// </summary>
-        internal string Origin { get; }
+        internal string Origin { get; set; }
 
         /// <summary>
         /// Gets the trace context.

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -309,10 +309,12 @@ namespace Datadog.Trace.Tagging
                 }
             }
 
-            if (!isOriginWritten && !string.IsNullOrEmpty(span.Context.Origin))
+            string origin = span.Context.Origin;
+            if (!isOriginWritten && !string.IsNullOrEmpty(origin))
             {
                 count++;
-                WriteTag(ref bytes, ref offset, Trace.Tags.Origin, span.Context.Origin);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, StringBytesCache.OriginTagName);
+                offset += MessagePackBinary.WriteString(ref bytes, offset, origin);
             }
 
             if (count > 0)
@@ -375,6 +377,11 @@ namespace Datadog.Trace.Tagging
             }
 
             return offset - originalOffset;
+        }
+
+        private static class StringBytesCache
+        {
+            public static byte[] OriginTagName { get; } = Encoding.UTF8.GetBytes(Trace.Tags.Origin);
         }
     }
 }

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.Tagging
     {
         private static byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
         private static byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
+        private static byte[] _originBytes = Encoding.UTF8.GetBytes(Trace.Tags.Origin);
 
         private List<KeyValuePair<string, double>> _metrics;
         private List<KeyValuePair<string, string>> _tags;
@@ -313,7 +314,7 @@ namespace Datadog.Trace.Tagging
             if (!isOriginWritten && !string.IsNullOrEmpty(origin))
             {
                 count++;
-                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, StringBytesCache.OriginTagName);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _originBytes);
                 offset += MessagePackBinary.WriteString(ref bytes, offset, origin);
             }
 
@@ -377,11 +378,6 @@ namespace Datadog.Trace.Tagging
             }
 
             return offset - originalOffset;
-        }
-
-        private static class StringBytesCache
-        {
-            public static byte[] OriginTagName { get; } = Encoding.UTF8.GetBytes(Trace.Tags.Origin);
         }
     }
 }

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -284,11 +284,6 @@ namespace Datadog.Trace.Tagging
 
                     foreach (var pair in tags)
                     {
-                        if (pair.Key == Trace.Tags.Origin)
-                        {
-                            isOriginWritten = true;
-                        }
-
                         WriteTag(ref bytes, ref offset, pair.Key, pair.Value);
                     }
                 }

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.Tagging
     {
         private static byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
         private static byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
-        private static byte[] _originBytes = Encoding.UTF8.GetBytes(Trace.Tags.Origin);
+        private static byte[] _originBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Origin);
 
         private List<KeyValuePair<string, double>> _metrics;
         private List<KeyValuePair<string, string>> _tags;

--- a/src/Datadog.Trace/TraceContext.cs
+++ b/src/Datadog.Trace/TraceContext.cs
@@ -179,12 +179,6 @@ namespace Datadog.Trace
                 span.SetTag(Tags.AzureAppServicesRuntime, AzureAppServices.Metadata.Runtime);
                 span.SetTag(Tags.AzureAppServicesExtensionVersion, AzureAppServices.Metadata.SiteExtensionVersion);
             }
-
-            // set the origin tag to the root span of each trace/subtrace
-            if (span.Context.Origin != null)
-            {
-                span.SetTag(Tags.Origin, span.Context.Origin);
-            }
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -74,6 +74,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // checks the origin tag
+                        CheckOriginTag(targetSpan);
+
                         // check specific test span
                         switch (targetSpan.Tags[TestTags.Name])
                         {
@@ -253,6 +256,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             // Check the traits tag value
             AssertTargetSpanEqual(targetSpan, TestTags.Traits, "{\"Category\":[\"Category01\"],\"Compatibility\":[\"Windows\",\"Linux\"]}");
+        }
+
+        private static void CheckOriginTag(MockTracerAgent.Span targetSpan)
+        {
+            // Check the test origin tag
+            AssertTargetSpanEqual(targetSpan, Tags.Origin, TestTags.CIAppTestOriginName);
         }
 
         private static void CheckSimpleTestSpan(MockTracerAgent.Span targetSpan)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -93,6 +93,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // checks the origin tag
+                        CheckOriginTag(targetSpan);
+
                         // check specific test span
                         switch (targetSpan.Tags[TestTags.Name])
                         {
@@ -274,6 +277,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             // Check the traits tag value
             AssertTargetSpanEqual(targetSpan, TestTags.Traits, "{\"Category\":[\"Category01\"],\"Compatibility\":[\"Windows\",\"Linux\"]}");
+        }
+
+        private static void CheckOriginTag(MockTracerAgent.Span targetSpan)
+        {
+            // Check the test origin tag
+            AssertTargetSpanEqual(targetSpan, Tags.Origin, TestTags.CIAppTestOriginName);
         }
 
         private static void CheckSimpleTestSpan(MockTracerAgent.Span targetSpan)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -84,6 +84,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // checks the origin tag
+                        CheckOriginTag(targetSpan);
+
                         // check specific test span
                         switch (targetSpan.Tags[TestTags.Name])
                         {
@@ -274,6 +277,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             // Check the traits tag value
             AssertTargetSpanEqual(targetSpan, TestTags.Traits, "{\"Category\":[\"Category01\"],\"Compatibility\":[\"Windows\",\"Linux\"]}");
+        }
+
+        private static void CheckOriginTag(MockTracerAgent.Span targetSpan)
+        {
+            // Check the test origin tag
+            AssertTargetSpanEqual(targetSpan, Tags.Origin, TestTags.CIAppTestOriginName);
         }
 
         private static void CheckSimpleTestSpan(MockTracerAgent.Span targetSpan)

--- a/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
+++ b/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
@@ -1,0 +1,119 @@
+using System;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using MsgPack;
+using Xunit;
+
+namespace Datadog.Trace.IntegrationTests
+{
+    public class OriginTagSendTraces
+    {
+        private readonly Tracer _tracer;
+        private readonly TestApi _testApi;
+
+        public OriginTagSendTraces()
+        {
+            var settings = new TracerSettings();
+            _testApi = new TestApi();
+            var agentWriter = new AgentWriter(_testApi, statsd: null);
+            _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
+        }
+
+        [Fact]
+        public void NormalSpan()
+        {
+            var scope = _tracer.StartActive("Operation");
+            scope.Dispose();
+
+            var objects = _testApi.Wait();
+            var spanDictio = objects[0].FirstDictionary();
+            var metaDictio = spanDictio["meta"].AsDictionary();
+            Assert.False(metaDictio.ContainsKey(Tags.Origin));
+        }
+
+        [Fact]
+        public void NormalOriginSpan()
+        {
+            const string originValue = "ciapp-test";
+
+            using (var scope = _tracer.StartActive("Operation"))
+            {
+                scope.Span.SetTag(Tags.Origin, originValue);
+            }
+
+            var objects = _testApi.Wait();
+            var spanDictio = objects[0].FirstDictionary();
+            var metaDictio = spanDictio["meta"].AsDictionary();
+            Assert.True(metaDictio.ContainsKey(Tags.Origin));
+            Assert.Equal(originValue, metaDictio[Tags.Origin]);
+        }
+
+        [Fact]
+        public void OriginInMultipleSpans()
+        {
+            const string originValue = "ciapp-test";
+
+            using (var scope = _tracer.StartActive("Operation"))
+            {
+                scope.Span.SetTag(Tags.Origin, originValue);
+                using (var cs1 = _tracer.StartActive("Operation2"))
+                {
+                    using var cs01 = _tracer.StartActive("Operation2_01");
+                }
+
+                using (var cs2 = _tracer.StartActive("Operation2"))
+                {
+                    using var cs02 = _tracer.StartActive("Operation2_01");
+                }
+            }
+
+            var objects = _testApi.Wait();
+            var objectsList = objects[0].AsList();
+            foreach (MessagePackObject objValue in objectsList)
+            {
+                var spanDictio = objValue.FirstDictionary();
+                var metaDictio = spanDictio["meta"].AsDictionary();
+                Assert.True(metaDictio.ContainsKey(Tags.Origin));
+                Assert.Equal(originValue, metaDictio[Tags.Origin]);
+            }
+        }
+
+        [Fact]
+        public void MultipleOriginsSpans()
+        {
+            const string originValue = "ciapp-test_";
+            var origins = new string[] { originValue + "01", originValue + "02", originValue + "03" };
+
+            using (var scope = _tracer.StartActive("Operation"))
+            {
+                scope.Span.SetTag(Tags.Origin, originValue + "01");
+
+                using (var cs1 = _tracer.StartActive("Operation2"))
+                {
+                    cs1.Span.SetTag(Tags.Origin, originValue + "02");
+
+                    using var cs01 = _tracer.StartActive("Operation2_01");
+                }
+
+                using (var cs2 = _tracer.StartActive("Operation2"))
+                {
+                    cs2.Span.SetTag(Tags.Origin, originValue + "03");
+
+                    using var cs02 = _tracer.StartActive("Operation2_01");
+                }
+            }
+
+            var objects = _testApi.Wait();
+            var objectsList = objects[0].AsList();
+            foreach (MessagePackObject objValue in objectsList)
+            {
+                var spanDictio = objValue.FirstDictionary();
+                var metaDictio = spanDictio["meta"].AsDictionary();
+                Assert.True(metaDictio.ContainsKey(Tags.Origin));
+                var value = metaDictio[Tags.Origin];
+                Assert.True(Array.IndexOf(origins, value.ToString()) != -1);
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
+++ b/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
@@ -1,4 +1,10 @@
+// <copyright file="OriginTagSendTraces.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -83,7 +89,14 @@ namespace Datadog.Trace.IntegrationTests
         public void MultipleOriginsSpans()
         {
             const string originValue = "ciapp-test_";
-            var origins = new string[] { originValue + "01", originValue + "02", originValue + "03" };
+            var origins = new List<string>
+            {
+                originValue + "01",
+                originValue + "02",
+                originValue + "02",
+                originValue + "03",
+                originValue + "03"
+            };
 
             using (var scope = _tracer.StartActive("Operation"))
             {
@@ -112,7 +125,7 @@ namespace Datadog.Trace.IntegrationTests
                 var metaDictio = spanDictio["meta"].AsDictionary();
                 Assert.True(metaDictio.ContainsKey(Tags.Origin));
                 var value = metaDictio[Tags.Origin];
-                Assert.True(Array.IndexOf(origins, value.ToString()) != -1);
+                Assert.True(origins.Remove(value.ToString()));
             }
         }
     }

--- a/test/Datadog.Trace.IntegrationTests/TestApi.cs
+++ b/test/Datadog.Trace.IntegrationTests/TestApi.cs
@@ -1,3 +1,8 @@
+// <copyright file="TestApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/Datadog.Trace.IntegrationTests/TestApi.cs
+++ b/test/Datadog.Trace.IntegrationTests/TestApi.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using MsgPack;
+
+namespace Datadog.Trace.IntegrationTests
+{
+    internal class TestApi : IApi
+    {
+        private ManualResetEventSlim _resetEvent = new ManualResetEventSlim();
+        private List<MessagePackObject> _objects = null;
+
+        public List<MessagePackObject> Wait()
+        {
+            _resetEvent.Wait();
+            var objects = Interlocked.Exchange(ref _objects, null);
+            _resetEvent.Reset();
+            return objects;
+        }
+
+        public Task<bool> SendTracesAsync(ArraySegment<byte> traces, int numberOfTraces)
+        {
+            var packObject = Unpacking.UnpackObject(traces.ToArray()).Value.AsList();
+            if (packObject.Count > 0)
+            {
+                var previous = Interlocked.Exchange(ref _objects, null);
+                if (previous is not null)
+                {
+                    Interlocked.Exchange(ref _objects, previous.Concat(packObject.ToList()).ToList());
+                }
+                else
+                {
+                    Interlocked.Exchange(ref _objects, packObject.ToList());
+                }
+
+                _resetEvent.Set();
+            }
+
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/test/Datadog.Trace.TestHelpers/MsgPackHelpers.cs
+++ b/test/Datadog.Trace.TestHelpers/MsgPackHelpers.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
-        private static MessagePackObjectDictionary FirstDictionary(this MessagePackObject obj)
+        public static MessagePackObjectDictionary FirstDictionary(this MessagePackObject obj)
         {
             if (obj.IsList)
             {

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -354,7 +354,7 @@ namespace Datadog.Trace.Tests
             using var secondSpan = _tracer.StartActive("Child", firstSpan.Span.Context);
             Assert.False(secondSpan.Span.IsRootSpan);
             Assert.Equal(origin, secondSpan.Span.Context.Origin);
-            Assert.Null(secondSpan.Span.GetTag(Tags.Origin));
+            Assert.Equal(origin, secondSpan.Span.GetTag(Tags.Origin));
         }
 
         [Fact]

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -19,7 +19,8 @@ namespace Benchmarks.Trace
         private static readonly IAgentWriter AgentWriter;
         private static readonly Span[] Spans;
         private static readonly Span[] EnrichedSpans;
-
+        private static readonly Span[] SpansWithOrigin;
+        private static readonly Span[] EnrichedSpansWithOrigin;
         static AgentWriterBenchmark()
         {
             var settings = TracerSettings.FromDefaultSources();
@@ -33,6 +34,8 @@ namespace Benchmarks.Trace
 
             Spans = new Span[SpanCount];
             EnrichedSpans = new Span[SpanCount];
+            SpansWithOrigin = new Span[SpanCount];
+            EnrichedSpansWithOrigin = new Span[SpanCount];
             var now = DateTimeOffset.UtcNow;
 
             for (int i = 0; i < SpanCount; i++)
@@ -41,6 +44,13 @@ namespace Benchmarks.Trace
                 EnrichedSpans[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
                 EnrichedSpans[i].SetTag(Tags.Env, "Benchmark");
                 EnrichedSpans[i].SetMetric(Metrics.SamplingRuleDecision, 1.0);
+                //
+                SpansWithOrigin[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
+                SpansWithOrigin[i].SetTag(Tags.Origin, "synthetics");
+                EnrichedSpansWithOrigin[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
+                SpansWithOrigin[i].SetTag(Tags.Origin, "synthetics");
+                EnrichedSpansWithOrigin[i].SetTag(Tags.Env, "Benchmark");
+                EnrichedSpansWithOrigin[i].SetMetric(Metrics.SamplingRuleDecision, 1.0);
             }
 
             // Run benchmarks once to reduce noise
@@ -65,6 +75,26 @@ namespace Benchmarks.Trace
         public Task WriteAndFlushEnrichedTraces()
         {
             AgentWriter.WriteTrace(EnrichedSpans);
+            return AgentWriter.FlushTracesAsync();
+        }
+
+        /// <summary>
+        /// Write traces with origin to the agent and flushes them
+        /// </summary>
+        [Benchmark]
+        public Task WriteAndFlushTracesWithOrigin()
+        {
+            AgentWriter.WriteTrace(SpansWithOrigin);
+            return AgentWriter.FlushTracesAsync();
+        }
+
+        /// <summary>
+        /// Same as WriteAndFlushTraces but with more realistic traces (with tags and metrics) with origin
+        /// </summary>
+        [Benchmark]
+        public Task WriteAndFlushEnrichedTracesWithOrigin()
+        {
+            AgentWriter.WriteTrace(EnrichedSpansWithOrigin);
             return AgentWriter.FlushTracesAsync();
         }
 

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -56,6 +56,8 @@ namespace Benchmarks.Trace
             // Run benchmarks once to reduce noise
             new AgentWriterBenchmark().WriteAndFlushTraces().GetAwaiter().GetResult();
             new AgentWriterBenchmark().WriteAndFlushEnrichedTraces().GetAwaiter().GetResult();
+            new AgentWriterBenchmark().WriteAndFlushTracesWithOrigin().GetAwaiter().GetResult();
+            new AgentWriterBenchmark().WriteAndFlushEnrichedTracesWithOrigin().GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -48,7 +48,7 @@ namespace Benchmarks.Trace
                 SpansWithOrigin[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
                 SpansWithOrigin[i].SetTag(Tags.Origin, "synthetics");
                 EnrichedSpansWithOrigin[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
-                SpansWithOrigin[i].SetTag(Tags.Origin, "synthetics");
+                EnrichedSpansWithOrigin[i].SetTag(Tags.Origin, "synthetics");
                 EnrichedSpansWithOrigin[i].SetTag(Tags.Env, "Benchmark");
                 EnrichedSpansWithOrigin[i].SetMetric(Metrics.SamplingRuleDecision, 1.0);
             }


### PR DESCRIPTION
This PR includes the changes and improvements for Synthetics and CIApp over the internal `_dd.origin` tag.

#### Benchmarks:

Time in microseconds.

// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Xeon CPU E5-2673 v3 2.40GHz, 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  Job-QUYPTY : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
  Job-FQLGSK : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT

IterationTime=1.5000 s  

|                                Method |     Toolchain |     Mean |    Error |   StdDev | Allocated |
|-------------------------------------- |-------------- |---------:|---------:|---------:|----------:|
|                   WriteAndFlushTraces |        net472 | 611.3 us | 10.27 us | 10.09 us |   3.03 KB |
|                   WriteAndFlushTraces | netcoreapp3.1 | 482.3 us |  7.40 us |  6.92 us |   2.45 KB |
|                                       |               |          |          |          |           |
|           WriteAndFlushEnrichedTraces |        net472 | 821.9 us | 11.94 us | 10.58 us |   3.03 KB |
|           WriteAndFlushEnrichedTraces | netcoreapp3.1 | 641.6 us |  8.43 us |  7.48 us |   2.45 KB |
|                                       |               |          |          |          |           |
|         WriteAndFlushTracesWithOrigin |        net472 | 712.7 us | 13.93 us | 15.48 us |   3.03 KB |
|         WriteAndFlushTracesWithOrigin | netcoreapp3.1 | 537.6 us | 10.29 us | 10.57 us |   2.45 KB |
|                                       |               |          |          |          |           |
| WriteAndFlushEnrichedTracesWithOrigin |        net472 | 900.3 us |  9.71 us |  8.61 us |   3.03 KB |
| WriteAndFlushEnrichedTracesWithOrigin | netcoreapp3.1 | 689.2 us |  9.99 us |  9.34 us |   2.45 KB |

#### Performance impact over 1000 spans.
```
WriteAndFlushTraces/net472 = +101.4 us [max error 24.2 us]
WriteAndFlushTraces/netcoreapp3.1 = +55.3 us [max error 17.69 us]

WriteAndFlushEnrichedTraces/net472 = +78.4 us [max error 21.65 us]
WriteAndFlushEnrichedTraces/netcoreapp3.1 = +47.6 us [max error 18.42 us]
```
@DataDog/apm-dotnet