### PR TITLE
Adds CorLib detection for assembly ref

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -723,24 +723,37 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
   return true;
 }
 
-HRESULT CreateAssemblyRefToMscorlib(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit, mdAssemblyRef* mscorlib_ref) {
-  // Define an AssemblyRef to mscorlib, needed to create TypeRefs later
-  ASSEMBLYMETADATA metadata{};
-  metadata.usMajorVersion = 4;
-  metadata.usMinorVersion = 0;
-  metadata.usBuildNumber = 0;
-  metadata.usRevisionNumber = 0;
-  BYTE public_key[] = {0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89};
-  HRESULT hr = assembly_emit->DefineAssemblyRef(public_key, sizeof(public_key),
-                                   WStr("mscorlib"), &metadata, NULL, 0, 0,
-                                   mscorlib_ref);
-
-  return hr;
+HRESULT GetCORLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit, AssemblyProperty& corAssemblyProperty, mdAssemblyRef* corlib_ref) {
+  if (corAssemblyProperty.ppbPublicKey != nullptr) {
+    // the corlib module is already loaded, use that information to create the assembly ref
+    Debug("Using existing corlib reference: ", corAssemblyProperty.szName);
+    return assembly_emit->DefineAssemblyRef(
+        corAssemblyProperty.ppbPublicKey,
+        corAssemblyProperty.pcbPublicKey,
+        corAssemblyProperty.szName.c_str(),
+        &corAssemblyProperty.pMetaData,
+        NULL, 0, 0, corlib_ref);
+  } else {
+    // Define an AssemblyRef to mscorlib, needed to create TypeRefs later
+    ASSEMBLYMETADATA metadata{};
+    metadata.usMajorVersion = 4;
+    metadata.usMinorVersion = 0;
+    metadata.usBuildNumber = 0;
+    metadata.usRevisionNumber = 0;
+    BYTE public_key[] = {0xB7, 0x7A, 0x5C, 0x56, 0x19, 0x34, 0xE0, 0x89};
+    return assembly_emit->DefineAssemblyRef(
+        public_key,
+        sizeof(public_key),
+        WStr("mscorlib"),
+        &metadata,
+        NULL, 0, 0, corlib_ref);
+  }
 }
 
 bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
                                             const ComPtr<IMetaDataEmit2>& metadata_emit,
                                             const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
+                                            AssemblyProperty& corAssemblyProperty,
                                             mdToken* ret_type_token) {
   const auto cor_element_type = CorElementType(*p_sig);
   WSTRING managed_type_name = WStr("");
@@ -812,7 +825,7 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
   // Create reference to Mscorlib
   mdModuleRef mscorlib_ref;
   HRESULT hr;
-  hr = CreateAssemblyRefToMscorlib(assembly_emit, &mscorlib_ref);
+  hr = GetCORLibAssemblyRef(assembly_emit, corAssemblyProperty, &mscorlib_ref);
 
   if (FAILED(hr)) {
     Warn("[trace::ReturnTypeTokenforElementType] failed to define AssemblyRef to mscorlib");
@@ -840,6 +853,7 @@ bool ReturnTypeIsValueTypeOrGeneric(
                       const ComPtr<IMetaDataImport2>& metadata_import,
                       const ComPtr<IMetaDataEmit2>& metadata_emit,
                       const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
+                      AssemblyProperty& corAssemblyProperty,
                       const mdToken targetFunctionToken,
                       const MethodSignature targetFunctionSignature,
                       mdToken* ret_type_token) {
@@ -1010,6 +1024,7 @@ bool ReturnTypeIsValueTypeOrGeneric(
               p_current_byte,
               metadata_emit,
               assembly_emit,
+              corAssemblyProperty,
               ret_type_token);
         }
       }
@@ -1022,6 +1037,7 @@ bool ReturnTypeIsValueTypeOrGeneric(
           PCCOR_SIGNATURE(&targetFunctionSignature.data[method_def_sig_index]),
           metadata_emit,
           assembly_emit,
+          corAssemblyProperty,
           ret_type_token);
   }
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -723,7 +723,9 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
   return true;
 }
 
-HRESULT GetCORLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit, AssemblyProperty& corAssemblyProperty, mdAssemblyRef* corlib_ref) {
+HRESULT GetCorLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
+                             AssemblyProperty& corAssemblyProperty,
+                             mdAssemblyRef* corlib_ref) {
   if (corAssemblyProperty.ppbPublicKey != nullptr) {
     // the corlib module is already loaded, use that information to create the assembly ref
     Debug("Using existing corlib reference: ", corAssemblyProperty.szName);
@@ -825,7 +827,7 @@ bool ReturnTypeTokenforValueTypeElementType(PCCOR_SIGNATURE p_sig,
   // Create reference to Mscorlib
   mdModuleRef mscorlib_ref;
   HRESULT hr;
-  hr = GetCORLibAssemblyRef(assembly_emit, corAssemblyProperty, &mscorlib_ref);
+  hr = GetCorLibAssemblyRef(assembly_emit, corAssemblyProperty, &mscorlib_ref);
 
   if (FAILED(hr)) {
     Warn("[trace::ReturnTypeTokenforElementType] failed to define AssemblyRef to mscorlib");

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -480,7 +480,7 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
                          const FunctionInfo& function_info,
                          std::vector<WSTRING>& signature_result);
 
-HRESULT GetCORLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
+HRESULT GetCorLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
                              AssemblyProperty& corAssemblyProperty,
                              mdAssemblyRef* corlib_ref);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -480,13 +480,14 @@ bool TryParseSignatureTypes(const ComPtr<IMetaDataImport2>& metadata_import,
                          const FunctionInfo& function_info,
                          std::vector<WSTRING>& signature_result);
 
-HRESULT CreateAssemblyRefToMscorlib(
-    const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
-    mdAssemblyRef* mscorlib_ref);
+HRESULT GetCORLibAssemblyRef(const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
+                             AssemblyProperty& corAssemblyProperty,
+                             mdAssemblyRef* corlib_ref);
 
 bool ReturnTypeIsValueTypeOrGeneric(const ComPtr<IMetaDataImport2>& metadata_import,
                       const ComPtr<IMetaDataEmit2>& metadata_emit,
                       const ComPtr<IMetaDataAssemblyEmit>& assembly_emit,
+                      AssemblyProperty& corAssemblyProperty,
                       const mdToken targetFunctionToken,
                       const MethodSignature targetFunctionSignature,
                       mdToken* ret_type_token);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1725,7 +1725,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id,
       metadata_interfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
 
   mdAssemblyRef corlib_ref;
-  hr = GetCORLibAssemblyRef(assembly_emit, corAssemblyProperty, &corlib_ref);
+  hr = GetCorLibAssemblyRef(assembly_emit, corAssemblyProperty, &corlib_ref);
 
   if (FAILED(hr)) {
     Warn("GenerateVoidILStartupMethod: failed to define AssemblyRef to mscorlib");
@@ -2431,7 +2431,7 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(
 
   // Get corlib assembly ref
   mdAssemblyRef corlib_ref;
-  hr = GetCORLibAssemblyRef(assembly_emit, corAssemblyProperty, &corlib_ref);
+  hr = GetCorLibAssemblyRef(assembly_emit, corAssemblyProperty, &corlib_ref);
 
   // Get System.Boolean type token
   mdToken boolToken;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2345,7 +2345,7 @@ Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler l
   pNewInstr->m_Arg8 = 5;
   rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
 
-  // callvirt System.Reflection.Assembly System.Reflection.Assembly.Load(uint8[], uint8[])
+  // call System.Reflection.Assembly System.Reflection.Assembly.Load(uint8[], uint8[])
   pNewInstr = rewriter_void.NewILInstr();
   pNewInstr->m_opcode = CEE_CALL;
   pNewInstr->m_Arg32 = appdomain_load_member_ref;

--- a/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
+++ b/test/Datadog.Trace.ClrProfiler.Native.Tests/clr_helper_test.cpp
@@ -360,10 +360,12 @@ TEST_F(CLRHelperTest,
       if (type_info.IsValid() &&
           type_info.name == L"Samples.ExampleLibrary.Class1") {
         mdToken type_token = mdTokenNil;
+        AssemblyProperty asm_prop{};
         auto target = GetFunctionInfo(metadata_import_, method_def);
         bool result = ReturnTypeIsValueTypeOrGeneric(metadata_import_,
                                                      metadata_emit_,
                                                      assembly_emit_,
+                                                     asm_prop,
                                                      target.id,
                                                      target.signature,
                                                      &type_token) &&
@@ -402,9 +404,11 @@ TEST_F(CLRHelperTest,
     auto target = GetFunctionInfo(metadata_import_, current);
     if (target.name == L"ReturnT1" || target.name == L"ReturnT2") {
       mdToken type_token = mdTokenNil;
+      AssemblyProperty asm_prop{};
       bool result = ReturnTypeIsValueTypeOrGeneric(metadata_import_,
                                                   metadata_emit_,
                                                   assembly_emit_,
+                                                  asm_prop,
                                                   target.id,
                                                   target.signature,
                                                   &type_token) &&
@@ -435,11 +439,13 @@ TEST_F(CLRHelperTest,
 
   for (mdMethodSpec current = mdtMethodSpec + 1; metadata_import_->IsValidToken(current); current++) {
     mdToken type_token = mdTokenNil;
+    AssemblyProperty asm_prop{};
     auto target = GetFunctionInfo(metadata_import_, current);
     if (target.name.find(L"ReturnM") != std::string::npos) {
       bool result = ReturnTypeIsValueTypeOrGeneric(metadata_import_,
                                                    metadata_emit_,
                                                    assembly_emit_,
+                                                   asm_prop,
                                                    target.id,
                                                    target.signature,
                                                    &type_token) &&


### PR DESCRIPTION
This PR adds CorLib detection and use that on assembly ref instead of forcing mscorlib reference.

Related to: https://github.com/DataDog/dd-trace-dotnet/issues/1478

@DataDog/apm-dotnet