### PR TITLE
Remove the static collection in the HTTP module

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -81,6 +81,8 @@ namespace Datadog.Trace.AspNet
                     return;
                 }
 
+                // Make sure the request wasn't already handled by another TracingHttpModule,
+                // in case they're registered multiple times
                 if (httpContext.Items.Contains(_httpContextScopeKey))
                 {
                     return;
@@ -167,6 +169,7 @@ namespace Datadog.Trace.AspNet
 
                     scope.Dispose();
 
+                    // Clear the context to make sure another TracingHttpModule doesn't try to close the same scope
                     app.Context.Items.Remove(_httpContextScopeKey);
                 }
             }


### PR DESCRIPTION
The collection was there to make sure only one scope is created when the module is registered multiple times. This collection can be source of concerns for customers who see it as a GC root holding large amounts of memory. We can achieve the same results by checking the state stored in the HttpContext and this will clear any confusion.