### PR TITLE
Downgrade the version of cmake used for MacOs builds

### DIFF
--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -114,6 +114,7 @@ jobs:
   pool:
     vmImage: macOS-10.15
   steps:
+  - template: steps/downgrade-macos-cmake.yml
 
   - task: UseDotNet@2
     displayName: install dotnet core runtime 3.1

--- a/.azure-pipelines/steps/downgrade-macos-cmake.yml
+++ b/.azure-pipelines/steps/downgrade-macos-cmake.yml
@@ -1,0 +1,18 @@
+steps:
+# Downgrade the cmake to 3.19.x. 3.20.x causes failure embedded dll and pdb
+- script: |
+    CMAKE_VERSION=3.19.8
+    echo "Uninstalling brew CMake"
+    brew uninstall cmake
+    echo "Downloading CMake $CMAKE_VERSION"
+    curl --output cmake-$CMAKE_VERSION-macos-universal.tar.gz -L https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-macos-universal.tar.gz
+    echo "Extracting archive"
+    tar -xzvf cmake-$CMAKE_VERSION-macos-universal.tar.gz
+    echo "Copying Cmake.app to Applications"
+    cp -rf ./cmake-$CMAKE_VERSION-macos-universal/CMake.app /Applications
+    echo "Updating PATH"
+    echo "##vso[task.setvariable variable=PATH]${PATH}:/Applications/CMake.app/Contents/bin"
+    echo "Cleaning up files"
+    rm -rf ./cmake-$CMAKE_VERSION-macos-universal
+    rm ./cmake-$CMAKE_VERSION-macos-universal.tar.gz
+  displayName: Downgrade cmake version

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -138,6 +138,7 @@ stages:
       vmImage: macOS-10.15
     steps:
     - template: steps/install-dotnet-5-sdk.yml
+    - template: steps/downgrade-macos-cmake.yml
 
     - script: ./build.sh BuildTracerHome
       displayName: Build tracer home


### PR DESCRIPTION
Version 3.20.x causes the loader dll and pdb to not be embedded correctly in the _.dylib_ file.
You can confirm this behaviour by running `xcrun size -x -l -m Datadog.Trace.ClrProfiler.Native.dylib` and checking for the `Segment binary` section. In a bad build (with 3.20.x) it will be missing.

@DataDog/apm-dotnet