### PR TITLE
Use a UUID for runtime-id instead of container id

### DIFF
--- a/src/Datadog.Trace/Tagging/TagsList.cs
+++ b/src/Datadog.Trace/Tagging/TagsList.cs
@@ -17,6 +17,8 @@ namespace Datadog.Trace.Tagging
         private static byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
         private static byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");
         private static byte[] _originBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Origin);
+        private static byte[] _runtimeIdBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.RuntimeId);
+        private static byte[] _runtimeIdValueBytes = StringEncoding.UTF8.GetBytes(Tracer.RuntimeId);
 
         private List<KeyValuePair<string, double>> _metrics;
         private List<KeyValuePair<string, string>> _tags;
@@ -303,6 +305,13 @@ namespace Datadog.Trace.Tagging
                     count++;
                     WriteTag(ref bytes, ref offset, property.Key, value);
                 }
+            }
+
+            if (span.IsTopLevel)
+            {
+                count++;
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdBytes);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _runtimeIdValueBytes);
             }
 
             string origin = span.Context.Origin;

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -403,5 +403,7 @@ namespace Datadog.Trace
         internal const string ElasticsearchMethod = "elasticsearch.method";
 
         internal const string ElasticsearchUrl = "elasticsearch.url";
+
+        internal const string RuntimeId = "runtime-id";
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -140,7 +140,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                     .ExcludingMissingMembers()
                     .ExcludingDefaultSpanProperties()
                     .AssertMetricsMatchExcludingKeys("_dd.tracer_kr", "_sampling_priority_v1")
-                    .AssertTagsMatchAndSpecifiedTagsPresent("env", "aws.requestId", "aws.queue.url"));
+                    .AssertTagsMatchAndSpecifiedTagsPresent("env", "aws.requestId", "aws.queue.url", "runtime-id"));
             }
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -53,7 +53,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -53,7 +53,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -53,7 +53,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -47,7 +47,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -53,7 +53,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -58,7 +58,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -40,7 +40,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -65,7 +65,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -40,7 +40,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -65,7 +65,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -40,7 +40,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -65,7 +65,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -40,7 +40,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_Index_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_Home_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin/home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Admin_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /admin,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_BadRequest_statusCode=InternalServerError.verified.txt
@@ -65,7 +65,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_BadValue_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_OptionalIdentifier_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/optionalidentifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_StatusCode-value=503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/statuscode?value=503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_123_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/123,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_BadValue_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier/badvalue,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_identifier_statusCode=InternalServerError.verified.txt
@@ -70,7 +70,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/identifier,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -57,7 +57,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -56,7 +56,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -57,7 +57,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -56,7 +56,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -57,7 +57,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -56,7 +56,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -45,7 +45,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -42,7 +42,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -57,7 +57,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -56,7 +56,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -44,7 +44,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -41,7 +41,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -69,7 +69,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -68,7 +68,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -44,7 +44,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -41,7 +41,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -69,7 +69,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -68,7 +68,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -44,7 +44,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -41,7 +41,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -69,7 +69,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -68,7 +68,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -44,7 +44,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -41,7 +41,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_Woof_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse/woof,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_DogHouse_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog/doghouse,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_DataDog_statusCode=OK.verified.txt
@@ -37,7 +37,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /datadog,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_3_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get/3,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Get_statusCode=InternalServerError.verified.txt
@@ -69,7 +69,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/get,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_Index_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home/index,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_Home_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /home,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=__statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_badrequest_statusCode=InternalServerError.verified.txt
@@ -68,7 +68,8 @@ at System.Web.HttpApplication.ExecuteStep(IExecutionStep step, Boolean& complete
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /badrequest,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay-async_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay-optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallSite.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Classic.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delayasync/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -40,7 +40,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -36,7 +36,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api2/transientfailure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/absolute-route,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-async/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional/1,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay-optional,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/delay/0,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/environment,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/201,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -38,7 +38,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/statuscode/503,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -16,7 +16,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/false,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -34,7 +34,8 @@
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.url: /api/transient-failure/true,
-      language: dotnet
+      language: dotnet,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -29,7 +29,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -27,7 +27,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -28,7 +28,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -26,7 +26,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -29,7 +29,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -27,7 +27,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -28,7 +28,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -26,7 +26,8 @@ at System.Web.Http.Controllers.ActionFilterResult.<ExecuteAsync>d__5.MoveNext(),
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallSite.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -31,7 +31,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -29,7 +29,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -32,7 +32,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -30,7 +30,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.NoFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -31,7 +31,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -29,7 +29,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X64.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_delayAsync_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delayasync
+      aspnet.action: delayasync,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_delay_0_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: delay
+      aspnet.action: delay,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_optional_1_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_optional_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: optional
+      aspnet.action: optional,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_statuscode_201_statusCode=Created.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -19,7 +19,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: statuscode
+      aspnet.action: statuscode,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_false_statusCode=InternalServerError.verified.txt
@@ -32,7 +32,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api2_transientfailure_true_statusCode=OK.verified.txt
@@ -17,7 +17,8 @@
       language: dotnet,
       aspnet.route: api2/{action}/{value},
       aspnet.controller: conventions,
-      aspnet.action: transientfailure
+      aspnet.action: transientfailure,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_absolute-route_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/absolute-route,
       language: dotnet,
-      aspnet.route: api/absolute-route
+      aspnet.route: api/absolute-route,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay-async_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-async/0,
       language: dotnet,
-      aspnet.route: api/delay-async/{seconds}
+      aspnet.route: api/delay-async/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay-optional_1_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional/1,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay-optional_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay-optional,
       language: dotnet,
-      aspnet.route: api/delay-optional/{seconds}
+      aspnet.route: api/delay-optional/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_delay_0_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/delay/0,
       language: dotnet,
-      aspnet.route: api/delay/{seconds}
+      aspnet.route: api/delay/{seconds},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_environment_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/environment,
       language: dotnet,
-      aspnet.route: api/environment
+      aspnet.route: api/environment,
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_statuscode_201_statusCode=Created.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/201,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_statuscode_503_statusCode=ServiceUnavailable.verified.txt
@@ -17,7 +17,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/statuscode/503,
       language: dotnet,
-      aspnet.route: api/statuscode/{value}
+      aspnet.route: api/statuscode/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_transient-failure_false_statusCode=InternalServerError.verified.txt
@@ -30,7 +30,8 @@ at Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration.<ExecuteAsync
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/false,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.CallTarget.WithFF.X86.SubmitsTraces_path=_api_transient-failure_true_statusCode=OK.verified.txt
@@ -15,7 +15,8 @@
       http.request.headers.host: localhost:00000,
       http.url: http://localhost:00000/api/transient-failure/true,
       language: dotnet,
-      aspnet.route: api/transient-failure/{value}
+      aspnet.route: api/transient-failure/{value},
+      runtime-id: Guid_1
     },
     Metrics: {
       _sampling_priority_v1: 1.0,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -74,6 +74,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // checks the runtime id tag
+                        AssertTargetSpanExists(targetSpan, Tags.RuntimeId);
+
                         // checks the origin tag
                         CheckOriginTag(targetSpan);
 
@@ -196,6 +199,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         private static void AssertTargetSpanEqual(MockTracerAgent.Span targetSpan, string key, string value)
         {
             Assert.Equal(value, targetSpan.Tags[key]);
+            targetSpan.Tags.Remove(key);
+        }
+
+        private static void AssertTargetSpanExists(MockTracerAgent.Span targetSpan, string key)
+        {
+            Assert.True(targetSpan.Tags.ContainsKey(key));
             targetSpan.Tags.Remove(key);
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -100,6 +100,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");
 
+                        // checks the runtime id tag
+                        AssertTargetSpanExists(targetSpan, Tags.RuntimeId);
+
                         // checks the origin tag
                         CheckOriginTag(targetSpan);
 
@@ -238,6 +241,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         private static void AssertTargetSpanEqual(MockTracerAgent.Span targetSpan, string key, string value)
         {
             Assert.Equal(value, targetSpan.Tags[key]);
+            targetSpan.Tags.Remove(key);
+        }
+
+        private static void AssertTargetSpanExists(MockTracerAgent.Span targetSpan, string key)
+        {
+            Assert.True(targetSpan.Tags.ContainsKey(key));
             targetSpan.Tags.Remove(key);
         }
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -89,6 +89,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         // checks the origin tag
                         CheckOriginTag(targetSpan);
 
+                        // checks the runtime id tag
+                        AssertTargetSpanExists(targetSpan, Tags.RuntimeId);
+
                         // Check the Environment
                         AssertTargetSpanEqual(targetSpan, Tags.Env, "integration_tests");
 
@@ -219,6 +222,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         private static void AssertTargetSpanEqual(MockTracerAgent.Span targetSpan, string key, string value)
         {
             Assert.Equal(value, targetSpan.Tags[key]);
+            targetSpan.Tags.Remove(key);
+        }
+
+        private static void AssertTargetSpanExists(MockTracerAgent.Span targetSpan, string key)
+        {
+            Assert.True(targetSpan.Tags.ContainsKey(key));
             targetSpan.Tags.Remove(key);
         }
 

--- a/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
+++ b/test/Datadog.Trace.Tests/Tagging/TagsListTests.cs
@@ -125,7 +125,8 @@ namespace Datadog.Trace.Tests.Tagging
 
             var deserializedSpan = MessagePack.MessagePackSerializer.Deserialize<FakeSpan>(buffer);
 
-            Assert.Equal(16, deserializedSpan.Tags.Count);
+            // For top-level spans, there is one tag added during serialization
+            Assert.Equal(topLevelSpan ? 17 : 16, deserializedSpan.Tags.Count);
 
             // For top-level spans, there is one metric added during serialization
             Assert.Equal(topLevelSpan ? 17 : 16, deserializedSpan.Metrics.Count);
@@ -141,6 +142,7 @@ namespace Datadog.Trace.Tests.Tagging
 
             if (topLevelSpan)
             {
+                Assert.Equal(Tracer.RuntimeId, deserializedSpan.Tags[Tags.RuntimeId]);
                 Assert.Equal(1.0, deserializedSpan.Metrics[Metrics.TopLevelSpan]);
             }
         }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -400,6 +400,18 @@ namespace Datadog.Trace.Tests
             _tracer.ShouldLogPartialFlushWarning(agentVersion).Should().BeFalse();
         }
 
+        [Fact]
+        public void RuntimeId()
+        {
+            var runtimeId = Tracer.RuntimeId;
+
+            // Runtime id should be stable for a given process
+            Tracer.RuntimeId.Should().Be(runtimeId);
+
+            // Runtime id should be a UUID
+            Guid.TryParse(runtimeId, out _).Should().BeTrue();
+        }
+
 #if NET452
 
         // Test that storage in the Logical Call Context does not expire


### PR DESCRIPTION
Also add the runtime-id tag on top-level spans.