### PR TITLE
Flush both span buffers in a FlushTracesAsync() call

### DIFF
--- a/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -182,7 +182,7 @@ namespace Datadog.Trace.Agent
                 await tcs.Task.ConfigureAwait(false);
             }
 
-            await FlushBuffers().ConfigureAwait(false);
+            await FlushBuffers(true).ConfigureAwait(false);
         }
 
         internal void WriteWatermark(Action watermark, bool wakeUpThread = true)


### PR DESCRIPTION
`FlushTracesAsync()` is a public api to flush traces in the AgentWriter, this PR ensures that both front and back buffer are flushed when this method is called, to match the flush behavior of `FlushAndCloseAsync()`


@DataDog/apm-dotnet