### PR TITLE
MessagePack Formatter: Cache Span tag keys in UTF8

### DIFF
--- a/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -7,6 +7,17 @@ namespace Datadog.Trace.Agent.MessagePack
 {
     internal class SpanMessagePackFormatter : IMessagePackFormatter<Span>
     {
+        private static byte[] _traceIdBytes = StringEncoding.UTF8.GetBytes("trace_id");
+        private static byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
+        private static byte[] _nameBytes = StringEncoding.UTF8.GetBytes("name");
+        private static byte[] _resourceBytes = StringEncoding.UTF8.GetBytes("resource");
+        private static byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("service");
+        private static byte[] _typeBytes = StringEncoding.UTF8.GetBytes("type");
+        private static byte[] _startBytes = StringEncoding.UTF8.GetBytes("start");
+        private static byte[] _durationBytes = StringEncoding.UTF8.GetBytes("duration");
+        private static byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
+        private static byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
+
         public int Serialize(ref byte[] bytes, int offset, Span value, IFormatterResolver formatterResolver)
         {
             // First, pack array length (or map length).
@@ -29,39 +40,39 @@ namespace Datadog.Trace.Agent.MessagePack
 
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, len);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "trace_id");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _traceIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.Context.TraceId);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "span_id");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanIdBytes);
             offset += MessagePackBinary.WriteUInt64(ref bytes, offset, value.Context.SpanId);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "name");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _nameBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, value.OperationName);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "resource");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _resourceBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, value.ResourceName);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "service");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _serviceBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, value.ServiceName);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "type");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _typeBytes);
             offset += MessagePackBinary.WriteString(ref bytes, offset, value.Type);
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "start");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _startBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, value.StartTime.ToUnixTimeNanoseconds());
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "duration");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _durationBytes);
             offset += MessagePackBinary.WriteInt64(ref bytes, offset, value.Duration.ToNanoseconds());
 
             if (value.Context.ParentId != null)
             {
-                offset += MessagePackBinary.WriteString(ref bytes, offset, "parent_id");
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _parentIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, (ulong)value.Context.ParentId);
             }
 
             if (value.Error)
             {
-                offset += MessagePackBinary.WriteString(ref bytes, offset, "error");
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _errorBytes);
                 offset += MessagePackBinary.WriteByte(ref bytes, offset, 1);
             }
 

--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -9,6 +9,9 @@ namespace Datadog.Trace.Tagging
 {
     internal abstract class TagsList : ITags
     {
+        private static byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
+        private static byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
+
         private List<KeyValuePair<string, double>> _metrics;
         private List<KeyValuePair<string, string>> _tags;
 
@@ -255,7 +258,7 @@ namespace Datadog.Trace.Tagging
         {
             int originalOffset = offset;
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "meta");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metaBytes);
 
             int count = 0;
 
@@ -302,7 +305,7 @@ namespace Datadog.Trace.Tagging
         {
             int originalOffset = offset;
 
-            offset += MessagePackBinary.WriteString(ref bytes, offset, "metrics");
+            offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _metricsBytes);
 
             int count = 0;
 


### PR DESCRIPTION
#### Old:

// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Xeon CPU E5-2673 v3 2.40GHz, 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  Job-WEIHTL : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
  Job-VTKECX : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT

IterationTime=1.5000 s  

|                      Method |        Job |       Runtime |     Toolchain |     Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------- |----------- |-------------- |-------------- |---------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
|         WriteAndFlushTraces | Job-WEIHTL |    .NET 4.7.2 |        net472 | 748.0 us | 10.84 us |  9.61 us |  1.00 |    0.00 |     - |     - |     - |   3.03 KB |
|         WriteAndFlushTraces | Job-VTKECX | .NET Core 3.1 | netcoreapp3.1 | 604.5 us | 11.94 us | 12.78 us |  0.81 |    0.02 |     - |     - |     - |   2.45 KB |
|                             |            |               |               |          |          |          |       |         |       |       |       |           |
| WriteAndFlushEnrichedTraces | Job-WEIHTL |    .NET 4.7.2 |        net472 | 937.3 us | 13.01 us | 11.54 us |  1.00 |    0.00 |     - |     - |     - |   3.04 KB |
| WriteAndFlushEnrichedTraces | Job-VTKECX | .NET Core 3.1 | netcoreapp3.1 | 743.7 us | 14.43 us | 16.04 us |  0.79 |    0.02 |     - |     - |     - |   2.45 KB |


#### New:

// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Xeon CPU E5-2673 v3 2.40GHz, 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=5.0.201
  [Host]     : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT
  Job-GAZNKL : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT
  Job-NQGFHJ : .NET Core 3.1.7 (CoreCLR 4.700.20.36602, CoreFX 4.700.20.37001), X64 RyuJIT

IterationTime=1.5000 s  

|                      Method |        Job |       Runtime |     Toolchain |     Mean |    Error |   StdDev | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------- |----------- |-------------- |-------------- |---------:|---------:|---------:|------:|--------:|------:|------:|------:|----------:|
|         WriteAndFlushTraces | Job-GAZNKL |    .NET 4.7.2 |        net472 | 604.9 us |  6.84 us |  6.06 us |  1.00 |    0.00 |     - |     - |     - |   3.03 KB |
|         WriteAndFlushTraces | Job-NQGFHJ | .NET Core 3.1 | netcoreapp3.1 | 467.7 us |  6.88 us |  5.74 us |  0.77 |    0.01 |     - |     - |     - |   2.45 KB |
|                             |            |               |               |          |          |          |       |         |       |       |       |           |
| WriteAndFlushEnrichedTraces | Job-GAZNKL |    .NET 4.7.2 |        net472 | 819.3 us | 15.33 us | 14.34 us |  1.00 |    0.00 |     - |     - |     - |   3.03 KB |
| WriteAndFlushEnrichedTraces | Job-NQGFHJ | .NET Core 3.1 | netcoreapp3.1 | 624.5 us |  7.92 us |  6.18 us |  0.76 |    0.02 |     - |     - |     - |   2.45 KB |


#### Diff:

1) WriteAndFlushTraces/net472: -143.1 us
2) WriteAndFlushTraces/netcoreapp3.1: -136,8 us
3) WriteAndFlushEnrichedTraces/net472: -118 us
4) WriteAndFlushEnrichedTraces/netcoreapp3.1: -119,2 us

![image](https://user-images.githubusercontent.com/69803/119346624-bdc93e00-bc9a-11eb-8d73-d6d449597d6d.png)


@DataDog/apm-dotnet