### PR TITLE
Revert to CallSite instrumentation by default

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
@@ -47,7 +47,14 @@ bool EnableInlining(bool defaultValue) {
 }
 
 bool IsCallTargetEnabled() {
+#if defined(ARM64) || defined(ARM)
+  //
+  // If the architecture is ARM64 or ARM, we enable CallTarget instrumentation by default
+  //
   ToBooleanWithDefault(GetEnvironmentValue(environment::calltarget_enabled), true);
+#else
+  ToBooleanWithDefault(GetEnvironmentValue(environment::calltarget_enabled), false);
+#endif
 }
 
 bool IsDebugEnabled() {


### PR DESCRIPTION
Due to limitations with .NET Framework 4.5.x, we  will leave CallTarget disabled by default for now

@DataDog/apm-dotnet 