### PR TITLE
run pipelines in release branches

### DIFF
--- a/.azure-pipelines/benchmarks.yml
+++ b/.azure-pipelines/benchmarks.yml
@@ -1,17 +1,5 @@
-trigger:
-  branches:
-    include:
-      - master
-      - refs/tags/*
-
-schedules:
-- cron: "0 3 * * *"
-  displayName: Daily 3am (UTC) build
-  branches:
-    include:
-    - master
-    - /benchmarks/*
-  always: true
+trigger: none
+pr: none
 
 variables:
   buildConfiguration: release
@@ -34,11 +22,11 @@ stages:
 - stage: build
   jobs:
 
-  #### Windows 
+  #### Windows
 
   - job: Windows
     pool: Benchmarks
-    
+
     workspace:
       clean: all
 

--- a/.azure-pipelines/crank.yml
+++ b/.azure-pipelines/crank.yml
@@ -1,32 +1,7 @@
-trigger:
-  branches:
-    include:
-      - master
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
-pr:
-  branches:
-    include:
-      - master
-      - release/*
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
-
-schedules:
-- cron: "0 4 * * *"
-  displayName: Daily 4am (UTC) build
-  branches:
-    include:
-    - master
-    - /benchmarks/*
-  always: true
+trigger: none
+pr: none
 
 jobs:
-
 
 - job: windows_profiler
   pool:

--- a/.azure-pipelines/integration-tests.yml
+++ b/.azure-pipelines/integration-tests.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
       - master
+      - release/*
   paths:
     exclude:
       - docs/*
@@ -68,7 +69,7 @@ jobs:
       zipAfterPublish: false
       projects: src/Datadog.Trace.ClrProfiler.Managed/Datadog.Trace.ClrProfiler.Managed.csproj
       arguments: --configuration $(buildConfiguration) --framework netcoreapp3.1 --output $(publishOutput)/netcoreapp3.1
-      
+
   - task: DockerCompose@0
     displayName: docker-compose run Profiler
     inputs:
@@ -91,7 +92,7 @@ jobs:
         publishTargetFramework: netcoreapp3.1
       net5_0:
         publishTargetFramework: net5.0
-        
+
   variables:
     TestAllPackageVersions: true
 
@@ -290,7 +291,7 @@ jobs:
       packageType: sdk
       version: $(dotnetCoreSdk5Version)
       includePreviewVersions: true
-      
+
   - task: NuGetToolInstaller@1
     displayName: install nuget
 
@@ -362,7 +363,7 @@ jobs:
       containerregistrytype: Container Registry
       dockerComposeCommand: down
     condition: succeededOrFailed()
-    
+
 - job: Windows_IIS
   timeoutInMinutes: 100
   strategy:

--- a/.azure-pipelines/packages.yml
+++ b/.azure-pipelines/packages.yml
@@ -1,8 +1,4 @@
-trigger:
-  branches:
-    include:
-      - master
-      - refs/tags/*
+trigger: none
 pr: none
 
 variables:

--- a/.azure-pipelines/runner.yml
+++ b/.azure-pipelines/runner.yml
@@ -1,14 +1,5 @@
-trigger:
-  branches:
-    include:
-      - master
-      - refs/tags/*
-    exclude:
-      - refs/pull/*/head
-  paths:
-    exclude:
-      - docs/*
-      - .github/*
+trigger: none
+pr: none
 
 variables:
   publishOutput: $(System.DefaultWorkingDirectory)/src/bin/managed-publish

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1,17 +1,26 @@
 trigger:
   branches:
     include:
-      - master # Only run on master for now
+      - master
+      - release/*
+      - refs/tags/*
     exclude:
       - refs/pull/*/head
   paths:
     exclude:
       - docs/*
       - .github/*
-pr:
-  branches:
-    exclude: # Don't run PR validation for now
-    - '*'
+
+
+schedules:
+  - cron: "0 3 * * *"
+    displayName: Daily 3am (UTC) build
+    branches:
+      include:
+        - master
+        - release/*
+        - /benchmarks/*
+    always: true
 
 # Global variables
 variables:
@@ -839,11 +848,11 @@ stages:
   dependsOn: build
   jobs:
 
-  #### Windows 
+  #### Windows
 
   - job: Windows
     pool: Benchmarks
-    
+
     workspace:
       clean: all
 
@@ -1144,7 +1153,7 @@ stages:
 
   - job: Linux
     pool: Throughput
-    
+
     workspace:
       clean: all
 

--- a/.azure-pipelines/unit-tests.yml
+++ b/.azure-pipelines/unit-tests.yml
@@ -2,6 +2,7 @@ trigger:
   branches:
     include:
       - master
+      - release/*
       - refs/tags/*
     exclude:
       - refs/pull/*/head
@@ -270,7 +271,7 @@ jobs:
       arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-  
+
   - script: |
       sudo apt-get update
       sudo apt-get install -y llvm clang
@@ -297,7 +298,7 @@ jobs:
       arguments: /nowarn:netsdk1138
       projects: |
         src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
-  
+
   - script: |
       cd ./src/Datadog.Trace.ClrProfiler.Native
       CXX=clang++ CC=clang cmake .


### PR DESCRIPTION
As we plan for the next major release (2.0), we will use release branches (e.g. `release/1.x`) as the main development branch for older versions of the tracer. Release branches such as `release/1.27.1` can also be used for hotfixes that will not include changes already merged into the main development branch. As such, we should treat `release/*` branches similar to `master` (use PRs to merge changes, run the same pipelines, etc).

Tracer version | Main development branch
-|-
2.x | `master`
1.x | `release/1.x`
hotfix | `hotfix/<version>`