### PR TITLE
Fix race condition in runner pipeline

### DIFF
--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -158,6 +158,7 @@ jobs:
 - job: build_runner_tool_and_standalone
   dependsOn:
   - build_linux_profiler
+  - build_linux_profiler_arm64
   - macos_profiler
   condition: succeeded()
 


### PR DESCRIPTION
This should fix the `Artifact linux-tracer-home_arm64 was not found for build xxxxx` error.