### PR TITLE
Add code coverage to the consolidated pipeline

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -949,6 +949,9 @@ stages:
     - job: Windows
       timeoutInMinutes: 30
 
+      pool:
+        vmImage: windows-2019
+
       steps:
       - template: steps/install-dotnet-sdks.yml
       - template: steps/restore-working-directory.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -964,11 +964,7 @@ stages:
         inputs:
           patterns: '**/coverage.cobertura.xml'
           path: $(Build.SourcesDirectory)/cover
-    
-      - task: CmdLine@2
-        inputs:
-          script: 'tree $(Build.SourcesDirectory) /F /A'     
-    
+
       - task: reportgenerator@4
         inputs:
           reports: '$(Build.SourcesDirectory)\cover\**\coverage.cobertura.xml'

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -612,6 +612,11 @@ stages:
             testResultsFiles: build_data/results/**/*.trx
           condition: succeededOrFailed()
 
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: 'build_data/results/'
+      continueOnError: true
+
 - stage: benchmarks
   dependsOn: build_windows
   jobs:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -951,7 +951,7 @@ stages:
         DD_SERVICE: dd-trace-dotnet
 - stage: coverage
   condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
-  dependsOn: [integration_tests_windows, integration_tests_windows_iis]
+  dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]
   jobs:
     - job: Windows
       timeoutInMinutes: 30

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -958,7 +958,6 @@ stages:
         vmImage: windows-2019
 
       steps:
-      - template: steps/install-dotnet-sdks.yml
       - template: steps/restore-working-directory.yml
     
       - task: DownloadPipelineArtifact@2
@@ -968,16 +967,17 @@ stages:
     
       - task: CmdLine@2
         inputs:
-          script: 'tree $(Build.SourcesDirectory)\cover /F /A'     
+          script: 'tree $(Build.SourcesDirectory) /F /A'     
     
       - task: reportgenerator@4
         inputs:
           reports: '$(Build.SourcesDirectory)\cover\**\coverage.cobertura.xml'
           targetdir: '$(Build.SourcesDirectory)\coveragereport'
-          sourcedirs: '$(Build.SourcesDirectory)'
+          sourcedirs: '$(Build.SourcesDirectory);..'
           reporttypes: 'Cobertura'
      
       - task: PublishCodeCoverageResults@1
         inputs:
           codeCoverageTool: 'Cobertura'
           summaryFileLocation: '$(Build.SourcesDirectory)/coveragereport/Cobertura.xml'
+          pathToSources: '$(Build.SourcesDirectory)'

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -944,7 +944,7 @@ stages:
       env:
         DD_SERVICE: dd-trace-dotnet
 - stage: coverage
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]
   jobs:
     - job: Windows

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -214,11 +214,6 @@ stages:
           testResultsFiles: build_data/results/**/*.trx
         condition: succeededOrFailed()
         
-      - task: PublishPipelineArtifact@1
-        inputs:
-          targetPath: 'build_data/results/'
-        continueOnError: true
-
     - job: native
       steps:
       - template: steps/install-dotnet.yml
@@ -260,10 +255,7 @@ stages:
           testResultsFiles: build_data/results/**/*.trx
         condition: succeededOrFailed()
         
-      - task: PublishPipelineArtifact@1
-        inputs:
-          targetPath: 'build_data/results/'
-        continueOnError: true
+
 
 - stage: unit_tests_linux
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
@@ -626,11 +618,6 @@ stages:
             testResultsFormat: VSTest
             testResultsFiles: build_data/results/**/*.trx
           condition: succeededOrFailed()
-
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'build_data/results/'
-      continueOnError: true
 
 - stage: benchmarks
   dependsOn: build_windows

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -200,7 +200,7 @@ stages:
       - template: steps/install-dotnet.yml
       - template: steps/restore-working-directory.yml
 
-      - script: build.cmd BuildAndRunManagedUnitTests
+      - script: build.cmd BuildAndRunManagedUnitTests --code-coverage
         displayName: Build and Test
 
       - publish: build_data
@@ -213,6 +213,11 @@ stages:
           testResultsFormat: VSTest
           testResultsFiles: build_data/results/**/*.trx
         condition: succeededOrFailed()
+        
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: 'build_data/results/'
+        continueOnError: true
 
     - job: native
       steps:
@@ -241,7 +246,7 @@ stages:
         parameters:
           artifact: build-macos-working-directory
 
-      - script: ./build.sh BuildAndRunManagedUnitTests
+      - script: ./build.sh BuildAndRunManagedUnitTests --code-coverage
         displayName: Build and Test
 
       - publish: build_data
@@ -254,6 +259,11 @@ stages:
           testResultsFormat: VSTest
           testResultsFiles: build_data/results/**/*.trx
         condition: succeededOrFailed()
+        
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: 'build_data/results/'
+        continueOnError: true
 
 - stage: unit_tests_linux
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
@@ -278,7 +288,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildAndRunManagedUnitTests"
+        command: "BuildAndRunManagedUnitTests --code-coverage"
 
     - publish: build_data
       artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
@@ -290,6 +300,11 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
+      
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: 'build_data/results/'
+      continueOnError: true
 
 - stage: unit_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -350,7 +350,7 @@ stages:
       displayName: 'Start CosmosDB Emulator'
       workingDirectory: $(Pipeline.Workspace)
 
-    - script: build.cmd BuildAndRunWindowsIntegrationTests --PrintDriveSpace
+    - script: build.cmd BuildAndRunWindowsIntegrationTests --PrintDriveSpace --code-coverage
       displayName: Run integration tests
 
     - task: PublishTestResults@2
@@ -359,6 +359,11 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
+      
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: 'build_data/results/'
+      continueOnError: true
 
 - stage: integration_tests_windows_iis
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
@@ -423,6 +428,11 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: 'build_data/results/'
+      continueOnError: true
 
     - task: DockerCompose@0
       displayName: docker-compose stop services
@@ -932,3 +942,30 @@ stages:
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
+- stage: coverage
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  dependsOn: [integration_tests_windows, integration_tests_windows_iis]
+  jobs:
+    - job: Windows
+      timeoutInMinutes: 30
+
+      steps:
+      - template: steps/install-dotnet-sdks.yml
+      - template: steps/restore-working-directory.yml
+    
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          patterns: '**/coverage.cobertura.xml'
+          path: $(Build.SourcesDirectory)/cover
+    
+      - task: reportgenerator@4
+        inputs:
+          reports: '$(Build.SourcesDirectory)\cover\*\*\coverage.cobertura.xml'
+          targetdir: '$(Build.SourcesDirectory)\coveragereport'
+          sourcedirs: '$(Build.SourcesDirectory)'
+          reporttypes: 'Cobertura'
+     
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: '$(Build.SourcesDirectory)/coveragereport/Cobertura.xml'

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -958,9 +958,13 @@ stages:
           patterns: '**/coverage.cobertura.xml'
           path: $(Build.SourcesDirectory)/cover
     
+      - task: CmdLine@2
+        inputs:
+          script: 'tree $(Build.SourcesDirectory)\cover /F /A'     
+    
       - task: reportgenerator@4
         inputs:
-          reports: '$(Build.SourcesDirectory)\cover\*\*\coverage.cobertura.xml'
+          reports: '$(Build.SourcesDirectory)\cover\**\coverage.cobertura.xml'
           targetdir: '$(Build.SourcesDirectory)\coveragereport'
           sourcedirs: '$(Build.SourcesDirectory)'
           reporttypes: 'Cobertura'

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -420,13 +420,7 @@ stages:
         containerregistrytype: Container Registry
         dockerComposeCommand: up -d IntegrationTests.IIS
 
-    - powershell: |
-        [System.Reflection.Assembly]::Load("System.EnterpriseServices, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a")
-        $publish = New-Object System.EnterpriseServices.Internal.Publish
-        Get-ChildItem $(tracerHome)/net45 -Filter *.dll | Foreach-Object { $publish.GacInstall($_.FullName) }
-      displayName: Add net45 Datadog.Trace.ClrProfiler.Managed assets to the GAC
-
-    - script: build.cmd RunWindowsIisIntegrationTests
+    - script: build.cmd RunWindowsIisIntegrationTests --code-coverage
       displayName: RunWindowsIisIntegrationTests
 
     - task: PublishTestResults@2

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -522,6 +522,7 @@ partial class Build
                     .SetTargetPlatformAnyCPU()
                     .SetDDEnvironmentVariables("dd-tracer-dotnet")
                     .EnableMemoryDumps()
+                    .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(testProjects, (x, project) => x
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .SetProjectFile(project)));

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -1092,6 +1092,8 @@ partial class Build
 
     private DotNetTestSettings ConfigureCodeCoverage(DotNetTestSettings settings)
     {
+        var strongNameKeyPath = Solution.Directory / "Datadog.Trace.snk";
+
         return settings.SetDataCollector("XPlat Code Coverage")
                 .SetProcessArgumentConfigurator(
                      args =>
@@ -1099,6 +1101,7 @@ partial class Build
                              .Add("RunConfiguration.DisableAppDomain=true") // https://github.com/coverlet-coverage/coverlet/issues/347
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SkipAutoProps=true")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura")
+                             .Add($"DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.StrongNameKey=\"{strongNameKeyPath}\"")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*]Datadog.Trace.Vendors.*,")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include=\"[Datadog.Trace.ClrProfiler.*]*,[Datadog.Trace]*,[Datadog.Trace.AspNet]*\""));
     }

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -1095,7 +1095,8 @@ partial class Build
                              .Add("RunConfiguration.DisableAppDomain=true") // https://github.com/coverlet-coverage/coverlet/issues/347
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SkipAutoProps=true")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura")
-                             .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*]Datadog.Trace.Vendors.*"));
+                             .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*]Datadog.Trace.Vendors.*,")
+                             .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include=\"[Datadog.Trace.ClrProfiler.*]*,[Datadog.Trace]*,[Datadog.Trace.AspNet]*\""));
     }
 
     protected override void OnTargetStart(string target)

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -745,6 +745,7 @@ partial class Build
         .After(CompileIntegrationTests)
         .After(CompileSamples)
         .After(CompileFrameworkReproductions)
+        .After(BuildWindowsIntegrationTests)
         .Requires(() => IsWin)
         .Executes(() =>
         {
@@ -775,6 +776,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "(RunOnWindows=True|Category=Smoke)&LoadFromGAC!=True&IIS!=True")
+                    .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .SetProjectFile(project)));
@@ -805,6 +807,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True")
+                    .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .SetProjectFile(project)));
@@ -1092,8 +1095,8 @@ partial class Build
         return settings.SetDataCollector("XPlat Code Coverage")
                 .SetProcessArgumentConfigurator(
                      args =>
-                         args.Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura")
-                             // .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.IncludeDirectory={0}", profilerLibFolder)
+                         args.Add("--")
+                             .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*]Datadog.Trace.Vendors.*"));
     }
 

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -1035,6 +1035,7 @@ partial class Build
                         .SetFilter(filter)
                         .When(TestAllPackageVersions, o => o
                             .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                        .When(CodeCoverage, ConfigureCodeCoverage)
                         .CombineWith(ParallelIntegrationTests, (s, project) => s
                             .EnableTrxLogOutput(GetResultsDirectory(project))
                             .SetProjectFile(project)),
@@ -1051,6 +1052,7 @@ partial class Build
                     .SetFilter(filter)
                     .When(TestAllPackageVersions, o => o
                         .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                    .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .SetProjectFile(project))
@@ -1085,13 +1087,6 @@ partial class Build
 
     private DotNetTestSettings ConfigureCodeCoverage(DotNetTestSettings settings)
     {
-        // if (settings.Framework != TargetFramework.NETCOREAPP3_1)
-        // {
-        //     return settings;
-        // }
-
-        // var profilerLibFolder = Solution.GetProject(Projects.ClrProfilerIntegrationTests).Directory / "bin" / BuildConfiguration / TargetFramework.NETCOREAPP3_1 / "profiler-lib" / TargetFramework.NETCOREAPP3_1;
-
         return settings.SetDataCollector("XPlat Code Coverage")
                 .SetProcessArgumentConfigurator(
                      args =>

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -1092,6 +1092,7 @@ partial class Build
                 .SetProcessArgumentConfigurator(
                      args =>
                          args.Add("--")
+                             .Add("RunConfiguration.DisableAppDomain=true") // https://github.com/coverlet-coverage/coverlet/issues/347
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*]Datadog.Trace.Vendors.*"));
     }

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -954,6 +954,8 @@ partial class Build
                 .SetProperty("TargetFramework", Framework.ToString())
                 .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                 .SetProperty("BuildInParallel", "true")
+                .SetProperty("ExcludeManagedProfiler", "true")
+                .SetProperty("ExcludeNativeProfiler", "true")
                 .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
                 .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
                 .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -562,8 +562,8 @@ partial class Build
 
     Target CompileDependencyLibs => _ => _
         .Unlisted()
-        .DependsOn(Restore)
-        .DependsOn(CompileManagedSrc)
+        .After(Restore)
+        .After(CompileManagedSrc)
         .Executes(() =>
         {
             // Always AnyCPU
@@ -758,7 +758,7 @@ partial class Build
                     .SetDotnetPath(Platform)
                     .SetConfiguration(BuildConfiguration)
                     .SetTargetPlatform(Platform)
-                                    .EnableNoRestore()
+                    .EnableNoRestore()
                     .EnableNoBuild()
                     .When(!string.IsNullOrEmpty(Filter), c => c.SetFilter(Filter))
                     .When(CodeCoverage, ConfigureCodeCoverage)

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -1093,6 +1093,7 @@ partial class Build
                      args =>
                          args.Add("--")
                              .Add("RunConfiguration.DisableAppDomain=true") // https://github.com/coverlet-coverage/coverlet/issues/347
+                             .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.SkipAutoProps=true")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura")
                              .Add("DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude=[*]Datadog.Trace.Vendors.*"));
     }

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -735,7 +735,7 @@ partial class Build
                 .SetProperty("DeployOnBuild", true)
                 .SetProperty("PublishProfile", publishProfile)
                 .SetMaxCpuCount(null)
-                .CombineWith(aspnetProjects, (c, project ) => c
+                .CombineWith(aspnetProjects, (c, project) => c
                     .SetTargetPath(project))
             );
         });
@@ -908,6 +908,8 @@ partial class Build
                     .SetFramework(Framework)
                     // .SetTargetPlatform(Platform)
                     .SetNoWarnDotNetCore3()
+                    .SetProperty("ExcludeManagedProfiler", "true")
+                    .SetProperty("ExcludeNativeProfiler", "true")
                     .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                     .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -805,6 +805,7 @@ partial class Build
                     .SetDotnetPath(Platform)
                     .SetConfiguration(BuildConfiguration)
                     .SetTargetPlatform(Platform)
+                    .When(Framework != null, o => o.SetFramework(Framework))
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "(RunOnWindows=True|Category=Smoke)&LoadFromGAC=True")

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -59,6 +59,9 @@ partial class Build : NukeBuild
     [Parameter("Override the default test filters for integration tests. (Optional)")]
     readonly string Filter;
 
+    [Parameter("Enables code coverage")]
+    readonly bool CodeCoverage;
+
     Target Info => _ => _
         .Description("Describes the current configuration")
         .Before(Clean, Restore, BuildTracerHome)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,7 +217,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdk5Version:-5.0.103}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
+    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
       - ./:/project
     environment:

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,7 @@
   <packageSources>
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
+    <add key="Azure" value="https://pkgs.dev.azure.com/datadoghq/dd-trace-dotnet/_packaging/Public_Feed/nuget/v3/index.json" />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -106,6 +106,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode);
             _testName = nameof(AspNetMvc4Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -106,6 +106,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode);
             _testName = nameof(AspNetMvc5Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -106,6 +106,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode);
             _testName = nameof(AspNetWebApi2Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
 
             _iisFixture = iisFixture;
+            _iisFixture.ShutdownPath = "/account/login?shutdown=1";
             _iisFixture.TryStartIis(this, classicMode: false);
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -176,6 +176,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         {
                             if (!_process.HasExited)
                             {
+                                SubmitRequest(null, "/shutdown").GetAwaiter().GetResult();
+
                                 _process.Kill();
                             }
                         }
@@ -275,7 +277,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 HttpResponseMessage response = await _httpClient.GetAsync($"http://localhost:{HttpPort}{path}");
                 string responseText = await response.Content.ReadAsStringAsync();
-                output.WriteLine($"[http] {response.StatusCode} {responseText}");
+                output?.WriteLine($"[http] {response.StatusCode} {responseText}");
                 return response.StatusCode;
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -270,7 +270,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     return true;
                 }
 
-                return !url.Contains("alive-check");
+                return !url.Contains("alive-check") && !url.Contains("shutdown");
             }
 
             private async Task<HttpStatusCode> SubmitRequest(ITestOutputHelper output, string path)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -224,7 +224,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
                 if (!process.HasExited)
                 {
-                    process.Kill();
+                    // Try shutting down gracefully
+                    await SubmitRequest(aspNetCorePort, "/shutdown");
+
+                    if (!process.WaitForExit(5000))
+                    {
+                        process.Kill();
+                    }
                 }
 
                 SpanTestHelpers.AssertExpectationsMet(Expectations, spans);
@@ -248,9 +254,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                                   resourceName,
                                   httpStatus,
                                   httpMethod)
-                              {
-                                  OriginalUri = url,
-                              };
+            {
+                OriginalUri = url,
+            };
 
             expectation.RegisterDelegateExpectation(additionalCheck);
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -299,7 +299,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                 return true;
             }
 
-            return !url.Contains("alive-check");
+            return !url.Contains("alive-check") && !url.Contains("shutdown");
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -36,12 +36,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 if (Directory.Exists(finalDirectory))
                 {
                     var file = typeof(Datadog.Trace.ClrProfiler.Instrumentation).Assembly.Location;
-                    File.Copy(file, Path.Combine(finalDirectory, Path.GetFileName(file)), true);
+                    var destination = Path.Combine(finalDirectory, Path.GetFileName(file));
+                    File.Copy(file, destination, true);
+
+                    messageSink.OnMessage(new DiagnosticMessage("Replaced {0} with {1} to setup code coverage", file, destination));
+
                     return;
                 }
             }
 
-            throw new DirectoryNotFoundException($"Could not find the {targetFrameworkDirectory} folder. Tried: {string.Join("; ", paths)}");
+            var message = $"Could not find the {targetFrameworkDirectory} folder. Tried: {string.Join("; ", paths)}";
+
+            messageSink.OnMessage(new DiagnosticMessage(message));
+
+            throw new DirectoryNotFoundException(message);
         }
 
         protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -59,13 +59,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private static string GetTargetFrameworkDirectory()
         {
-#if NETCOREAPP3_1_OR_GREATER
+            // The conditions looks weird, but it seems like _OR_GREATER is not supported yet in all environments
+            // We can trim all the additional conditions when this is fixed
+#if NETCOREAPP3_1_OR_GREATER || NETCOREAPP3_1 || NET50
             return "netcoreapp3.1";
 #elif NETCOREAPP || NETSTANDARD
             return "netstandard2.0";
-#elif NET461_OR_GREATER
+#elif NET461_OR_GREATER || NET461 || NET47 || NET471 || NET472 || NET48
             return "net461";
-#elif NET45_OR_GREATER
+#elif NET45_OR_GREATER || NET45 || NET451 || NET452 || NET46
             return "net45";
 #else
 #error Unexpected TFM

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     var destination = Path.Combine(finalDirectory, Path.GetFileName(file));
                     File.Copy(file, destination, true);
 
-                    messageSink.OnMessage(new DiagnosticMessage("Replaced {0} with {1} to setup code coverage", file, destination));
+                    messageSink.OnMessage(new DiagnosticMessage("Replaced {0} with {1} to setup code coverage", destination, file));
 
                     return;
                 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #elif NET45_OR_GREATER
             return "net45";
 #else
-            throw new InvalidOperationException("Unexpected TFM");
+#error Unexpected TFM
 #endif
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -25,6 +25,11 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
 
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 
   </ItemGroup>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
 
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -36,6 +36,7 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net452'">

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -155,7 +155,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 if (!process.HasExited)
                 {
-                    process.Kill();
+                    // Try shutting down gracefully
+                    var shutdownRequest = new RequestInfo() { HttpMethod = "GET", Url = "/shutdown" };
+                    SubmitRequest(aspNetCorePort, shutdownRequest);
+
+                    if (!process.WaitForExit(5000))
+                    {
+                        process.Kill();
+                    }
                 }
 
                 var spans = graphQLValidateSpans.Concat(graphQLExecuteSpans).ToList();

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GacFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/GacFixture.cs
@@ -1,0 +1,40 @@
+// <copyright file="GacFixture.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class GacFixture
+    {
+        public void AddAssembliesToGac()
+        {
+#if NETFRAMEWORK
+            var publish = new System.EnterpriseServices.Internal.Publish();
+
+            var targetFolder = CustomTestFramework.GetProfilerTargetFolder();
+
+            foreach (var file in Directory.GetFiles(targetFolder, "*.dll"))
+            {
+                publish.GacInstall(file);
+            }
+#endif
+        }
+
+        public void RemoveAssembliesFromGac()
+        {
+#if NETFRAMEWORK
+            var publish = new System.EnterpriseServices.Internal.Publish();
+
+            var targetFolder = CustomTestFramework.GetProfilerTargetFolder();
+
+            foreach (var file in Directory.GetFiles(targetFolder, "*.dll"))
+            {
+                publish.GacRemove(file);
+            }
+#endif
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
@@ -6,12 +6,13 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Net;
 using Datadog.Core.Tools;
 using Datadog.Trace.TestHelpers;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public sealed class IisFixture : IDisposable
+    public sealed class IisFixture : GacFixture, IDisposable
     {
         private (Process Process, string ConfigFile) _iisExpress;
 
@@ -19,17 +20,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public int HttpPort { get; private set; }
 
+        public string ShutdownPath { get; set; }
+
         public void TryStartIis(TestHelper helper, bool classicMode)
         {
             lock (this)
             {
                 if (_iisExpress.Process == null)
                 {
+                    AddAssembliesToGac();
+
                     var initialAgentPort = TcpPortProvider.GetOpenPort();
                     Agent = new MockTracerAgent(initialAgentPort);
 
                     HttpPort = TcpPortProvider.GetOpenPort();
-
                     _iisExpress = helper.StartIISExpress(Agent.Port, HttpPort, classicMode);
                 }
             }
@@ -37,6 +41,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public void Dispose()
         {
+            if (ShutdownPath != null)
+            {
+                var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}{ShutdownPath}");
+                request.GetResponse().Close();
+            }
+
             Agent?.Dispose();
 
             lock (this)
@@ -69,6 +79,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     catch
                     {
                     }
+
+#if NETFRAMEWORK
+                    // If the operation fails, it could leave files in the GAC and impact the next tests
+                    // Therefore, we don't wrap this in a try/catch
+                    RemoveAssembliesFromGac();
+#endif
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
@@ -80,11 +80,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     {
                     }
 
-#if NETFRAMEWORK
                     // If the operation fails, it could leave files in the GAC and impact the next tests
                     // Therefore, we don't wrap this in a try/catch
                     RemoveAssembliesFromGac();
-#endif
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
@@ -36,12 +36,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 new object[] { "net451" },
                 new object[] { "net452" },
                 new object[] { "net46" },
+#if !NET45 && !NET451 && !NET452 && !NET46
                 new object[] { "net461" },
                 new object[] { "net462" },
                 new object[] { "net47" },
                 new object[] { "net471" },
                 new object[] { "net472" },
                 new object[] { "net48" },
+#endif
             };
 
         [Theory]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/MultiDomainHostTests.cs
@@ -18,6 +18,8 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
+    // Not actually an IIS test but it shouldn't run concurrently with them
+    [Collection("IisTests")]
     public class MultiDomainHostTests : TestHelper, IClassFixture<GacFixture>
     {
         private readonly GacFixture _gacFixture;

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -4,6 +4,11 @@
     <PackageReference Include="Npgsql" Version="4.0.10" />
     <PackageReference Include="Mysql.Data" Version="8.0.17" />
     <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
+
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -5,7 +5,7 @@
     <PackageReference Include="Mysql.Data" Version="8.0.17" />
     <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
 
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
 
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -8,6 +8,11 @@
   <ItemGroup>
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);INTERFACE_DEFAULTS</DefineConstants>

--- a/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+++ b/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <ProjectReference Include="..\test-applications\integrations\Samples.AspNetCoreRazorPages\Samples.AspNetCoreRazorPages.csproj" />
 
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
+++ b/test/Datadog.Trace.IntegrationTests/Datadog.Trace.IntegrationTests.csproj
@@ -19,6 +19,11 @@
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <ProjectReference Include="..\test-applications\integrations\Samples.AspNetCoreRazorPages\Samples.AspNetCoreRazorPages.csproj" />
+
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
@@ -4,11 +4,6 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\..\test\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
-
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
+++ b/test/Datadog.Trace.OpenTracing.IntegrationTests/Datadog.Trace.OpenTracing.IntegrationTests.csproj
@@ -4,6 +4,11 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\..\test\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
+
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -4,6 +4,11 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
+
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -4,7 +4,6 @@
     <ProjectReference Include="..\..\src\Datadog.Trace.OpenTracing\Datadog.Trace.OpenTracing.csproj" />
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
-
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -5,10 +5,6 @@
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
 
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -277,8 +277,6 @@ namespace Datadog.Trace.TestHelpers
         {
             if (_profilerFileLocation == null)
             {
-                int attempt = 1;
-
                 var paths = GetProfilerPathCandidates(GetSampleApplicationOutputDirectory()).ToArray();
 
                 foreach (var candidate in paths)
@@ -289,12 +287,9 @@ namespace Datadog.Trace.TestHelpers
                         _output?.WriteLine($"Found profiler at {_profilerFileLocation}.");
                         return candidate;
                     }
-
-                    _output?.WriteLine($"Attempt {attempt}: Unable to find profiler at {candidate}.");
-                    attempt++;
                 }
 
-                throw new Exception($"Unable to find profiler in any of the paths: {string.Join("; ", _profilerFileLocation)}");
+                throw new Exception($"Unable to find profiler in any of the paths: {string.Join("; ", paths)}");
             }
 
             return _profilerFileLocation;

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -83,6 +84,41 @@ namespace Datadog.Trace.TestHelpers
         public static bool IsCoreClr()
         {
             return RuntimeFrameworkDescription.Contains("core") || IsNet5();
+        }
+
+        public static string GetRuntimeIdentifier()
+        {
+            return IsCoreClr()
+                       ? string.Empty
+                       : $"{EnvironmentTools.GetOS()}-{EnvironmentTools.GetPlatform()}";
+        }
+
+        public static string GetSolutionDirectory()
+        {
+            return EnvironmentTools.GetSolutionDirectory();
+        }
+
+        public static IEnumerable<string> GetProfilerPathCandidates(string sampleApplicationOutputDirectory)
+        {
+            string extension = EnvironmentTools.GetOS() switch
+            {
+                "win" => "dll",
+                "linux" => "so",
+                "osx" => "dylib",
+                _ => throw new PlatformNotSupportedException()
+            };
+
+            string fileName = $"Datadog.Trace.ClrProfiler.Native.{extension}";
+
+            var relativePath = Path.Combine("profiler-lib", fileName);
+
+            if (sampleApplicationOutputDirectory != null)
+            {
+                yield return Path.Combine(sampleApplicationOutputDirectory, relativePath);
+            }
+
+            yield return Path.Combine(GetExecutingProjectBin(), relativePath);
+            yield return Path.Combine(GetProfilerProjectBin(), fileName);
         }
 
         public static void ClearProfilerEnvironmentVariables()
@@ -241,52 +277,24 @@ namespace Datadog.Trace.TestHelpers
         {
             if (_profilerFileLocation == null)
             {
-                string extension = EnvironmentTools.GetOS() switch
+                int attempt = 1;
+
+                var paths = GetProfilerPathCandidates(GetSampleApplicationOutputDirectory()).ToArray();
+
+                foreach (var candidate in paths)
                 {
-                    "win" => "dll",
-                    "linux" => "so",
-                    "osx" => "dylib",
-                    _ => throw new PlatformNotSupportedException()
-                };
+                    if (File.Exists(candidate))
+                    {
+                        _profilerFileLocation = candidate;
+                        _output?.WriteLine($"Found profiler at {_profilerFileLocation}.");
+                        return candidate;
+                    }
 
-                string fileName = $"Datadog.Trace.ClrProfiler.Native.{extension}";
-
-                var directory = GetSampleApplicationOutputDirectory();
-
-                var relativePath = Path.Combine(
-                    "profiler-lib",
-                    fileName);
-
-                _profilerFileLocation = Path.Combine(
-                    directory,
-                    relativePath);
-
-                // TODO: get rid of the fallback options when we have a consistent convention
-
-                if (!File.Exists(_profilerFileLocation))
-                {
-                    _output?.WriteLine($"Attempt 1: Unable to find profiler at {_profilerFileLocation}.");
-                    // Let's try the executing directory, as dotnet publish ignores the Copy attributes we currently use
-                    _profilerFileLocation = Path.Combine(
-                        GetExecutingProjectBin(),
-                        relativePath);
+                    _output?.WriteLine($"Attempt {attempt}: Unable to find profiler at {candidate}.");
+                    attempt++;
                 }
 
-                if (!File.Exists(_profilerFileLocation))
-                {
-                    _output?.WriteLine($"Attempt 2: Unable to find profiler at {_profilerFileLocation}.");
-                    // One last attempt at the actual native project directory
-                    _profilerFileLocation = Path.Combine(
-                        GetProfilerProjectBin(),
-                        fileName);
-                }
-
-                if (!File.Exists(_profilerFileLocation))
-                {
-                    throw new Exception($"Attempt 3: Unable to find profiler at {_profilerFileLocation}");
-                }
-
-                _output?.WriteLine($"Found profiler at {_profilerFileLocation}.");
+                throw new Exception($"Unable to find profiler in any of the paths: {string.Join("; ", _profilerFileLocation)}");
             }
 
             return _profilerFileLocation;
@@ -443,7 +451,7 @@ namespace Datadog.Trace.TestHelpers
             return $"net{_major}{_minor}{_patch ?? string.Empty}";
         }
 
-        private string GetProfilerProjectBin()
+        private static string GetProfilerProjectBin()
         {
             return Path.Combine(
                 EnvironmentTools.GetSolutionDirectory(),
@@ -454,7 +462,7 @@ namespace Datadog.Trace.TestHelpers
                 EnvironmentTools.GetPlatform().ToLower());
         }
 
-        private string GetExecutingProjectBin()
+        private static string GetExecutingProjectBin()
         {
             return Path.GetDirectoryName(ExecutingAssembly.Location);
         }

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -15,6 +15,11 @@
 
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
+
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
     <ProjectReference Include="..\Datadog.Trace.TestHelpers\Datadog.Trace.TestHelpers.csproj" />
 
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/test-applications/aspnet/Samples.AspNetMvc4/Controllers/HomeController.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc4/Controllers/HomeController.cs
@@ -24,6 +24,25 @@ namespace Samples.AspNetMvc4.Controllers
             return View(envVars.ToList());
         }
 
+        public ActionResult Shutdown()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.DefinedTypes)
+                {
+                    if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker")
+                    {
+                        var unloadModuleMethod = type.GetMethod("UnloadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        unloadModuleMethod.Invoke(null, new object[] { this, EventArgs.Empty });
+                    }
+                }
+            }
+
+            return RedirectToAction("Index");
+        }
+
         public ActionResult About()
         {
             ViewBag.Message = "Your application description page.";

--- a/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs
+++ b/test/test-applications/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs
@@ -25,6 +25,25 @@ namespace Samples.AspNetMvc5.Controllers
             return View(envVars.ToList());
         }
 
+        public ActionResult Shutdown()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.DefinedTypes)
+                {
+                    if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker")
+                    {
+                        var unloadModuleMethod = type.GetMethod("UnloadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        unloadModuleMethod.Invoke(null, new object[] { this, EventArgs.Empty });
+                    }
+                }
+            }
+
+            return RedirectToAction("Index");
+        }
+
         public ActionResult Get(int id)
         {
             return View("Delay", id);

--- a/test/test-applications/aspnet/Samples.WebForms/Account/Login.aspx.cs
+++ b/test/test-applications/aspnet/Samples.WebForms/Account/Login.aspx.cs
@@ -5,12 +5,35 @@ namespace Samples.WebForms.Account
 {
     public partial class Login : Page
     {
-        protected void Page_Load(object sender, EventArgs e) { }
+        protected void Page_Load(object sender, EventArgs e) 
+        {
+            if (Request.QueryString["shutdown"] == "1")
+            {
+                Shutdown();
+            }
+        }
 
         protected void LogIn(object sender, EventArgs e)
         {
             FailureText.Text = "Invalid username or password.";
             ErrorMessage.Visible = true;
+        }
+
+        private void Shutdown()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.DefinedTypes)
+                {
+                    if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker")
+                    {
+                        var unloadModuleMethod = type.GetMethod("UnloadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        unloadModuleMethod.Invoke(null, new object[] { this, EventArgs.Empty });
+                    }
+                }
+            }
         }
     }
 }

--- a/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -10,4 +10,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc21/Startup.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc21/Startup.cs
@@ -1,6 +1,8 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -40,6 +42,15 @@ namespace Samples.AspNetCoreMvc
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.Map("/shutdown", builder =>
+            {
+                builder.Run(async context =>
+                {
+                    await context.Response.WriteAsync("Shutting down");
+                    _ = Task.Run(() => builder.ApplicationServices.GetService<IApplicationLifetime>().StopApplication());
+                });
+            });
 
             app.UseMvc(routes =>
             {

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc30/Startup.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc30/Startup.cs
@@ -1,5 +1,7 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -28,6 +30,15 @@ namespace Samples.AspNetCoreMvc
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.Map("/shutdown", builder =>
+            {
+                builder.Run(async context =>
+                {
+                    await context.Response.WriteAsync("Shutting down");
+                    _ = Task.Run(() => builder.ApplicationServices.GetService<IHostApplicationLifetime>().StopApplication());
+                });
+            });
 
             app.UseRouting();
 

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc31/Startup.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc31/Startup.cs
@@ -1,5 +1,7 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -28,6 +30,15 @@ namespace Samples.AspNetCoreMvc
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.Map("/shutdown", builder =>
+            {
+                builder.Run(async context =>
+                {
+                    await context.Response.WriteAsync("Shutting down");
+                    _ = Task.Run(() => builder.ApplicationServices.GetService<IHostApplicationLifetime>().StopApplication());
+                });
+            });
 
             app.UseRouting();
 

--- a/test/test-applications/integrations/Samples.GraphQL/Program.cs
+++ b/test/test-applications/integrations/Samples.GraphQL/Program.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-using Datadog.Trace.ClrProfiler;
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -29,7 +28,8 @@ namespace Samples.GraphQL
                 .Build();
 
             var logger = host.Services.GetRequiredService<ILogger<Program>>();
-            logger.LogInformation($"Instrumentation.ProfilerAttached = {Instrumentation.ProfilerAttached}");
+
+                        logger.LogInformation($"Instrumentation.ProfilerAttached = {IsProfilerAttached()}");
 
             var prefixes = new[] { "COR_", "CORECLR_", "DD_", "DATADOG_" };
             var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()
@@ -46,6 +46,22 @@ namespace Samples.GraphQL
             }
 
             host.Run();
+        }
+
+        private static bool IsProfilerAttached()
+        {
+            var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: false);
+
+            if (instrumentationType == null)
+            {
+                return false;
+            }
+
+            var property = instrumentationType.GetProperty("ProfilerAttached");
+
+            var isAttached = property?.GetValue(null) as bool?;
+
+            return isAttached ?? false;
         }
     }
 }

--- a/test/test-applications/integrations/Samples.GraphQL/Program.cs
+++ b/test/test-applications/integrations/Samples.GraphQL/Program.cs
@@ -29,7 +29,7 @@ namespace Samples.GraphQL
 
             var logger = host.Services.GetRequiredService<ILogger<Program>>();
 
-                        logger.LogInformation($"Instrumentation.ProfilerAttached = {IsProfilerAttached()}");
+            logger.LogInformation($"Instrumentation.ProfilerAttached = {IsProfilerAttached()}");
 
             var prefixes = new[] { "COR_", "CORECLR_", "DD_", "DATADOG_" };
             var envVars = from envVar in Environment.GetEnvironmentVariables().Cast<DictionaryEntry>()

--- a/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="GraphQL" Version="2.3.0" />
     <PackageReference Include="GraphQL.StarWars" Version="1.0.0" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />

--- a/test/test-applications/integrations/Samples.GraphQL/Startup.cs
+++ b/test/test-applications/integrations/Samples.GraphQL/Startup.cs
@@ -72,7 +72,10 @@ namespace Samples.GraphQL
                 builder.Run(async context =>
                 {
                     await context.Response.WriteAsync("Shutting down");
+
+#pragma warning disable CS0618 // Type or member is obsolete
                     _ = Task.Run(() => builder.ApplicationServices.GetService<IApplicationLifetime>().StopApplication());
+#pragma warning restore CS0618 // Type or member is obsolete
                 });
             });
 

--- a/test/test-applications/integrations/Samples.GraphQL/Startup.cs
+++ b/test/test-applications/integrations/Samples.GraphQL/Startup.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using GraphQL.StarWars;
 using GraphQL.StarWars.Types;
+using System.Threading.Tasks;
 
 namespace Samples.GraphQL
 {
@@ -58,13 +59,22 @@ namespace Samples.GraphQL
             var starWarsSchema = (StarWarsSchema)app.ApplicationServices.GetService(typeof(ISchema));
 
             // Get StarWarsSubscription Singleton
-            var starWarsSubscription = (StarWarsExtensions.StarWarsSubscription) app.ApplicationServices.GetService(typeof(StarWarsExtensions.StarWarsSubscription));
+            var starWarsSubscription = (StarWarsExtensions.StarWarsSubscription)app.ApplicationServices.GetService(typeof(StarWarsExtensions.StarWarsSubscription));
 
             // Set the subscription
             // We do this roundabout mechanism to keep using the GraphQL.StarWars NuGet package
             starWarsSchema.Subscription = starWarsSubscription;
             app.UseDeveloperExceptionPage();
             app.UseWelcomePage("/alive-check");
+
+            app.Map("/shutdown", builder =>
+            {
+                builder.Run(async context =>
+                {
+                    await context.Response.WriteAsync("Shutting down");
+                    _ = Task.Run(() => builder.ApplicationServices.GetService<IApplicationLifetime>().StopApplication());
+                });
+            });
 
             // add http for Schema at default url /graphql
             app.UseGraphQL<ISchema>("/graphql");

--- a/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
-using Datadog.Trace.ClrProfiler;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Clusters;
@@ -21,7 +20,24 @@ namespace Samples.MongoDB
 
         public static void Main(string[] args)
         {
-            Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
+            bool IsProfilerAttached()
+            {
+                var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: false);
+
+                if (instrumentationType == null)
+                {
+                    return false;
+                }
+
+                var property = instrumentationType.GetProperty("ProfilerAttached");
+
+                var isAttached = property?.GetValue(null) as bool?;
+
+                return isAttached ?? false;
+            }
+
+
+            Console.WriteLine($"Profiler attached: {IsProfilerAttached()}");
             Console.WriteLine($"Platform: {(Environment.Is64BitProcess ? "x64" : "x32")}");
 
             var newDocument = new BsonDocument

--- a/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/test-applications/integrations/Samples.MultiDomainHost.Runner/Program.cs
+++ b/test/test-applications/integrations/Samples.MultiDomainHost.Runner/Program.cs
@@ -57,6 +57,8 @@ namespace Samples.MultiDomainHost.Runner
 
         private static void CreateAndRunAppDomain(string appName)
         {
+            AppDomain domain = null;
+
             try
             {
                 // Construct and initialize settings for a second AppDomain.
@@ -69,7 +71,7 @@ namespace Samples.MultiDomainHost.Runner
                     Path.Combine(ads.ApplicationBase, appName + ".exe.config");
 
                 PermissionSet ps = new PermissionSet(PermissionState.Unrestricted);
-                System.AppDomain appDomain1 = System.AppDomain.CreateDomain(
+                domain = System.AppDomain.CreateDomain(
                     appName,
                     System.AppDomain.CurrentDomain.Evidence,
                     ads,
@@ -77,7 +79,7 @@ namespace Samples.MultiDomainHost.Runner
 
                 Console.WriteLine("**********************************************");
                 Console.WriteLine($"Starting code execution in AppDomain {appName}");
-                appDomain1.ExecuteAssemblyByName(
+                domain.ExecuteAssemblyByName(
                     appName,
                     new string[0]);
             }
@@ -90,6 +92,13 @@ namespace Samples.MultiDomainHost.Runner
                 Console.WriteLine($"Finished code execution in AppDomain {appName}");
                 Console.WriteLine("**********************************************");
                 Console.WriteLine();
+
+                if (domain != null)
+                {
+                    // Wait for traces to be flushed, then unload the domain
+                    Thread.Sleep(2000);
+                    AppDomain.Unload(domain);
+                }
             }
         }
     }

--- a/test/test-applications/integrations/Samples.Owin.WebApi2/Controllers/HomeController.cs
+++ b/test/test-applications/integrations/Samples.Owin.WebApi2/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http;
+using System;
+using System.Web.Http;
 
 namespace Samples.Owin.WebApi2.Controllers
 {
@@ -10,6 +11,27 @@ namespace Samples.Owin.WebApi2.Controllers
         public string IsAlive()
         {
             return "Yes";
+        }
+
+        [HttpGet]
+        [Route("shutdown")]
+        public string Shutdown()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.DefinedTypes)
+                {
+                    if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker")
+                    {
+                        var unloadModuleMethod = type.GetMethod("UnloadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        unloadModuleMethod.Invoke(null, new object[] { this, EventArgs.Empty });
+                    }
+                }
+            }
+
+            return "Code coverage data has been flushed";
         }
     }
 }

--- a/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
+++ b/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
@@ -6,4 +6,8 @@
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+  </ItemGroup>
 </Project>

--- a/test/test-applications/regression/HttpMessageHandler.StackOverflowException/Program.cs
+++ b/test/test-applications/regression/HttpMessageHandler.StackOverflowException/Program.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
-using Datadog.Trace.ClrProfiler;
 
 namespace HttpMessageHandler.StackOverflowException
 {
@@ -13,7 +12,7 @@ namespace HttpMessageHandler.StackOverflowException
         {
             try
             {
-                Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
+                Console.WriteLine($"Profiler attached: {IsProfilerAttached()}");
 
                 var baseAddress = new Uri("https://www.example.com/");
                 var regularHttpClient = new HttpClient { BaseAddress = baseAddress };
@@ -46,6 +45,22 @@ namespace HttpMessageHandler.StackOverflowException
 #endif
 
             return (int)ExitCode.Success;
+        }
+
+        private static bool IsProfilerAttached()
+        {
+            var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: false);
+
+            if (instrumentationType == null)
+            {
+                return false;
+            }
+
+            var property = instrumentationType.GetProperty("ProfilerAttached");
+
+            var isAttached = property?.GetValue(null) as bool?;
+
+            return isAttached ?? false;
         }
     }
 

--- a/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
+++ b/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/ExpenseItDemo/ExpenseItDemo.csproj
@@ -129,16 +129,6 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed.Core\Datadog.Trace.ClrProfiler.Managed.Core.csproj">
-      <Project>{d95d5e26-f32a-481d-a15a-ef7b3b56d2e0}</Project>
-      <Name>Datadog.Trace.ClrProfiler.Managed.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj">
-      <Project>{85f35aaf-d102-4960-8b41-3bd9cbd0e77f}</Project>
-      <Name>Datadog.Trace.ClrProfiler.Managed</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Resource Include="Watermark.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/test-applications/regression/StackExchange.Redis.StackOverflowException/Program.cs
+++ b/test/test-applications/regression/StackExchange.Redis.StackOverflowException/Program.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Datadog.Trace.ClrProfiler;
 
 namespace StackExchange.Redis.StackOverflowException
 {
@@ -12,7 +11,7 @@ namespace StackExchange.Redis.StackOverflowException
         {
             try
             {
-                Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
+                Console.WriteLine($"Profiler attached: {IsProfilerAttached()}");
 
                 string host = Environment.GetEnvironmentVariable("STACKEXCHANGE_REDIS_HOST") ?? "localhost:6389";
                 const int database = 1;
@@ -64,6 +63,22 @@ namespace StackExchange.Redis.StackOverflowException
                 yield return new KeyValuePair<RedisKey, RedisValue>($"StackOverflowExceptionKey{count}", $"value{count}");
                 count++;
             }
+        }
+
+        private static bool IsProfilerAttached()
+        {
+            var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: false);
+
+            if (instrumentationType == null)
+            {
+                return false;
+            }
+
+            var property = instrumentationType.GetProperty("ProfilerAttached");
+
+            var isAttached = property?.GetValue(null) as bool?;
+
+            return isAttached ?? false;
         }
     }
 

--- a/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -5,8 +5,4 @@
     <Platforms>x64;x86;AnyCPU</Platforms>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Added a `--code-coverage` flag to the Nuke pipeline, and enabled it on the consolidated pipeline.

Coverlet patches assemblies when the processes start, and restores them at the end. Because of this, and because sample apps share the profiler assemblies, I couldn't run coverlet at the sample level (or it would try to patch/restore `Datadog.Trace.ClrProfiler.Managed.dll` while it's used by other samples).
Instead, I'm running it at the test project level. But then I ran into another difficulty: coverlet has a deduplication logic (it won't patch two assemblies with the same name). And because Datadog.Trace.ClrProfiler.IntegrationTests references `Datadog.Trace.ClrProfiler.Managed.dll`, I couldn't tell coverlet to also patch the `Datadog.Trace.ClrProfiler.Managed.dll` located in the `profiler-lib` folder (that will be used by sample apps). Instead, at the beginning of the test run, I overwrite the file in `profiler-lib` with the one references by the test project (after it has been patched). It's not great, so I'm open to suggestions.

Also, the OpenTracing test projects are excluded because they cause compilation errors when used with coverlet.
