### PR TITLE
Small build improvements

### DIFF
--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -918,6 +918,8 @@ partial class Build
             // Annoyingly this rebuilds everything again and again.
             var targets = new [] { "RestoreSamplesForPackageVersionsOnly", "RestoreAndBuildSamplesForPackageVersionsOnly" };
 
+            // /nowarn:NU1608 - Detected package version outside of dependency constraint
+            // /nowarn:NU1701 - Package 'x' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'.
             DotNetMSBuild(x => x
                 .SetTargetPath(MsBuildProject)
                 .SetConfiguration(BuildConfiguration)
@@ -925,6 +927,7 @@ partial class Build
                 .SetProperty("TargetFramework", Framework.ToString())
                 .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                 .SetProperty("BuildInParallel", "true")
+                .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701 /nowarn:NU1608"))
                 .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
                 .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                 .CombineWith(targets, (c, target) => c.SetTargets(target))

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -848,6 +848,9 @@ partial class Build
                 "Samples.Microsoft.Data.Sqlite",
                 "Samples.OracleMDA",
                 "Samples.OracleMDA.Core",
+                "Samples.XUnitTests",
+                "Samples.NUnitTests",
+                "Samples.MSTestTests",
             };
 
             var projectsToBuild = sampleProjects

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -918,7 +918,6 @@ partial class Build
             // Annoyingly this rebuilds everything again and again.
             var targets = new [] { "RestoreSamplesForPackageVersionsOnly", "RestoreAndBuildSamplesForPackageVersionsOnly" };
 
-            // /nowarn:NU1608 - Detected package version outside of dependency constraint
             // /nowarn:NU1701 - Package 'x' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'.
             DotNetMSBuild(x => x
                 .SetTargetPath(MsBuildProject)
@@ -927,7 +926,7 @@ partial class Build
                 .SetProperty("TargetFramework", Framework.ToString())
                 .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                 .SetProperty("BuildInParallel", "true")
-                .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701 /nowarn:NU1608"))
+                .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
                 .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
                 .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                 .CombineWith(targets, (c, target) => c.SetTargets(target))

--- a/build/_build/_build.csproj
+++ b/build/_build/_build.csproj
@@ -20,14 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\..\.azure-pipelines\steps\run-in-docker.yml">
-      <Link>ci\steps\run-in-docker.yml</Link>
-    </Content>
+    <Content Include="..\..\.azure-pipelines\steps\*" Link="ci\steps\%(Filename)%(Extension)" />
     <Content Include="..\..\.azure-pipelines\ultimate-pipeline.yml" Link="ci\ultimate-pipeline.yml" />
-    <Content Include="..\..\.azure-pipelines\steps\install-dotnet.yml" Link="ci\steps\install-dotnet.yml" />
-    <Content Include="..\..\.azure-pipelines\steps\install-dotnet-sdks.yml" Link="ci\steps\install-dotnet-sdks.yml" />
-    <Content Include="..\..\.azure-pipelines\steps\install-dotnet-5-sdk.yml" Link="ci\steps\install-dotnet-5-sdk.yml" />
-    <Content Include="..\..\.azure-pipelines\steps\restore-working-directory.yml" Link="ci\steps\restore-working-directory.yml" />
     <Content Include="..\..\docker.sh" Link="docker\docker.sh" />
   </ItemGroup>
 </Project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -631,6 +631,7 @@ services:
       - MYSQL57_PORT=3306
       - RABBITMQ_HOST=rabbitmq
       - KAFKA_BROKER_HOST=kafka-broker:29092
+      - AWS_SQS_HOST=aws_sqs:9324
     depends_on:
       - servicestackredis
       - stackexchangeredis
@@ -644,7 +645,7 @@ services:
       - rabbitmq
       - kafka-broker
       - kafka-zookeeper
-
+      - aws_sqs
 
   StartDependencies:
     image: andrewlock/wait-for-dependencies
@@ -661,9 +662,10 @@ services:
       - rabbitmq
       - kafka-broker
       - kafka-zookeeper
+      - aws_sqs
     environment:
       - TIMEOUT_LENGTH=60
-    command: servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181
+    command: servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 aws_sqs:9324
 
   NukeIntegrationTests.ARM64:
     build:

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 if (NOT EXISTS ${OUTPUT_DEPS_DIR}/re2)
     add_custom_command(
         OUTPUT ${OUTPUT_DEPS_DIR}/re2
-        COMMAND git clone --quiet --depth 1 --branch 2018-10-01 https://github.com/google/re2.git && cd re2 && env CXXFLAGS=\"-O3 -g -fPIC\" make
+        COMMAND git clone --quiet --depth 1 --branch 2018-10-01 https://github.com/google/re2.git && cd re2 && env ARFLAGS=\"-r -s -c\" CXXFLAGS=\"-O3 -g -fPIC\" make
         WORKING_DIRECTORY ${OUTPUT_DEPS_DIR}
     )
 endif()

--- a/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -9,6 +9,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+    <!--  Ignore package version outside of dependency constraint: NEST 5.3.0 requires Newtonsoft.Json (>= 9.0.0 && < 10.0.0)  -->
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.GraphQL/Startup.cs
+++ b/test/test-applications/integrations/Samples.GraphQL/Startup.cs
@@ -46,7 +46,13 @@ namespace Samples.GraphQL
             .AddUserContextBuilder(httpContext => new GraphQLUserContext { User = httpContext.User });
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app,
+#if NETCOREAPP2_1 || NET461
+                              IHostingEnvironment env,
+#else
+                              IWebHostEnvironment env,
+#endif
+                              ILoggerFactory loggerFactory)
         {
             // Get StarWarsSchema Singleton
             var starWarsSchema = (StarWarsSchema)app.ApplicationServices.GetService(typeof(ISchema));

--- a/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -83,7 +83,7 @@ namespace Samples.MongoDB
                 {
 #pragma warning disable 0618 // 'FindOptionsBase.Modifiers' is obsolete: 'Use individual properties instead.'
                     Modifiers = new BsonDocument("$explain", true)
-#pragma warning enable 0618
+#pragma warning restore 0618
                 };
                 // Without properly unboxing generic arguments whose instantiations
                 // are valuetypes, the following line will fail with

--- a/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -81,7 +81,9 @@ namespace Samples.MongoDB
                 // https://stackoverflow.com/questions/49506857/how-do-i-run-an-explain-query-with-the-2-4-c-sharp-mongo-driver
                 var options = new FindOptions
                 {
+#pragma warning disable 0618 // 'FindOptionsBase.Modifiers' is obsolete: 'Use individual properties instead.'
                     Modifiers = new BsonDocument("$explain", true)
+#pragma warning enable 0618
                 };
                 // Without properly unboxing generic arguments whose instantiations
                 // are valuetypes, the following line will fail with

--- a/test/test-applications/integrations/Samples.ServiceStack.Redis/Samples.ServiceStack.Redis.csproj
+++ b/test/test-applications/integrations/Samples.ServiceStack.Redis/Samples.ServiceStack.Redis.csproj
@@ -6,12 +6,11 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <!-- Ignore Found conflicts between different versions of "System.ValueTuple" (and others) that could not be resolved.   -->
-    <NoWarn>MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="ServiceStack.Redis" Version="$(ApiVersion)" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/test/test-applications/integrations/Samples.ServiceStack.Redis/Samples.ServiceStack.Redis.csproj
+++ b/test/test-applications/integrations/Samples.ServiceStack.Redis/Samples.ServiceStack.Redis.csproj
@@ -6,6 +6,8 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <!-- Ignore Found conflicts between different versions of "System.ValueTuple" (and others) that could not be resolved.   -->
+    <NoWarn>MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.XUnitTests/Program.cs
+++ b/test/test-applications/integrations/Samples.XUnitTests/Program.cs
@@ -1,0 +1,9 @@
+﻿namespace Samples.XUnitTests
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.XUnitTests/Samples.XUnitTests.csproj
+++ b/test/test-applications/integrations/Samples.XUnitTests/Samples.XUnitTests.csproj
@@ -12,6 +12,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
+++ b/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
@@ -3,12 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <!-- Ignore  Found conflicts between different versions of "System.Diagnostics.PerformanceCounter" that could not be resolved. -->
-    <NoWarn >MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="5.0.1" />
   </ItemGroup>
 
 </Project>

--- a/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
+++ b/test/test-applications/regression/StackExchange.Redis.StackOverflowException/StackExchange.Redis.StackOverflowException.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <!-- Ignore  Found conflicts between different versions of "System.Diagnostics.PerformanceCounter" that could not be resolved. -->
+    <NoWarn >MSB3277</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- xunit/nunit/mstest samples are built using multi api so don't need to be built separately
- Fix occasional flaky build for xunit sample on arm64
- Ignore NuGet package related warnings in CompileMultiApiPackageVersionSamples to reduce noise
- Try and reduce noise in build by setting ARFLAGS for re2 build
- Minor globbing improvement in build file
- Fix AWS SQS tests

@DataDog/apm-dotnet 
