### PR TITLE
Small build improvements

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -484,6 +484,16 @@ stages:
       vmImage: $(vmImage)
 
     steps:
+    # Doing a clean of obj files _before_ restore to remove build output from previous runs
+    # Can't do a full clean, as otherwise restore-working-directory fails
+    # Only necessary for ARM64, but shouldn't cause any harm on others
+    # Can't ifdef it as depends on a matrix variable
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        baseImage: $(baseImage)
+        command: "CleanObjFiles"
+
     - template: steps/restore-working-directory.yml
       parameters:
         artifact: build-linux-$(matrixName)-working-directory

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -26,6 +26,7 @@ variables:
   dotnetCoreSdk5Version: 5.0.103
   relativeTracerHome: /src/bin/windows-tracer-home
   relativeArtifacts: /src/bin/artifacts
+  ddTracerHome: $(System.DefaultWorkingDirectory)/src/bin/dd-tracer-home
   tracerHome: $(System.DefaultWorkingDirectory)/src/bin/windows-tracer-home
   artifacts: $(System.DefaultWorkingDirectory)/src/bin/artifacts
   ddApiKey: $(DD_API_KEY)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -104,8 +104,7 @@ stages:
         baseImage: $(baseImage)
         command: "Clean BuildTracerHome ZipTracerHome"
 
-    - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/build/bin/Release/x64
-      condition: ne(variables['matrixName'], 'arm64')
+    - publish: $(tracerHome)
       displayName: Uploading linux tracer home artifact
       artifact: linux-tracer-home-$(matrixName)
 
@@ -113,11 +112,6 @@ stages:
       condition: ne(variables['matrixName'], 'arm64')
       displayName: Upload linux-x64 packages
       artifact: linux-packages-$(matrixName)
-
-    - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/build/bin/Release/arm64
-      condition: eq(variables['matrixName'], 'arm64')
-      displayName: Uploading arm64 tracer home artifact
-      artifact: linux-tracer-home-$(matrixName)
 
     - publish: $(artifacts)/linux-arm64
       condition: eq(variables['matrixName'], 'arm64')
@@ -143,15 +137,7 @@ stages:
     - script: ./build.sh BuildTracerHome
       displayName: Build tracer home
 
-    ## TODO: Move to Nuke target
-    - script: |
-        mkdir -p src/Datadog.Trace.ClrProfiler.Native/bin/netstandard2.0
-        cp src/bin/windows-tracer-home/netstandard2.0/*.dll src/Datadog.Trace.ClrProfiler.Native/bin/netstandard2.0/
-        mkdir -p src/Datadog.Trace.ClrProfiler.Native/bin/netcoreapp3.1
-        cp src/bin/windows-tracer-home/netcoreapp3.1/*.dll src/Datadog.Trace.ClrProfiler.Native/bin/netcoreapp3.1/
-      displayName: Copy files into macos-tracer-home
-
-    - publish: $(System.DefaultWorkingDirectory)/src/Datadog.Trace.ClrProfiler.Native/bin
+    - publish: $(tracerHome)
       displayName: Uploading macos profiler artifact
       artifact: macos-tracer-home
 

--- a/.gitignore
+++ b/.gitignore
@@ -279,5 +279,11 @@ deploy/AzureAppServices/
 .DS_Store/*
 .DS_Store
 
-# profiler output files
+# profiler build files
 src/Datadog.Trace.ClrProfiler.Native/build/
+src/Datadog.Trace.ClrProfiler.Native/deps/
+src/Datadog.Trace.ClrProfiler.Native/CMakeFiles/
+src/Datadog.Trace.ClrProfiler.Native/tmp.*
+src/Datadog.Trace.ClrProfiler.Native/Makefile
+src/Datadog.Trace.ClrProfiler.Native/CMakeCache.txt
+src/Datadog.Trace.ClrProfiler.Native/cmake_install.cmake

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -324,7 +324,7 @@ partial class Build
         .After(CompileNativeSrc, PublishManagedProfiler)
         .Executes(() =>
         {
-            GlobFiles(NativeProfilerProject.Directory / "bin" / $"{NativeProfilerProject.Name}.*")
+            GlobFiles(NativeProfilerProject.Directory / "bin" / $"{NativeProfilerProject.Name}.dylib")
                 .ForEach(source =>
                 {
                     var dest = TracerHomeDirectory / $"osx-x64";

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -347,7 +347,7 @@ partial class Build
                return;
            }
 
-           // Move the native file to the art
+           // Move the native file to the architecture-specific folder
            var (architecture, fileName) = IsOsx
                ? ("osx-x64", $"{NativeProfilerProject.Name}.dylib")
                : ($"linux-{LinuxArchitectureIdentifier}", $"{NativeProfilerProject.Name}.so");

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -88,6 +88,7 @@ partial class Build : NukeBuild
             TestsDirectory.GlobDirectories("**/bin", "**/obj").ForEach(x => DeleteDirectory(x));
             EnsureCleanDirectory(OutputDirectory);
             EnsureCleanDirectory(TracerHomeDirectory);
+            EnsureCleanDirectory(DDTracerHomeDirectory);
             EnsureCleanDirectory(ArtifactsDirectory);
             EnsureCleanDirectory(NativeProfilerProject.Directory / "build");
             EnsureCleanDirectory(NativeProfilerProject.Directory / "deps");
@@ -114,10 +115,12 @@ partial class Build : NukeBuild
         .DependsOn(PublishNativeProfiler)
         .DependsOn(CopyIntegrationsJson);
 
+
     Target PackageTracerHome => _ => _
         .Description("Packages the already built src")
         .After(Clean, BuildTracerHome)
         .DependsOn(CreateRequiredDirectories)
+        .DependsOn(CreateDdTracerHome)
         .DependsOn(ZipTracerHome)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -106,6 +106,14 @@ partial class Build : NukeBuild
             }
         });
 
+    Target CleanObjFiles => _ => _
+         .Unlisted()
+         .Description("Deletes all build output files, but preserves folders to work around AzDo issues")
+         .Executes(() =>
+          {
+              TestsDirectory.GlobFiles("**/bin/*", "**/obj/*").ForEach(DeleteFile);
+          });
+
     Target BuildTracerHome => _ => _
         .Description("Builds the native and managed src, and publishes the tracer home directory")
         .After(Clean)

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -39,6 +39,8 @@ partial class Build : NukeBuild
 
     [Parameter("The location to create the tracer home directory. Default is ./bin/tracer-home ")]
     readonly AbsolutePath TracerHome;
+    [Parameter("The location to create the dd-trace home directory. Default is ./bin/dd-tracer-home ")]
+    readonly AbsolutePath DDTracerHome;
     [Parameter("The location to place NuGet packages and other packages. Default is ./bin/artifacts ")]
     readonly AbsolutePath Artifacts;
     
@@ -113,14 +115,14 @@ partial class Build : NukeBuild
         .DependsOn(PublishManagedProfiler)
         .DependsOn(CompileNativeSrc)
         .DependsOn(PublishNativeProfiler)
-        .DependsOn(CopyIntegrationsJson);
+        .DependsOn(CopyIntegrationsJson)
+        .DependsOn(CreateDdTracerHome);
 
 
     Target PackageTracerHome => _ => _
         .Description("Packages the already built src")
         .After(Clean, BuildTracerHome)
         .DependsOn(CreateRequiredDirectories)
-        .DependsOn(CreateDdTracerHome)
         .DependsOn(ZipTracerHome)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -664,7 +664,7 @@ services:
       - kafka-zookeeper
       - aws_sqs
     environment:
-      - TIMEOUT_LENGTH=60
+      - TIMEOUT_LENGTH=120
     command: servicestackredis:6379 stackexchangeredis:6379 elasticsearch5:9200 elasticsearch6:9200 sqlserver:1433 mongo:27017 postgres:5432 mysql:3306 mysql57:3306 rabbitmq:5672 kafka-broker:9092 kafka-zookeeper:2181 aws_sqs:9324
 
   NukeIntegrationTests.ARM64:
@@ -715,7 +715,7 @@ services:
       - mysql
       - rabbitmq
     environment:
-      - TIMEOUT_LENGTH=60
+      - TIMEOUT_LENGTH=120
     command: servicestackredis:6379 stackexchangeredis:6379 elasticsearch7_arm64:9200 sqledge:1433 mongo:27017 postgres:5432 mysql:3306 rabbitmq:5672
 
   IntegrationTests.ARM64.Core50:

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -198,6 +198,20 @@ elseif (ISARM)
 endif()
 
 # ******************************************************
+# Suppress Warning on MacOS
+# ******************************************************
+
+# Only necessary with cmake 3.19.x on macos
+# See https://stackoverflow.com/questions/4929255/building-static-libraries-on-mac-using-cmake-and-gcc#answer-4953904
+
+if (ISMACOS)
+    SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif()
+
+# ******************************************************
 # Define static target
 # ******************************************************
 add_library("Datadog.Trace.ClrProfiler.Native.static" STATIC


### PR DESCRIPTION
- Increase dependency warmup timeout to reduce flakiness
- Do a clean before Arm64 integration test builds to try fix XUnit Linux MultiPackage build flakiness 
- Ignore CMake temporary build files (macos)
- Don't need the static.a file in the tracer home directory
- Simplify/Unify the build tracer home step for linux + mac
- Add build step for generating the tracer home directory in the dd-trace format

@DataDog/apm-dotnet 
