### PR TITLE
Resolver and Formatter improvements for domain-neutral scenarios.

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanFormatterResolver.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanFormatterResolver.cs
@@ -13,17 +13,18 @@ namespace Datadog.Trace.Agent.MessagePack
     {
         public static readonly IFormatterResolver Instance = new SpanFormatterResolver();
 
-        private static readonly IMessagePackFormatter<Span> Formatter = new SpanMessagePackFormatter();
+        private readonly IMessagePackFormatter<Span> _formatter;
 
         private SpanFormatterResolver()
         {
+            _formatter = SpanMessagePackFormatter.Instance;
         }
 
         public IMessagePackFormatter<T> GetFormatter<T>()
         {
             if (typeof(T) == typeof(Span))
             {
-                return (IMessagePackFormatter<T>)Formatter;
+                return (IMessagePackFormatter<T>)_formatter;
             }
 
             return StandardResolver.Instance.GetFormatter<T>();

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -12,16 +12,22 @@ namespace Datadog.Trace.Agent.MessagePack
 {
     internal class SpanMessagePackFormatter : IMessagePackFormatter<Span>
     {
-        private static byte[] _traceIdBytes = StringEncoding.UTF8.GetBytes("trace_id");
-        private static byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
-        private static byte[] _nameBytes = StringEncoding.UTF8.GetBytes("name");
-        private static byte[] _resourceBytes = StringEncoding.UTF8.GetBytes("resource");
-        private static byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("service");
-        private static byte[] _typeBytes = StringEncoding.UTF8.GetBytes("type");
-        private static byte[] _startBytes = StringEncoding.UTF8.GetBytes("start");
-        private static byte[] _durationBytes = StringEncoding.UTF8.GetBytes("duration");
-        private static byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
-        private static byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
+        public static readonly IMessagePackFormatter<Span> Instance = new SpanMessagePackFormatter();
+
+        private byte[] _traceIdBytes = StringEncoding.UTF8.GetBytes("trace_id");
+        private byte[] _spanIdBytes = StringEncoding.UTF8.GetBytes("span_id");
+        private byte[] _nameBytes = StringEncoding.UTF8.GetBytes("name");
+        private byte[] _resourceBytes = StringEncoding.UTF8.GetBytes("resource");
+        private byte[] _serviceBytes = StringEncoding.UTF8.GetBytes("service");
+        private byte[] _typeBytes = StringEncoding.UTF8.GetBytes("type");
+        private byte[] _startBytes = StringEncoding.UTF8.GetBytes("start");
+        private byte[] _durationBytes = StringEncoding.UTF8.GetBytes("duration");
+        private byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
+        private byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
+
+        private SpanMessagePackFormatter()
+        {
+        }
 
         public int Serialize(ref byte[] bytes, int offset, Span value, IFormatterResolver formatterResolver)
         {


### PR DESCRIPTION
Due to:

> When you decide whether to load assemblies as domain-neutral, you must make a tradeoff between reducing memory use and other performance factors.

> - Access to static data and methods is slower for domain-neutral assemblies because of the need to isolate assemblies. Each application domain that accesses the assembly must have a separate copy of the static data, to prevent references to objects in static fields from crossing domain boundaries. As a result, the runtime contains additional logic to direct a caller to the appropriate copy of the static data or method. This extra logic slows down the call.

from the previous [PR comment](https://github.com/DataDog/dd-trace-dotnet/pull/1482#discussion_r639152628)

This PR reduces static accesses at serialization time.

@DataDog/apm-dotnet