### PR TITLE
Add DuckInclude attribute

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckIncludeAttribute.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckIncludeAttribute.cs
@@ -1,0 +1,17 @@
+// <copyright file="DuckIncludeAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.DuckTyping
+{
+    /// <summary>
+    /// Use to include a member that would normally be ignored
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class DuckIncludeAttribute : Attribute
+    {
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckIncludeTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckIncludeTests.cs
@@ -1,0 +1,42 @@
+// <copyright file="DuckIncludeTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class DuckIncludeTests
+    {
+        [Fact]
+        public void ShouldOverrideToString()
+        {
+            var instance = new SomeClass();
+
+            var proxy = instance.DuckCast<IInterface>();
+
+            proxy.ToString().Should().Be(instance.ToString());
+        }
+
+        public class SomeClass
+        {
+            public override string ToString()
+            {
+                return "OK";
+            }
+        }
+
+        public interface IInterface
+        {
+        }
+    }
+}


### PR DESCRIPTION
Add a DuckInclude attribute to force the ducktyping library to include overriden base object methods.

This will be used in log4net log injection to override ToString.