### PR TITLE
Avoid the trace copy when flushing spans

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.Agent
             return _api.SendTracesAsync(EmptyPayload, 0);
         }
 
-        public void WriteTrace(Span[] trace)
+        public void WriteTrace(ArraySegment<Span> trace)
         {
             if (_serializationTask.IsCompleted)
             {
@@ -125,7 +125,7 @@ namespace Datadog.Trace.Agent
             if (_statsd != null)
             {
                 _statsd.Increment(TracerMetricNames.Queue.EnqueuedTraces);
-                _statsd.Increment(TracerMetricNames.Queue.EnqueuedSpans, trace.Length);
+                _statsd.Increment(TracerMetricNames.Queue.EnqueuedSpans, trace.Count);
             }
         }
 
@@ -323,7 +323,7 @@ namespace Datadog.Trace.Agent
             }
         }
 
-        private void SerializeTrace(Span[] trace)
+        private void SerializeTrace(ArraySegment<Span> trace)
         {
             // Declaring as inline method because only safe to invoke in the context of SerializeTrace
             SpanBuffer SwapBuffers()
@@ -349,7 +349,7 @@ namespace Datadog.Trace.Agent
             }
 
             // Add the current keep rate to the root span
-            var rootSpan = trace[0].Context.TraceContext?.RootSpan;
+            var rootSpan = trace.Array[trace.Offset].Context.TraceContext?.RootSpan;
             if (rootSpan is not null)
             {
                 var currentKeepRate = _traceKeepRateCalculator.GetKeepRate();
@@ -395,7 +395,7 @@ namespace Datadog.Trace.Agent
             if (_statsd != null)
             {
                 _statsd.Increment(TracerMetricNames.Queue.DroppedTraces);
-                _statsd.Increment(TracerMetricNames.Queue.DroppedSpans, trace.Length);
+                _statsd.Increment(TracerMetricNames.Queue.DroppedSpans, trace.Count);
             }
         }
 
@@ -421,7 +421,7 @@ namespace Datadog.Trace.Agent
                 {
                     while (_pendingTraces.TryDequeue(out var item))
                     {
-                        if (item.Trace == null)
+                        if (item.Callback != null)
                         {
                             // Found a watermark
                             item.Callback();
@@ -457,10 +457,10 @@ namespace Datadog.Trace.Agent
 
         private readonly struct WorkItem
         {
-            public readonly Span[] Trace;
+            public readonly ArraySegment<Span> Trace;
             public readonly Action Callback;
 
-            public WorkItem(Span[] trace)
+            public WorkItem(ArraySegment<Span> trace)
             {
                 Trace = trace;
                 Callback = null;
@@ -468,7 +468,7 @@ namespace Datadog.Trace.Agent
 
             public WorkItem(Action callback)
             {
-                Trace = null;
+                Trace = default;
                 Callback = callback;
             }
         }

--- a/src/Datadog.Trace/Agent/IAgentWriter.cs
+++ b/src/Datadog.Trace/Agent/IAgentWriter.cs
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
 {
     internal interface IAgentWriter
     {
-        void WriteTrace(Span[] trace);
+        void WriteTrace(ArraySegment<Span> trace);
 
         Task<bool> Ping();
 

--- a/src/Datadog.Trace/Agent/SpanBuffer.cs
+++ b/src/Datadog.Trace/Agent/SpanBuffer.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Agent
         internal const int HeaderSize = 5;
         internal const int InitialBufferSize = 64 * 1024;
 
-        private readonly IMessagePackFormatter<Span[]> _formatter;
+        private readonly IMessagePackFormatter<ArraySegment<Span>> _formatter;
         private readonly IFormatterResolver _formatterResolver;
         private readonly object _syncRoot = new object();
         private readonly int _maxBufferSize;
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Agent
             _offset = HeaderSize;
             _buffer = new byte[Math.Min(InitialBufferSize, maxBufferSize)];
             _formatterResolver = formatterResolver;
-            _formatter = _formatterResolver.GetFormatter<Span[]>();
+            _formatter = _formatterResolver.GetFormatter<ArraySegment<Span>>();
         }
 
         public ArraySegment<byte> Data
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Agent
         // For tests only
         internal bool IsEmpty => !_locked && !IsFull && TraceCount == 0 && SpanCount == 0 && _offset == HeaderSize;
 
-        public bool TryWrite(Span[] trace, ref byte[] temporaryBuffer)
+        public bool TryWrite(ArraySegment<Span> trace, ref byte[] temporaryBuffer)
         {
             bool lockTaken = false;
 
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Agent
 
                 _offset += size;
                 TraceCount++;
-                SpanCount += trace.Length;
+                SpanCount += trace.Count;
 
                 return true;
             }

--- a/src/Datadog.Trace/IDatadogTracer.cs
+++ b/src/Datadog.Trace/IDatadogTracer.cs
@@ -29,6 +29,8 @@ namespace Datadog.Trace
 
         void Write(Span[] span);
 
+        void Write(ArraySegment<Span> span);
+
         /// <summary>
         /// Make a span the active span and return its new scope.
         /// </summary>

--- a/src/Datadog.Trace/IDatadogTracer.cs
+++ b/src/Datadog.Trace/IDatadogTracer.cs
@@ -27,8 +27,6 @@ namespace Datadog.Trace
 
         Span StartSpan(string operationName, ISpanContext parent, string serviceName, DateTimeOffset? startTime, bool ignoreActiveScope);
 
-        void Write(Span[] span);
-
         void Write(ArraySegment<Span> span);
 
         /// <summary>

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -372,18 +372,6 @@ namespace Datadog.Trace
         /// Writes the specified <see cref="Span"/> collection to the agent writer.
         /// </summary>
         /// <param name="trace">The <see cref="Span"/> collection to write.</param>
-        void IDatadogTracer.Write(Span[] trace)
-        {
-            if (Settings.TraceEnabled)
-            {
-                _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
-            }
-        }
-
-        /// <summary>
-        /// Writes the specified <see cref="Span"/> collection to the agent writer.
-        /// </summary>
-        /// <param name="trace">The <see cref="Span"/> collection to write.</param>
         void IDatadogTracer.Write(ArraySegment<Span> trace)
         {
             if (Settings.TraceEnabled)

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -376,6 +376,18 @@ namespace Datadog.Trace
         {
             if (Settings.TraceEnabled)
             {
+                _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
+            }
+        }
+
+        /// <summary>
+        /// Writes the specified <see cref="Span"/> collection to the agent writer.
+        /// </summary>
+        /// <param name="trace">The <see cref="Span"/> collection to write.</param>
+        void IDatadogTracer.Write(ArraySegment<Span> trace)
+        {
+            if (Settings.TraceEnabled)
+            {
                 _agentWriter.WriteTrace(trace);
             }
         }
@@ -395,10 +407,7 @@ namespace Datadog.Trace
             if (parent is SpanContext parentSpanContext)
             {
                 traceContext = parentSpanContext.TraceContext ??
-                               new TraceContext(this)
-                               {
-                                   SamplingPriority = parentSpanContext.SamplingPriority
-                               };
+                    new TraceContext(this) { SamplingPriority = parentSpanContext.SamplingPriority };
             }
             else
             {

--- a/src/Datadog.Trace/Util/ArrayBuilder.cs
+++ b/src/Datadog.Trace/Util/ArrayBuilder.cs
@@ -1,0 +1,55 @@
+// <copyright file="ArrayBuilder.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.Util
+{
+    internal struct ArrayBuilder<T>
+    {
+        private const int DefaultInitialCapacity = 4;
+
+        private T[] _array;
+        private int _count;
+
+        public ArrayBuilder(int initialCapacity)
+        {
+            _array = new T[initialCapacity];
+            _count = 0;
+        }
+
+        public int Count => _count;
+
+        public void Add(T item)
+        {
+            GrowIfNeeded();
+            _array[_count] = item;
+            _count++;
+        }
+
+        public ArraySegment<T> GetArray() => new(_array, 0, _count);
+
+        private void GrowIfNeeded()
+        {
+            if (_array == null)
+            {
+                _array = new T[DefaultInitialCapacity];
+                return;
+            }
+
+            if (_count < _array.Length)
+            {
+                // The array is already big enough
+                return;
+            }
+
+            var newArray = new T[_array.Length * 2];
+
+            Array.Copy(_array, 0, newArray, 0, _array.Length);
+
+            _array = newArray;
+        }
+    }
+}

--- a/src/Datadog.Trace/Util/ArrayBuilder.cs
+++ b/src/Datadog.Trace/Util/ArrayBuilder.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Util
             _count++;
         }
 
-        public ArraySegment<T> GetArray() => new(_array, 0, _count);
+        public ArraySegment<T> GetArray() => new(_array ?? ArrayHelper.Empty<T>(), 0, _count);
 
         private void GrowIfNeeded()
         {

--- a/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -271,7 +271,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
         private class AgentWriterStub : IAgentWriter
         {
-            public List<Span[]> Traces { get; } = new();
+            public List<ArraySegment<Span>> Traces { get; } = new();
 
             public Task FlushAndCloseAsync() => Task.CompletedTask;
 
@@ -279,7 +279,7 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
             public Task<bool> Ping() => Task.FromResult(true);
 
-            public void WriteTrace(Span[] trace) => Traces.Add(trace);
+            public void WriteTrace(ArraySegment<Span> trace) => Traces.Add(trace);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
+++ b/test/Datadog.Trace.Tests/Agent/SpanBufferTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
 
-            var traces = new List<Span[]>();
+            var traces = new List<ArraySegment<Span>>();
 
             for (int i = 0; i < traceCount; i++)
             {
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests.Agent
                     spans[j] = new Span(new SpanContext((ulong)i, (ulong)i), DateTimeOffset.UtcNow);
                 }
 
-                traces.Add(spans);
+                traces.Add(new ArraySegment<Span>(spans));
             }
 
             foreach (var trace in traces)
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests.Agent
 
             Assert.False(buffer.IsFull);
 
-            var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
+            var trace = new ArraySegment<Span>(new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) });
 
             var result = buffer.TryWrite(trace, ref _temporaryBuffer);
 
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
 
-            var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
+            var trace = new ArraySegment<Span>(new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) });
 
             Assert.True(buffer.TryWrite(trace, ref _temporaryBuffer));
 
@@ -110,12 +110,12 @@ namespace Datadog.Trace.Tests.Agent
         {
             var buffer = new SpanBuffer(10 * 1024 * 1024, SpanFormatterResolver.Instance);
 
-            var trace = new[]
+            var trace = new ArraySegment<Span>(new[]
             {
                 new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow),
                 new Span(new SpanContext(2, 2), DateTimeOffset.UtcNow),
                 new Span(new SpanContext(3, 3), DateTimeOffset.UtcNow),
-            };
+            });
 
             Assert.True(buffer.TryWrite(trace, ref _temporaryBuffer));
 

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -323,7 +323,7 @@ namespace Datadog.Trace.Tests
                     return Task.FromResult(true);
                 });
 
-            var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
+            var trace = new ArraySegment<Span>(new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) });
 
             // Write trace to the front buffer
             agentWriter.WriteTrace(trace);

--- a/test/Datadog.Trace.Tests/AgentWriterTests.cs
+++ b/test/Datadog.Trace.Tests/AgentWriterTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Tests
             var trace = new[] { new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow) };
             var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, new FormatterResolverWrapper(SpanFormatterResolver.Instance));
 
-            _agentWriter.WriteTrace(trace);
+            _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
             await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData1)), It.Is<int>(i => i == 1)), Times.Once);
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests
             trace = new[] { new Span(new SpanContext(2, 2), DateTimeOffset.UtcNow) };
             var expectedData2 = Vendors.MessagePack.MessagePackSerializer.Serialize(trace, new FormatterResolverWrapper(SpanFormatterResolver.Instance));
 
-            _agentWriter.WriteTrace(trace);
+            _agentWriter.WriteTrace(new ArraySegment<Span>(trace));
             await _agentWriter.FlushTracesAsync(); // Force a flush to make sure the trace is written to the API
 
             _api.Verify(x => x.SendTracesAsync(It.Is<ArraySegment<byte>>(y => Equals(y, expectedData2)), It.Is<int>(i => i == 1)), Times.Once);
@@ -267,7 +267,7 @@ namespace Datadog.Trace.Tests
             var childSpan = new Span(new SpanContext(rootSpanContext, traceContext, null), DateTimeOffset.UtcNow);
             traceContext.AddSpan(rootSpan);
             traceContext.AddSpan(childSpan);
-            var trace = new[] { rootSpan, childSpan };
+            var trace = new ArraySegment<Span>(new[] { rootSpan, childSpan });
             var sizeOfTrace = ComputeSizeOfTrace(trace);
 
             // Make the buffer size big enough for a single trace
@@ -361,16 +361,18 @@ namespace Datadog.Trace.Tests
             return data.Array.Skip(data.Offset).Take(data.Count).Skip(SpanBuffer.HeaderSize).SequenceEqual(expectedData);
         }
 
-        private static int ComputeSizeOfTrace(Span[] trace)
+        private static int ComputeSizeOfTrace(ArraySegment<Span> trace)
         {
             return Vendors.MessagePack.MessagePackSerializer.Serialize(trace, new FormatterResolverWrapper(SpanFormatterResolver.Instance)).Length;
         }
 
-        private static Span[] CreateTrace(int numberOfSpans)
+        private static ArraySegment<Span> CreateTrace(int numberOfSpans)
         {
-            return Enumerable.Range(0, numberOfSpans)
+            var array = Enumerable.Range(0, numberOfSpans)
                 .Select(i => new Span(new SpanContext((ulong)i + 1, (ulong)i + 1), DateTimeOffset.UtcNow))
                 .ToArray();
+
+            return new ArraySegment<Span>(array);
         }
     }
 }

--- a/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/test/Datadog.Trace.Tests/SpanTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Tests
 
             span.SetTag(key, value);
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<Span[]>()), Times.Never);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>()), Times.Never);
             Assert.Equal(span.GetTag(key), value);
         }
 
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Tests
             await Task.Delay(TimeSpan.FromMilliseconds(1));
             span.Finish();
 
-            _writerMock.Verify(x => x.WriteTrace(It.IsAny<Span[]>()), Times.Once);
+            _writerMock.Verify(x => x.WriteTrace(It.IsAny<ArraySegment<Span>>()), Times.Once);
             Assert.True(span.Duration > TimeSpan.Zero);
         }
 

--- a/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -69,18 +69,18 @@ namespace Datadog.Trace.Tests
             }
 
             // At this point in time, we have 4 closed spans in the trace
-            tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
+            tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
 
             AddAndCloseSpan();
 
             // Now we have 5 closed spans, partial flush should kick-in if activated
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 5)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5)), Times.Once);
             }
             else
             {
-                tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
+                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
             }
 
             for (int i = 0; i < 5; i++)
@@ -91,11 +91,11 @@ namespace Datadog.Trace.Tests
             // We have 5 more closed spans, partial flush should kick-in a second time if activated
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 5)), Times.Exactly(2));
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 5)), Times.Exactly(2));
             }
             else
             {
-                tracer.Verify(t => t.Write(It.IsAny<Span[]>()), Times.Never);
+                tracer.Verify(t => t.Write(It.IsAny<ArraySegment<Span>>()), Times.Never);
             }
 
             traceContext.CloseSpan(rootSpan);
@@ -103,11 +103,11 @@ namespace Datadog.Trace.Tests
             // Now the remaining spans are flushed
             if (partialFlush)
             {
-                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 1)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 1)), Times.Once);
             }
             else
             {
-                tracer.Verify(t => t.Write(It.Is<Span[]>(s => s.Length == 11)), Times.Once);
+                tracer.Verify(t => t.Write(It.Is<ArraySegment<Span>>(s => s.Count == 11)), Times.Once);
             }
         }
     }

--- a/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Tests
 
             var assertion = areTracesEnabled ? Times.Once() : Times.Never();
 
-            _writerMock.Verify(w => w.WriteTrace(It.IsAny<Span[]>()), assertion);
+            _writerMock.Verify(w => w.WriteTrace(It.IsAny<ArraySegment<Span>>()), assertion);
         }
 
         [Theory]

--- a/test/Datadog.Trace.Tests/Util/ArrayBuilderTests.cs
+++ b/test/Datadog.Trace.Tests/Util/ArrayBuilderTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Tests.Util
 
             var result = _builder.GetArray();
 
-            result.Should().BeEquivalentTo(Enumerable.Range(0, 20));
+            result.Should().BeEquivalentTo(Enumerable.Range(0, numberOfElements));
         }
 
         [Fact]

--- a/test/Datadog.Trace.Tests/Util/ArrayBuilderTests.cs
+++ b/test/Datadog.Trace.Tests/Util/ArrayBuilderTests.cs
@@ -47,5 +47,41 @@ namespace Datadog.Trace.Tests.Util
             result.Count.Should().Be(0);
             result.Array.Length.Should().Be(numberOfElements);
         }
+
+        [Fact]
+        public void Empty()
+        {
+            ArrayBuilder<int> builder = default;
+
+            var result = builder.GetArray();
+
+            result.Count.Should().Be(0);
+        }
+
+        [Fact]
+        public void DoubleSizeWhenGrowing()
+        {
+            ArrayBuilder<int> builder = default;
+
+            builder.GetArray().Array.Should().BeEmpty();
+
+            for (int i = 0; i < 4; i++)
+            {
+                builder.Add(i);
+                builder.GetArray().Array.Should().HaveCount(4);
+            }
+
+            for (int i = 0; i < 4; i++)
+            {
+                builder.Add(i);
+                builder.GetArray().Array.Should().HaveCount(8);
+            }
+
+            for (int i = 0; i < 8; i++)
+            {
+                builder.Add(i);
+                builder.GetArray().Array.Should().HaveCount(16);
+            }
+        }
     }
 }

--- a/test/Datadog.Trace.Tests/Util/ArrayBuilderTests.cs
+++ b/test/Datadog.Trace.Tests/Util/ArrayBuilderTests.cs
@@ -1,0 +1,51 @@
+// <copyright file="ArrayBuilderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Linq;
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util
+{
+    public class ArrayBuilderTests
+    {
+        // Store the builder in a field, to make sure copy-semantics of structs don't get in the way
+        // of how the type is expected to be used
+        private ArrayBuilder<int> _builder;
+
+        [Fact]
+        public void BuildArray()
+        {
+            const int numberOfElements = 20;
+
+            _builder = default;
+
+            for (int i = 0; i < numberOfElements; i++)
+            {
+                _builder.Add(i);
+            }
+
+            _builder.Count.Should().Be(numberOfElements);
+
+            var result = _builder.GetArray();
+
+            result.Should().BeEquivalentTo(Enumerable.Range(0, 20));
+        }
+
+        [Fact]
+        public void InitialCapacity()
+        {
+            const int numberOfElements = 10;
+
+            var builder = new ArrayBuilder<int>(numberOfElements);
+
+            var result = builder.GetArray();
+
+            result.Count.Should().Be(0);
+            result.Array.Length.Should().Be(numberOfElements);
+        }
+    }
+}

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -17,7 +17,7 @@ namespace Benchmarks.Trace
         private const int SpanCount = 1000;
 
         private static readonly IAgentWriter AgentWriter;
-        private static readonly Span[] EnrichedSpans;
+        private static readonly ArraySegment<Span> EnrichedSpans;
         static AgentWriterBenchmark()
         {
             var settings = TracerSettings.FromDefaultSources();
@@ -29,15 +29,17 @@ namespace Benchmarks.Trace
 
             AgentWriter = new AgentWriter(api, statsd: null, automaticFlush: false);
 
-            EnrichedSpans = new Span[SpanCount];
+            var enrichedSpans = new Span[SpanCount];
             var now = DateTimeOffset.UtcNow;
 
             for (int i = 0; i < SpanCount; i++)
             {
-                EnrichedSpans[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
-                EnrichedSpans[i].SetTag(Tags.Env, "Benchmark");
-                EnrichedSpans[i].SetMetric(Metrics.SamplingRuleDecision, 1.0);
+                enrichedSpans[i] = new Span(new SpanContext((ulong)i, (ulong)i, SamplingPriority.UserReject, "Benchmark", null), now);
+                enrichedSpans[i].SetTag(Tags.Env, "Benchmark");
+                enrichedSpans[i].SetMetric(Metrics.SamplingRuleDecision, 1.0);
             }
+
+            EnrichedSpans = new ArraySegment<Span>(enrichedSpans);
 
             // Run benchmarks once to reduce noise
             new AgentWriterBenchmark().WriteAndFlushEnrichedTraces().GetAwaiter().GetResult();

--- a/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
+++ b/test/benchmarks/Benchmarks.Trace/DummyAgentWriter.cs
@@ -32,7 +32,7 @@ namespace Benchmarks.Trace
             return PingTask;
         }
 
-        public void WriteTrace(Span[] trace)
+        public void WriteTrace(ArraySegment<Span> trace)
         {
         }
     }


### PR DESCRIPTION
When flushing spans, we make a copy of the span array because `List<T>` gives no mean to fetch the internal buffer. This PR introduces a custom `ArrayBuilder<T>` that uses the same growing mechanics as `List<T>`, but exposes the internal buffer.

Benchmarks:

|               Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
|  StartFinishSpan old | 770.4 ns | 16.65 ns | 48.82 ns | 0.0048 |     - |     - |     488 B |
|  StartFinishSpan new | 554.8 ns | 10.28 ns |  8.59 ns | 0.0048 |     - |     - |     432 B |
| StartFinishScope old | 885.6 ns | 24.11 ns | 69.95 ns | 0.0076 |     - |     - |     608 B |
| StartFinishScope new | 655.1 ns | 13.12 ns | 15.61 ns | 0.0057 |     - |     - |     552 B |