### PR TITLE
AgentWriter FlushTracesAsync changes

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -76,11 +76,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
                     // So the last spans in buffer aren't send to the agent.
                     Log.Debug("Integration flushing spans.");
                     await TestTracer.FlushAsync().ConfigureAwait(false);
-                    // The current agent writer FlushAsync method can return inmediately if a payload is being sent (there is buffer lock)
-                    // There is not api in the agent writer that guarantees the send has been sucessfully completed.
-                    // Until we change the behavior of the agentwriter we should at least wait 2 seconds before returning.
-                    Log.Debug("Waiting 2 seconds to flush.");
-                    await Task.Delay(2000).ConfigureAwait(false);
                     Log.Debug("Integration flushed.");
                 }
                 catch (Exception ex)

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -27,8 +27,8 @@ namespace Datadog.Trace.Tests
             var tracer = new Mock<IDatadogTracer>();
             tracer.Setup(x => x.DefaultServiceName).Returns("Default");
 
-            _api = null; // new Mock<IApi>();
-            _agentWriter = null; // new AgentWriter(_api.Object, statsd: null);
+            _api = new Mock<IApi>();
+            _agentWriter = new AgentWriter(_api.Object, statsd: null);
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -322,7 +322,6 @@ namespace Datadog.Trace.Tests
                 agentWriter.WriteTrace(trace);
 
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                var idx = i;
                 if (i > 0)
                 {
                     tasks.Add(agentWriter.FlushTracesAsync().ContinueWith(t => times.Add(sw.Elapsed.TotalMilliseconds)));


### PR DESCRIPTION
This PR's changes the behavior of the FlushTracesAsync method to enqueue flush continuations per buffer.

@DataDog/apm-dotnet