### PR TITLE
CIApp: Correctness and stability fixes.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -84,5 +84,32 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
                 }
             }
         }
+
+        internal static string GetParametersValueData(object paramValue)
+        {
+            if (paramValue is null)
+            {
+                return "(null)";
+            }
+            else if (paramValue is Array pValueArray)
+            {
+                const int maxArrayLength = 50;
+                int length = pValueArray.Length > maxArrayLength ? maxArrayLength : pValueArray.Length;
+
+                string[] strValueArray = new string[length];
+                for (var i = 0; i < length; i++)
+                {
+                    strValueArray[i] = GetParametersValueData(pValueArray.GetValue(i));
+                }
+
+                return "[" + string.Join(", ", strValueArray) + (pValueArray.Length > maxArrayLength ? ", ..." : string.Empty) + "]";
+            }
+            else if (paramValue is Delegate pValueDelegate)
+            {
+                return $"{paramValue}[{pValueDelegate.GetHashCode()}]";
+            }
+
+            return paramValue.ToString();
+        }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
             }
             else if (paramValue is Delegate pValueDelegate)
             {
-                return $"{paramValue}[{pValueDelegate.GetHashCode()}]";
+                return $"{paramValue}[{pValueDelegate.Target}|{pValueDelegate.Method}]";
             }
 
             return paramValue.ToString();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
                 {
                     if (testMethodArguments != null && i < testMethodArguments.Length)
                     {
-                        testParameters.Arguments[methodParameters[i].Name] = testMethodArguments[i]?.ToString() ?? "(null)";
+                        testParameters.Arguments[methodParameters[i].Name] = Common.GetParametersValueData(testMethodArguments[i]);
                     }
                     else
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/FailureSite.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/FailureSite.cs
@@ -1,4 +1,4 @@
-// <copyright file="ITestResult.cs" company="Datadog">
+// <copyright file="FailureSite.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -6,28 +6,34 @@
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 {
     /// <summary>
-    /// DuckTyping interface for NUnit.Framework.Internal.TestResult
+    /// The FailureSite enum indicates the stage of a test
+    /// in which an error or failure occurred.
     /// </summary>
-    public interface ITestResult
+    public enum FailureSite
     {
         /// <summary>
-        /// Gets the test with which this result is associated.
+        /// Failure in the test itself
         /// </summary>
-        ITest Test { get; }
+        Test,
 
         /// <summary>
-        /// Gets the resultstate of the test result.
+        /// Failure in the SetUp method
         /// </summary>
-        IResultState ResultState { get; }
+        SetUp,
 
         /// <summary>
-        /// Gets the message associated with a test failure.
+        /// Failure in the TearDown method
         /// </summary>
-        string Message { get; }
+        TearDown,
 
         /// <summary>
-        /// Gets any stacktrace associated with an error or failure.
+        /// Failure of a parent test
         /// </summary>
-        string StackTrace { get; }
+        Parent,
+
+        /// <summary>
+        /// Failure of a child test
+        /// </summary>
+        Child
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/ICompositeWorkItem.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/ICompositeWorkItem.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
     /// <summary>
     /// DuckTyping interface for NUnit.Framework.Internal.Execution.CompositeWorkItem
     /// </summary>
-    public interface ICompositeWorkItem
+    public interface ICompositeWorkItem : IWorkItem
     {
         /// <summary>
         /// Gets the List of Child WorkItems

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/IResultState.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/IResultState.cs
@@ -17,12 +17,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         TestStatus Status { get; }
 
         /// <summary>
-        /// Gets the label under which this test result is
-        /// categorized, or <see cref="string.Empty"/> if none.
-        /// </summary>
-        string Label { get; }
-
-        /// <summary>
         /// Gets the stage of test execution in which
         /// the failure or other result took place.
         /// </summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/IResultState.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/IResultState.cs
@@ -1,0 +1,31 @@
+// <copyright file="IResultState.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
+{
+    /// <summary>
+    /// DuckTyping interface for NUnit.Framework.Interfaces.ResultState
+    /// </summary>
+    public interface IResultState
+    {
+        /// <summary>
+        /// Gets the TestStatus for the test.
+        /// </summary>
+        /// <value>The status.</value>
+        TestStatus Status { get; }
+
+        /// <summary>
+        /// Gets the label under which this test result is
+        /// categorized, or <see cref="string.Empty"/> if none.
+        /// </summary>
+        string Label { get; }
+
+        /// <summary>
+        /// Gets the stage of test execution in which
+        /// the failure or other result took place.
+        /// </summary>
+        FailureSite Site { get; }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemSkipChildrenIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitCompositeWorkItemSkipChildrenIntegration.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.Ci;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DuckTyping;
 
@@ -36,6 +37,54 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TSuite, TResultState>(TTarget instance, TSuite testSuite, TResultState resultState, string message)
         {
+            if (testSuite is not null)
+            {
+                string typeName = testSuite.GetType().Name;
+
+                if (typeName == "CompositeWorkItem")
+                {
+                    // In case we have a CompositeWorkItem we check if there is a OneTimeSetUp failure
+                    var compositeWorkItem = testSuite.DuckCast<ICompositeWorkItem>();
+
+                    if (compositeWorkItem.Result?.ResultState?.Status == TestStatus.Failed && compositeWorkItem.Result.ResultState.Site == FailureSite.SetUp)
+                    {
+                        foreach (var item in compositeWorkItem.Children)
+                        {
+                            if (item.GetType().Name == "CompositeWorkItem")
+                            {
+                                var compositeWorkItem2 = item.DuckCast<ICompositeWorkItem>();
+                                foreach (var item2 in compositeWorkItem2.Children)
+                                {
+                                    var testResult = item2.DuckCast<IWorkItem>().Result;
+                                    Scope scope = NUnitIntegration.CreateScope(testResult.Test, typeof(TTarget));
+                                    scope.Span.Error = true;
+                                    scope.Span.SetTag(Tags.ErrorMsg, compositeWorkItem.Result.Message);
+                                    scope.Span.SetTag(Tags.ErrorStack, compositeWorkItem.Result.StackTrace);
+                                    scope.Span.SetTag(Tags.ErrorType, "SetUpException");
+                                    scope.Span.SetTag(TestTags.Status, TestTags.StatusFail);
+                                    scope.Span.Finish(new TimeSpan(10));
+                                    scope.Dispose();
+                                }
+                            }
+                            else
+                            {
+                                var testResult = item.DuckCast<IWorkItem>().Result;
+                                Scope scope = NUnitIntegration.CreateScope(testResult.Test, typeof(TTarget));
+                                scope.Span.Error = true;
+                                scope.Span.SetTag(Tags.ErrorMsg, compositeWorkItem.Result.Message);
+                                scope.Span.SetTag(Tags.ErrorStack, compositeWorkItem.Result.StackTrace);
+                                scope.Span.SetTag(Tags.ErrorType, "SetUpException");
+                                scope.Span.SetTag(TestTags.Status, TestTags.StatusFail);
+                                scope.Span.Finish(new TimeSpan(10));
+                                scope.Dispose();
+                            }
+                        }
+
+                        return new CallTargetState((Scope)null, (object)null);
+                    }
+                }
+            }
+
             return new CallTargetState(null, new object[] { testSuite, message });
         }
 
@@ -52,14 +101,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             if (state.State != null)
             {
                 object[] stateArray = (object[])state.State;
+                object testSuiteOrWorkItem = stateArray[0];
                 string skipMessage = (string)stateArray[1];
+
+                bool isOneTimeSetup = false;
                 const string startString = "OneTimeSetUp:";
                 if (skipMessage?.StartsWith(startString, StringComparison.OrdinalIgnoreCase) == true)
                 {
                     skipMessage = skipMessage.Substring(startString.Length).Trim();
+                    isOneTimeSetup = true;
                 }
-
-                object testSuiteOrWorkItem = stateArray[0];
 
                 if (testSuiteOrWorkItem is not null)
                 {
@@ -75,13 +126,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                             NUnitIntegration.FinishSkippedScope(scope, skipMessage);
                         }
                     }
-                    else if (typeName == "CompositeWorkItem")
+                    else if (typeName == "CompositeWorkItem" && !isOneTimeSetup)
                     {
                         // In case we have a CompositeWorkItem
                         var compositeWorkItem = testSuiteOrWorkItem.DuckCast<ICompositeWorkItem>();
+
                         foreach (var item in compositeWorkItem.Children)
                         {
-                            Scope scope = NUnitIntegration.CreateScope(item.DuckCast<IWorkItem>().Result.Test, typeof(TTarget));
+                            var testResult = item.DuckCast<IWorkItem>().Result;
+                            Scope scope = NUnitIntegration.CreateScope(testResult.Test, typeof(TTarget));
                             NUnitIntegration.FinishSkippedScope(scope, skipMessage);
                         }
                     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -150,7 +150,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                 {
                     scope.Span.SetTag(TestTags.Status, TestTags.StatusPass);
                 }
-                else if (exTypeName == "NUnit.Framework.IgnoreException")
+                else if (exTypeName == "NUnit.Framework.IgnoreException" || exTypeName == "NUnit.Framework.InconclusiveException")
                 {
                     scope.Span.SetTag(TestTags.Status, TestTags.StatusSkip);
                     scope.Span.SetTag(TestTags.SkipReason, ex.Message);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
                 if (traits.Count > 0)
                 {
-                    span.SetTag(TestTags.Traits, Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(traits));
+                    span.SetTag(TestTags.Traits, Vendors.Newtonsoft.Json.JsonConvert.SerializeObject(traits));
                 }
             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                 {
                     if (testMethodArguments != null && i < testMethodArguments.Length)
                     {
-                        testParameters.Arguments[methodParameters[i].Name] = testMethodArguments[i]?.ToString() ?? "(null)";
+                        testParameters.Arguments[methodParameters[i].Name] = Common.GetParametersValueData(testMethodArguments[i]);
                     }
                     else
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/TestStatus.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/TestStatus.cs
@@ -1,4 +1,4 @@
-// <copyright file="ITestResult.cs" company="Datadog">
+// <copyright file="TestStatus.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -6,28 +6,33 @@
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 {
     /// <summary>
-    /// DuckTyping interface for NUnit.Framework.Internal.TestResult
+    /// The TestStatus enum indicates the result of running a test
     /// </summary>
-    public interface ITestResult
+    public enum TestStatus
     {
         /// <summary>
-        /// Gets the test with which this result is associated.
+        /// The test was inconclusive
         /// </summary>
-        ITest Test { get; }
+        Inconclusive,
 
         /// <summary>
-        /// Gets the resultstate of the test result.
+        /// The test has skipped
         /// </summary>
-        IResultState ResultState { get; }
+        Skipped,
 
         /// <summary>
-        /// Gets the message associated with a test failure.
+        /// The test succeeded
         /// </summary>
-        string Message { get; }
+        Passed,
 
         /// <summary>
-        /// Gets any stacktrace associated with an error or failure.
+        /// There was a warning
         /// </summary>
-        string StackTrace { get; }
+        Warning,
+
+        /// <summary>
+        /// The test failed
+        /// </summary>
+        Failed
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
                 {
                     if (i < testMethodArguments.Length)
                     {
-                        testParameters.Arguments[methodParameters[i].Name] = testMethodArguments[i]?.ToString() ?? "(null)";
+                        testParameters.Arguments[methodParameters[i].Name] = Common.GetParametersValueData(testMethodArguments[i]);
                     }
                     else
                     {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Configuration;
 
@@ -40,6 +41,33 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
 
                 return _testTracer;
             }
+        }
+
+        internal static string GetParametersValueData(object paramValue)
+        {
+            if (paramValue is null)
+            {
+                return "(null)";
+            }
+            else if (paramValue is Array pValueArray)
+            {
+                const int maxArrayLength = 50;
+                int length = pValueArray.Length > maxArrayLength ? maxArrayLength : pValueArray.Length;
+
+                string[] strValueArray = new string[length];
+                for (var i = 0; i < length; i++)
+                {
+                    strValueArray[i] = GetParametersValueData(pValueArray.GetValue(i));
+                }
+
+                return "[" + string.Join(", ", strValueArray) + (pValueArray.Length > maxArrayLength ? ", ..." : string.Empty) + "]";
+            }
+            else if (paramValue is Delegate pValueDelegate)
+            {
+                return $"{paramValue}[{pValueDelegate.Target}|{pValueDelegate.Method}]";
+            }
+
+            return paramValue.ToString();
         }
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/XUnitIntegration.cs
@@ -391,7 +391,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                         {
                             if (i < testMethodArguments.Length)
                             {
-                                testParameters.Arguments[methodParameters[i].Name] = testMethodArguments[i]?.ToString() ?? "(null)";
+                                testParameters.Arguments[methodParameters[i].Name] = Common.GetParametersValueData(testMethodArguments[i]);
                             }
                             else
                             {

--- a/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -19,7 +19,8 @@ namespace Samples.NUnitTests
             }
             writer.WriteLine(string.Empty);
         }
-        
+
+
         [Test]
         public void SimplePassTest()
         {
@@ -96,6 +97,20 @@ namespace Samples.NUnitTests
         public void SimpleErrorParameterizedTest(int xValue, int yValue, int expectedResult)
         {
             Assert.AreEqual(expectedResult, xValue / yValue);
+        }
+
+        // **********************************************************************************
+
+        [Test]
+        public void SimpleAssertPassTest()
+        {
+            Assert.Pass("The test passed.");
+        }
+
+        [Test]
+        public void SimpleAssertInconclusive()
+        {
+            Assert.Inconclusive("The test is inconclusive.");
         }
     }
 }


### PR DESCRIPTION
- Fixes a scenario when a NUnit test suite fails on the OneTimeSetUp method gets reported different than the console output.
- Improves render of parameter values.


@DataDog/apm-dotnet