### PR TITLE
Remove callsite benchmarks and set iteration time back to 2 seconds

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -68,7 +68,7 @@ stages:
       inputs:
         command: 'run'
         projects: '$(System.DefaultWorkingDirectory)/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj'
-        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 1500'
+        arguments: '-c Release -f netcoreapp3.1 -- -r net472 netcoreapp3.1 -m -f * --iterationTime 2000'
       env:
         DD_ENV: CI
         DD_SERVICE: dd-trace-dotnet

--- a/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -2,14 +2,11 @@
 
 using System;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.HttpClientHandler;
-using Datadog.Trace.ClrProfiler.Emit;
-using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.Configuration;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -26,10 +23,7 @@ namespace Benchmarks.Trace
 
         static AspNetCoreBenchmark()
         {
-            var settings = new TracerSettings
-            {
-                StartupDiagnosticLogEnabled = false,
-            };
+            var settings = new TracerSettings { StartupDiagnosticLogEnabled = false };
 
             Tracer.Instance = new Tracer(settings, new DummyAgentWriter(), null, null, null);
 
@@ -41,23 +35,14 @@ namespace Benchmarks.Trace
 
             Datadog.Trace.ClrProfiler.Instrumentation.Initialize();
 
-            HomeController.Initialize();
-
             var bench = new AspNetCoreBenchmark();
             bench.SendRequest();
-            bench.CallTargetSendRequest();
         }
 
         [Benchmark]
         public string SendRequest()
         {
             return Client.GetStringAsync("/Home").GetAwaiter().GetResult();
-        }
-
-        [Benchmark]
-        public string CallTargetSendRequest()
-        {
-            return Client.GetStringAsync("/CallTargetHome").GetAwaiter().GetResult();
         }
 
         private class Startup
@@ -86,62 +71,11 @@ namespace Benchmarks.Trace
     public class HomeController : Controller
     {
         private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };
-        private static readonly HttpMessageHandler Handler = new CustomHttpClientHandler();
-        private static readonly object BoxedCancellationToken = new CancellationToken();
-        private static int _mdToken;
-        private static IntPtr _guidPtr;
-
-        internal static void Initialize()
-        {
-            var methodInfo = typeof(HttpMessageHandler).GetMethod("SendAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-
-            _mdToken = methodInfo.MetadataToken;
-            var guid = typeof(HttpMessageHandler).Module.ModuleVersionId;
-
-            _guidPtr = Marshal.AllocHGlobal(Marshal.SizeOf(guid));
-
-            Marshal.StructureToPtr(guid, _guidPtr, false);
-        }
-
-        public async Task<string> Index()
-        {
-            var task = (Task)HttpMessageHandlerIntegration.HttpMessageHandler_SendAsync(
-                Handler,
-                HttpRequest,
-                BoxedCancellationToken,
-                (int)OpCodeValue.Callvirt,
-                _mdToken,
-                (long)_guidPtr);
-
-            await task;
-
-            return "OK";
-        }
-
-        internal class CustomHttpClientHandler : HttpClientHandler
-        {
-            private static readonly Task<HttpResponseMessage> CachedResult = Task.FromResult(new HttpResponseMessage());
-
-            internal static HttpClientHandler Create() => new HttpClientHandler();
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                return CachedResult;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Simple controller used for the calltarget aspnetcore benchmark
-    /// </summary>
-    public class CallTargetHomeController : Controller
-    {
-        private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };
         private static readonly Task<HttpResponseMessage> CachedResult = Task.FromResult(new HttpResponseMessage());
-        
+
         public unsafe string Index()
         {
-            CallTarget.Run<HttpClientHandlerIntegration, CallTargetHomeController, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>
+            CallTarget.Run<HttpClientHandlerIntegration, HomeController, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>
                 (this, HttpRequest, CancellationToken.None, &GetResult).GetAwaiter().GetResult();
 
             return "OK";
@@ -150,7 +84,6 @@ namespace Benchmarks.Trace
         }
     }
 }
-
 #else
 
 using System.Threading.Tasks;

--- a/test/benchmarks/Benchmarks.Trace/DbCommandBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/DbCommandBenchmark.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Data;
-using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet;
-using Datadog.Trace.ClrProfiler.Emit;
-using Datadog.Trace.ClrProfiler.Integrations.AdoNet;
 using Datadog.Trace.Configuration;
 
 namespace Benchmarks.Trace
@@ -13,9 +10,6 @@ namespace Benchmarks.Trace
     [MemoryDiagnoser]
     public class DbCommandBenchmark
     {
-        private static readonly int MdToken;
-        private static readonly IntPtr GuidPtr;
-        private static readonly IDbCommand DbCommand = new CustomDbCommand();
         private static readonly CustomDbCommand CustomCommand = new CustomDbCommand();
 
         static DbCommandBenchmark()
@@ -27,28 +21,12 @@ namespace Benchmarks.Trace
 
             Tracer.Instance = new Tracer(settings, new DummyAgentWriter(), null, null, null);
 
-            var methodInfo = typeof(IDbCommand).GetMethod("ExecuteNonQuery", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-
-            MdToken = methodInfo.MetadataToken;
-            var guid = typeof(IDbCommand).Module.ModuleVersionId;
-
-            GuidPtr = Marshal.AllocHGlobal(Marshal.SizeOf(guid));
-
-            Marshal.StructureToPtr(guid, GuidPtr, false);
-
             var bench = new DbCommandBenchmark();
             bench.ExecuteNonQuery();
-            bench.CallTargetExecuteNonQuery();
         }
 
         [Benchmark]
-        public int ExecuteNonQuery()
-        {
-            return IDbCommandIntegration.ExecuteNonQuery(DbCommand, (int)OpCodeValue.Callvirt, MdToken, (long)GuidPtr);
-        }
-
-        [Benchmark]
-        public unsafe int CallTargetExecuteNonQuery()
+        public unsafe int ExecuteNonQuery()
         {
             return CallTarget.Run<CommandExecuteNonQueryIntegration, CustomDbCommand, int>(CustomCommand, &InternalExecuteNonQuery);
 

--- a/test/benchmarks/Benchmarks.Trace/ElasticsearchBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/ElasticsearchBenchmark.cs
@@ -1,12 +1,9 @@
 using System;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V6;
-using Datadog.Trace.ClrProfiler.Emit;
-using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.Configuration;
 using Elasticsearch.Net;
 
@@ -15,10 +12,7 @@ namespace Benchmarks.Trace
     [MemoryDiagnoser]
     public class ElasticsearchBenchmark
     {
-        private static readonly int MdToken;
-        private static readonly IntPtr GuidPtr;
         private static readonly RequestPipeline Pipeline = new RequestPipeline();
-        private static readonly object PipelineObject = new RequestPipeline();
         private static readonly RequestData Data = new RequestData
         {
             Method = HttpMethod.POST,
@@ -35,49 +29,13 @@ namespace Benchmarks.Trace
 
             Tracer.Instance = new Tracer(settings, new DummyAgentWriter(), null, null, null);
 
-            var methodInfo = typeof(RequestPipeline).GetMethod("CallElasticsearchAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-
-            MdToken = methodInfo.MetadataToken;
-            var guid = typeof(RequestPipeline).Module.ModuleVersionId;
-
-            GuidPtr = Marshal.AllocHGlobal(Marshal.SizeOf(guid));
-
-            Marshal.StructureToPtr(guid, GuidPtr, false);
-
             var bench = new ElasticsearchBenchmark();
             bench.CallElasticsearch();
             bench.CallElasticsearchAsync();
-            bench.CallTargetCallElasticsearch();
-            bench.CallTargetCallElasticsearchAsync();
         }
 
         [Benchmark]
-        public object CallElasticsearch()
-        {
-            return ElasticsearchNet6Integration.CallElasticsearch<int>(
-                PipelineObject,
-                Data,
-                (int)OpCodeValue.Callvirt,
-                MdToken,
-                (long)GuidPtr);
-        }
-
-        [Benchmark]
-        public int CallElasticsearchAsync()
-        {
-            var task = (Task<int>)ElasticsearchNet6Integration.CallElasticsearchAsync<int>(
-                PipelineObject,
-                Data,
-                CancellationToken.None,
-                (int)OpCodeValue.Callvirt,
-                MdToken,
-                (long)GuidPtr);
-
-            return task.GetAwaiter().GetResult();
-        }
-
-        [Benchmark]
-        public unsafe object CallTargetCallElasticsearch()
+        public unsafe object CallElasticsearch()
         {
             return CallTarget.Run<RequestPipeline_CallElasticsearch_Integration, RequestPipeline, RequestData, int>(Pipeline, Data, &GetData);
 
@@ -86,7 +44,7 @@ namespace Benchmarks.Trace
 
 
         [Benchmark]
-        public unsafe int CallTargetCallElasticsearchAsync()
+        public unsafe int CallElasticsearchAsync()
         {
             return CallTarget.Run<RequestPipeline_CallElasticsearchAsync_Integration, RequestPipeline, RequestData, CancellationToken, Task<int>>
                 (Pipeline, Data, CancellationToken.None, &GetData).GetAwaiter().GetResult();

--- a/test/benchmarks/Benchmarks.Trace/GraphQLBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/GraphQLBenchmark.cs
@@ -1,11 +1,7 @@
-using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
-using Datadog.Trace.ClrProfiler.Emit;
-using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.Configuration;
 using GraphQL;
 using GraphQL.Execution;
@@ -16,8 +12,6 @@ namespace Benchmarks.Trace
     public class GraphQLBenchmark
     {
         private static readonly Task<ExecutionResult> Result = Task.FromResult(new ExecutionResult { Value = 42 });
-        private static readonly int MdToken;
-        private static readonly IntPtr GuidPtr;
         private static readonly GraphQLClient Client = new GraphQLClient();
         private static readonly ExecutionContext Context = new ExecutionContext();
 
@@ -30,29 +24,11 @@ namespace Benchmarks.Trace
 
             Tracer.Instance = new Tracer(settings, new DummyAgentWriter(), null, null, null);
 
-            var methodInfo = typeof(GraphQLClient).GetMethod("ExecuteAsync", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-
-            MdToken = methodInfo.MetadataToken;
-            var guid = typeof(GraphQLClient).Module.ModuleVersionId;
-
-            GuidPtr = Marshal.AllocHGlobal(Marshal.SizeOf(guid));
-
-            Marshal.StructureToPtr(guid, GuidPtr, false);
-
             new GraphQLBenchmark().ExecuteAsync();
-
         }
 
         [Benchmark]
-        public int ExecuteAsync()
-        {
-            var task = (Task<ExecutionResult>)GraphQLIntegration.ExecuteAsync(Client, Context, (int)OpCodeValue.Callvirt, MdToken, (long)GuidPtr);
-
-            return task.GetAwaiter().GetResult().Value;
-        }
-
-        [Benchmark]
-        public unsafe int CallTargetExecuteAsync()
+        public unsafe int ExecuteAsync()
         {
             var task = CallTarget.Run<Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.ExecuteAsyncIntegration, GraphQLClient, ExecutionContext, Task<ExecutionResult>>(
                 Client,

--- a/test/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Net.Http;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.HttpClientHandler;
-using Datadog.Trace.ClrProfiler.Emit;
-using Datadog.Trace.ClrProfiler.Integrations;
 using Datadog.Trace.Configuration;
 
 namespace Benchmarks.Trace
@@ -16,11 +13,6 @@ namespace Benchmarks.Trace
     public class HttpClientBenchmark
     {
         private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };
-        private static readonly HttpMessageHandler Handler = new CustomHttpClientHandler();
-
-        private static readonly object BoxedCancellationToken = new CancellationToken();
-        private static readonly int MdToken;
-        private static readonly IntPtr GuidPtr;
 
         private static readonly Task<HttpResponseMessage> CachedResult = Task.FromResult(new HttpResponseMessage());
 
@@ -33,49 +25,12 @@ namespace Benchmarks.Trace
 
             Tracer.Instance = new Tracer(settings, new DummyAgentWriter(), null, null, null);
 
-            var methodInfo = typeof(HttpMessageHandler).GetMethod("SendAsync", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-
-            MdToken = methodInfo.MetadataToken;
-            var guid = typeof(HttpMessageHandler).Module.ModuleVersionId;
-
-            GuidPtr = Marshal.AllocHGlobal(Marshal.SizeOf(guid));
-
-            Marshal.StructureToPtr(guid, GuidPtr, false);
-
             var bench = new HttpClientBenchmark();
             bench.SendAsync();
-            bench.CallTargetSendAsync();
-        }
-
-        internal class CustomHttpClientHandler : HttpClientHandler
-        {
-            private static readonly Task<HttpResponseMessage> CachedResult = Task.FromResult(new HttpResponseMessage());
-
-            internal static HttpClientHandler Create() => new HttpClientHandler();
-
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                return CachedResult;
-            }
         }
 
         [Benchmark]
-        public string SendAsync()
-        {
-            var task = (Task)HttpMessageHandlerIntegration.HttpMessageHandler_SendAsync(
-                Handler,
-                HttpRequest,
-                BoxedCancellationToken,
-                (int)OpCodeValue.Callvirt,
-                MdToken,
-                (long)GuidPtr);
-
-            task.GetAwaiter().GetResult();
-            return "OK";
-        }
-
-        [Benchmark]
-        public unsafe string CallTargetSendAsync()
+        public unsafe string SendAsync()
         {
             CallTarget.Run<HttpClientHandlerIntegration, HttpClientBenchmark, HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>
                 (this, HttpRequest, CancellationToken.None, &GetResult).GetAwaiter().GetResult();


### PR DESCRIPTION
We should keep the tests until callsite is completely deprecated, but there's no point in keeping the benchmarks. Removing them should give some relief to the CI, and allows to restore the old iteration time.

