### PR TITLE
Fix CosomsDb tests and disable PR triggers for old pipelines

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 variables:
   buildConfiguration: release

--- a/.azure-pipelines/crank.yml
+++ b/.azure-pipelines/crank.yml
@@ -1,13 +1,5 @@
 trigger: none
-
-schedules:
-- cron: "0 4 * * *"
-  displayName: Daily 4am (UTC) build
-  branches:
-    include:
-    - master
-    - /benchmarks/*
-  always: true
+pr: none
 
 jobs:
 

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 variables:
   buildConfiguration: release

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 variables:
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -322,6 +322,13 @@ stages:
     - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
 
+    - powershell: |
+        Write-Host "Starting CosmosDB Emulator"
+        Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
+        Start-CosmosDbEmulator
+      displayName: 'Start CosmosDB Emulator'
+      workingDirectory: $(Pipeline.Workspace)
+
     - script: build.cmd BuildAndRunWindowsIntegrationTests --PrintDriveSpace
       displayName: Run integration tests
 

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -981,6 +981,14 @@ partial class Build
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 
+
+            var filter = (string.IsNullOrEmpty(Filter), IsArm64) switch
+            {
+                (true, false) => "Category!=LinuxUnsupported",
+                (true, true) => "(Category!=ArmUnsupported)&(Category!=LinuxUnsupported",
+                _ => Filter
+            };
+
             try
             {
                 // Run these ones in parallel
@@ -992,7 +1000,7 @@ partial class Build
                         .EnableNoBuild()
                         .SetFramework(Framework)
                         .EnableMemoryDumps()
-                        .When(!string.IsNullOrEmpty(Filter), x => x.SetFilter(Filter))
+                        .SetFilter(filter)
                         .When(TestAllPackageVersions, o => o
                             .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                         .CombineWith(ParallelIntegrationTests, (s, project) => s
@@ -1008,7 +1016,7 @@ partial class Build
                     .EnableNoBuild()
                     .SetFramework(Framework)
                     .EnableMemoryDumps()
-                    .SetFilter(Filter ?? (IsArm64 ? "Category!=ArmUnsupported" : null))
+                    .SetFilter(filter)
                     .When(TestAllPackageVersions, o => o
                         .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -811,7 +811,7 @@ partial class Build
             // These samples are currently skipped.
             var projectsToSkip = new[]
             {
-                "Samples.Msmq",
+                "Samples.Msmq",  // Doesn't run on Linux
                 "Samples.MultiDomainHost.Runner",
                 "Samples.RateLimiter", // I think we _should_ run this one (assuming it has tests)
                 "Samples.SqlServer.NetFramework20",
@@ -833,6 +833,7 @@ partial class Build
             // TODO: Load this list dynamically
             var multiApiProjects = new[]
             {
+                "Samples.CosmosDb",
                 "Samples.MongoDB",
                 "Samples.Elasticsearch",
                 "Samples.Elasticsearch.V5",


### PR DESCRIPTION
Fix CosmosDb tests in unified pipeline 

Disable scheduled triggers for benchmark/throughput (run by ultimate pipeline).

Previous attempt just disabled for CI pushes, not PR validation

@DataDog/apm-dotnet