### PR TITLE
NUnit integration improvements

### DIFF
--- a/src/Datadog.Trace.Ci.Shared/TestTags.cs
+++ b/src/Datadog.Trace.Ci.Shared/TestTags.cs
@@ -84,6 +84,12 @@ namespace Datadog.Trace.Ci
         public const string SkipReason = "test.skip_reason";
 
         /// <summary>
+        /// Test output message
+        /// </summary>
+        [FeatureTracking]
+        public const string Message = "test.message";
+
+        /// <summary>
         /// Parameters metadata TestName
         /// </summary>
         public const string MetadataTestName = "test_name";

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci;
@@ -36,6 +37,23 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
                         {
                             var settings = TracerSettings.FromDefaultSources();
                             settings.TraceBufferSize = 1024 * 1024 * 45; // slightly lower than the 50mb payload agent limit.
+
+                            if (string.IsNullOrEmpty(settings.ServiceName))
+                            {
+                                // Extract repository name from the git url and use it as a default service name.
+                                string repository = CIEnvironmentValues.Repository;
+                                Regex regex = new Regex(@"/([a-zA-Z0-9\\\-_.]*)$");
+                                Match match = regex.Match(repository);
+                                if (match.Success && match.Groups.Count > 1)
+                                {
+                                    const string gitSuffix = ".git";
+                                    string repoName = match.Groups[1].Value;
+                                    if (repoName.EndsWith(gitSuffix))
+                                    {
+                                        settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
+                                    }
+                                }
+                            }
 
                             _testTracer = new Tracer(settings);
                             Tracer.Instance = _testTracer;

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -52,6 +52,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
                                     {
                                         settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
                                     }
+                                    else
+                                    {
+                                        settings.ServiceName = repoName;
+                                    }
                                 }
                             }
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/Common.cs
@@ -42,19 +42,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing
                             {
                                 // Extract repository name from the git url and use it as a default service name.
                                 string repository = CIEnvironmentValues.Repository;
-                                Regex regex = new Regex(@"/([a-zA-Z0-9\\\-_.]*)$");
-                                Match match = regex.Match(repository);
-                                if (match.Success && match.Groups.Count > 1)
+                                if (!string.IsNullOrEmpty(repository))
                                 {
-                                    const string gitSuffix = ".git";
-                                    string repoName = match.Groups[1].Value;
-                                    if (repoName.EndsWith(gitSuffix))
+                                    Regex regex = new Regex(@"/([a-zA-Z0-9\\\-_.]*)$");
+                                    Match match = regex.Match(repository);
+                                    if (match.Success && match.Groups.Count > 1)
                                     {
-                                        settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
-                                    }
-                                    else
-                                    {
-                                        settings.ServiceName = repoName;
+                                        const string gitSuffix = ".git";
+                                        string repoName = match.Groups[1].Value;
+                                        if (repoName.EndsWith(gitSuffix))
+                                        {
+                                            settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
+                                        }
+                                        else
+                                        {
+                                            settings.ServiceName = repoName;
+                                        }
                                     }
                                 }
                             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/ITest.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/ITest.cs
@@ -16,6 +16,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         string Name { get; }
 
         /// <summary>
+        /// Gets the fully qualified name of the test
+        /// </summary>
+        public string FullName { get; }
+
+        /// <summary>
         /// Gets a MethodInfo for the method implementing this test.
         /// Returns null if the test is not implemented as a method.
         /// </summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             string testName = testMethod.Name;
             string testSuite = testMethod.DeclaringType?.FullName;
 
-            // Extract the test suite from the full name to support custom fixture parameters.
+            // Extract the test suite from the full name to support custom fixture parameters and test declared in base classes.
             if (fullName.EndsWith("." + composedTestName))
             {
                 testSuite = fullName.Substring(0, fullName.Length - (composedTestName.Length + 1));

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -34,8 +34,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             }
 
             string testFramework = "NUnit " + targetType?.Assembly?.GetName().Version;
-            string testSuite = testMethod.DeclaringType?.FullName;
+            string fullName = currentTest.FullName;
+            string composedTestName = currentTest.Name;
+
             string testName = testMethod.Name;
+            string testSuite = testMethod.DeclaringType?.FullName;
+
+            // Extract the test suite from the full name to support custom fixture parameters.
+            if (fullName.EndsWith("." + composedTestName))
+            {
+                testSuite = fullName.Substring(0, fullName.Length - (composedTestName.Length + 1));
+            }
+
             string skipReason = null;
 
             Scope scope = Common.TestTracer.StartActive("nunit.test", serviceName: Common.TestTracer.DefaultServiceName);

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -159,6 +159,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                 if (exTypeName == "NUnit.Framework.SuccessException")
                 {
                     scope.Span.SetTag(TestTags.Status, TestTags.StatusPass);
+                    scope.Span.SetTag(TestTags.Message, ex.Message);
                 }
                 else if (exTypeName == "NUnit.Framework.IgnoreException" || exTypeName == "NUnit.Framework.InconclusiveException")
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
@@ -38,19 +38,22 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                             {
                                 // Extract repository name from the git url and use it as a default service name.
                                 string repository = CIEnvironmentValues.Repository;
-                                Regex regex = new Regex(@"/([a-zA-Z0-9\\\-_.]*)$");
-                                Match match = regex.Match(repository);
-                                if (match.Success && match.Groups.Count > 1)
+                                if (!string.IsNullOrEmpty(repository))
                                 {
-                                    const string gitSuffix = ".git";
-                                    string repoName = match.Groups[1].Value;
-                                    if (repoName.EndsWith(gitSuffix))
+                                    Regex regex = new Regex(@"/([a-zA-Z0-9\\\-_.]*)$");
+                                    Match match = regex.Match(repository);
+                                    if (match.Success && match.Groups.Count > 1)
                                     {
-                                        settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
-                                    }
-                                    else
-                                    {
-                                        settings.ServiceName = repoName;
+                                        const string gitSuffix = ".git";
+                                        string repoName = match.Groups[1].Value;
+                                        if (repoName.EndsWith(gitSuffix))
+                                        {
+                                            settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
+                                        }
+                                        else
+                                        {
+                                            settings.ServiceName = repoName;
+                                        }
                                     }
                                 }
                             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/Testing/Common.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Text.RegularExpressions;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Configuration;
 
@@ -32,6 +33,27 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                         {
                             var settings = TracerSettings.FromDefaultSources();
                             settings.TraceBufferSize = 1024 * 1024 * 45; // slightly lower than the 50mb payload agent limit.
+
+                            if (string.IsNullOrEmpty(settings.ServiceName))
+                            {
+                                // Extract repository name from the git url and use it as a default service name.
+                                string repository = CIEnvironmentValues.Repository;
+                                Regex regex = new Regex(@"/([a-zA-Z0-9\\\-_.]*)$");
+                                Match match = regex.Match(repository);
+                                if (match.Success && match.Groups.Count > 1)
+                                {
+                                    const string gitSuffix = ".git";
+                                    string repoName = match.Groups[1].Value;
+                                    if (repoName.EndsWith(gitSuffix))
+                                    {
+                                        settings.ServiceName = repoName.Substring(0, repoName.Length - gitSuffix.Length);
+                                    }
+                                    else
+                                    {
+                                        settings.ServiceName = repoName;
+                                    }
+                                }
+                            }
 
                             _testTracer = new Tracer(settings);
                             Tracer.Instance = _testTracer;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -18,8 +18,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class NUnitTests : TestHelper
     {
-        private const string TestSuiteName = "Samples.NUnitTests.TestSuite";
-        private const int ExpectedSpanCount = 17;
+        private const int ExpectedSpanCount = 20;
+
+        private static string[] _testSuiteNames = new string[]
+        {
+            "Samples.NUnitTests.TestSuite",
+            "Samples.NUnitTests.TestFixtureTest(\"Test01\")",
+            "Samples.NUnitTests.TestFixtureTest(\"Test02\")",
+            "Samples.NUnitTests.TestString",
+        };
 
         public NUnitTests(ITestOutputHelper output)
             : base("NUnitTests", output)
@@ -82,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         CheckRuntimeValues(targetSpan);
 
                         // check the suite name
-                        AssertTargetSpanEqual(targetSpan, TestTags.Suite, TestSuiteName);
+                        AssertTargetSpanAnyOf(targetSpan, TestTags.Suite, _testSuiteNames);
 
                         // check the test type
                         AssertTargetSpanEqual(targetSpan, TestTags.Type, TestTags.TypeTest);
@@ -103,6 +110,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         switch (targetSpan.Tags[TestTags.Name])
                         {
                             case "SimplePassTest":
+                            case "Test":
+                            case "IsNull":
                                 CheckSimpleTestSpan(targetSpan);
                                 break;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -313,6 +313,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             // Check the Test Status
             AssertTargetSpanEqual(targetSpan, TestTags.Status, TestTags.StatusPass);
+
+            // Check the `test.message` tag. We check if contains the default or the custom message.
+            if (targetSpan.Tags.ContainsKey(TestTags.Message))
+            {
+                AssertTargetSpanAnyOf(targetSpan, TestTags.Message, new string[] { "Test is ok", "The test passed." });
+            }
         }
 
         private static void CheckSimpleSkipFromAttributeTest(MockTracerAgent.Span targetSpan, string skipReason = "Simple skip reason")

--- a/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -129,6 +129,7 @@ namespace Samples.NUnitTests
         [Test]
         public void Test()
         {
+            Assert.Pass("Test is ok");
         }
     }
 

--- a/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -113,4 +113,34 @@ namespace Samples.NUnitTests
             Assert.Inconclusive("The test is inconclusive.");
         }
     }
+
+    [TestFixture("Test01")]
+    [TestFixture("Test02")]
+    public class TestFixtureTest
+    {
+        private string _name;
+
+        public TestFixtureTest(string name)
+        {
+            _name = name;
+            // Assert.Fail(Environment.StackTrace);
+        }
+
+        [Test]
+        public void Test()
+        {
+        }
+    }
+
+    public class TestBase<T>
+    {
+        [Test]
+        public void IsNull()
+        {
+            Assert.IsNull(default(T));
+        }
+    }
+
+    public class TestString : TestBase<string>
+    { }
 }

--- a/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -123,7 +123,6 @@ namespace Samples.NUnitTests
         public TestFixtureTest(string name)
         {
             _name = name;
-            // Assert.Fail(Environment.StackTrace);
         }
 
         [Test]


### PR DESCRIPTION
This PR includes some improvements to the NUnit integrations:

- Adds support for parameterized fixtures.
- Adds support for test declared in base classes.
- Adds support for `test.message` tag.
- Sets the service name = repo name (in case no value is set).


@DataDog/apm-dotnet