### PR TITLE
Fix Enable32Bit flag for IIS container

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -365,7 +365,7 @@ stages:
       displayName: docker-compose build IIS containers
       inputs:
         containerregistrytype: Container Registry
-        dockerComposeCommand: build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg enable_32_bit=$(enable32bit) IntegrationTests.IIS.LoaderOptimizationRegKey
+        dockerComposeCommand: build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS.LoaderOptimizationRegKey
 
     - task: DockerCompose@0
       displayName: docker-compose start IIS containers

--- a/build/docker/IIS/LoaderOptimizationRegKey.dockerfile
+++ b/build/docker/IIS/LoaderOptimizationRegKey.dockerfile
@@ -12,6 +12,7 @@ ADD test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/bin
 ARG ENABLE_32_BIT
 ENV ENABLE_32_BIT=${ENABLE_32_BIT:-false}
 RUN Remove-WebSite -Name 'Default Web Site'; \
+    Write-Host "Creating website with 32 bit reg key: $env:ENABLE_32_BIT"; \
     New-Website -Name 'LoaderOptimizationRegKey' -Port 80 -PhysicalPath 'c:\LoaderOptimizationRegKey'
 RUN c:\Windows\System32\inetsrv\appcmd set apppool /apppool.name:DefaultAppPool /enable32bitapponwin64:$env:ENABLE_32_BIT
 


### PR DESCRIPTION
For some reason, this _has_ to be uppercase to be picked up.
Unlike the other arg. Which must _not_ be uppercase..


@DataDog/apm-dotnet