### PR TITLE
Add GH Action to auto-create benchmark branch

### DIFF
--- a/.github/workflows/create_benchmarks_branch.yml
+++ b/.github/workflows/create_benchmarks_branch.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+on:
+  push:
+    tags: [ v* ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get the tag name version
+        run: echo "TRACER_VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+
+      - name: Create benchmarks branch    
+        uses: peterjgrainger/action-create-branch@v2.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          branch: 'benchmarks/${{ env.TRACER_VERSION }}'


### PR DESCRIPTION
When we push a tag, we want to auto-create the benchmarks branch. This should extract the version number for the tag, and create a corresponding benchmarks branch. The benchmarks branches are used by CI to show historical performance. We use a branch instead of keying directly off the tags, as we don't want to benchmark _every_ release, and so we can delete branches if applicable.

What's that? No, I haven't tested this 🙈 But I have checked the `action-create-branch` action looks legit at least!

@DataDog/apm-dotnet