### PR TITLE
Refactor DisposeWithException invocations to remove null conditional operator

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearchAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearchAsync_Integration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V5
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static TExecutionResult OnAsyncMethodEnd<TTarget, TExecutionResult>(TTarget instance, TExecutionResult executionResult, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
 
             return executionResult;
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearch_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearch_Integration.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V5
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return new CallTargetReturn<TResponse>(response);
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearchAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearchAsync_Integration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V6
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static TExecutionResult OnAsyncMethodEnd<TTarget, TExecutionResult>(TTarget instance, TExecutionResult executionResult, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
 
             return executionResult;
         }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearch_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearch_Integration.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V6
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return new CallTargetReturn<TResponse>(response);
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
             }
 
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return response;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return CallTargetReturn.GetDefault();
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/ServiceStack/RedisNativeClientSendReceiveIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/ServiceStack/RedisNativeClientSendReceiveIntegration.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.ServiceStack
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return new CallTargetReturn<TResponse>(response);
         }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return response;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return new CallTargetReturn<TResponse>(response);
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return response;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/RedisExecuteSyncIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Redis/StackExchange/RedisExecuteSyncIntegration.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return new CallTargetReturn<TResponse>(response);
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Wcf/ChannelHandlerIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Wcf/ChannelHandlerIntegration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
         {
-            state.Scope?.DisposeWithException(exception);
+            state.Scope.DisposeWithException(exception);
             return new CallTargetReturn<TReturn>(returnValue);
         }
     }


### PR DESCRIPTION
The DisposeWithException extension method already provides a null-check so this `?.` is unnecessary. Removing them makes all the method invocations consistent.

@DataDog/apm-dotnet