### PR TITLE
Enable ultimate pipeline for PRs

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -1,17 +1,4 @@
-trigger:
-  branches:
-    include:
-      - master
-      - refs/tags/*
-
-schedules:
-- cron: "0 3 * * *"
-  displayName: Daily 3am (UTC) build
-  branches:
-    include:
-    - master
-    - /benchmarks/*
-  always: true
+trigger: none
 
 variables:
   buildConfiguration: release

--- a/.azure-pipelines/crank.yml
+++ b/.azure-pipelines/crank.yml
@@ -1,20 +1,4 @@
-trigger:
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
-pr:
-  branches:
-    include:
-      - master
-      - release/*
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
+trigger: none
 
 schedules:
 - cron: "0 4 * * *"

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -1,9 +1,4 @@
-trigger:
-  branches:
-    include:
-      - master
-      - refs/tags/*
-pr: none
+trigger: none
 
 variables:
   buildConfiguration: release

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -1,14 +1,4 @@
-trigger:
-  branches:
-    include:
-      - master
-      - refs/tags/*
-    exclude:
-      - refs/pull/*/head
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
+trigger: none
 
 variables:
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1,17 +1,15 @@
 trigger:
   branches:
     include:
-      - master # Only run on master for now
+      - master
+      - refs/tags/*
     exclude:
       - refs/pull/*/head
   paths:
     exclude:
       - docs/*
       - .github/*
-pr:
-  branches:
-    exclude: # Don't run PR validation for now
-    - '*'
+
 
 # Global variables
 variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -33,6 +33,9 @@ variables:
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
+  # For scheduled builds, only run benchmarks and crank (and deps).
+  # Allow forcing a benchmark/throughput run using run_benchmarks_only=true
+  benchmarksOnly: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['run_benchmarks_only'], 'true'))
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:
@@ -126,7 +129,7 @@ stages:
       artifact: build-linux-$(matrixName)-working-directory
 
 - stage: build_macos
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: []
   jobs:
   - job: build
@@ -156,7 +159,7 @@ stages:
       artifact: build-macos-working-directory
 
 - stage: package_windows
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -186,7 +189,7 @@ stages:
         artifact: nuget-packages
 
 - stage: unit_tests_windows
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -225,7 +228,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_macos
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: build_macos
   jobs:
   - job: managed
@@ -252,7 +255,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_linux
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: [build_linux]
   jobs:
   - job: test
@@ -300,7 +303,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -330,7 +333,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows_iis
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: [build_windows, package_windows]
   jobs:
   - job: Windows_IIS
@@ -399,7 +402,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_linux
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: [build_linux]
   jobs:
   - job: Test
@@ -564,7 +567,7 @@ stages:
         script: 'Start-Sleep -s 120'
 
 - stage: dotnet_tool
-  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: [build_windows, build_linux, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone
@@ -669,6 +672,7 @@ stages:
       artifact: runner-standalone-osx-x64
 
 - stage: upload
+  condition: and(succeeded(), not(variables['benchmarksOnly']))
   dependsOn: [package_windows, build_linux]
   jobs:
   - job: s3_upload
@@ -760,6 +764,7 @@ stages:
             eq(variables.isMainBranch, true)
           )
         )
+
 
 - stage: throughput
   dependsOn: [build_linux, build_windows]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -35,7 +35,7 @@ variables:
   relativeNugetPackageDirectory: packages
   # For scheduled builds, only run benchmarks and crank (and deps).
   # Allow forcing a benchmark/throughput run using run_benchmarks_only=true
-  benchmarksOnly: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['run_benchmarks_only'], 'true'))
+  benchmarksOnly: ${{ or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['run_benchmarks_only'], 'true')) }} # only works if you have a main branch
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:
@@ -129,7 +129,7 @@ stages:
       artifact: build-linux-$(matrixName)-working-directory
 
 - stage: build_macos
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: []
   jobs:
   - job: build
@@ -159,7 +159,7 @@ stages:
       artifact: build-macos-working-directory
 
 - stage: package_windows
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -189,7 +189,7 @@ stages:
         artifact: nuget-packages
 
 - stage: unit_tests_windows
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -228,7 +228,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_macos
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: build_macos
   jobs:
   - job: managed
@@ -255,7 +255,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_linux
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: [build_linux]
   jobs:
   - job: test
@@ -303,7 +303,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -333,7 +333,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows_iis
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: [build_windows, package_windows]
   jobs:
   - job: Windows_IIS
@@ -402,7 +402,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_linux
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: [build_linux]
   jobs:
   - job: Test
@@ -568,7 +568,7 @@ stages:
         script: 'Start-Sleep -s 120'
 
 - stage: dotnet_tool
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: [build_windows, build_linux, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone
@@ -673,7 +673,7 @@ stages:
       artifact: runner-standalone-osx-x64
 
 - stage: upload
-  condition: and(succeeded(), not(variables['benchmarksOnly']))
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
   dependsOn: [package_windows, build_linux]
   jobs:
   - job: s3_upload
@@ -765,6 +765,7 @@ stages:
             eq(variables.isMainBranch, true)
           )
         )
+
 
 
 - stage: throughput

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -11,6 +11,15 @@ trigger:
       - .github/*
 
 
+schedules:
+  - cron: "0 3 * * *"
+    displayName: Daily 3am (UTC) build
+    branches:
+      include:
+        - master
+        - /benchmarks/*
+    always: true
+
 # Global variables
 variables:
   buildConfiguration: Release
@@ -117,6 +126,7 @@ stages:
       artifact: build-linux-$(matrixName)-working-directory
 
 - stage: build_macos
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: []
   jobs:
   - job: build
@@ -146,6 +156,7 @@ stages:
       artifact: build-macos-working-directory
 
 - stage: package_windows
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -175,6 +186,7 @@ stages:
         artifact: nuget-packages
 
 - stage: unit_tests_windows
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -213,6 +225,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_macos
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: build_macos
   jobs:
   - job: managed
@@ -239,6 +252,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_linux
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: [build_linux]
   jobs:
   - job: test
@@ -286,6 +300,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -315,6 +330,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows_iis
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: [build_windows, package_windows]
   jobs:
   - job: Windows_IIS
@@ -383,6 +399,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_linux
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: [build_linux]
   jobs:
   - job: Test
@@ -547,6 +564,7 @@ stages:
         script: 'Start-Sleep -s 120'
 
 - stage: dotnet_tool
+  condition: ne(variables['Build.Reason'], 'Schedule') # skip for scheduled builds
   dependsOn: [build_windows, build_linux, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -539,6 +539,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: benchmarks
+  condition: and(succeeded(), ne(variables['skip_benchmarks'], 'true'))
   dependsOn: build_windows
   jobs:
 
@@ -767,6 +768,7 @@ stages:
 
 
 - stage: throughput
+  condition: and(succeeded(), ne(variables['skip_benchmarks'], 'true'))
   dependsOn: [build_linux, build_windows]
   jobs:
 


### PR DESCRIPTION
Disable the other pipelines for now (should still be able to run them manually). Left the unit tests and integration test pipelines enabled for now, but we may want to disable those too?

Also configured the ultimate pipeline to run the throughput and benchmark tests nightly.

@DataDog/apm-dotnet