### PR TITLE
Change native format to custom style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,7 +11,7 @@ BraceWrapping:
   AfterEnum: true
   AfterStruct: true
   AfterClass: true
-  SplitEmptyFunction: false
+  SplitEmptyFunction: true
   SplitEmptyRecord: true
   AfterControlStatement: true
   AfterFunction: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,44 @@
 ---
-BasedOnStyle: Microsoft
-BreakBeforeBraces: WebKit
+ColumnLimit: 120
+
+UseTab: Never
+IndentWidth: 4
+AccessModifierOffset: -4
+NamespaceIndentation: Inner
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterNamespace: true
+  AfterEnum: true
+  AfterStruct: true
+  AfterClass: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+  AfterControlStatement: true
+  AfterFunction: true
+  AfterUnion: true
+  BeforeElse: true
+  AfterCaseLabel: true
+  AfterExternBlock: true
+  BeforeCatch: true
+
+BreakBeforeConceptDeclarations: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+CompactNamespaces: false
+EmptyLineBeforeAccessModifier: LogicalBlock
+
+AlwaysBreakTemplateDeclarations: true
+BreakConstructorInitializersBeforeComma: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortFunctionsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+
 PointerAlignment: Left
-ColumnLimit: '120'
+AlignConsecutiveAssignments: false
+AlignTrailingComments: true
+
+SpaceAfterCStyleCast: true
+CommentPragmas: '^ NO-FORMAT:'

--- a/.clang-format
+++ b/.clang-format
@@ -21,11 +21,9 @@ BraceWrapping:
   AfterExternBlock: true
   BeforeCatch: true
 
-BreakBeforeConceptDeclarations: true
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
 CompactNamespaces: false
-EmptyLineBeforeAccessModifier: LogicalBlock
 AlwaysBreakTemplateDeclarations: true
 BreakConstructorInitializersBeforeComma: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
@@ -40,3 +38,7 @@ SpaceAfterCStyleCast: true
 CommentPragmas: '^ NO-FORMAT:'
 IndentCaseLabels: true
 IndentGotoLabels: true
+
+# The following doesn't work pre clang-format version 13
+#BreakBeforeConceptDeclarations: true
+#EmptyLineBeforeAccessModifier: LogicalBlock

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,5 @@
 ---
 ColumnLimit: 120
-
 UseTab: Never
 IndentWidth: 4
 AccessModifierOffset: -4
@@ -27,7 +26,6 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
 CompactNamespaces: false
 EmptyLineBeforeAccessModifier: LogicalBlock
-
 AlwaysBreakTemplateDeclarations: true
 BreakConstructorInitializersBeforeComma: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
@@ -35,10 +33,10 @@ AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
-
 PointerAlignment: Left
 AlignConsecutiveAssignments: false
 AlignTrailingComments: true
-
 SpaceAfterCStyleCast: true
 CommentPragmas: '^ NO-FORMAT:'
+IndentCaseLabels: true
+IndentGotoLabels: true

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -5,7 +5,8 @@
 #include "logging.h"
 #include "module_metadata.h"
 
-namespace trace {
+namespace trace
+{
 
 const int signatureBufferSize = 500;
 
@@ -19,56 +20,67 @@ HRESULT CallTargetTokens::EnsureCorLibTokens()
     AssemblyProperty corAssemblyProperty = *module_metadata->corAssemblyProperty;
 
     // *** Ensure corlib assembly ref
-    if (corLibAssemblyRef == mdAssemblyRefNil) {
+    if (corLibAssemblyRef == mdAssemblyRefNil)
+    {
         auto hr = module_metadata->assembly_emit->DefineAssemblyRef(
             corAssemblyProperty.ppbPublicKey, corAssemblyProperty.pcbPublicKey, corAssemblyProperty.szName.data(),
             &corAssemblyProperty.pMetaData, &corAssemblyProperty.pulHashAlgId, sizeof(corAssemblyProperty.pulHashAlgId),
             corAssemblyProperty.assemblyFlags, &corLibAssemblyRef);
-        if (corLibAssemblyRef == mdAssemblyRefNil) {
+        if (corLibAssemblyRef == mdAssemblyRefNil)
+        {
             Warn("Wrapper corLibAssemblyRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure System.Object type ref
-    if (objectTypeRef == mdTypeRefNil) {
+    if (objectTypeRef == mdTypeRefNil)
+    {
         auto hr = module_metadata->metadata_emit->DefineTypeRefByName(corLibAssemblyRef, SystemObject, &objectTypeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper objectTypeRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure System.Exception type ref
-    if (exTypeRef == mdTypeRefNil) {
+    if (exTypeRef == mdTypeRefNil)
+    {
         auto hr = module_metadata->metadata_emit->DefineTypeRefByName(corLibAssemblyRef, SystemException, &exTypeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper exTypeRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure System.Type type ref
-    if (typeRef == mdTypeRefNil) {
+    if (typeRef == mdTypeRefNil)
+    {
         auto hr = module_metadata->metadata_emit->DefineTypeRefByName(corLibAssemblyRef, SystemTypeName, &typeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper typeRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure System.RuntimeTypeHandle type ref
-    if (runtimeTypeHandleRef == mdTypeRefNil) {
+    if (runtimeTypeHandleRef == mdTypeRefNil)
+    {
         auto hr = module_metadata->metadata_emit->DefineTypeRefByName(corLibAssemblyRef, RuntimeTypeHandleTypeName,
                                                                       &runtimeTypeHandleRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper runtimeTypeHandleRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure Type.GetTypeFromHandle token
-    if (getTypeFromHandleToken == mdTokenNil) {
+    if (getTypeFromHandleToken == mdTokenNil)
+    {
         unsigned runtimeTypeHandle_buffer;
         auto runtimeTypeHandle_size = CorSigCompressToken(runtimeTypeHandleRef, &runtimeTypeHandle_buffer);
 
@@ -89,17 +101,20 @@ HRESULT CallTargetTokens::EnsureCorLibTokens()
 
         auto hr = module_metadata->metadata_emit->DefineMemberRef(typeRef, GetTypeFromHandleMethodName, signature,
                                                                   offset, &getTypeFromHandleToken);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper getTypeFromHandleToken could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure System.RuntimeMethodHandle type ref
-    if (runtimeMethodHandleRef == mdTypeRefNil) {
+    if (runtimeMethodHandleRef == mdTypeRefNil)
+    {
         auto hr = module_metadata->metadata_emit->DefineTypeRefByName(corLibAssemblyRef, RuntimeMethodHandleTypeName,
                                                                       &runtimeMethodHandleRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper runtimeMethodHandleRef could not be defined.");
             return hr;
         }
@@ -111,14 +126,16 @@ HRESULT CallTargetTokens::EnsureCorLibTokens()
 HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
 {
     auto hr = EnsureCorLibTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
 
     ModuleMetadata* module_metadata = GetMetadata();
 
     // *** Ensure profiler assembly ref
-    if (profilerAssemblyRef == mdAssemblyRefNil) {
+    if (profilerAssemblyRef == mdAssemblyRefNil)
+    {
         const AssemblyReference assemblyReference = managed_profiler_full_assembly_version;
         ASSEMBLYMETADATA assembly_metadata{};
 
@@ -126,16 +143,20 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
         assembly_metadata.usMinorVersion = assemblyReference.version.minor;
         assembly_metadata.usBuildNumber = assemblyReference.version.build;
         assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-        if (assemblyReference.locale == WStr("neutral")) {
+        if (assemblyReference.locale == WStr("neutral"))
+        {
             assembly_metadata.szLocale = const_cast<WCHAR*>(WStr("\0"));
             assembly_metadata.cbLocale = 0;
-        } else {
+        }
+        else
+        {
             assembly_metadata.szLocale = const_cast<WCHAR*>(assemblyReference.locale.c_str());
-            assembly_metadata.cbLocale = (DWORD)(assemblyReference.locale.size());
+            assembly_metadata.cbLocale = (DWORD) (assemblyReference.locale.size());
         }
 
         DWORD public_key_size = 8;
-        if (assemblyReference.public_key == trace::PublicKey()) {
+        if (assemblyReference.public_key == trace::PublicKey())
+        {
             public_key_size = 0;
         }
 
@@ -143,34 +164,40 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
                                                                assemblyReference.name.data(), &assembly_metadata, NULL,
                                                                0, 0, &profilerAssemblyRef);
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper profilerAssemblyRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure calltarget type ref
-    if (callTargetTypeRef == mdTypeRefNil) {
+    if (callTargetTypeRef == mdTypeRefNil)
+    {
         hr = module_metadata->metadata_emit->DefineTypeRefByName(
             profilerAssemblyRef, managed_profiler_calltarget_type.data(), &callTargetTypeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper callTargetTypeRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure calltargetstate type ref
-    if (callTargetStateTypeRef == mdTypeRefNil) {
+    if (callTargetStateTypeRef == mdTypeRefNil)
+    {
         hr = module_metadata->metadata_emit->DefineTypeRefByName(
             profilerAssemblyRef, managed_profiler_calltarget_statetype.data(), &callTargetStateTypeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper callTargetStateTypeRef could not be defined.");
             return hr;
         }
     }
 
     // *** Ensure CallTargetState.GetDefault() member ref
-    if (callTargetStateTypeGetDefault == mdMemberRefNil) {
+    if (callTargetStateTypeGetDefault == mdMemberRefNil)
+    {
         unsigned callTargetStateTypeBuffer;
         auto callTargetStateTypeSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateTypeBuffer);
 
@@ -188,7 +215,8 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
         auto hr = module_metadata->metadata_emit->DefineMemberRef(
             callTargetStateTypeRef, managed_profiler_calltarget_statetype_getdefault_name.data(), signature,
             signatureLength, &callTargetStateTypeGetDefault);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper callTargetStateTypeGetDefault could not be defined.");
             return hr;
         }
@@ -200,7 +228,8 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
 mdTypeRef CallTargetTokens::GetTargetStateTypeRef()
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdTypeRefNil;
     }
     return callTargetStateTypeRef;
@@ -209,17 +238,20 @@ mdTypeRef CallTargetTokens::GetTargetStateTypeRef()
 mdTypeRef CallTargetTokens::GetTargetVoidReturnTypeRef()
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdTypeRefNil;
     }
 
     ModuleMetadata* module_metadata = GetMetadata();
 
     // *** Ensure calltargetreturn void type ref
-    if (callTargetReturnVoidTypeRef == mdTypeRefNil) {
+    if (callTargetReturnVoidTypeRef == mdTypeRefNil)
+    {
         hr = module_metadata->metadata_emit->DefineTypeRefByName(
             profilerAssemblyRef, managed_profiler_calltarget_returntype.data(), &callTargetReturnVoidTypeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper callTargetReturnVoidTypeRef could not be defined.");
             return mdTypeRefNil;
         }
@@ -231,7 +263,8 @@ mdTypeRef CallTargetTokens::GetTargetVoidReturnTypeRef()
 mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(FunctionMethodArgument* returnArgument)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdTypeSpecNil;
     }
 
@@ -239,10 +272,12 @@ mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(FunctionMethodArgument*
     mdTypeSpec returnValueTypeSpec = mdTypeSpecNil;
 
     // *** Ensure calltargetreturn type ref
-    if (callTargetReturnTypeRef == mdTypeRefNil) {
+    if (callTargetReturnTypeRef == mdTypeRefNil)
+    {
         hr = module_metadata->metadata_emit->DefineTypeRefByName(
             profilerAssemblyRef, managed_profiler_calltarget_returntype_generics.data(), &callTargetReturnTypeRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper callTargetReturnTypeRef could not be defined.");
             return mdTypeSpecNil;
         }
@@ -268,7 +303,8 @@ mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(FunctionMethodArgument*
     offset += returnSignatureLength;
 
     hr = module_metadata->metadata_emit->GetTokenFromTypeSpec(signature, signatureLength, &returnValueTypeSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating return value type spec");
         return mdTypeSpecNil;
     }
@@ -279,7 +315,8 @@ mdTypeSpec CallTargetTokens::GetTargetReturnValueTypeRef(FunctionMethodArgument*
 mdMemberRef CallTargetTokens::GetCallTargetStateDefaultMemberRef()
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdMemberRefNil;
     }
     return callTargetStateTypeGetDefault;
@@ -288,12 +325,14 @@ mdMemberRef CallTargetTokens::GetCallTargetStateDefaultMemberRef()
 mdMemberRef CallTargetTokens::GetCallTargetReturnVoidDefaultMemberRef()
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdMemberRefNil;
     }
 
     // *** Ensure CallTargetReturn.GetDefault() member ref
-    if (callTargetReturnVoidTypeGetDefault == mdMemberRefNil) {
+    if (callTargetReturnVoidTypeGetDefault == mdMemberRefNil)
+    {
         ModuleMetadata* module_metadata = GetMetadata();
 
         unsigned callTargetReturnVoidTypeBuffer;
@@ -314,7 +353,8 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnVoidDefaultMemberRef()
         hr = module_metadata->metadata_emit->DefineMemberRef(
             callTargetReturnVoidTypeRef, managed_profiler_calltarget_returntype_getdefault_name.data(), signature,
             signatureLength, &callTargetReturnVoidTypeGetDefault);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper callTargetReturnVoidTypeGetDefault could not be defined.");
             return mdMemberRefNil;
         }
@@ -326,10 +366,12 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnVoidDefaultMemberRef()
 mdMemberRef CallTargetTokens::GetCallTargetReturnValueDefaultMemberRef(mdTypeSpec callTargetReturnTypeSpec)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdMemberRefNil;
     }
-    if (callTargetReturnTypeRef == mdTypeRefNil) {
+    if (callTargetReturnTypeRef == mdTypeRefNil)
+    {
         Warn("Wrapper callTargetReturnTypeGetDefault could not be defined because callTargetReturnTypeRef is null.");
         return mdMemberRefNil;
     }
@@ -359,7 +401,8 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnValueDefaultMemberRef(mdTypeSpe
     hr = module_metadata->metadata_emit->DefineMemberRef(callTargetReturnTypeSpec,
                                                          managed_profiler_calltarget_returntype_getdefault_name.data(),
                                                          signature, signatureLength, &callTargetReturnTypeGetDefault);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Wrapper callTargetReturnTypeGetDefault could not be defined.");
         return mdMemberRefNil;
     }
@@ -370,7 +413,8 @@ mdMemberRef CallTargetTokens::GetCallTargetReturnValueDefaultMemberRef(mdTypeSpe
 mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMethodArgument* methodArgument)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdMethodSpecNil;
     }
 
@@ -378,7 +422,8 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMetho
     ModuleMetadata* module_metadata = GetMetadata();
 
     // *** Ensure we have the CallTargetInvoker.GetDefaultValue<> memberRef
-    if (getDefaultMemberRef == mdMemberRefNil) {
+    if (getDefaultMemberRef == mdMemberRefNil)
+    {
         auto signatureLength = 5;
         COR_SIGNATURE signature[signatureBufferSize];
         unsigned offset = 0;
@@ -393,7 +438,8 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMetho
         auto hr = module_metadata->metadata_emit->DefineMemberRef(
             callTargetTypeRef, managed_profiler_calltarget_getdefaultvalue_name.data(), signature, signatureLength,
             &getDefaultMemberRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper getDefaultMemberRef could not be defined.");
             return hr;
         }
@@ -417,7 +463,8 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMetho
 
     hr = module_metadata->metadata_emit->DefineMethodSpec(getDefaultMemberRef, signature, signatureLength,
                                                           &getDefaultMethodSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating getDefaultMethodSpec.");
         return mdMethodSpecNil;
     }
@@ -427,14 +474,19 @@ mdMethodSpec CallTargetTokens::GetCallTargetDefaultValueMethodSpec(FunctionMetho
 
 mdToken CallTargetTokens::GetCurrentTypeRef(const TypeInfo* currentType, bool& isValueType)
 {
-    if (currentType->type_spec != mdTypeSpecNil) {
+    if (currentType->type_spec != mdTypeSpecNil)
+    {
         return currentType->type_spec;
-    } else {
+    }
+    else
+    {
 
         TypeInfo* cType = const_cast<TypeInfo*>(currentType);
-        while (!cType->isGeneric) {
+        while (!cType->isGeneric)
+        {
 
-            if (cType->parent_type == nullptr) {
+            if (cType->parent_type == nullptr)
+            {
                 return cType->id;
             }
 
@@ -453,7 +505,8 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
                                          mdToken* callTargetReturnToken)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
 
@@ -463,7 +516,8 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     ULONG originalSignatureSize = 0;
     mdToken localVarSig = reWriter->GetTkLocalVarSig();
 
-    if (localVarSig != mdTokenNil) {
+    if (localVarSig != mdTokenNil)
+    {
         IfFailRet(
             module_metadata->metadata_import->GetSigFromToken(localVarSig, &originalSignature, &originalSignatureSize));
 
@@ -471,9 +525,12 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
         // should be the callTargetState)
         unsigned temp = 0;
         const auto len = CorSigCompressToken(callTargetStateTypeRef, &temp);
-        if (originalSignatureSize - len > 0) {
-            if (originalSignature[originalSignatureSize - len - 1] == ELEMENT_TYPE_VALUETYPE) {
-                if (memcmp(&originalSignature[originalSignatureSize - len], &temp, len) == 0) {
+        if (originalSignatureSize - len > 0)
+        {
+            if (originalSignature[originalSignatureSize - len - 1] == ELEMENT_TYPE_VALUETYPE)
+            {
+                if (memcmp(&originalSignature[originalSignatureSize - len], &temp, len) == 0)
+                {
                     Warn("The signature for this method has been already modified.");
                     return E_FAIL;
                 }
@@ -505,20 +562,24 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     unsigned retTypeElementType;
     auto retTypeFlags = methodReturnValue->GetTypeFlags(retTypeElementType);
 
-    if (retTypeFlags != TypeFlagVoid) {
+    if (retTypeFlags != TypeFlagVoid)
+    {
         returnSignatureTypeSize = methodReturnValue->GetSignature(returnSignatureType);
         callTargetReturn = GetTargetReturnValueTypeRef(methodReturnValue);
 
         hr = module_metadata->metadata_import->GetTypeSpecFromToken(callTargetReturn, &callTargetReturnSignature,
                                                                     &callTargetReturnSignatureSize);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             return E_FAIL;
         }
 
         callTargetReturnSizeForNewSignature = callTargetReturnSignatureSize;
 
         newLocalsCount++;
-    } else {
+    }
+    else
+    {
         callTargetReturn = GetTargetVoidReturnTypeRef();
         callTargetReturnSize = CorSigCompressToken(callTargetReturn, &callTargetReturnBuffer);
         callTargetReturnSizeForNewSignature = 1 + callTargetReturnSize;
@@ -535,10 +596,13 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     ULONG newLocalsLen;
 
     // Calculate the new locals count
-    if (originalSignatureSize == 0) {
+    if (originalSignatureSize == 0)
+    {
         newSignatureSize += 2;
         newLocalsLen = CorSigCompressData(newLocalsCount, &newLocalsBuffer);
-    } else {
+    }
+    else
+    {
         oldLocalsLen = CorSigUncompressData(originalSignature + 1, &oldLocalsBuffer);
         newLocalsCount += oldLocalsBuffer;
         newLocalsLen = CorSigCompressData(newLocalsCount, &newLocalsBuffer);
@@ -554,7 +618,8 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     newSignatureOffset += newLocalsLen;
 
     // Copy previous locals to the signature
-    if (originalSignatureSize > 0) {
+    if (originalSignatureSize > 0)
+    {
         const auto copyLength = originalSignatureSize - 1 - oldLocalsLen;
         memcpy(&newSignatureBuffer[newSignatureOffset], originalSignature + 1 + oldLocalsLen, copyLength);
         newSignatureOffset += copyLength;
@@ -563,7 +628,8 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     // Add new locals
 
     // Return value local
-    if (returnSignatureType != nullptr) {
+    if (returnSignatureType != nullptr)
+    {
         memcpy(&newSignatureBuffer[newSignatureOffset], returnSignatureType, returnSignatureTypeSize);
         newSignatureOffset += returnSignatureTypeSize;
     }
@@ -574,10 +640,13 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     newSignatureOffset += exTypeRefSize;
 
     // CallTarget Return value
-    if (callTargetReturnSignature != nullptr) {
+    if (callTargetReturnSignature != nullptr)
+    {
         memcpy(&newSignatureBuffer[newSignatureOffset], callTargetReturnSignature, callTargetReturnSignatureSize);
         newSignatureOffset += callTargetReturnSignatureSize;
-    } else {
+    }
+    else
+    {
         newSignatureBuffer[newSignatureOffset++] = ELEMENT_TYPE_VALUETYPE;
         memcpy(&newSignatureBuffer[newSignatureOffset], &callTargetReturnBuffer, callTargetReturnSize);
         newSignatureOffset += callTargetReturnSize;
@@ -591,7 +660,8 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     // Get new locals token
     mdToken newLocalVarSig;
     hr = module_metadata->metadata_emit->GetTokenFromSig(newSignatureBuffer, newSignatureSize, &newLocalVarSig);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating new locals var signature.");
         return hr;
     }
@@ -600,9 +670,12 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, FunctionMethodArg
     *callTargetStateToken = callTargetStateTypeRef;
     *exceptionToken = exTypeRef;
     *callTargetReturnToken = callTargetReturn;
-    if (returnSignatureType != nullptr) {
+    if (returnSignatureType != nullptr)
+    {
         *returnValueIndex = newLocalsCount - 4;
-    } else {
+    }
+    else
+    {
         *returnValueIndex = static_cast<ULONG>(ULONG_MAX);
     }
     *exceptionIndex = newLocalsCount - 3;
@@ -616,13 +689,15 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapp
                                                              const TypeInfo* currentType, ILInstr** instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
     ModuleMetadata* module_metadata = GetMetadata();
 
-    if (beginArrayMemberRef == mdMemberRefNil) {
+    if (beginArrayMemberRef == mdMemberRefNil)
+    {
         unsigned callTargetStateBuffer;
         auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
@@ -647,7 +722,8 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapp
         auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
                                                                   managed_profiler_calltarget_beginmethod_name.data(),
                                                                   signature, signatureLength, &beginArrayMemberRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper beginArrayMemberRef could not be defined.");
             return hr;
         }
@@ -674,9 +750,12 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapp
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
     offset += integrationTypeSize;
 
-    if (isValueType) {
+    if (isValueType)
+    {
         signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    } else {
+    }
+    else
+    {
         signature[offset++] = ELEMENT_TYPE_CLASS;
     }
     memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
@@ -684,7 +763,8 @@ HRESULT CallTargetTokens::WriteBeginMethodWithArgumentsArray(void* rewriterWrapp
 
     hr = module_metadata->metadata_emit->DefineMethodSpec(beginArrayMemberRef, signature, signatureLength,
                                                           &beginArrayMethodSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating begin method spec.");
         return hr;
     }
@@ -716,7 +796,7 @@ HRESULT CallTargetTokens::ModifyLocalSigAndInitialize(void* rewriterWrapperPtr, 
                                                       mdToken* callTargetStateToken, mdToken* exceptionToken,
                                                       mdToken* callTargetReturnToken, ILInstr** firstInstruction)
 {
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
 
     // Modify the Local Var Signature of the method
     auto returnFunctionMethod = functionInfo->method_signature.GetRet();
@@ -725,20 +805,24 @@ HRESULT CallTargetTokens::ModifyLocalSigAndInitialize(void* rewriterWrapperPtr, 
                              exceptionIndex, callTargetReturnIndex, returnValueIndex, callTargetStateToken,
                              exceptionToken, callTargetReturnToken);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("ModifyLocalSig() failed.");
         return hr;
     }
 
     // Init locals
-    if (*returnValueIndex != static_cast<ULONG>(ULONG_MAX)) {
+    if (*returnValueIndex != static_cast<ULONG>(ULONG_MAX))
+    {
         *firstInstruction =
             rewriterWrapper->CallMember(GetCallTargetDefaultValueMethodSpec(&returnFunctionMethod), false);
         rewriterWrapper->StLocal(*returnValueIndex);
 
         rewriterWrapper->CallMember(GetCallTargetReturnValueDefaultMemberRef(*callTargetReturnToken), false);
         rewriterWrapper->StLocal(*callTargetReturnIndex);
-    } else {
+    }
+    else
+    {
         *firstInstruction = rewriterWrapper->CallMember(GetCallTargetReturnVoidDefaultMemberRef(), false);
         rewriterWrapper->StLocal(*callTargetReturnIndex);
     }
@@ -756,15 +840,17 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
                                            std::vector<FunctionMethodArgument>& methodArguments, ILInstr** instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
 
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
     ModuleMetadata* module_metadata = GetMetadata();
 
-    auto numArguments = (int)methodArguments.size();
-    if (numArguments >= FASTPATH_COUNT) {
+    auto numArguments = (int) methodArguments.size();
+    if (numArguments >= FASTPATH_COUNT)
+    {
         return WriteBeginMethodWithArgumentsArray(rewriterWrapperPtr, integrationTypeRef, currentType, instruction);
     }
 
@@ -772,7 +858,8 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
     // FastPath
     //
 
-    if (beginMethodFastPathRefs[numArguments] == mdMemberRefNil) {
+    if (beginMethodFastPathRefs[numArguments] == mdMemberRefNil)
+    {
         unsigned callTargetStateBuffer;
         auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
@@ -791,7 +878,8 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
         signature[offset++] = ELEMENT_TYPE_MVAR;
         signature[offset++] = 0x01;
 
-        for (auto i = 0; i < numArguments; i++) {
+        for (auto i = 0; i < numArguments; i++)
+        {
             signature[offset++] = ELEMENT_TYPE_MVAR;
             signature[offset++] = 0x01 + (i + 1);
         }
@@ -799,7 +887,8 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
         auto hr = module_metadata->metadata_emit->DefineMemberRef(
             callTargetTypeRef, managed_profiler_calltarget_beginmethod_name.data(), signature, signatureLength,
             &beginMethodFastPathRefs[numArguments]);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper beginMethod for ", numArguments, " arguments could not be defined.");
             return hr;
         }
@@ -820,7 +909,8 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
 
     PCCOR_SIGNATURE argumentsSignatureBuffer[FASTPATH_COUNT];
     ULONG argumentsSignatureSize[FASTPATH_COUNT];
-    for (auto i = 0; i < numArguments; i++) {
+    for (auto i = 0; i < numArguments; i++)
+    {
         auto signatureSize = methodArguments[i].GetSignature(argumentsSignatureBuffer[i]);
         argumentsSignatureSize[i] = signatureSize;
         signatureLength += signatureSize;
@@ -836,22 +926,27 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
     offset += integrationTypeSize;
 
-    if (isValueType) {
+    if (isValueType)
+    {
         signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    } else {
+    }
+    else
+    {
         signature[offset++] = ELEMENT_TYPE_CLASS;
     }
     memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
     offset += currentTypeSize;
 
-    for (auto i = 0; i < numArguments; i++) {
+    for (auto i = 0; i < numArguments; i++)
+    {
         memcpy(&signature[offset], argumentsSignatureBuffer[i], argumentsSignatureSize[i]);
         offset += argumentsSignatureSize[i];
     }
 
     hr = module_metadata->metadata_emit->DefineMethodSpec(beginMethodFastPathRefs[numArguments], signature,
                                                           signatureLength, &beginMethodSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating begin method spec.");
         return hr;
     }
@@ -865,13 +960,15 @@ HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, 
                                                       const TypeInfo* currentType, ILInstr** instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
     ModuleMetadata* module_metadata = GetMetadata();
 
-    if (endVoidMemberRef == mdMemberRefNil) {
+    if (endVoidMemberRef == mdMemberRefNil)
+    {
         unsigned callTargetReturnVoidBuffer;
         auto callTargetReturnVoidSize = CorSigCompressToken(callTargetReturnVoidTypeRef, &callTargetReturnVoidBuffer);
 
@@ -907,7 +1004,8 @@ HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, 
         auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
                                                                   managed_profiler_calltarget_endmethod_name.data(),
                                                                   signature, signatureLength, &endVoidMemberRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper endVoidMemberRef could not be defined.");
             return hr;
         }
@@ -934,9 +1032,12 @@ HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, 
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
     offset += integrationTypeSize;
 
-    if (isValueType) {
+    if (isValueType)
+    {
         signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    } else {
+    }
+    else
+    {
         signature[offset++] = ELEMENT_TYPE_CLASS;
     }
     memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
@@ -944,7 +1045,8 @@ HRESULT CallTargetTokens::WriteEndVoidReturnMemberRef(void* rewriterWrapperPtr, 
 
     hr = module_metadata->metadata_emit->DefineMethodSpec(endVoidMemberRef, signature, signatureLength,
                                                           &endVoidMethodSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating end void method method spec.");
         return hr;
     }
@@ -959,10 +1061,11 @@ HRESULT CallTargetTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTy
                                                   ILInstr** instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
     ModuleMetadata* module_metadata = GetMetadata();
     GetTargetReturnValueTypeRef(returnArgument);
 
@@ -1012,7 +1115,8 @@ HRESULT CallTargetTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTy
     hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
                                                          managed_profiler_calltarget_endmethod_name.data(), signature,
                                                          signatureLength, &endMethodMemberRef);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Wrapper endMethodMemberRef could not be defined.");
         return hr;
     }
@@ -1043,9 +1147,12 @@ HRESULT CallTargetTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTy
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
     offset += integrationTypeSize;
 
-    if (isValueType) {
+    if (isValueType)
+    {
         signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    } else {
+    }
+    else
+    {
         signature[offset++] = ELEMENT_TYPE_CLASS;
     }
     memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
@@ -1056,7 +1163,8 @@ HRESULT CallTargetTokens::WriteEndReturnMemberRef(void* rewriterWrapperPtr, mdTy
 
     hr = module_metadata->metadata_emit->DefineMethodSpec(endMethodMemberRef, signature, signatureLength,
                                                           &endMethodSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating end method member spec.");
         return hr;
     }
@@ -1070,13 +1178,15 @@ HRESULT CallTargetTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef 
                                             const TypeInfo* currentType, ILInstr** instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return hr;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
     ModuleMetadata* module_metadata = GetMetadata();
 
-    if (logExceptionRef == mdMemberRefNil) {
+    if (logExceptionRef == mdMemberRefNil)
+    {
         unsigned exTypeRefBuffer;
         auto exTypeRefSize = CorSigCompressToken(exTypeRef, &exTypeRefBuffer);
 
@@ -1096,7 +1206,8 @@ HRESULT CallTargetTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef 
         auto hr = module_metadata->metadata_emit->DefineMemberRef(callTargetTypeRef,
                                                                   managed_profiler_calltarget_logexception_name.data(),
                                                                   signature, signatureLength, &logExceptionRef);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("Wrapper logExceptionRef could not be defined.");
             return hr;
         }
@@ -1123,9 +1234,12 @@ HRESULT CallTargetTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef 
     memcpy(&signature[offset], &integrationTypeBuffer, integrationTypeSize);
     offset += integrationTypeSize;
 
-    if (isValueType) {
+    if (isValueType)
+    {
         signature[offset++] = ELEMENT_TYPE_VALUETYPE;
-    } else {
+    }
+    else
+    {
         signature[offset++] = ELEMENT_TYPE_CLASS;
     }
     memcpy(&signature[offset], &currentTypeBuffer, currentTypeSize);
@@ -1133,7 +1247,8 @@ HRESULT CallTargetTokens::WriteLogException(void* rewriterWrapperPtr, mdTypeRef 
 
     hr = module_metadata->metadata_emit->DefineMethodSpec(logExceptionRef, signature, signatureLength,
                                                           &logExceptionMethodSpec);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Error creating log exception method spec.");
         return hr;
     }
@@ -1147,10 +1262,11 @@ HRESULT CallTargetTokens::WriteCallTargetReturnGetReturnValue(void* rewriterWrap
                                                               ILInstr** instruction)
 {
     auto hr = EnsureBaseCalltargetTokens();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         return mdMemberRefNil;
     }
-    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*)rewriterWrapperPtr;
+    ILRewriterWrapper* rewriterWrapper = (ILRewriterWrapper*) rewriterWrapperPtr;
     ModuleMetadata* module_metadata = GetMetadata();
 
     // Ensure T CallTargetReturn<T>.GetReturnValue() member ref
@@ -1167,7 +1283,8 @@ HRESULT CallTargetTokens::WriteCallTargetReturnGetReturnValue(void* rewriterWrap
     hr = module_metadata->metadata_emit->DefineMemberRef(
         callTargetReturnTypeSpec, managed_profiler_calltarget_returntype_getreturnvalue_name.data(), signature,
         signatureLength, &callTargetReturnGetValueMemberRef);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Wrapper callTargetReturnGetValueMemberRef could not be defined.");
         return mdMemberRefNil;
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -151,7 +151,7 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
         else
         {
             assembly_metadata.szLocale = const_cast<WCHAR*>(assemblyReference.locale.c_str());
-            assembly_metadata.cbLocale = (DWORD) (assemblyReference.locale.size());
+            assembly_metadata.cbLocale = (DWORD)(assemblyReference.locale.size());
         }
 
         DWORD public_key_size = 8;

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
@@ -15,14 +15,16 @@
 
 #define FASTPATH_COUNT 9
 
-namespace trace {
+namespace trace
+{
 
 /// <summary>
 /// Class to control all the token references of the module where the calltarget will be called.
 /// Also provides useful helpers for the rewriting process
 /// </summary>
-class CallTargetTokens {
-  private:
+class CallTargetTokens
+{
+private:
     void* module_metadata_ptr = nullptr;
 
     // CallTarget constants
@@ -70,7 +72,7 @@ class CallTargetTokens {
 
     inline ModuleMetadata* GetMetadata()
     {
-        return (ModuleMetadata*)module_metadata_ptr;
+        return (ModuleMetadata*) module_metadata_ptr;
     }
     HRESULT EnsureCorLibTokens();
     HRESULT EnsureBaseCalltargetTokens();
@@ -90,11 +92,12 @@ class CallTargetTokens {
     HRESULT WriteBeginMethodWithArgumentsArray(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
                                                const TypeInfo* currentType, ILInstr** instruction);
 
-  public:
+public:
     CallTargetTokens(void* module_metadata_ptr)
     {
         this->module_metadata_ptr = module_metadata_ptr;
-        for (int i = 0; i < FASTPATH_COUNT; i++) {
+        for (int i = 0; i < FASTPATH_COUNT; i++)
+        {
             beginMethodFastPathRefs[i] = mdMemberRefNil;
         }
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/class_factory.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/class_factory.cpp
@@ -8,16 +8,15 @@
 #include "version.h"
 
 ClassFactory::ClassFactory() : refCount(0)
-{
-}
+{}
 
 ClassFactory::~ClassFactory()
-{
-}
+{}
 
 HRESULT STDMETHODCALLTYPE ClassFactory::QueryInterface(REFIID riid, void** ppvObject)
 {
-    if (riid == IID_IUnknown || riid == IID_IClassFactory) {
+    if (riid == IID_IUnknown || riid == IID_IClassFactory)
+    {
         *ppvObject = this;
         this->AddRef();
         return S_OK;
@@ -35,7 +34,8 @@ ULONG STDMETHODCALLTYPE ClassFactory::AddRef()
 ULONG STDMETHODCALLTYPE ClassFactory::Release()
 {
     int count = std::atomic_fetch_sub(&this->refCount, 1) - 1;
-    if (count <= 0) {
+    if (count <= 0)
+    {
         delete this;
     }
 
@@ -45,7 +45,8 @@ ULONG STDMETHODCALLTYPE ClassFactory::Release()
 // profiler entry point
 HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown* pUnkOuter, REFIID riid, void** ppvObject)
 {
-    if (pUnkOuter != nullptr) {
+    if (pUnkOuter != nullptr)
+    {
         *ppvObject = nullptr;
         return CLASS_E_NOAGGREGATION;
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/class_factory.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/class_factory.cpp
@@ -8,10 +8,12 @@
 #include "version.h"
 
 ClassFactory::ClassFactory() : refCount(0)
-{}
+{
+}
 
 ClassFactory::~ClassFactory()
-{}
+{
+}
 
 HRESULT STDMETHODCALLTYPE ClassFactory::QueryInterface(REFIID riid, void** ppvObject)
 {

--- a/src/Datadog.Trace.ClrProfiler.Native/class_factory.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/class_factory.h
@@ -8,11 +8,12 @@
 #include "unknwn.h"
 #include <atomic>
 
-class ClassFactory : public IClassFactory {
-  private:
+class ClassFactory : public IClassFactory
+{
+private:
     std::atomic<int> refCount;
 
-  public:
+public:
     ClassFactory();
     virtual ~ClassFactory();
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppvObject) override;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -1672,8 +1672,8 @@ HRESULT FunctionMethodSignature::TryParse()
 
     IfFalseRetFAIL(ParseRetType(pbCur, pbEnd));
     ret.pbBase = pbBase;
-    ret.length = (ULONG) (pbCur - pbRet);
-    ret.offset = (ULONG) (pbCur - pbBase - ret.length);
+    ret.length = (ULONG)(pbCur - pbRet);
+    ret.offset = (ULONG)(pbCur - pbBase - ret.length);
 
     auto fEncounteredSentinal = false;
     for (unsigned i = 0; i < param_count; i++)
@@ -1694,8 +1694,8 @@ HRESULT FunctionMethodSignature::TryParse()
 
         FunctionMethodArgument argument{};
         argument.pbBase = pbBase;
-        argument.length = (ULONG) (pbCur - pbParam);
-        argument.offset = (ULONG) (pbCur - pbBase - argument.length);
+        argument.length = (ULONG)(pbCur - pbParam);
+        argument.offset = (ULONG)(pbCur - pbBase - argument.length);
 
         params.push_back(argument);
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -11,7 +11,8 @@
 #include "util.h"
 #include <set>
 
-namespace trace {
+namespace trace
+{
 class ModuleMetadata;
 
 const size_t kNameMaxSize = 1024;
@@ -41,19 +42,21 @@ const auto SystemReflectionMethodBaseName = WStr("System.Reflection.MethodBase")
 const auto GetMethodFromHandleMethodName = WStr("GetMethodFromHandle");
 const auto RuntimeMethodHandleTypeName = WStr("System.RuntimeMethodHandle");
 
-template <typename T> class EnumeratorIterator;
+template <typename T>
+class EnumeratorIterator;
 
-template <typename T> class Enumerator {
-  private:
+template <typename T>
+class Enumerator
+{
+private:
     const std::function<HRESULT(HCORENUM*, T[], ULONG, ULONG*)> callback_;
     const std::function<void(HCORENUM)> close_;
     mutable HCORENUM ptr_;
 
-  public:
-    Enumerator(std::function<HRESULT(HCORENUM*, T[], ULONG, ULONG*)> callback, std::function<void(HCORENUM)> close)
-        : callback_(callback), close_(close), ptr_(nullptr)
-    {
-    }
+public:
+    Enumerator(std::function<HRESULT(HCORENUM*, T[], ULONG, ULONG*)> callback, std::function<void(HCORENUM)> close) :
+        callback_(callback), close_(close), ptr_(nullptr)
+    {}
 
     Enumerator(const Enumerator& other) = default;
 
@@ -80,23 +83,29 @@ template <typename T> class Enumerator {
     }
 };
 
-template <typename T> class EnumeratorIterator {
-  private:
+template <typename T>
+class EnumeratorIterator
+{
+private:
     const Enumerator<T>* enumerator_;
     HRESULT status_ = S_FALSE;
     T arr_[kEnumeratorMax]{};
     ULONG idx_ = 0;
     ULONG sz_ = 0;
 
-  public:
+public:
     EnumeratorIterator(const Enumerator<T>* enumerator, HRESULT status) : enumerator_(enumerator)
     {
-        if (status == S_OK) {
+        if (status == S_OK)
+        {
             status_ = enumerator_->Next(arr_, kEnumeratorMax, &sz_);
-            if (status_ == S_OK && sz_ == 0) {
+            if (status_ == S_OK && sz_ == 0)
+            {
                 status_ = S_FALSE;
             }
-        } else {
+        }
+        else
+        {
             status_ = status;
         }
     }
@@ -113,12 +122,16 @@ template <typename T> class EnumeratorIterator {
 
     EnumeratorIterator<T>& operator++()
     {
-        if (idx_ < sz_ - 1) {
+        if (idx_ < sz_ - 1)
+        {
             idx_++;
-        } else {
+        }
+        else
+        {
             idx_ = 0;
             status_ = enumerator_->Next(arr_, kEnumeratorMax, &sz_);
-            if (status_ == S_OK && sz_ == 0) {
+            if (status_ == S_OK && sz_ == 0)
+            {
                 status_ = S_FALSE;
             }
         }
@@ -181,24 +194,26 @@ static Enumerator<mdAssemblyRef> EnumAssemblyRefs(const ComPtr<IMetaDataAssembly
         [assembly_import](HCORENUM ptr) -> void { assembly_import->CloseEnum(ptr); });
 }
 
-struct RuntimeInformation {
+struct RuntimeInformation
+{
     COR_PRF_RUNTIME_TYPE runtime_type;
     USHORT major_version;
     USHORT minor_version;
     USHORT build_version;
     USHORT qfe_version;
 
-    RuntimeInformation()
-        : runtime_type((COR_PRF_RUNTIME_TYPE)0x0), major_version(0), minor_version(0), build_version(0), qfe_version(0)
-    {
-    }
+    RuntimeInformation() :
+        runtime_type((COR_PRF_RUNTIME_TYPE) 0x0), major_version(0), minor_version(0), build_version(0), qfe_version(0)
+    {}
 
     RuntimeInformation(COR_PRF_RUNTIME_TYPE runtime_type, USHORT major_version, USHORT minor_version,
-                       USHORT build_version, USHORT qfe_version)
-        : runtime_type(runtime_type), major_version(major_version), minor_version(minor_version),
-          build_version(build_version), qfe_version(qfe_version)
-    {
-    }
+                       USHORT build_version, USHORT qfe_version) :
+        runtime_type(runtime_type),
+        major_version(major_version),
+        minor_version(minor_version),
+        build_version(build_version),
+        qfe_version(qfe_version)
+    {}
 
     RuntimeInformation& operator=(const RuntimeInformation& other)
     {
@@ -220,7 +235,8 @@ struct RuntimeInformation {
     }
 };
 
-struct AssemblyInfo {
+struct AssemblyInfo
+{
     const AssemblyID id;
     const WSTRING name;
     const ModuleID manifest_module_id;
@@ -228,15 +244,16 @@ struct AssemblyInfo {
     const WSTRING app_domain_name;
 
     AssemblyInfo() : id(0), name(WStr("")), manifest_module_id(0), app_domain_id(0), app_domain_name(WStr(""))
-    {
-    }
+    {}
 
     AssemblyInfo(AssemblyID id, WSTRING name, ModuleID manifest_module_id, AppDomainID app_domain_id,
-                 WSTRING app_domain_name)
-        : id(id), name(name), manifest_module_id(manifest_module_id), app_domain_id(app_domain_id),
-          app_domain_name(app_domain_name)
-    {
-    }
+                 WSTRING app_domain_name) :
+        id(id),
+        name(name),
+        manifest_module_id(manifest_module_id),
+        app_domain_id(app_domain_id),
+        app_domain_name(app_domain_name)
+    {}
 
     bool IsValid() const
     {
@@ -244,22 +261,23 @@ struct AssemblyInfo {
     }
 };
 
-struct AssemblyMetadata {
+struct AssemblyMetadata
+{
     const ModuleID module_id;
     const WSTRING name;
     const mdAssembly assembly_token;
     const Version version;
 
     AssemblyMetadata() : module_id(0), name(WStr("")), assembly_token(mdTokenNil)
-    {
-    }
+    {}
 
     AssemblyMetadata(ModuleID module_id, WSTRING name, mdAssembly assembly_token, USHORT major, USHORT minor,
-                     USHORT build, USHORT revision)
-        : module_id(module_id), name(name), assembly_token(assembly_token),
-          version(Version(major, minor, build, revision))
-    {
-    }
+                     USHORT build, USHORT revision) :
+        module_id(module_id),
+        name(name),
+        assembly_token(assembly_token),
+        version(Version(major, minor, build, revision))
+    {}
 
     bool IsValid() const
     {
@@ -267,7 +285,8 @@ struct AssemblyMetadata {
     }
 };
 
-struct AssemblyProperty {
+struct AssemblyProperty
+{
     const void* ppbPublicKey;
     ULONG pcbPublicKey;
     ULONG pulHashAlgId;
@@ -276,23 +295,21 @@ struct AssemblyProperty {
     DWORD assemblyFlags = 0;
 
     AssemblyProperty() : ppbPublicKey(nullptr), pcbPublicKey(0), pulHashAlgId(0), szName(WStr(""))
-    {
-    }
+    {}
 };
 
-struct ModuleInfo {
+struct ModuleInfo
+{
     const ModuleID id;
     const WSTRING path;
     const AssemblyInfo assembly;
     const DWORD flags;
 
     ModuleInfo() : id(0), path(WStr("")), assembly({}), flags(0)
-    {
-    }
-    ModuleInfo(ModuleID id, WSTRING path, AssemblyInfo assembly, DWORD flags)
-        : id(id), path(path), assembly(assembly), flags(flags)
-    {
-    }
+    {}
+    ModuleInfo(ModuleID id, WSTRING path, AssemblyInfo assembly, DWORD flags) :
+        id(id), path(path), assembly(assembly), flags(flags)
+    {}
 
     bool IsValid() const
     {
@@ -305,7 +322,8 @@ struct ModuleInfo {
     }
 };
 
-struct TypeInfo {
+struct TypeInfo
+{
     const mdToken id;
     const WSTRING name;
     const mdTypeSpec type_spec;
@@ -315,17 +333,27 @@ struct TypeInfo {
     const bool isGeneric;
     const TypeInfo* parent_type;
 
-    TypeInfo()
-        : id(0), name(WStr("")), type_spec(0), token_type(0), extend_from(nullptr), valueType(false), isGeneric(false),
-          parent_type(nullptr)
-    {
-    }
+    TypeInfo() :
+        id(0),
+        name(WStr("")),
+        type_spec(0),
+        token_type(0),
+        extend_from(nullptr),
+        valueType(false),
+        isGeneric(false),
+        parent_type(nullptr)
+    {}
     TypeInfo(mdToken id, WSTRING name, mdTypeSpec type_spec, ULONG32 token_type, const TypeInfo* extend_from,
-             bool valueType, bool isGeneric, const TypeInfo* parent_type)
-        : id(id), name(name), type_spec(type_spec), token_type(token_type), extend_from(extend_from),
-          valueType(valueType), isGeneric(isGeneric), parent_type(parent_type)
-    {
-    }
+             bool valueType, bool isGeneric, const TypeInfo* parent_type) :
+        id(id),
+        name(name),
+        type_spec(type_spec),
+        token_type(token_type),
+        extend_from(extend_from),
+        valueType(valueType),
+        isGeneric(isGeneric),
+        parent_type(parent_type)
+    {}
 
     bool IsValid() const
     {
@@ -340,7 +368,8 @@ enum MethodArgumentTypeFlag
     TypeFlagBoxedType = 0x04
 };
 
-struct FunctionMethodArgument {
+struct FunctionMethodArgument
+{
     ULONG offset;
     ULONG length;
     PCCOR_SIGNATURE pbBase;
@@ -350,8 +379,9 @@ struct FunctionMethodArgument {
     ULONG GetSignature(PCCOR_SIGNATURE& data) const;
 };
 
-struct FunctionMethodSignature {
-  private:
+struct FunctionMethodSignature
+{
+private:
     PCCOR_SIGNATURE pbBase;
     unsigned len;
     ULONG numberOfTypeArguments = 0;
@@ -359,10 +389,9 @@ struct FunctionMethodSignature {
     FunctionMethodArgument ret{};
     std::vector<FunctionMethodArgument> params;
 
-  public:
+public:
     FunctionMethodSignature() : pbBase(nullptr), len(0)
-    {
-    }
+    {}
     FunctionMethodSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer)
     {
         pbBase = pb;
@@ -403,7 +432,8 @@ struct FunctionMethodSignature {
     }
 };
 
-struct FunctionInfo {
+struct FunctionInfo
+{
     const mdToken id;
     const WSTRING name;
     const TypeInfo type;
@@ -414,24 +444,31 @@ struct FunctionInfo {
     FunctionMethodSignature method_signature;
 
     FunctionInfo() : id(0), name(WStr("")), type({}), is_generic(false), method_def_id(0), method_signature({})
-    {
-    }
+    {}
 
     FunctionInfo(mdToken id, WSTRING name, TypeInfo type, MethodSignature signature,
                  MethodSignature function_spec_signature, mdToken method_def_id,
-                 FunctionMethodSignature method_signature)
-        : id(id), name(name), type(type), is_generic(true), signature(signature),
-          function_spec_signature(function_spec_signature), method_def_id(method_def_id),
-          method_signature(method_signature)
-    {
-    }
+                 FunctionMethodSignature method_signature) :
+        id(id),
+        name(name),
+        type(type),
+        is_generic(true),
+        signature(signature),
+        function_spec_signature(function_spec_signature),
+        method_def_id(method_def_id),
+        method_signature(method_signature)
+    {}
 
     FunctionInfo(mdToken id, WSTRING name, TypeInfo type, MethodSignature signature,
-                 FunctionMethodSignature method_signature)
-        : id(id), name(name), type(type), is_generic(false), signature(signature), method_def_id(0),
-          method_signature(method_signature)
-    {
-    }
+                 FunctionMethodSignature method_signature) :
+        id(id),
+        name(name),
+        type(type),
+        is_generic(false),
+        signature(signature),
+        method_def_id(0),
+        method_signature(method_signature)
+    {}
 
     bool IsValid() const
     {
@@ -479,8 +516,9 @@ std::vector<IntegrationMethod> FilterIntegrationsByTarget(const std::vector<Inte
 
 // FilterIntegrationsByTargetAssemblyName removes any integrations which target any
 // of the specified assemblies
-std::vector<IntegrationMethod> FilterIntegrationsByTargetAssemblyName(
-    const std::vector<IntegrationMethod>& integration_methods, const std::vector<WSTRING>& excluded_assembly_names);
+std::vector<IntegrationMethod>
+FilterIntegrationsByTargetAssemblyName(const std::vector<IntegrationMethod>& integration_methods,
+                                       const std::vector<WSTRING>& excluded_assembly_names);
 
 mdMethodSpec DefineMethodSpec(const ComPtr<IMetaDataEmit2>& metadata_emit, const mdToken& token,
                               const MethodSignature& signature);

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -56,7 +56,8 @@ private:
 public:
     Enumerator(std::function<HRESULT(HCORENUM*, T[], ULONG, ULONG*)> callback, std::function<void(HCORENUM)> close) :
         callback_(callback), close_(close), ptr_(nullptr)
-    {}
+    {
+    }
 
     Enumerator(const Enumerator& other) = default;
 
@@ -204,7 +205,8 @@ struct RuntimeInformation
 
     RuntimeInformation() :
         runtime_type((COR_PRF_RUNTIME_TYPE) 0x0), major_version(0), minor_version(0), build_version(0), qfe_version(0)
-    {}
+    {
+    }
 
     RuntimeInformation(COR_PRF_RUNTIME_TYPE runtime_type, USHORT major_version, USHORT minor_version,
                        USHORT build_version, USHORT qfe_version) :
@@ -213,7 +215,8 @@ struct RuntimeInformation
         minor_version(minor_version),
         build_version(build_version),
         qfe_version(qfe_version)
-    {}
+    {
+    }
 
     RuntimeInformation& operator=(const RuntimeInformation& other)
     {
@@ -244,7 +247,8 @@ struct AssemblyInfo
     const WSTRING app_domain_name;
 
     AssemblyInfo() : id(0), name(WStr("")), manifest_module_id(0), app_domain_id(0), app_domain_name(WStr(""))
-    {}
+    {
+    }
 
     AssemblyInfo(AssemblyID id, WSTRING name, ModuleID manifest_module_id, AppDomainID app_domain_id,
                  WSTRING app_domain_name) :
@@ -253,7 +257,8 @@ struct AssemblyInfo
         manifest_module_id(manifest_module_id),
         app_domain_id(app_domain_id),
         app_domain_name(app_domain_name)
-    {}
+    {
+    }
 
     bool IsValid() const
     {
@@ -269,7 +274,8 @@ struct AssemblyMetadata
     const Version version;
 
     AssemblyMetadata() : module_id(0), name(WStr("")), assembly_token(mdTokenNil)
-    {}
+    {
+    }
 
     AssemblyMetadata(ModuleID module_id, WSTRING name, mdAssembly assembly_token, USHORT major, USHORT minor,
                      USHORT build, USHORT revision) :
@@ -277,7 +283,8 @@ struct AssemblyMetadata
         name(name),
         assembly_token(assembly_token),
         version(Version(major, minor, build, revision))
-    {}
+    {
+    }
 
     bool IsValid() const
     {
@@ -295,7 +302,8 @@ struct AssemblyProperty
     DWORD assemblyFlags = 0;
 
     AssemblyProperty() : ppbPublicKey(nullptr), pcbPublicKey(0), pulHashAlgId(0), szName(WStr(""))
-    {}
+    {
+    }
 };
 
 struct ModuleInfo
@@ -306,10 +314,12 @@ struct ModuleInfo
     const DWORD flags;
 
     ModuleInfo() : id(0), path(WStr("")), assembly({}), flags(0)
-    {}
+    {
+    }
     ModuleInfo(ModuleID id, WSTRING path, AssemblyInfo assembly, DWORD flags) :
         id(id), path(path), assembly(assembly), flags(flags)
-    {}
+    {
+    }
 
     bool IsValid() const
     {
@@ -342,7 +352,8 @@ struct TypeInfo
         valueType(false),
         isGeneric(false),
         parent_type(nullptr)
-    {}
+    {
+    }
     TypeInfo(mdToken id, WSTRING name, mdTypeSpec type_spec, ULONG32 token_type, const TypeInfo* extend_from,
              bool valueType, bool isGeneric, const TypeInfo* parent_type) :
         id(id),
@@ -353,7 +364,8 @@ struct TypeInfo
         valueType(valueType),
         isGeneric(isGeneric),
         parent_type(parent_type)
-    {}
+    {
+    }
 
     bool IsValid() const
     {
@@ -391,7 +403,8 @@ private:
 
 public:
     FunctionMethodSignature() : pbBase(nullptr), len(0)
-    {}
+    {
+    }
     FunctionMethodSignature(PCCOR_SIGNATURE pb, unsigned cbBuffer)
     {
         pbBase = pb;
@@ -444,7 +457,8 @@ struct FunctionInfo
     FunctionMethodSignature method_signature;
 
     FunctionInfo() : id(0), name(WStr("")), type({}), is_generic(false), method_def_id(0), method_signature({})
-    {}
+    {
+    }
 
     FunctionInfo(mdToken id, WSTRING name, TypeInfo type, MethodSignature signature,
                  MethodSignature function_spec_signature, mdToken method_def_id,
@@ -457,7 +471,8 @@ struct FunctionInfo
         function_spec_signature(function_spec_signature),
         method_def_id(method_def_id),
         method_signature(method_signature)
-    {}
+    {
+    }
 
     FunctionInfo(mdToken id, WSTRING name, TypeInfo type, MethodSignature signature,
                  FunctionMethodSignature method_signature) :
@@ -468,7 +483,8 @@ struct FunctionInfo
         signature(signature),
         method_def_id(0),
         method_signature(method_signature)
-    {}
+    {
+    }
 
     bool IsValid() const
     {

--- a/src/Datadog.Trace.ClrProfiler.Native/com_ptr.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/com_ptr.h
@@ -6,13 +6,17 @@
 
 // https://msdn.microsoft.com/en-us/magazine/dn904668.aspx
 
-template <typename Interface> class RemoveAddRefRelease : public Interface {
+template <typename Interface>
+class RemoveAddRefRelease : public Interface
+{
     ULONG __stdcall AddRef();
     ULONG __stdcall Release();
 };
 
-template <typename Interface> class ComPtr {
-  public:
+template <typename Interface>
+class ComPtr
+{
+public:
     ComPtr() noexcept = default;
 
     ComPtr(ComPtr const& other) noexcept : m_ptr(other.m_ptr)
@@ -20,14 +24,17 @@ template <typename Interface> class ComPtr {
         InternalAddRef();
     }
 
-    template <typename T> friend class ComPtr;
+    template <typename T>
+    friend class ComPtr;
 
-    template <typename T> ComPtr(ComPtr<T> const& other) noexcept : m_ptr(other.m_ptr)
+    template <typename T>
+    ComPtr(ComPtr<T> const& other) noexcept : m_ptr(other.m_ptr)
     {
         InternalAddRef();
     }
 
-    template <typename T> ComPtr(ComPtr<T>&& other) noexcept : m_ptr(other.m_ptr)
+    template <typename T>
+    ComPtr(ComPtr<T>&& other) noexcept : m_ptr(other.m_ptr)
     {
         other.m_ptr = nullptr;
     }
@@ -84,7 +91,8 @@ template <typename Interface> class ComPtr {
         *other = m_ptr;
     }
 
-    template <typename T> ComPtr<T> As(IID iid) const noexcept
+    template <typename T>
+    ComPtr<T> As(IID iid) const noexcept
     {
         ComPtr<T> temp;
         m_ptr->QueryInterface(iid, reinterpret_cast<void**>(temp.GetAddressOf()));
@@ -102,13 +110,15 @@ template <typename Interface> class ComPtr {
         return *this;
     }
 
-    template <typename T> ComPtr& operator=(ComPtr<T> const& other) noexcept
+    template <typename T>
+    ComPtr& operator=(ComPtr<T> const& other) noexcept
     {
         InternalCopy(other.m_ptr);
         return *this;
     }
 
-    template <typename T> ComPtr& operator=(ComPtr<T>&& other) noexcept
+    template <typename T>
+    ComPtr& operator=(ComPtr<T>&& other) noexcept
     {
         InternalMove(other);
         return *this;
@@ -124,12 +134,13 @@ template <typename Interface> class ComPtr {
         return nullptr != m_ptr;
     }
 
-  private:
+private:
     Interface* m_ptr = nullptr;
 
     void InternalAddRef() const noexcept
     {
-        if (m_ptr) {
+        if (m_ptr)
+        {
             m_ptr->AddRef();
         }
     }
@@ -137,7 +148,8 @@ template <typename Interface> class ComPtr {
     void InternalRelease() noexcept
     {
         Interface* temp = m_ptr;
-        if (temp) {
+        if (temp)
+        {
             m_ptr = nullptr;
             temp->Release();
         }
@@ -145,16 +157,19 @@ template <typename Interface> class ComPtr {
 
     void InternalCopy(Interface* other) noexcept
     {
-        if (m_ptr != other) {
+        if (m_ptr != other)
+        {
             InternalRelease();
             m_ptr = other;
             InternalAddRef();
         }
     }
 
-    template <typename T> void InternalMove(ComPtr<T>& other) noexcept
+    template <typename T>
+    void InternalMove(ComPtr<T>& other) noexcept
     {
-        if (m_ptr != other.m_ptr) {
+        if (m_ptr != other.m_ptr)
+        {
             InternalRelease();
             m_ptr = other.m_ptr;
             other.m_ptr = nullptr;
@@ -162,7 +177,8 @@ template <typename Interface> class ComPtr {
     }
 };
 
-template <typename Interface> void swap(ComPtr<Interface>& left, ComPtr<Interface>& right) noexcept
+template <typename Interface>
+void swap(ComPtr<Interface>& left, ComPtr<Interface>& right) noexcept
 {
     left.Swap(right);
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -27,7 +27,8 @@
 #include <mach-o/getsect.h>
 #endif
 
-namespace trace {
+namespace trace
+{
 
 CorProfiler* profiler = nullptr;
 
@@ -47,7 +48,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     CorProfilerBase::Initialize(cor_profiler_info_unknown);
 
     // check if tracing is completely disabled
-    if (IsTracingDisabled()) {
+    if (IsTracingDisabled())
+    {
         Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled in ", environment::tracing_enabled);
         return E_FAIL;
     }
@@ -57,10 +59,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // In ARM64 and ARM, complete ReJIT support is only available from .NET 5.0
     //
     ICorProfilerInfo12* info12;
-    HRESULT hrInfo12 = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo12), (void**)&info12);
-    if (SUCCEEDED(hrInfo12)) {
+    HRESULT hrInfo12 = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo12), (void**) &info12);
+    if (SUCCEEDED(hrInfo12))
+    {
         Info(".NET 5.0 runtime or greater was detected.");
-    } else {
+    }
+    else
+    {
         Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: .NET 5.0 runtime or greater is required on this "
              "architecture.");
         return E_FAIL;
@@ -72,7 +77,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     // if there is a process inclusion list, attach profiler only if this
     // process's name is on the list
-    if (!include_process_names.empty() && !Contains(include_process_names, process_name)) {
+    if (!include_process_names.empty() && !Contains(include_process_names, process_name))
+    {
         Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name, " not found in ",
              environment::include_process_names, ".");
         return E_FAIL;
@@ -81,34 +87,40 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto exclude_process_names = GetEnvironmentValues(environment::exclude_process_names);
 
     // attach profiler only if this process's name is NOT on the list
-    if (Contains(exclude_process_names, process_name)) {
+    if (Contains(exclude_process_names, process_name))
+    {
         Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", process_name, " found in ",
              environment::exclude_process_names, ".");
         return E_FAIL;
     }
 
     // get Profiler interface
-    HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo4), (void**)&this->info_);
-    if (FAILED(hr)) {
+    HRESULT hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo4), (void**) &this->info_);
+    if (FAILED(hr))
+    {
         Warn("DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: interface ICorProfilerInfo4 not found.");
         return E_FAIL;
     }
 
     Info("Environment variables:");
-    for (auto&& env_var : env_vars_to_display) {
+    for (auto&& env_var : env_vars_to_display)
+    {
         WSTRING env_var_value = GetEnvironmentValue(env_var);
-        if (debug_logging_enabled || !env_var_value.empty()) {
+        if (debug_logging_enabled || !env_var_value.empty())
+        {
             Info("  ", env_var, "=", env_var_value);
         }
     }
 
-    if (IsAzureAppServices()) {
+    if (IsAzureAppServices())
+    {
         Info("Profiler is operating within Azure App Services context.");
         in_azure_app_services = true;
 
         const auto app_pool_id_value = GetEnvironmentValue(environment::azure_app_services_app_pool_id);
 
-        if (app_pool_id_value.size() > 1 && app_pool_id_value.at(0) == '~') {
+        if (app_pool_id_value.size() > 1 && app_pool_id_value.at(0) == '~')
+        {
             Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", environment::azure_app_services_app_pool_id, " ",
                  app_pool_id_value, " is recognized as an Azure App Services infrastructure process.");
             return E_FAIL;
@@ -117,7 +129,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         const auto cli_telemetry_profile_value =
             GetEnvironmentValue(environment::azure_app_services_cli_telemetry_profile_value);
 
-        if (cli_telemetry_profile_value == WStr("AzureKudu")) {
+        if (cli_telemetry_profile_value == WStr("AzureKudu"))
+        {
             Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", app_pool_id_value,
                  " is recognized as Kudu, an Azure App Services reserved process.");
             return E_FAIL;
@@ -127,7 +140,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // get path to integration definition JSON files
     const WSTRING integrations_paths = GetEnvironmentValue(environment::integrations_path);
 
-    if (integrations_paths.empty()) {
+    if (integrations_paths.empty())
+    {
         Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: ", environment::integrations_path,
              " environment variable not set.");
         return E_FAIL;
@@ -136,12 +150,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto is_calltarget_enabled = IsCallTargetEnabled();
 
     // Initialize ReJIT handler and define the Rewriter Callback
-    if (is_calltarget_enabled) {
+    if (is_calltarget_enabled)
+    {
         rejit_handler =
             new RejitHandler(this->info_, [this](RejitHandlerModule* mod, RejitHandlerModuleMethod* method) {
                 return this->CallTarget_RewriterCallback(mod, method);
             });
-    } else {
+    }
+    else
+    {
         rejit_handler = nullptr;
     }
 
@@ -158,10 +175,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     integration_methods_ = FlattenIntegrations(integrations, is_calltarget_enabled);
 
     // check if there are any enabled integrations left
-    if (integration_methods_.empty()) {
+    if (integration_methods_.empty())
+    {
         Warn("DATADOG TRACER DIAGNOSTICS - Profiler disabled: no enabled integrations found.");
         return E_FAIL;
-    } else {
+    }
+    else
+    {
         Debug("Number of Integrations loaded: ", integration_methods_.size());
     }
 
@@ -169,57 +189,71 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     // https://github.com/DataDog/dd-trace-dotnet/pull/753.
     // users can opt-in to the additional instrumentation by setting environment
     // variable DD_TRACE_NETSTANDARD_ENABLED
-    if (!IsNetstandardEnabled()) {
+    if (!IsNetstandardEnabled())
+    {
         integration_methods_ = FilterIntegrationsByTargetAssemblyName(integration_methods_, {WStr("netstandard")});
     }
 
     DWORD event_mask = COR_PRF_MONITOR_JIT_COMPILATION | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST |
                        COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_MONITOR_ASSEMBLY_LOADS | COR_PRF_DISABLE_ALL_NGEN_IMAGES;
 
-    if (is_calltarget_enabled) {
+    if (is_calltarget_enabled)
+    {
         Info("CallTarget instrumentation is enabled.");
         event_mask |= COR_PRF_ENABLE_REJIT;
-    } else {
+    }
+    else
+    {
         Info("CallTarget instrumentation is disabled.");
     }
 
-    if (!EnableInlining(is_calltarget_enabled)) {
+    if (!EnableInlining(is_calltarget_enabled))
+    {
         Info("JIT Inlining is disabled.");
         event_mask |= COR_PRF_DISABLE_INLINING;
-    } else {
+    }
+    else
+    {
         Info("JIT Inlining is enabled.");
     }
 
-    if (DisableOptimizations()) {
+    if (DisableOptimizations())
+    {
         Info("Disabling all code optimizations.");
         event_mask |= COR_PRF_DISABLE_OPTIMIZATIONS;
     }
 
     const WSTRING domain_neutral_instrumentation = GetEnvironmentValue(environment::domain_neutral_instrumentation);
 
-    if (domain_neutral_instrumentation == WStr("1") || domain_neutral_instrumentation == WStr("true")) {
+    if (domain_neutral_instrumentation == WStr("1") || domain_neutral_instrumentation == WStr("true"))
+    {
         instrument_domain_neutral_assemblies = true;
     }
 
     // set event mask to subscribe to events and disable NGEN images
     // get ICorProfilerInfo6 for net452+
     ICorProfilerInfo6* info6;
-    hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo6), (void**)&info6);
+    hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo6), (void**) &info6);
 
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr))
+    {
         Debug("Interface ICorProfilerInfo6 found.");
         is_net46_or_greater = true;
         hr = info6->SetEventMask2(event_mask, COR_PRF_HIGH_ADD_ASSEMBLY_REFERENCES);
 
-        if (instrument_domain_neutral_assemblies) {
+        if (instrument_domain_neutral_assemblies)
+        {
             Info("Note: The ", environment::domain_neutral_instrumentation,
                  " environment variable is not needed when running on .NET Framework 4.5.2 or higher, and will be "
                  "ignored.");
         }
-    } else {
+    }
+    else
+    {
         hr = this->info_->SetEventMask(event_mask);
 
-        if (instrument_domain_neutral_assemblies) {
+        if (instrument_domain_neutral_assemblies)
+        {
             Info("Detected environment variable ", environment::domain_neutral_instrumentation, "=",
                  domain_neutral_instrumentation);
             Info("Enabling automatic instrumentation of methods called from domain-neutral assemblies. ",
@@ -228,13 +262,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
                  "Otherwise, a sharing violation (HRESULT 0x80131401) may occur.");
         }
     }
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("DATADOG TRACER DIAGNOSTICS - Failed to attach profiler: unable to set event mask.");
         return E_FAIL;
     }
 
     runtime_information_ = GetRuntimeInformation(this->info_);
-    if (process_name == WStr("w3wp.exe") || process_name == WStr("iisexpress.exe")) {
+    if (process_name == WStr("w3wp.exe") || process_name == WStr("iisexpress.exe"))
+    {
         is_desktop_iis = runtime_information_.is_desktop();
     }
 
@@ -257,7 +293,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
 {
     auto _ = trace::Stats::Instance()->AssemblyLoadFinishedMeasure();
 
-    if (FAILED(hr_status)) {
+    if (FAILED(hr_status))
+    {
         // if assembly failed to load, skip it entirely,
         // otherwise we can crash the process if module is not valid
         CorProfilerBase::AssemblyLoadFinished(assembly_id, hr_status);
@@ -269,20 +306,24 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
     const auto assembly_info = GetAssemblyInfo(this->info_, assembly_id);
-    if (!assembly_info.IsValid()) {
+    if (!assembly_info.IsValid())
+    {
         Debug("AssemblyLoadFinished: ", assembly_id, " ", hr_status);
         return S_OK;
     }
 
     const auto is_instrumentation_assembly = assembly_info.name == WStr("Datadog.Trace.ClrProfiler.Managed");
 
-    if (is_instrumentation_assembly || debug_logging_enabled) {
-        if (debug_logging_enabled) {
+    if (is_instrumentation_assembly || debug_logging_enabled)
+    {
+        if (debug_logging_enabled)
+        {
             Debug("AssemblyLoadFinished: ", assembly_id, " ", hr_status);
         }
 
@@ -290,7 +331,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         auto hr = this->info_->GetModuleMetaData(assembly_info.manifest_module_id, ofRead | ofWrite,
                                                  IID_IMetaDataImport2, metadata_interfaces.GetAddressOf());
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("AssemblyLoadFinished failed to get metadata interface for module id ",
                  assembly_info.manifest_module_id, " from assembly ", assembly_info.name);
             return S_OK;
@@ -300,12 +342,14 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         const auto assembly_import = metadata_interfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
         const auto assembly_metadata = GetAssemblyImportMetadata(assembly_import);
 
-        if (debug_logging_enabled) {
+        if (debug_logging_enabled)
+        {
             Debug("AssemblyLoadFinished: AssemblyName=", assembly_info.name,
                   " AssemblyVersion=", assembly_metadata.version.str());
         }
 
-        if (is_instrumentation_assembly) {
+        if (is_instrumentation_assembly)
+        {
             // Configure a version string to compare with the profiler version
             std::stringstream ss;
             ss << assembly_metadata.version.major << '.' << assembly_metadata.version.minor << '.'
@@ -314,22 +358,29 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
             auto assembly_version = ToWSTRING(ss.str());
 
             // Check that Major.Minor.Build match the profiler version
-            if (assembly_version == ToWSTRING(PROFILER_VERSION)) {
+            if (assembly_version == ToWSTRING(PROFILER_VERSION))
+            {
                 Info("AssemblyLoadFinished: Datadog.Trace.ClrProfiler.Managed v", assembly_version,
                      " matched profiler version v", PROFILER_VERSION);
                 managed_profiler_loaded_app_domains.insert(assembly_info.app_domain_id);
 
-                if (runtime_information_.is_desktop() && corlib_module_loaded) {
+                if (runtime_information_.is_desktop() && corlib_module_loaded)
+                {
                     // Set the managed_profiler_loaded_domain_neutral flag whenever the
                     // managed profiler is loaded shared
-                    if (assembly_info.app_domain_id == corlib_app_domain_id) {
+                    if (assembly_info.app_domain_id == corlib_app_domain_id)
+                    {
                         Info("AssemblyLoadFinished: Datadog.Trace.ClrProfiler.Managed was loaded domain-neutral");
                         managed_profiler_loaded_domain_neutral = true;
-                    } else {
+                    }
+                    else
+                    {
                         Info("AssemblyLoadFinished: Datadog.Trace.ClrProfiler.Managed was not loaded domain-neutral");
                     }
                 }
-            } else {
+            }
+            else
+            {
                 Warn("AssemblyLoadFinished: Datadog.Trace.ClrProfiler.Managed v", assembly_version,
                      " did not match profiler version v", PROFILER_VERSION);
             }
@@ -343,14 +394,16 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
 {
     auto _ = trace::Stats::Instance()->ModuleLoadFinishedMeasure();
 
-    if (FAILED(hr_status)) {
+    if (FAILED(hr_status))
+    {
         // if module failed to load, skip it entirely,
         // otherwise we can crash the process if module is not valid
         CorProfilerBase::ModuleLoadFinished(module_id, hr_status);
         return S_OK;
     }
 
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -359,16 +412,19 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
     const auto module_info = GetModuleInfo(this->info_, module_id);
-    if (!module_info.IsValid()) {
+    if (!module_info.IsValid())
+    {
         return S_OK;
     }
 
-    if (debug_logging_enabled) {
+    if (debug_logging_enabled)
+    {
         Debug("ModuleLoadFinished: ", module_id, " ", module_info.assembly.name, " AppDomain ",
               module_info.assembly.app_domain_id, " ", module_info.assembly.app_domain_name);
     }
@@ -377,8 +433,9 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
 
     // Identify the AppDomain ID of mscorlib which will be the Shared Domain
     // because mscorlib is always a domain-neutral assembly
-    if (!corlib_module_loaded && (module_info.assembly.name == WStr("mscorlib") ||
-                                  module_info.assembly.name == WStr("System.Private.CoreLib"))) {
+    if (!corlib_module_loaded &&
+        (module_info.assembly.name == WStr("mscorlib") || module_info.assembly.name == WStr("System.Private.CoreLib")))
+    {
         corlib_module_loaded = true;
         corlib_app_domain_id = app_domain_id;
 
@@ -396,7 +453,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
                                                NULL, 0, NULL, &corAssemblyProperty.pMetaData,
                                                &corAssemblyProperty.assemblyFlags);
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("AssemblyLoadFinished failed to get properties for COR assembly ");
         }
 
@@ -412,29 +470,35 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     // but the Datadog.Trace.ClrProfiler.Managed.Loader assembly that the startup hook loads from a
     // byte array will be loaded into a non-shared AppDomain.
     // In this case, do not insert another startup hook into that non-shared AppDomain
-    if (module_info.assembly.name == WStr("Datadog.Trace.ClrProfiler.Managed.Loader")) {
+    if (module_info.assembly.name == WStr("Datadog.Trace.ClrProfiler.Managed.Loader"))
+    {
         Info("ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain ", app_domain_id, " ",
              module_info.assembly.app_domain_name);
         first_jit_compilation_app_domains.insert(app_domain_id);
         return S_OK;
     }
 
-    if (module_info.IsWindowsRuntime()) {
+    if (module_info.IsWindowsRuntime())
+    {
         // We cannot obtain writable metadata interfaces on Windows Runtime modules
         // or instrument their IL.
         Debug("ModuleLoadFinished skipping Windows Metadata module: ", module_id, " ", module_info.assembly.name);
         return S_OK;
     }
 
-    for (auto&& skip_assembly_pattern : skip_assembly_prefixes) {
-        if (module_info.assembly.name.rfind(skip_assembly_pattern, 0) == 0) {
+    for (auto&& skip_assembly_pattern : skip_assembly_prefixes)
+    {
+        if (module_info.assembly.name.rfind(skip_assembly_pattern, 0) == 0)
+        {
             Debug("ModuleLoadFinished skipping module by pattern: ", module_id, " ", module_info.assembly.name);
             return S_OK;
         }
     }
 
-    for (auto&& skip_assembly : skip_assemblies) {
-        if (module_info.assembly.name == skip_assembly) {
+    for (auto&& skip_assembly : skip_assemblies)
+    {
+        if (module_info.assembly.name == skip_assembly)
+        {
             Debug("ModuleLoadFinished skipping known module: ", module_id, " ", module_info.assembly.name);
             return S_OK;
         }
@@ -444,7 +508,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         IsCallTargetEnabled() ? integration_methods_
                               : FilterIntegrationsByCaller(integration_methods_, module_info.assembly);
 
-    if (filtered_integrations.empty()) {
+    if (filtered_integrations.empty())
+    {
         // we don't need to instrument anything in this module, skip it
         Debug("ModuleLoadFinished skipping module (filtered by caller): ", module_id, " ", module_info.assembly.name);
         return S_OK;
@@ -454,7 +519,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     auto hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
                                              metadata_interfaces.GetAddressOf());
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("ModuleLoadFinished failed to get metadata interface for ", module_id, " ", module_info.assembly.name);
         return S_OK;
     }
@@ -469,10 +535,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
     // don't skip Dapper: it makes ADO.NET calls even though it doesn't reference
     // System.Data or System.Data.Common
     if (module_info.assembly.name != WStr("Microsoft.AspNetCore.Hosting") &&
-        module_info.assembly.name != WStr("Dapper") && !IsCallTargetEnabled()) {
+        module_info.assembly.name != WStr("Dapper") && !IsCallTargetEnabled())
+    {
         filtered_integrations = FilterIntegrationsByTarget(filtered_integrations, assembly_import);
 
-        if (filtered_integrations.empty()) {
+        if (filtered_integrations.empty())
+        {
             // we don't need to instrument anything in this module, skip it
             Debug("ModuleLoadFinished skipping module (filtered by target): ", module_id, " ",
                   module_info.assembly.name);
@@ -482,14 +550,16 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
 
     mdModule module;
     hr = metadata_import->GetModuleFromScope(&module);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("ModuleLoadFinished failed to get module metadata token for ", module_id, " ", module_info.assembly.name);
         return S_OK;
     }
 
     GUID module_version_id;
     hr = metadata_import->GetScopeProps(nullptr, 0, nullptr, &module_version_id);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("ModuleLoadFinished failed to get module_version_id for ", module_id, " ", module_info.assembly.name);
         return S_OK;
     }
@@ -505,7 +575,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
           module_info.assembly.app_domain_id, " ", module_info.assembly.app_domain_name);
 
     // We call the function to analyze the module and request the ReJIT of integrations defined in this module.
-    if (IsCallTargetEnabled()) {
+    if (IsCallTargetEnabled())
+    {
         CallTarget_RequestRejitForModule(module_id, module_metadata, filtered_integrations);
     }
 
@@ -516,17 +587,22 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
 {
     auto _ = trace::Stats::Instance()->ModuleUnloadStartedMeasure();
 
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
-    if (debug_logging_enabled) {
+    if (debug_logging_enabled)
+    {
         const auto module_info = GetModuleInfo(this->info_, module_id);
 
-        if (module_info.IsValid()) {
+        if (module_info.IsValid())
+        {
             Debug("ModuleUnloadStarted: ", module_id, " ", module_info.assembly.name, " AppDomain ",
                   module_info.assembly.app_domain_id, " ", module_info.assembly.app_domain_name);
-        } else {
+        }
+        else
+        {
             Debug("ModuleUnloadStarted: ", module_id);
         }
     }
@@ -536,18 +612,21 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
     // remove module metadata from map
     auto findRes = module_id_to_info_map_.find(module_id);
-    if (findRes != module_id_to_info_map_.end()) {
+    if (findRes != module_id_to_info_map_.end())
+    {
         ModuleMetadata* metadata = findRes->second;
 
         // remove appdomain id from managed_profiler_loaded_app_domains set
         if (managed_profiler_loaded_app_domains.find(metadata->app_domain_id) !=
-            managed_profiler_loaded_app_domains.end()) {
+            managed_profiler_loaded_app_domains.end())
+        {
             managed_profiler_loaded_app_domains.erase(metadata->app_domain_id);
         }
 
@@ -566,7 +645,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
     // to prevent it from unloading while in use
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
-    if (rejit_handler != nullptr) {
+    if (rejit_handler != nullptr)
+    {
         rejit_handler->Shutdown();
     }
     Warn("Exiting. Stats: ", Stats::Instance()->ToString());
@@ -577,7 +657,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Shutdown()
 
 HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerDetachSucceeded()
 {
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
     CorProfilerBase::ProfilerDetachSucceeded();
@@ -587,7 +668,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ProfilerDetachSucceeded()
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -601,7 +683,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 {
     auto _ = trace::Stats::Instance()->JITCompilationStartedMeasure();
 
-    if (!is_attached_ || !is_safe_to_block) {
+    if (!is_attached_ || !is_safe_to_block)
+    {
         return S_OK;
     }
 
@@ -610,7 +693,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
     std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
 
     // double check if is_attached_ has changed to avoid possible race condition with shutdown function
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -619,7 +703,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
     HRESULT hr = this->info_->GetFunctionInfo(function_id, nullptr, &module_id, &function_token);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("JITCompilationStarted: Call to ICorProfilerInfo4.GetFunctionInfo() failed for ", function_id);
         return S_OK;
     }
@@ -628,11 +713,13 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
     ModuleMetadata* module_metadata = nullptr;
 
     auto findRes = module_id_to_info_map_.find(module_id);
-    if (findRes != module_id_to_info_map_.end()) {
+    if (findRes != module_id_to_info_map_.end())
+    {
         module_metadata = findRes->second;
     }
 
-    if (module_metadata == nullptr) {
+    if (module_metadata == nullptr)
+    {
         // we haven't stored a ModuleMetadata for this module,
         // so we can't modify its IL
         return S_OK;
@@ -644,18 +731,21 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         first_jit_compilation_app_domains.find(module_metadata->app_domain_id) !=
         first_jit_compilation_app_domains.end();
 
-    if (is_calltarget_enabled && has_loader_injected_in_appdomain) {
+    if (is_calltarget_enabled && has_loader_injected_in_appdomain)
+    {
         // Loader was already injected in a calltarget scenario, we don't need to do anything else here
         return S_OK;
     }
 
     // get function info
     const auto caller = GetFunctionInfo(module_metadata->metadata_import, function_token);
-    if (!caller.IsValid()) {
+    if (!caller.IsValid())
+    {
         return S_OK;
     }
 
-    if (debug_logging_enabled) {
+    if (debug_logging_enabled)
+    {
         Debug("JITCompilationStarted: function_id=", function_id, " token=", function_token, " name=", caller.type.name,
               ".", caller.name, "()");
     }
@@ -669,12 +759,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
     // Note: This check must only run on desktop because it is possible (and the default) to host
     // ASP.NET Core in-process, so a new .NET Core runtime is instantiated and run in the same w3wp.exe process
     auto valid_startup_hook_callsite = true;
-    if (is_desktop_iis) {
+    if (is_desktop_iis)
+    {
         valid_startup_hook_callsite = module_metadata->assemblyName == WStr("System.Web") &&
                                       caller.type.name == WStr("System.Web.Compilation.BuildManager") &&
                                       caller.name == WStr("InvokePreStartInitMethods");
-    } else if (module_metadata->assemblyName == WStr("System") ||
-               module_metadata->assemblyName == WStr("System.Net.Http")) {
+    }
+    else if (module_metadata->assemblyName == WStr("System") ||
+             module_metadata->assemblyName == WStr("System.Net.Http"))
+    {
         valid_startup_hook_callsite = false;
     }
 
@@ -682,7 +775,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
     // hook which, at a minimum, must add an AssemblyResolve event so we can find
     // Datadog.Trace.ClrProfiler.Managed.dll and its dependencies on-disk since it
     // is no longer provided in a NuGet package
-    if (valid_startup_hook_callsite && !has_loader_injected_in_appdomain) {
+    if (valid_startup_hook_callsite && !has_loader_injected_in_appdomain)
+    {
         bool domain_neutral_assembly = runtime_information_.is_desktop() && corlib_module_loaded &&
                                        module_metadata->app_domain_id == corlib_app_domain_id;
         Info("JITCompilationStarted: Startup hook registered in function_id=", function_id, " token=", function_token,
@@ -693,15 +787,18 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
         hr = RunILStartupHook(module_metadata->metadata_emit, module_id, function_token);
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("JITCompilationStarted: Call to RunILStartupHook() failed for ", module_id, " ", function_token);
             return S_OK;
         }
 
-        if (is_desktop_iis) {
+        if (is_desktop_iis)
+        {
             hr = AddIISPreStartInitFlags(module_id, function_token);
 
-            if (FAILED(hr)) {
+            if (FAILED(hr))
+            {
                 Warn("JITCompilationStarted: Call to AddIISPreStartInitFlags() failed for ", module_id, " ",
                      function_token);
                 return S_OK;
@@ -709,17 +806,20 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         }
     }
 
-    if (!is_calltarget_enabled) {
+    if (!is_calltarget_enabled)
+    {
         // we don't actually need to instrument anything in
         // Microsoft.AspNetCore.Hosting, it was included only to ensure the startup
         // hook is called for AspNetCore applications
-        if (module_metadata->assemblyName == WStr("Microsoft.AspNetCore.Hosting")) {
+        if (module_metadata->assemblyName == WStr("Microsoft.AspNetCore.Hosting"))
+        {
             return S_OK;
         }
 
         // Get valid method replacements for this caller method
         const auto method_replacements = module_metadata->GetMethodReplacementsForCaller(caller);
-        if (method_replacements.empty()) {
+        if (method_replacements.empty())
+        {
             return S_OK;
         }
 
@@ -727,7 +827,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         hr =
             ProcessInsertionCalls(module_metadata, function_id, module_id, function_token, caller, method_replacements);
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("JITCompilationStarted: Call to ProcessInsertionCalls() failed for ", function_id, " ", module_id, " ",
                  function_token);
             return S_OK;
@@ -737,7 +838,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
         hr = ProcessReplacementCalls(module_metadata, function_id, module_id, function_token, caller,
                                      method_replacements);
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("JITCompilationStarted: Call to ProcessReplacementCalls() failed for ", function_id, " ", module_id,
                  " ", function_token);
             return S_OK;
@@ -751,7 +853,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID callerId, Function
 {
     auto _ = trace::Stats::Instance()->JITInliningMeasure();
 
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -761,19 +864,23 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID callerId, Function
 
     *pfShouldInline = true;
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("*** JITInlining: Failed to get the function info of the calleId: ", calleeId);
         return S_OK;
     }
 
-    if (rejit_handler == nullptr) {
+    if (rejit_handler == nullptr)
+    {
         return S_OK;
     }
 
     RejitHandlerModule* handlerModule = nullptr;
-    if (rejit_handler->TryGetModule(calleeModuleId, &handlerModule)) {
+    if (rejit_handler->TryGetModule(calleeModuleId, &handlerModule))
+    {
         RejitHandlerModuleMethod* handlerMethod = nullptr;
-        if (handlerModule->TryGetMethod(calleFunctionToken, &handlerMethod)) {
+        if (handlerModule->TryGetMethod(calleFunctionToken, &handlerMethod))
+        {
             Debug("*** JITInlining: Inlining disabled for [ModuleId=", calleeModuleId,
                   ", MethodDef=", TokenStr(&calleFunctionToken), "]");
             *pfShouldInline = false;
@@ -790,7 +897,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITInlining(FunctionID callerId, Function
 HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAssemblyPath,
                                                              ICorProfilerAssemblyReferenceProvider* pAsmRefProvider)
 {
-    if (in_azure_app_services) {
+    if (in_azure_app_services)
+    {
         Debug("GetAssemblyReferences skipping entire callback because this is running in Azure App Services, which "
               "isn't yet supported for this feature. AssemblyPath=",
               wszAssemblyPath);
@@ -803,9 +911,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     auto filename = assemblyPathString.substr(assemblyPathString.find_last_of("\\/") + 1);
     auto lastNiDllPeriodIndex = filename.rfind(".ni.dll");
     auto lastDllPeriodIndex = filename.rfind(".dll");
-    if (lastNiDllPeriodIndex != std::string::npos) {
+    if (lastNiDllPeriodIndex != std::string::npos)
+    {
         filename.erase(lastNiDllPeriodIndex, 7);
-    } else if (lastDllPeriodIndex != std::string::npos) {
+    }
+    else if (lastDllPeriodIndex != std::string::npos)
+    {
         filename.erase(lastDllPeriodIndex, 4);
     }
 
@@ -814,15 +925,19 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     // Skip known framework assemblies that we will not instrument and,
     // as a result, will not need an assembly reference to the
     // managed profiler
-    for (auto&& skip_assembly_pattern : skip_assembly_prefixes) {
-        if (assembly_name.rfind(skip_assembly_pattern, 0) == 0) {
+    for (auto&& skip_assembly_pattern : skip_assembly_prefixes)
+    {
+        if (assembly_name.rfind(skip_assembly_pattern, 0) == 0)
+        {
             Debug("GetAssemblyReferences skipping module by pattern: Name=", assembly_name, " Path=", wszAssemblyPath);
             return S_OK;
         }
     }
 
-    for (auto&& skip_assembly : skip_assemblies) {
-        if (assembly_name == skip_assembly) {
+    for (auto&& skip_assembly : skip_assemblies)
+    {
+        if (assembly_name == skip_assembly)
+        {
             Debug("GetAssemblyReferences skipping known assembly: Name=", assembly_name, " Path=", wszAssemblyPath);
             return S_OK;
         }
@@ -837,21 +952,25 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     assembly_metadata.usMinorVersion = assemblyReference.version.minor;
     assembly_metadata.usBuildNumber = assemblyReference.version.build;
     assembly_metadata.usRevisionNumber = assemblyReference.version.revision;
-    if (assemblyReference.locale == WStr("neutral")) {
+    if (assemblyReference.locale == WStr("neutral"))
+    {
         assembly_metadata.szLocale = const_cast<WCHAR*>(WStr("\0"));
         assembly_metadata.cbLocale = 0;
-    } else {
+    }
+    else
+    {
         assembly_metadata.szLocale = const_cast<WCHAR*>(assemblyReference.locale.c_str());
-        assembly_metadata.cbLocale = (DWORD)(assemblyReference.locale.size());
+        assembly_metadata.cbLocale = (DWORD) (assemblyReference.locale.size());
     }
 
     DWORD public_key_size = 8;
-    if (assemblyReference.public_key == trace::PublicKey()) {
+    if (assemblyReference.public_key == trace::PublicKey())
+    {
         public_key_size = 0;
     }
 
     COR_PRF_ASSEMBLY_REFERENCE_INFO asmRefInfo;
-    asmRefInfo.pbPublicKeyOrToken = (void*)&assemblyReference.public_key.data[0];
+    asmRefInfo.pbPublicKeyOrToken = (void*) &assemblyReference.public_key.data[0];
     asmRefInfo.cbPublicKeyOrToken = public_key_size;
     asmRefInfo.szName = assemblyReference.name.c_str();
     asmRefInfo.pMetaData = &assembly_metadata;
@@ -862,7 +981,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     // Attempt to extend the assembly closure of the provided assembly to include
     // the managed profiler
     auto hr = pAsmRefProvider->AddAssemblyReference(&asmRefInfo);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GetAssemblyReferences failed for call from ", wszAssemblyPath);
         return S_OK;
     }
@@ -891,46 +1011,54 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
     bool modified = false;
     auto hr = rewriter.Import();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("ProcessReplacementCalls: Call to ILRewriter.Import() failed for ", module_id, " ", function_token);
         return hr;
     }
 
     std::string original_code;
-    if (dump_il_rewrite_enabled) {
+    if (dump_il_rewrite_enabled)
+    {
         original_code = GetILCodes("***   IL original code for caller: ", &rewriter, caller, module_metadata);
     }
 
     // Perform method call replacements
-    for (auto& method_replacement : method_replacements) {
+    for (auto& method_replacement : method_replacements)
+    {
         // Exit early if the method replacement isn't actually doing a replacement
-        if (method_replacement.wrapper_method.action != WStr("ReplaceTargetMethod")) {
+        if (method_replacement.wrapper_method.action != WStr("ReplaceTargetMethod"))
+        {
             continue;
         }
 
         const auto& wrapper_method_key = method_replacement.wrapper_method.get_method_cache_key();
         // Exit early if we previously failed to store the method ref for this wrapper_method
-        if (module_metadata->IsFailedWrapperMemberKey(wrapper_method_key)) {
+        if (module_metadata->IsFailedWrapperMemberKey(wrapper_method_key))
+        {
             continue;
         }
 
         // for each IL instruction
-        for (ILInstr* pInstr = rewriter.GetILList()->m_pNext; pInstr != rewriter.GetILList();
-             pInstr = pInstr->m_pNext) {
+        for (ILInstr* pInstr = rewriter.GetILList()->m_pNext; pInstr != rewriter.GetILList(); pInstr = pInstr->m_pNext)
+        {
             // only CALL or CALLVIRT
-            if (pInstr->m_opcode != CEE_CALL && pInstr->m_opcode != CEE_CALLVIRT) {
+            if (pInstr->m_opcode != CEE_CALL && pInstr->m_opcode != CEE_CALLVIRT)
+            {
                 continue;
             }
 
             // get the target function info, continue if its invalid
             auto target = GetFunctionInfo(module_metadata->metadata_import, pInstr->m_Arg32);
-            if (!target.IsValid()) {
+            if (!target.IsValid())
+            {
                 continue;
             }
 
             // make sure the type and method names match
             if (method_replacement.target_method.type_name != target.type.name ||
-                method_replacement.target_method.method_name != target.name) {
+                method_replacement.target_method.method_name != target.name)
+            {
                 continue;
             }
 
@@ -940,10 +1068,12 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
 
             auto wrapper_method_signature_size = method_replacement.wrapper_method.method_signature.data.size();
 
-            if (wrapper_method_signature_size < (added_parameters_count + 3)) {
+            if (wrapper_method_signature_size < (added_parameters_count + 3))
+            {
                 // wrapper signature must have at least 6 bytes
                 // 0:{CallingConvention}|1:{ParamCount}|2:{ReturnType}|3:{OpCode}|4:{mdToken}|5:{ModuleVersionId}
-                if (debug_logging_enabled) {
+                if (debug_logging_enabled)
+                {
                     Debug("JITCompilationStarted skipping function call: wrapper signature "
                           "too short. function_id=",
                           function_id, " token=", function_token,
@@ -960,16 +1090,19 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             // subtract the last arguments we add to every wrapper
             expected_number_args = expected_number_args - added_parameters_count;
 
-            if (target.signature.IsInstanceMethod()) {
+            if (target.signature.IsInstanceMethod())
+            {
                 // We always pass the instance as the first argument
                 expected_number_args--;
             }
 
             auto target_arg_count = target.signature.NumberOfArguments();
 
-            if (expected_number_args != target_arg_count) {
+            if (expected_number_args != target_arg_count)
+            {
                 // Number of arguments does not match our wrapper method
-                if (debug_logging_enabled) {
+                if (debug_logging_enabled)
+                {
                     Debug("JITCompilationStarted skipping function call: argument counts "
                           "don't match. function_id=",
                           function_id, " token=", function_token, " target_name=", target.type.name, ".", target.name,
@@ -986,7 +1119,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             mdTypeRef wrapper_type_ref = mdTypeRefNil;
             auto generated_wrapper_method_ref = GetWrapperMethodRef(module_metadata, module_id, method_replacement,
                                                                     wrapper_method_ref, wrapper_type_ref);
-            if (!generated_wrapper_method_ref) {
+            if (!generated_wrapper_method_ref)
+            {
                 Warn("JITCompilationStarted failed to obtain wrapper method ref for ",
                      method_replacement.wrapper_method.type_name, ".", method_replacement.wrapper_method.method_name,
                      "().", " function_id=", function_id, " function_token=", function_token,
@@ -996,9 +1130,11 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
 
             auto method_def_md_token = target.id;
 
-            if (target.is_generic) {
+            if (target.is_generic)
+            {
                 if (target.signature.NumberOfTypeArguments() !=
-                    method_replacement.wrapper_method.method_signature.NumberOfTypeArguments()) {
+                    method_replacement.wrapper_method.method_signature.NumberOfTypeArguments())
+                {
                     // Number of generic arguments does not match our wrapper method
                     continue;
                 }
@@ -1014,8 +1150,10 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
                 TryParseSignatureTypes(module_metadata->metadata_import, target, actual_sig);
             auto expected_sig = method_replacement.target_method.signature_types;
 
-            if (!successfully_parsed_signature) {
-                if (debug_logging_enabled) {
+            if (!successfully_parsed_signature)
+            {
+                if (debug_logging_enabled)
+                {
                     Debug("JITCompilationStarted skipping function call: failed to parse "
                           "signature. function_id=",
                           function_id, " token=", function_token, " target_name=", target.type.name, ".", target.name,
@@ -1026,9 +1164,11 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
                 continue;
             }
 
-            if (actual_sig.size() != expected_sig.size()) {
+            if (actual_sig.size() != expected_sig.size())
+            {
                 // we can't safely assume our wrapper methods handle the types
-                if (debug_logging_enabled) {
+                if (debug_logging_enabled)
+                {
                     Debug("JITCompilationStarted skipping function call: unexpected type "
                           "count. function_id=",
                           function_id, " token=", function_token, " target_name=", target.type.name, ".", target.name,
@@ -1040,14 +1180,18 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             }
 
             auto is_match = true;
-            for (size_t i = 0; i < expected_sig.size(); i++) {
-                if (expected_sig[i] == WStr("_")) {
+            for (size_t i = 0; i < expected_sig.size(); i++)
+            {
+                if (expected_sig[i] == WStr("_"))
+                {
                     // We are supposed to ignore this index
                     continue;
                 }
-                if (expected_sig[i] != actual_sig[i]) {
+                if (expected_sig[i] != actual_sig[i])
+                {
                     // we have a type mismatch, drop out
-                    if (debug_logging_enabled) {
+                    if (debug_logging_enabled)
+                    {
                         Debug("JITCompilationStarted skipping function call: types don't "
                               "match. function_id=",
                               function_id, " token=", function_token, " target_name=", target.type.name, ".",
@@ -1060,7 +1204,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
                 }
             }
 
-            if (!is_match) {
+            if (!is_match)
+            {
                 // signatures don't match
                 continue;
             }
@@ -1072,7 +1217,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             //   by a callvirt IL instruction)
 
             //   1) The managed profiler has not been loaded yet
-            if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id)) {
+            if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id))
+            {
                 Warn("JITCompilationStarted skipping method: Method replacement "
                      "found but the managed profiler has not yet been loaded "
                      "into AppDomain with id=",
@@ -1086,7 +1232,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             bool caller_assembly_is_domain_neutral = runtime_information_.is_desktop() && corlib_module_loaded &&
                                                      module_metadata->app_domain_id == corlib_app_domain_id;
 
-            if (caller_assembly_is_domain_neutral && !instrument_domain_neutral_assemblies) {
+            if (caller_assembly_is_domain_neutral && !instrument_domain_neutral_assemblies)
+            {
                 Warn("JITCompilationStarted skipping method: Method replacement", " found but the calling assembly ",
                      module_metadata->assemblyName,
                      " has been loaded domain-neutral so its code is being shared across AppDomains,"
@@ -1098,7 +1245,8 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
 
             //   3) The target instruction is a constrained virtual method call (a constrained IL instruction followed
             //   by a callvirt IL instruction)
-            if (pInstr->m_opcode == CEE_CALLVIRT && pInstr->m_pPrev->m_opcode == CEE_CONSTRAINED) {
+            if (pInstr->m_opcode == CEE_CALLVIRT && pInstr->m_pPrev->m_opcode == CEE_CONSTRAINED)
+            {
                 Warn("JITCompilationStarted skipping method: Method replacement",
                      " found but the target method call is a constrained virtual method call ",
                      " (a 'constrained' IL instruction followed by a 'callvirt' IL instruction).",
@@ -1174,33 +1322,39 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             bool signature_read_success = true;
 
             // iterate until the pointer is pointing at the last argument
-            for (size_t signature_types_index = 0; signature_types_index < argument_count; signature_types_index++) {
-                if (!ParseType(&pSigCurrent)) {
+            for (size_t signature_types_index = 0; signature_types_index < argument_count; signature_types_index++)
+            {
+                if (!ParseType(&pSigCurrent))
+                {
                     signature_read_success = false;
                     break;
                 }
             }
 
             // read the last argument type
-            if (signature_read_success && *pSigCurrent == ELEMENT_TYPE_VALUETYPE) {
+            if (signature_read_success && *pSigCurrent == ELEMENT_TYPE_VALUETYPE)
+            {
                 pSigCurrent++;
                 mdToken valuetype_type_token = CorSigUncompressToken(pSigCurrent);
 
                 // Currently, we only expect to see `System.Threading.CancellationToken` as a valuetype in this position
                 // If we expand this to a general case, we would always perform the boxing regardless of type
                 if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name ==
-                    WStr("System.Threading.CancellationToken")) {
+                    WStr("System.Threading.CancellationToken"))
+                {
                     rewriter_wrapper.Box(valuetype_type_token);
                 }
             }
 
-            if (signature_read_success && *pSigCurrent == ELEMENT_TYPE_GENERICINST) {
+            if (signature_read_success && *pSigCurrent == ELEMENT_TYPE_GENERICINST)
+            {
                 PCCOR_SIGNATURE p_start_byte = pSigCurrent;
                 PCCOR_SIGNATURE p_end_byte = p_start_byte;
 
                 pSigCurrent++;
 
-                if (*pSigCurrent == ELEMENT_TYPE_VALUETYPE) {
+                if (*pSigCurrent == ELEMENT_TYPE_VALUETYPE)
+                {
                     pSigCurrent++;
                     mdToken valuetype_type_token = CorSigUncompressToken(pSigCurrent);
 
@@ -1210,10 +1364,11 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
                     // perform the boxing regardless of type
                     if (GetTypeInfo(module_metadata->metadata_import, valuetype_type_token).name ==
                             WStr("System.ReadOnlyMemory`1") &&
-                        ParseType(&p_end_byte)) {
+                        ParseType(&p_end_byte))
+                    {
                         size_t length = p_end_byte - p_start_byte;
                         mdTypeSpec type_token;
-                        module_metadata->metadata_emit->GetTokenFromTypeSpec(p_start_byte, (ULONG)length, &type_token);
+                        module_metadata->metadata_emit->GetTokenFromTypeSpec(p_start_byte, (ULONG) length, &type_token);
                         rewriter_wrapper.Box(type_token);
                     }
                 }
@@ -1248,8 +1403,10 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
             if (method_replacement.wrapper_method.method_signature.ReturnTypeIsObject() &&
                 ReturnTypeIsValueTypeOrGeneric(module_metadata->metadata_import, module_metadata->metadata_emit,
                                                module_metadata->assembly_emit, corAssemblyProperty, target.id,
-                                               target.signature, &typeToken)) {
-                if (debug_logging_enabled) {
+                                               target.signature, &typeToken))
+            {
+                if (debug_logging_enabled)
+                {
                     Debug("JITCompilationStarted inserting 'unbox.any ", typeToken,
                           "' instruction after calling target function."
                           " function_id=",
@@ -1268,16 +1425,19 @@ HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, co
         }
     }
 
-    if (modified) {
+    if (modified)
+    {
         hr = rewriter.Export();
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("ProcessReplacementCalls: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ",
                  function_token);
             return hr;
         }
 
-        if (dump_il_rewrite_enabled) {
+        if (dump_il_rewrite_enabled)
+        {
             Info(original_code);
             Info(GetILCodes("***   IL modification  for caller: ", &rewriter, caller, module_metadata));
         }
@@ -1297,7 +1457,8 @@ HRESULT CorProfiler::ProcessInsertionCalls(ModuleMetadata* module_metadata, cons
 
     auto hr = rewriter.Import();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("ProcessInsertionCalls: Call to ILRewriter.Import() failed for ", module_id, " ", function_token);
         return hr;
     }
@@ -1306,15 +1467,18 @@ HRESULT CorProfiler::ProcessInsertionCalls(ModuleMetadata* module_metadata, cons
     ILInstr* firstInstr = rewriter.GetILList()->m_pNext;
     ILInstr* lastInstr = rewriter.GetILList()->m_pPrev; // Should be a 'ret' instruction
 
-    for (auto& method_replacement : method_replacements) {
-        if (method_replacement.wrapper_method.action == WStr("ReplaceTargetMethod")) {
+    for (auto& method_replacement : method_replacements)
+    {
+        if (method_replacement.wrapper_method.action == WStr("ReplaceTargetMethod"))
+        {
             continue;
         }
 
         const auto& wrapper_method_key = method_replacement.wrapper_method.get_method_cache_key();
 
         // Exit early if we previously failed to store the method ref for this wrapper_method
-        if (module_metadata->IsFailedWrapperMemberKey(wrapper_method_key)) {
+        if (module_metadata->IsFailedWrapperMemberKey(wrapper_method_key))
+        {
             continue;
         }
 
@@ -1323,7 +1487,8 @@ HRESULT CorProfiler::ProcessInsertionCalls(ModuleMetadata* module_metadata, cons
         mdTypeRef wrapper_type_ref = mdTypeRefNil;
         auto generated_wrapper_method_ref =
             GetWrapperMethodRef(module_metadata, module_id, method_replacement, wrapper_method_ref, wrapper_type_ref);
-        if (!generated_wrapper_method_ref) {
+        if (!generated_wrapper_method_ref)
+        {
             Warn("JITCompilationStarted failed to obtain wrapper method ref for ",
                  method_replacement.wrapper_method.type_name, ".", method_replacement.wrapper_method.method_name, "().",
                  " function_id=", function_id, " function_token=", function_token, " name=", caller.type.name, ".",
@@ -1332,7 +1497,8 @@ HRESULT CorProfiler::ProcessInsertionCalls(ModuleMetadata* module_metadata, cons
         }
 
         // After successfully getting the method reference, insert a call to it
-        if (method_replacement.wrapper_method.action == WStr("InsertFirst")) {
+        if (method_replacement.wrapper_method.action == WStr("InsertFirst"))
+        {
             // Get first instruction and set the rewriter to that location
             rewriter_wrapper.SetILPosition(firstInstr);
             rewriter_wrapper.CallMember(wrapper_method_ref, false);
@@ -1345,10 +1511,12 @@ HRESULT CorProfiler::ProcessInsertionCalls(ModuleMetadata* module_metadata, cons
         }
     }
 
-    if (modified) {
+    if (modified)
+    {
         hr = rewriter.Export();
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("ProcessInsertionCalls: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ",
                  function_token);
             return hr;
@@ -1367,15 +1535,18 @@ bool CorProfiler::GetWrapperMethodRef(ModuleMetadata* module_metadata, ModuleID 
 
     // Resolve the MethodRef now. If the method is generic, we'll need to use it
     // later to define a MethodSpec
-    if (!module_metadata->TryGetWrapperMemberRef(wrapper_method_key, wrapper_method_ref)) {
+    if (!module_metadata->TryGetWrapperMemberRef(wrapper_method_key, wrapper_method_ref))
+    {
         const auto module_info = GetModuleInfo(this->info_, module_id);
-        if (!module_info.IsValid()) {
+        if (!module_info.IsValid())
+        {
             return false;
         }
 
         mdModule module;
         auto hr = module_metadata->metadata_import->GetModuleFromScope(&module);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("JITCompilationStarted failed to get module metadata token for "
                  "module_id=",
                  module_id, " module_name=", module_info.assembly.name);
@@ -1388,7 +1559,8 @@ bool CorProfiler::GetWrapperMethodRef(ModuleMetadata* module_metadata, ModuleID 
 
         // for each wrapper assembly, emit an assembly reference
         hr = metadata_builder.EmitAssemblyRef(method_replacement.wrapper_method.assembly);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("JITCompilationStarted failed to emit wrapper assembly ref for assembly=",
                  method_replacement.wrapper_method.assembly.name,
                  ", Version=", method_replacement.wrapper_method.assembly.version.str(),
@@ -1400,12 +1572,15 @@ bool CorProfiler::GetWrapperMethodRef(ModuleMetadata* module_metadata, ModuleID 
         // for each method replacement in each enabled integration,
         // emit a reference to the instrumentation wrapper methods
         hr = metadata_builder.StoreWrapperMethodRef(method_replacement);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("JITCompilationStarted failed to obtain wrapper method ref for ",
                  method_replacement.wrapper_method.type_name, ".", method_replacement.wrapper_method.method_name,
                  "().");
             return false;
-        } else {
+        }
+        else
+        {
             module_metadata->TryGetWrapperMemberRef(wrapper_method_key, wrapper_method_ref);
         }
     }
@@ -1453,10 +1628,12 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
     ULONG originalSignatureSize = 0;
     mdToken localVarSig = rewriter->GetTkLocalVarSig();
 
-    if (localVarSig != mdTokenNil) {
+    if (localVarSig != mdTokenNil)
+    {
         auto hr =
             module_metadata->metadata_import->GetSigFromToken(localVarSig, &originalSignature, &originalSignatureSize);
-        if (SUCCEEDED(hr)) {
+        if (SUCCEEDED(hr))
+        {
             orig_sstream << std::endl
                          << ". Local Var Signature: " << ToString(HexStr(originalSignature, originalSignatureSize))
                          << std::endl;
@@ -1464,28 +1641,38 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
     }
 
     orig_sstream << std::endl;
-    for (ILInstr* cInstr = rewriter->GetILList()->m_pNext; cInstr != rewriter->GetILList(); cInstr = cInstr->m_pNext) {
+    for (ILInstr* cInstr = rewriter->GetILList()->m_pNext; cInstr != rewriter->GetILList(); cInstr = cInstr->m_pNext)
+    {
 
-        if (ehCount > 0) {
-            for (unsigned int i = 0; i < ehCount; i++) {
+        if (ehCount > 0)
+        {
+            for (unsigned int i = 0; i < ehCount; i++)
+            {
                 const auto currentEH = ehPtr[i];
-                if (currentEH.m_Flags == COR_ILEXCEPTION_CLAUSE_FINALLY) {
-                    if (currentEH.m_pTryBegin == cInstr) {
-                        if (indent > 0) {
+                if (currentEH.m_Flags == COR_ILEXCEPTION_CLAUSE_FINALLY)
+                {
+                    if (currentEH.m_pTryBegin == cInstr)
+                    {
+                        if (indent > 0)
+                        {
                             orig_sstream << indent_values[indent];
                         }
                         orig_sstream << ".try {" << std::endl;
                         indent++;
                     }
-                    if (currentEH.m_pTryEnd == cInstr) {
+                    if (currentEH.m_pTryEnd == cInstr)
+                    {
                         indent--;
-                        if (indent > 0) {
+                        if (indent > 0)
+                        {
                             orig_sstream << indent_values[indent];
                         }
                         orig_sstream << "}" << std::endl;
                     }
-                    if (currentEH.m_pHandlerBegin == cInstr) {
-                        if (indent > 0) {
+                    if (currentEH.m_pHandlerBegin == cInstr)
+                    {
+                        if (indent > 0)
+                        {
                             orig_sstream << indent_values[indent];
                         }
                         orig_sstream << ".finally {" << std::endl;
@@ -1493,25 +1680,33 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
                     }
                 }
             }
-            for (unsigned int i = 0; i < ehCount; i++) {
+            for (unsigned int i = 0; i < ehCount; i++)
+            {
                 const auto currentEH = ehPtr[i];
-                if (currentEH.m_Flags == COR_ILEXCEPTION_CLAUSE_NONE) {
-                    if (currentEH.m_pTryBegin == cInstr) {
-                        if (indent > 0) {
+                if (currentEH.m_Flags == COR_ILEXCEPTION_CLAUSE_NONE)
+                {
+                    if (currentEH.m_pTryBegin == cInstr)
+                    {
+                        if (indent > 0)
+                        {
                             orig_sstream << indent_values[indent];
                         }
                         orig_sstream << ".try {" << std::endl;
                         indent++;
                     }
-                    if (currentEH.m_pTryEnd == cInstr) {
+                    if (currentEH.m_pTryEnd == cInstr)
+                    {
                         indent--;
-                        if (indent > 0) {
+                        if (indent > 0)
+                        {
                             orig_sstream << indent_values[indent];
                         }
                         orig_sstream << "}" << std::endl;
                     }
-                    if (currentEH.m_pHandlerBegin == cInstr) {
-                        if (indent > 0) {
+                    if (currentEH.m_pHandlerBegin == cInstr)
+                    {
+                        if (indent > 0)
+                        {
                             orig_sstream << indent_values[indent];
                         }
                         orig_sstream << ".catch {" << std::endl;
@@ -1521,64 +1716,85 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
             }
         }
 
-        if (indent > 0) {
+        if (indent > 0)
+        {
             orig_sstream << indent_values[indent];
         }
         orig_sstream << cInstr;
         orig_sstream << ": ";
-        if (cInstr->m_opcode < opcodes_names.size()) {
+        if (cInstr->m_opcode < opcodes_names.size())
+        {
             orig_sstream << std::setw(10) << opcodes_names[cInstr->m_opcode];
-        } else {
+        }
+        else
+        {
             orig_sstream << "0x";
             orig_sstream << std::setfill('0') << std::setw(2) << std::hex << cInstr->m_opcode;
         }
-        if (cInstr->m_pTarget != NULL) {
+        if (cInstr->m_pTarget != NULL)
+        {
             orig_sstream << "  ";
             orig_sstream << cInstr->m_pTarget;
 
-            if (cInstr->m_opcode == CEE_CALL || cInstr->m_opcode == CEE_CALLVIRT || cInstr->m_opcode == CEE_NEWOBJ) {
-                const auto memberInfo = GetFunctionInfo(module_metadata->metadata_import, (mdMemberRef)cInstr->m_Arg32);
+            if (cInstr->m_opcode == CEE_CALL || cInstr->m_opcode == CEE_CALLVIRT || cInstr->m_opcode == CEE_NEWOBJ)
+            {
+                const auto memberInfo =
+                    GetFunctionInfo(module_metadata->metadata_import, (mdMemberRef) cInstr->m_Arg32);
                 orig_sstream << "  | ";
                 orig_sstream << ToString(memberInfo.type.name);
                 orig_sstream << ".";
                 orig_sstream << ToString(memberInfo.name);
-                if (memberInfo.signature.NumberOfArguments() > 0) {
+                if (memberInfo.signature.NumberOfArguments() > 0)
+                {
                     orig_sstream << "(";
                     orig_sstream << memberInfo.signature.NumberOfArguments();
                     orig_sstream << " argument{s}";
                     orig_sstream << ")";
-                } else {
+                }
+                else
+                {
                     orig_sstream << "()";
                 }
-            } else if (cInstr->m_opcode == CEE_CASTCLASS || cInstr->m_opcode == CEE_BOX ||
-                       cInstr->m_opcode == CEE_UNBOX_ANY || cInstr->m_opcode == CEE_NEWARR ||
-                       cInstr->m_opcode == CEE_INITOBJ) {
-                const auto typeInfo = GetTypeInfo(module_metadata->metadata_import, (mdTypeRef)cInstr->m_Arg32);
+            }
+            else if (cInstr->m_opcode == CEE_CASTCLASS || cInstr->m_opcode == CEE_BOX ||
+                     cInstr->m_opcode == CEE_UNBOX_ANY || cInstr->m_opcode == CEE_NEWARR ||
+                     cInstr->m_opcode == CEE_INITOBJ)
+            {
+                const auto typeInfo = GetTypeInfo(module_metadata->metadata_import, (mdTypeRef) cInstr->m_Arg32);
                 orig_sstream << "  | ";
                 orig_sstream << ToString(typeInfo.name);
-            } else if (cInstr->m_opcode == CEE_LDSTR) {
+            }
+            else if (cInstr->m_opcode == CEE_LDSTR)
+            {
                 LPWSTR szString = new WCHAR[1024];
                 ULONG szStringLength;
-                auto hr = module_metadata->metadata_import->GetUserString((mdString)cInstr->m_Arg32, szString, 1024,
+                auto hr = module_metadata->metadata_import->GetUserString((mdString) cInstr->m_Arg32, szString, 1024,
                                                                           &szStringLength);
-                if (SUCCEEDED(hr)) {
+                if (SUCCEEDED(hr))
+                {
                     orig_sstream << "  | \"";
                     orig_sstream << ToString(WSTRING(szString, szStringLength));
                     orig_sstream << "\"";
                 }
             }
-        } else if (cInstr->m_Arg64 != 0) {
+        }
+        else if (cInstr->m_Arg64 != 0)
+        {
             orig_sstream << " ";
             orig_sstream << cInstr->m_Arg64;
         }
         orig_sstream << std::endl;
 
-        if (ehCount > 0) {
-            for (unsigned int i = 0; i < ehCount; i++) {
+        if (ehCount > 0)
+        {
+            for (unsigned int i = 0; i < ehCount; i++)
+            {
                 const auto currentEH = ehPtr[i];
-                if (currentEH.m_pHandlerEnd == cInstr) {
+                if (currentEH.m_pHandlerEnd == cInstr)
+                {
                     indent--;
-                    if (indent > 0) {
+                    if (indent > 0)
+                    {
                         orig_sstream << indent_values[indent];
                     }
                     orig_sstream << "}" << std::endl;
@@ -1598,7 +1814,8 @@ HRESULT CorProfiler::RunILStartupHook(const ComPtr<IMetaDataEmit2>& metadata_emi
     mdMethodDef ret_method_token;
     auto hr = GenerateVoidILStartupMethod(module_id, &ret_method_token);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("RunILStartupHook: Call to GenerateVoidILStartupMethod failed for ", module_id);
         return hr;
     }
@@ -1606,7 +1823,8 @@ HRESULT CorProfiler::RunILStartupHook(const ComPtr<IMetaDataEmit2>& metadata_emi
     ILRewriter rewriter(this->info_, nullptr, module_id, function_token);
     hr = rewriter.Import();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("RunILStartupHook: Call to ILRewriter.Import() failed for ", module_id, " ", function_token);
         return hr;
     }
@@ -1619,7 +1837,8 @@ HRESULT CorProfiler::RunILStartupHook(const ComPtr<IMetaDataEmit2>& metadata_emi
     rewriter_wrapper.CallMember(ret_method_token, false);
     hr = rewriter.Export();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("RunILStartupHook: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ", function_token);
         return hr;
     }
@@ -1632,7 +1851,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     ComPtr<IUnknown> metadata_interfaces;
     auto hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
                                              metadata_interfaces.GetAddressOf());
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: failed to get metadata interface for ", module_id);
         return hr;
     }
@@ -1645,7 +1865,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     mdAssemblyRef corlib_ref;
     hr = GetCorLibAssemblyRef(assembly_emit, corAssemblyProperty, &corlib_ref);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: failed to define AssemblyRef to mscorlib");
         return hr;
     }
@@ -1653,7 +1874,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     // Define a TypeRef for System.Object
     mdTypeRef object_type_ref;
     hr = metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.Object"), &object_type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
         return hr;
     }
@@ -1662,7 +1884,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     mdTypeDef new_type_def;
     hr = metadata_emit->DefineTypeDef(WStr("__DDVoidMethodType__"), tdAbstract | tdSealed, object_type_ref, NULL,
                                       &new_type_def);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineTypeDef failed");
         return hr;
     }
@@ -1676,7 +1899,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     };
     hr = metadata_emit->DefineMethod(new_type_def, WStr("__DDVoidMethodCall__"), mdStatic, initialize_signature,
                                      sizeof(initialize_signature), 0, 0, ret_method_token);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineMethod failed");
         return hr;
     }
@@ -1697,20 +1921,23 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     hr = metadata_emit->DefineMethod(new_type_def, WStr("IsAlreadyLoaded"), mdStatic | mdPrivate,
                                      already_loaded_signature, sizeof(already_loaded_signature), 0, 0,
                                      &alreadyLoadedMethodToken);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineMethod IsAlreadyLoaded failed");
         return hr;
     }
 
     // If .NET Framework 4.6 or greater
-    if (is_net46_or_greater) {
+    if (is_net46_or_greater)
+    {
 
         // Define a new static int field _isAssemblyLoaded on the new type.
         mdFieldDef isAssemblyLoadedFieldToken = mdFieldDefNil;
         BYTE field_signature[] = {IMAGE_CEE_CS_CALLCONV_FIELD, ELEMENT_TYPE_I4};
         hr = metadata_emit->DefineField(new_type_def, WStr("_isAssemblyLoaded"), fdStatic | fdPrivate, field_signature,
                                         sizeof(field_signature), 0, nullptr, 0, &isAssemblyLoadedFieldToken);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("GenerateVoidILStartupMethod: DefineField _isAssemblyLoaded failed");
             return hr;
         }
@@ -1719,7 +1946,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         mdTypeRef interlocked_type_ref;
         hr =
             metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.Threading.Interlocked"), &interlocked_type_ref);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("GenerateVoidILStartupMethod: DefineTypeRefByName interlocked_type_ref failed");
             return hr;
         }
@@ -1737,7 +1965,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         hr = metadata_emit->DefineMemberRef(
             interlocked_type_ref, WStr("CompareExchange"), interlocked_compare_exchange_signature,
             sizeof(interlocked_compare_exchange_signature), &interlocked_compare_member_ref);
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("GenerateVoidILStartupMethod: DefineMemberRef CompareExchange failed");
             return hr;
         }
@@ -1795,11 +2024,14 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
 
         hr = rewriter_already_loaded.Export();
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("GenerateVoidILStartupMethod: Call to ILRewriter.Export() failed for ModuleID=", module_id);
             return hr;
         }
-    } else {
+    }
+    else
+    {
 
         /////////////////////////////////////////////
         // Add IL instructions into the IsAlreadyLoaded method
@@ -1825,7 +2057,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         rewriter_already_loaded.InsertBefore(pALFirstInstr, pALNewInstr);
 
         hr = rewriter_already_loaded.Export();
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             Warn("GenerateVoidILStartupMethod: Call to ILRewriter.Export() failed for ModuleID=", module_id);
             return hr;
         }
@@ -1852,13 +2085,15 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     hr = metadata_emit->DefineMethod(new_type_def, WStr("GetAssemblyAndSymbolsBytes"),
                                      mdStatic | mdPinvokeImpl | mdHideBySig, get_assembly_bytes_signature,
                                      sizeof(get_assembly_bytes_signature), 0, 0, &pinvoke_method_def);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineMethod failed");
         return hr;
     }
 
     metadata_emit->SetMethodImplFlags(pinvoke_method_def, miPreserveSig);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: SetMethodImplFlags failed");
         return hr;
     }
@@ -1870,14 +2105,16 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
 #ifdef BIT64
     WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_64"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_64 defined as: ", native_profiler_file);
-    if (native_profiler_file == WStr("")) {
+    if (native_profiler_file == WStr(""))
+    {
         native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
         Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
     }
 #else  // BIT64
     WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_32"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_32 defined as: ", native_profiler_file);
-    if (native_profiler_file == WStr("")) {
+    if (native_profiler_file == WStr(""))
+    {
         native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
         Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
     }
@@ -1889,13 +2126,15 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
 
     mdModuleRef profiler_ref;
     hr = metadata_emit->DefineModuleRef(native_profiler_file.c_str(), &profiler_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineModuleRef failed");
         return hr;
     }
 
     hr = metadata_emit->DefinePinvokeMap(pinvoke_method_def, 0, WStr("GetAssemblyAndSymbolsBytes"), profiler_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefinePinvokeMap failed");
         return hr;
     }
@@ -1903,7 +2142,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     // Get a TypeRef for System.Byte
     mdTypeRef byte_type_ref;
     hr = metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.Byte"), &byte_type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
         return hr;
     }
@@ -1912,7 +2152,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     mdTypeRef marshal_type_ref;
     hr = metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.Runtime.InteropServices.Marshal"),
                                             &marshal_type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
         return hr;
     }
@@ -1929,7 +2170,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
                                               ELEMENT_TYPE_I4};
     hr = metadata_emit->DefineMemberRef(marshal_type_ref, WStr("Copy"), marshal_copy_signature,
                                         sizeof(marshal_copy_signature), &marshal_copy_member_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineMemberRef failed");
         return hr;
     }
@@ -1938,7 +2180,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     mdTypeRef system_reflection_assembly_type_ref;
     hr = metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.Reflection.Assembly"),
                                             &system_reflection_assembly_type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
         return hr;
     }
@@ -1946,7 +2189,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     // Get a MemberRef for System.Object.ToString()
     mdTypeRef system_object_type_ref;
     hr = metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.Object"), &system_object_type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineTypeRefByName failed");
         return hr;
     }
@@ -1975,7 +2219,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     mdMemberRef appdomain_load_member_ref;
     hr = metadata_emit->DefineMemberRef(system_reflection_assembly_type_ref, WStr("Load"), appdomain_load_signature,
                                         appdomain_load_signature_length, &appdomain_load_member_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineMemberRef failed");
         return hr;
     }
@@ -1989,7 +2234,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     hr = metadata_emit->DefineMemberRef(system_reflection_assembly_type_ref, WStr("CreateInstance"),
                                         assembly_create_instance_signature, sizeof(assembly_create_instance_signature),
                                         &assembly_create_instance_member_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineMemberRef failed");
         return hr;
     }
@@ -2007,8 +2253,9 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
 #endif
 
     mdString load_helper_token;
-    hr = metadata_emit->DefineUserString(load_helper_str, (ULONG)load_helper_str_size, &load_helper_token);
-    if (FAILED(hr)) {
+    hr = metadata_emit->DefineUserString(load_helper_str, (ULONG) load_helper_str_size, &load_helper_token);
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineUserString failed");
         return hr;
     }
@@ -2038,7 +2285,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     };
     CorSigCompressToken(system_reflection_assembly_type_ref, &locals_signature[11]);
     hr = metadata_emit->GetTokenFromSig(locals_signature, sizeof(locals_signature), &locals_signature_token);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: Unable to generate locals signature. ModuleID=", module_id);
         return hr;
     }
@@ -2261,7 +2509,8 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
 
     hr = rewriter_void.Export();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: Call to ILRewriter.Export() failed for ModuleID=", module_id);
         return hr;
     }
@@ -2274,7 +2523,8 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     ComPtr<IUnknown> metadata_interfaces;
     auto hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
                                              metadata_interfaces.GetAddressOf());
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: failed to get metadata interface for ", module_id);
         return hr;
     }
@@ -2287,7 +2537,8 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     ILRewriter rewriter(this->info_, nullptr, module_id, function_token);
     hr = rewriter.Import();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("RunILStartupHook: Call to ILRewriter.Import() failed for ", module_id, " ", function_token);
         return hr;
     }
@@ -2305,7 +2556,8 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     // Get System.AppDomain type ref
     mdTypeRef system_appdomain_type_ref;
     hr = metadata_emit->DefineTypeRefByName(corlib_ref, WStr("System.AppDomain"), &system_appdomain_type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("Wrapper objectTypeRef could not be defined.");
         return hr;
     }
@@ -2358,9 +2610,10 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
 #endif
 
     mdString pre_init_start_string_token;
-    hr = metadata_emit->DefineUserString(pre_init_start_str, (ULONG)pre_init_start_str_size,
+    hr = metadata_emit->DefineUserString(pre_init_start_str, (ULONG) pre_init_start_str_size,
                                          &pre_init_start_string_token);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("GenerateVoidILStartupMethod: DefineUserString failed");
         return hr;
     }
@@ -2426,7 +2679,8 @@ HRESULT CorProfiler::AddIISPreStartInitFlags(const ModuleID module_id, const mdT
     // Finished with the IL rewriting, save the result
     hr = rewriter.Export();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("RunILStartupHook: Call to ILRewriter.Export() failed for ModuleID=", module_id, " ", function_token);
         return hr;
     }
@@ -2450,10 +2704,13 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
     LPCWSTR dllLpName;
     LPCWSTR symbolsLpName;
 
-    if (runtime_information_.is_desktop()) {
+    if (runtime_information_.is_desktop())
+    {
         dllLpName = MAKEINTRESOURCE(NET45_MANAGED_ENTRYPOINT_DLL);
         symbolsLpName = MAKEINTRESOURCE(NET45_MANAGED_ENTRYPOINT_SYMBOLS);
-    } else {
+    }
+    else
+    {
         dllLpName = MAKEINTRESOURCE(NETCOREAPP20_MANAGED_ENTRYPOINT_DLL);
         symbolsLpName = MAKEINTRESOURCE(NETCOREAPP20_MANAGED_ENTRYPOINT_SYMBOLS);
     }
@@ -2461,36 +2718,38 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
     HRSRC hResAssemblyInfo = FindResource(hInstance, dllLpName, L"ASSEMBLY");
     HGLOBAL hResAssembly = LoadResource(hInstance, hResAssemblyInfo);
     *assemblySize = SizeofResource(hInstance, hResAssemblyInfo);
-    *pAssemblyArray = (LPBYTE)LockResource(hResAssembly);
+    *pAssemblyArray = (LPBYTE) LockResource(hResAssembly);
 
     HRSRC hResSymbolsInfo = FindResource(hInstance, symbolsLpName, L"SYMBOLS");
     HGLOBAL hResSymbols = LoadResource(hInstance, hResSymbolsInfo);
     *symbolsSize = SizeofResource(hInstance, hResSymbolsInfo);
-    *pSymbolsArray = (LPBYTE)LockResource(hResSymbols);
+    *pSymbolsArray = (LPBYTE) LockResource(hResSymbols);
 #elif LINUX
     *assemblySize = dll_end - dll_start;
-    *pAssemblyArray = (BYTE*)dll_start;
+    *pAssemblyArray = (BYTE*) dll_start;
 
     *symbolsSize = pdb_end - pdb_start;
-    *pSymbolsArray = (BYTE*)pdb_start;
+    *pSymbolsArray = (BYTE*) pdb_start;
 #else
     const unsigned int imgCount = _dyld_image_count();
 
-    for (auto i = 0; i < imgCount; i++) {
+    for (auto i = 0; i < imgCount; i++)
+    {
         const std::string name = std::string(_dyld_get_image_name(i));
 
-        if (name.rfind("Datadog.Trace.ClrProfiler.Native.dylib") != std::string::npos) {
-            const mach_header_64* header = (const struct mach_header_64*)_dyld_get_image_header(i);
+        if (name.rfind("Datadog.Trace.ClrProfiler.Native.dylib") != std::string::npos)
+        {
+            const mach_header_64* header = (const struct mach_header_64*) _dyld_get_image_header(i);
 
             unsigned long dllSize;
             const auto dllData = getsectiondata(header, "binary", "dll", &dllSize);
             *assemblySize = dllSize;
-            *pAssemblyArray = (BYTE*)dllData;
+            *pAssemblyArray = (BYTE*) dllData;
 
             unsigned long pdbSize;
             const auto pdbData = getsectiondata(header, "binary", "pdb", &pdbSize);
             *symbolsSize = pdbSize;
-            *pSymbolsArray = (BYTE*)pdbData;
+            *pSymbolsArray = (BYTE*) pdbData;
             break;
         }
     }
@@ -2504,7 +2763,8 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId,
                                                                BOOL fIsSafeToBlock)
 {
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
     Debug("ReJITCompilationStarted: [functionId: ", functionId, ", rejitId: ", rejitId,
@@ -2516,7 +2776,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationStarted(FunctionID functi
 HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdMethodDef methodId,
                                                           ICorProfilerFunctionControl* pFunctionControl)
 {
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -2527,9 +2788,12 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdM
     {
         std::lock_guard<std::mutex> guard(module_id_to_info_map_lock_);
         auto findRes = module_id_to_info_map_.find(moduleId);
-        if (findRes != module_id_to_info_map_.end()) {
+        if (findRes != module_id_to_info_map_.end())
+        {
             module_metadata = findRes->second;
-        } else {
+        }
+        else
+        {
             return S_FALSE;
         }
     }
@@ -2541,7 +2805,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdM
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId,
                                                                 HRESULT hrStatus, BOOL fIsSafeToBlock)
 {
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -2553,7 +2818,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID funct
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,
                                                   HRESULT hrStatus)
 {
-    if (!is_attached_) {
+    if (!is_attached_)
+    {
         return S_OK;
     }
 
@@ -2584,25 +2850,30 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
     std::vector<ModuleID> vtModules;
     std::vector<mdMethodDef> vtMethodDefs;
 
-    for (const IntegrationMethod& integration : filtered_integrations) {
+    for (const IntegrationMethod& integration : filtered_integrations)
+    {
 
         // If the integration is not for the current assembly we skip.
-        if (integration.replacement.target_method.assembly.name != module_metadata->assemblyName) {
+        if (integration.replacement.target_method.assembly.name != module_metadata->assemblyName)
+        {
             continue;
         }
 
         // If the integration mode is not CallTarget we skip.
-        if (integration.replacement.wrapper_method.action != calltarget_modification_action) {
+        if (integration.replacement.wrapper_method.action != calltarget_modification_action)
+        {
             continue;
         }
 
         // Check min version
-        if (integration.replacement.target_method.min_version > assembly_metadata.version) {
+        if (integration.replacement.target_method.min_version > assembly_metadata.version)
+        {
             continue;
         }
 
         // Check max version
-        if (integration.replacement.target_method.max_version < assembly_metadata.version) {
+        if (integration.replacement.target_method.max_version < assembly_metadata.version)
+        {
             continue;
         }
 
@@ -2611,7 +2882,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
         auto foundType = FindTypeDefByName(integration.replacement.target_method.type_name,
                                            module_metadata->assemblyName, metadata_import, typeDef);
 
-        if (!foundType) {
+        if (!foundType)
+        {
             continue;
         }
 
@@ -2625,12 +2897,14 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
             [metadata_import](HCORENUM ptr) -> void { metadata_import->CloseEnum(ptr); });
 
         auto enumIterator = enumMethods.begin();
-        while (enumIterator != enumMethods.end()) {
+        while (enumIterator != enumMethods.end())
+        {
             auto methodDef = *enumIterator;
 
             // Extract the function info from the mdMethodDef
             const auto caller = GetFunctionInfo(module_metadata->metadata_import, methodDef);
-            if (!caller.IsValid()) {
+            if (!caller.IsValid())
+            {
                 Warn("The caller for the methoddef: ", TokenStr(&methodDef), " is not valid!");
                 enumIterator = ++enumIterator;
                 continue;
@@ -2640,7 +2914,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
             // in the ReJIT process
             auto functionInfo = new FunctionInfo(caller);
             auto hr = functionInfo->method_signature.TryParse();
-            if (FAILED(hr)) {
+            if (FAILED(hr))
+            {
                 Warn("The method signature: ", functionInfo->method_signature.str(), " cannot be parsed.");
                 delete functionInfo;
                 enumIterator = ++enumIterator;
@@ -2649,7 +2924,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
 
             // Compare if the current mdMethodDef contains the same number of arguments as the instrumentation target
             const auto numOfArgs = functionInfo->method_signature.NumberOfArguments();
-            if (numOfArgs != integration.replacement.target_method.signature_types.size() - 1) {
+            if (numOfArgs != integration.replacement.target_method.signature_types.size() - 1)
+            {
                 Debug("The caller for the methoddef: ", integration.replacement.target_method.method_name,
                       " doesn't have the right number of arguments.");
                 delete functionInfo;
@@ -2662,16 +2938,19 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
             const auto methodArguments = functionInfo->method_signature.GetMethodArguments();
             Debug("Comparing signature for method: ", integration.replacement.target_method.type_name, ".",
                   integration.replacement.target_method.method_name);
-            for (unsigned int i = 0; i < numOfArgs; i++) {
+            for (unsigned int i = 0; i < numOfArgs; i++)
+            {
                 const auto argumentTypeName = methodArguments[i].GetTypeTokName(metadata_import);
                 const auto integrationArgumentTypeName = integration.replacement.target_method.signature_types[i + 1];
                 Debug("  -> ", argumentTypeName, " = ", integrationArgumentTypeName);
-                if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != WStr("_")) {
+                if (argumentTypeName != integrationArgumentTypeName && integrationArgumentTypeName != WStr("_"))
+                {
                     argumentsMismatch = true;
                     break;
                 }
             }
-            if (argumentsMismatch) {
+            if (argumentsMismatch)
+            {
                 Debug("The caller for the methoddef: ", integration.replacement.target_method.method_name,
                       " doesn't have the right type of arguments.");
                 delete functionInfo;
@@ -2702,7 +2981,8 @@ size_t CorProfiler::CallTarget_RequestRejitForModule(ModuleID module_id, ModuleM
     }
 
     // Request the ReJIT for all integrations found in the module.
-    if (!vtMethodDefs.empty()) {
+    if (!vtMethodDefs.empty())
+    {
         this->rejit_handler->EnqueueForRejit(vtMethodDefs.size(), vtModules.data(), vtMethodDefs.data());
     }
 
@@ -2794,7 +3074,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
           ", Arguments=", numArgs, "]");
 
     // First we check if the managed profiler has not been loaded yet
-    if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id)) {
+    if (!ProfilerAssemblyIsLoadedIntoAppDomain(module_metadata->app_domain_id))
+    {
         Warn("*** CallTarget_RewriterCallback() skipping method: Method replacement found but the managed profiler has "
              "not yet been loaded into AppDomain with id=",
              module_metadata->app_domain_id, " token=", function_token, " caller_name=", caller->type.name, ".",
@@ -2806,7 +3087,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     ILRewriter rewriter(this->info_, methodHandler->GetFunctionControl(), module_id, function_token);
     bool modified = false;
     auto hr = rewriter.Import();
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("*** CallTarget_RewriterCallback(): Call to ILRewriter.Import() failed for ", module_id, " ",
              function_token);
         return S_FALSE;
@@ -2814,7 +3096,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
 
     // *** Store the original il code text if the dump_il option is enabled.
     std::string original_code;
-    if (dump_il_rewrite_enabled) {
+    if (dump_il_rewrite_enabled)
+    {
         original_code =
             GetILCodes("*** CallTarget_RewriterCallback(): Original Code: ", &rewriter, *caller, module_metadata);
     }
@@ -2841,8 +3124,10 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     // ***
 
     // *** Load instance into the stack (if not static)
-    if (isStatic) {
-        if (caller->type.valueType) {
+    if (isStatic)
+    {
+        if (caller->type.valueType)
+        {
             // Static methods in a ValueType can't be instrumented.
             // In the future this can be supported by adding a local for the valuetype and initialize it to the default
             // value. After the signature modification we need to emit the following IL to initialize and load into the
@@ -2854,14 +3139,22 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
             return S_FALSE;
         }
         reWriterWrapper.LoadNull();
-    } else {
+    }
+    else
+    {
         reWriterWrapper.LoadArgument(0);
-        if (caller->type.valueType) {
-            if (caller->type.type_spec != mdTypeSpecNil) {
+        if (caller->type.valueType)
+        {
+            if (caller->type.type_spec != mdTypeSpecNil)
+            {
                 reWriterWrapper.LoadObj(caller->type.type_spec);
-            } else if (!caller->type.isGeneric) {
+            }
+            else if (!caller->type.isGeneric)
+            {
                 reWriterWrapper.LoadObj(caller->type.id);
-            } else {
+            }
+            else
+            {
                 // Generic struct instrumentation is not supported
                 // IMetaDataImport::GetMemberProps and IMetaDataImport::GetMemberRefProps returns
                 // The parent token as mdTypeDef and not as a mdTypeSpec
@@ -2877,32 +3170,41 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
 
     // *** Load the method arguments to the stack
     unsigned elementType;
-    if (numArgs < FASTPATH_COUNT) {
+    if (numArgs < FASTPATH_COUNT)
+    {
         // Load the arguments directly (FastPath)
-        for (int i = 0; i < numArgs; i++) {
+        for (int i = 0; i < numArgs; i++)
+        {
             reWriterWrapper.LoadArgument(i + (isStatic ? 0 : 1));
             auto argTypeFlags = methodArguments[i].GetTypeFlags(elementType);
-            if (argTypeFlags & TypeFlagByRef) {
+            if (argTypeFlags & TypeFlagByRef)
+            {
                 Warn("*** CallTarget_RewriterCallback(): Methods with ref parameters "
                      "cannot be instrumented. ");
                 return S_FALSE;
             }
         }
-    } else {
+    }
+    else
+    {
         // Load the arguments inside an object array (SlowPath)
         reWriterWrapper.CreateArray(callTargetTokens->GetObjectTypeRef(), numArgs);
-        for (int i = 0; i < numArgs; i++) {
+        for (int i = 0; i < numArgs; i++)
+        {
             reWriterWrapper.BeginLoadValueIntoArray(i);
             reWriterWrapper.LoadArgument(i + (isStatic ? 0 : 1));
             auto argTypeFlags = methodArguments[i].GetTypeFlags(elementType);
-            if (argTypeFlags & TypeFlagByRef) {
+            if (argTypeFlags & TypeFlagByRef)
+            {
                 Warn("*** CallTarget_RewriterCallback(): Methods with ref parameters "
                      "cannot be instrumented. ");
                 return S_FALSE;
             }
-            if (argTypeFlags & TypeFlagBoxedType) {
+            if (argTypeFlags & TypeFlagBoxedType)
+            {
                 auto tok = methodArguments[i].GetTypeTok(metaEmit, callTargetTokens->GetCorLibAssemblyRef());
-                if (tok == mdTokenNil) {
+                if (tok == mdTokenNil)
+                {
                     return S_FALSE;
                 }
                 reWriterWrapper.Box(tok);
@@ -2912,7 +3214,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     }
 
     // *** Emit BeginMethod call
-    if (debug_logging_enabled) {
+    if (debug_logging_enabled)
+    {
         Debug("Caller Type.Id: ", HexStr(&caller->type.id, sizeof(mdToken)));
         Debug("Caller Type.IsGeneric: ", caller->type.isGeneric);
         Debug("Caller Type.IsValid: ", caller->type.IsValid());
@@ -2921,7 +3224,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
         Debug("Caller Type.Spec: ", HexStr(&caller->type.type_spec, sizeof(mdTypeSpec)));
         Debug("Caller Type.ValueType: ", caller->type.valueType);
         //
-        if (caller->type.extend_from != nullptr) {
+        if (caller->type.extend_from != nullptr)
+        {
             Debug("Caller Type Extend From.Id: ", HexStr(&caller->type.extend_from->id, sizeof(mdToken)));
             Debug("Caller Type Extend From.IsGeneric: ", caller->type.extend_from->isGeneric);
             Debug("Caller Type Extend From.IsValid: ", caller->type.extend_from->IsValid());
@@ -2931,7 +3235,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
             Debug("Caller Type Extend From.ValueType: ", caller->type.extend_from->valueType);
         }
         //
-        if (caller->type.parent_type != nullptr) {
+        if (caller->type.parent_type != nullptr)
+        {
             Debug("Caller ParentType.Id: ", HexStr(&caller->type.parent_type->id, sizeof(mdToken)));
             Debug("Caller ParentType.IsGeneric: ", caller->type.parent_type->isGeneric);
             Debug("Caller ParentType.IsValid: ", caller->type.parent_type->IsValid());
@@ -2945,7 +3250,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     ILInstr* beginCallInstruction;
     hr = callTargetTokens->WriteBeginMethod(&reWriterWrapper, wrapper_type_ref, &caller->type, methodArguments,
                                             &beginCallInstruction);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         // Error message is written to the log in WriteBeginMethod.
         return S_FALSE;
     }
@@ -2996,8 +3302,10 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     ILInstr* endMethodTryStartInstr;
 
     // *** Load instance into the stack (if not static)
-    if (isStatic) {
-        if (caller->type.valueType) {
+    if (isStatic)
+    {
+        if (caller->type.valueType)
+        {
             // Static methods in a ValueType can't be instrumented.
             // In the future this can be supported by adding a local for the valuetype
             // and initialize it to the default value. After the signature
@@ -3011,14 +3319,22 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
             return S_FALSE;
         }
         endMethodTryStartInstr = reWriterWrapper.LoadNull();
-    } else {
+    }
+    else
+    {
         endMethodTryStartInstr = reWriterWrapper.LoadArgument(0);
-        if (caller->type.valueType) {
-            if (caller->type.type_spec != mdTypeSpecNil) {
+        if (caller->type.valueType)
+        {
+            if (caller->type.type_spec != mdTypeSpecNil)
+            {
                 reWriterWrapper.LoadObj(caller->type.type_spec);
-            } else if (!caller->type.isGeneric) {
+            }
+            else if (!caller->type.isGeneric)
+            {
                 reWriterWrapper.LoadObj(caller->type.id);
-            } else {
+            }
+            else
+            {
                 // Generic struct instrumentation is not supported
                 // IMetaDataImport::GetMemberProps and IMetaDataImport::GetMemberRefProps returns
                 // The parent token as mdTypeDef and not as a mdTypeSpec
@@ -3033,7 +3349,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     }
 
     // *** Load the return value is is not void
-    if (!isVoid) {
+    if (!isVoid)
+    {
         reWriterWrapper.LoadLocal(returnValueIndex);
     }
 
@@ -3041,16 +3358,20 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     reWriterWrapper.LoadLocal(callTargetStateIndex);
 
     ILInstr* endMethodCallInstr;
-    if (isVoid) {
+    if (isVoid)
+    {
         callTargetTokens->WriteEndVoidReturnMemberRef(&reWriterWrapper, wrapper_type_ref, &caller->type,
                                                       &endMethodCallInstr);
-    } else {
+    }
+    else
+    {
         callTargetTokens->WriteEndReturnMemberRef(&reWriterWrapper, wrapper_type_ref, &caller->type, &retFuncArg,
                                                   &endMethodCallInstr);
     }
     reWriterWrapper.StLocal(callTargetReturnIndex);
 
-    if (!isVoid) {
+    if (!isVoid)
+    {
         ILInstr* callTargetReturnGetReturnInstr;
         reWriterWrapper.LoadLocalAddress(callTargetReturnIndex);
         callTargetTokens->WriteCallTargetReturnGetReturnValue(&reWriterWrapper, callTargetReturnToken,
@@ -3084,16 +3405,22 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     // ***
 
     // Load the current return value from the local var
-    if (!isVoid) {
+    if (!isVoid)
+    {
         reWriterWrapper.LoadLocal(returnValueIndex);
     }
 
     // Changes all returns to a LEAVE.S
-    for (ILInstr* pInstr = rewriter.GetILList()->m_pNext; pInstr != rewriter.GetILList(); pInstr = pInstr->m_pNext) {
-        switch (pInstr->m_opcode) {
-        case CEE_RET: {
-            if (pInstr != methodReturnInstr) {
-                if (!isVoid) {
+    for (ILInstr* pInstr = rewriter.GetILList()->m_pNext; pInstr != rewriter.GetILList(); pInstr = pInstr->m_pNext)
+    {
+        switch (pInstr->m_opcode)
+        {
+        case CEE_RET:
+        {
+            if (pInstr != methodReturnInstr)
+            {
+                if (!isVoid)
+                {
                     reWriterWrapper.SetILPosition(pInstr);
                     reWriterWrapper.StLocal(returnValueIndex);
                 }
@@ -3128,7 +3455,8 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     // ***
     auto ehCount = rewriter.GetEHCount();
     auto newEHClauses = new EHClause[ehCount + 4];
-    for (unsigned i = 0; i < ehCount; i++) {
+    for (unsigned i = 0; i < ehCount; i++)
+    {
         newEHClauses[i] = rewriter.GetEHPointer()[i];
     }
 
@@ -3140,14 +3468,16 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     newEHClauses[ehCount - 1] = finallyClause;
     rewriter.SetEHClause(newEHClauses, ehCount);
 
-    if (dump_il_rewrite_enabled) {
+    if (dump_il_rewrite_enabled)
+    {
         Info(original_code);
         Info(GetILCodes("*** CallTarget_RewriterCallback(): Modified Code: ", &rewriter, *caller, module_metadata));
     }
 
     hr = rewriter.Export();
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("*** CallTarget_RewriterCallback(): Call to ILRewriter.Export() failed for "
              "ModuleID=",
              module_id, " ", function_token);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -960,7 +960,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetAssemblyReferences(const WCHAR* wszAss
     else
     {
         assembly_metadata.szLocale = const_cast<WCHAR*>(assemblyReference.locale.c_str());
-        assembly_metadata.cbLocale = (DWORD) (assemblyReference.locale.size());
+        assembly_metadata.cbLocale = (DWORD)(assemblyReference.locale.size());
     }
 
     DWORD public_key_size = 8;
@@ -2110,7 +2110,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
         Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
     }
-#else  // BIT64
+#else // BIT64
     WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_32"));
     Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_32 defined as: ", native_profiler_file);
     if (native_profiler_file == WStr(""))

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -3415,22 +3415,22 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
     {
         switch (pInstr->m_opcode)
         {
-        case CEE_RET:
-        {
-            if (pInstr != methodReturnInstr)
+            case CEE_RET:
             {
-                if (!isVoid)
+                if (pInstr != methodReturnInstr)
                 {
-                    reWriterWrapper.SetILPosition(pInstr);
-                    reWriterWrapper.StLocal(returnValueIndex);
+                    if (!isVoid)
+                    {
+                        reWriterWrapper.SetILPosition(pInstr);
+                        reWriterWrapper.StLocal(returnValueIndex);
+                    }
+                    pInstr->m_opcode = CEE_LEAVE_S;
+                    pInstr->m_pTarget = endFinallyInstr->m_pNext;
                 }
-                pInstr->m_opcode = CEE_LEAVE_S;
-                pInstr->m_pTarget = endFinallyInstr->m_pNext;
+                break;
             }
-            break;
-        }
-        default:
-            break;
+            default:
+                break;
         }
     }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -17,10 +17,12 @@
 #include "pal.h"
 #include "rejit_handler.h"
 
-namespace trace {
+namespace trace
+{
 
-class CorProfiler : public CorProfilerBase {
-  private:
+class CorProfiler : public CorProfilerBase
+{
+private:
     std::atomic_bool is_attached_ = {false};
     RuntimeInformation runtime_information_;
     std::vector<IntegrationMethod> integration_methods_;
@@ -86,7 +88,7 @@ class CorProfiler : public CorProfilerBase {
                                             const std::vector<IntegrationMethod>& filtered_integrations);
     HRESULT CallTarget_RewriterCallback(RejitHandlerModule* moduleHandler, RejitHandlerModuleMethod* methodHandler);
 
-  public:
+public:
     CorProfiler() = default;
 
     bool IsAttached() const;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
@@ -5,7 +5,8 @@ namespace trace
 {
 
 CorProfilerBase::CorProfilerBase() : ref_count_(0), info_(nullptr)
-{}
+{
+}
 
 CorProfilerBase::~CorProfilerBase()
 {

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.cpp
@@ -1,15 +1,16 @@
 ﻿#include "cor_profiler_base.h"
 #include "logging.h"
 
-namespace trace {
+namespace trace
+{
 
 CorProfilerBase::CorProfilerBase() : ref_count_(0), info_(nullptr)
-{
-}
+{}
 
 CorProfilerBase::~CorProfilerBase()
 {
-    if (this->info_ != nullptr) {
+    if (this->info_ != nullptr)
+    {
         this->info_->Release();
         this->info_ = nullptr;
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_base.h
@@ -5,16 +5,18 @@
 #include <corhlpr.h>
 #include <corprof.h>
 
-namespace trace {
+namespace trace
+{
 
-class CorProfilerBase : public ICorProfilerCallback10 {
-  private:
+class CorProfilerBase : public ICorProfilerCallback10
+{
+private:
     std::atomic<int> ref_count_;
 
-  protected:
+protected:
     ICorProfilerInfo4* info_;
 
-  public:
+public:
     CorProfilerBase();
     virtual ~CorProfilerBase();
 
@@ -150,7 +152,8 @@ class CorProfilerBase : public ICorProfilerCallback10 {
             riid == __uuidof(ICorProfilerCallback8) || riid == __uuidof(ICorProfilerCallback7) ||
             riid == __uuidof(ICorProfilerCallback6) || riid == __uuidof(ICorProfilerCallback5) ||
             riid == __uuidof(ICorProfilerCallback4) || riid == __uuidof(ICorProfilerCallback3) ||
-            riid == __uuidof(ICorProfilerCallback2) || riid == __uuidof(ICorProfilerCallback) || riid == IID_IUnknown) {
+            riid == __uuidof(ICorProfilerCallback2) || riid == __uuidof(ICorProfilerCallback) || riid == IID_IUnknown)
+        {
             *ppvObject = this;
             this->AddRef();
             return S_OK;

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -6,7 +6,8 @@
 #include "environment_variables.h"
 #include "logging.h"
 
-namespace trace {
+namespace trace
+{
 
 inline WSTRING env_vars_to_display[]{environment::tracing_enabled,
                                      environment::debug_enabled,

--- a/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
@@ -11,33 +11,36 @@ const IID IID_IClassFactory = {0x00000001, 0x0000, 0x0000, {0xC0, 0x00, 0x00, 0x
 
 HINSTANCE DllHandle;
 
-extern "C" {
-BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+extern "C"
 {
-    DllHandle = hModule;
-    return TRUE;
-}
-
-HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
-{
-    // {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-    const GUID CLSID_CorProfiler = {0x846f5f1c, 0xf9ae, 0x4b07, {0x96, 0x9e, 0x5, 0xc2, 0x6b, 0xc0, 0x60, 0xd8}};
-
-    if (ppv == NULL || rclsid != CLSID_CorProfiler) {
-        return E_FAIL;
+    BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
+    {
+        DllHandle = hModule;
+        return TRUE;
     }
 
-    auto factory = new ClassFactory;
+    HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID riid, LPVOID* ppv)
+    {
+        // {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+        const GUID CLSID_CorProfiler = {0x846f5f1c, 0xf9ae, 0x4b07, {0x96, 0x9e, 0x5, 0xc2, 0x6b, 0xc0, 0x60, 0xd8}};
 
-    if (factory == NULL) {
-        return E_FAIL;
+        if (ppv == NULL || rclsid != CLSID_CorProfiler)
+        {
+            return E_FAIL;
+        }
+
+        auto factory = new ClassFactory;
+
+        if (factory == NULL)
+        {
+            return E_FAIL;
+        }
+
+        return factory->QueryInterface(riid, ppv);
     }
 
-    return factory->QueryInterface(riid, ppv);
-}
-
-HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
-{
-    return S_OK;
-}
+    HRESULT STDMETHODCALLTYPE DllCanUnloadNow()
+    {
+        return S_OK;
+    }
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -3,110 +3,112 @@
 
 #include "string.h" // NOLINT
 
-namespace trace {
-namespace environment {
+namespace trace
+{
+namespace environment
+{
 
-// Sets whether the profiler is enabled. Default is true.
-// Setting this to false disabled the profiler entirely.
-const WSTRING tracing_enabled = WStr("DD_TRACE_ENABLED");
+    // Sets whether the profiler is enabled. Default is true.
+    // Setting this to false disabled the profiler entirely.
+    const WSTRING tracing_enabled = WStr("DD_TRACE_ENABLED");
 
-// Sets whether debug mode is enabled. Default is false.
-const WSTRING debug_enabled = WStr("DD_TRACE_DEBUG");
+    // Sets whether debug mode is enabled. Default is false.
+    const WSTRING debug_enabled = WStr("DD_TRACE_DEBUG");
 
-// Sets the paths to integration definition JSON files.
-// Supports multiple values separated with semi-colons, for example:
-// "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
-const WSTRING integrations_path = WStr("DD_INTEGRATIONS");
+    // Sets the paths to integration definition JSON files.
+    // Supports multiple values separated with semi-colons, for example:
+    // "C:\Program Files\Datadog .NET Tracer\integrations.json;D:\temp\test_integrations.json"
+    const WSTRING integrations_path = WStr("DD_INTEGRATIONS");
 
-// Sets the path to the profiler's home directory, for example:
-// "C:\Program Files\Datadog .NET Tracer\" or "/opt/datadog/"
-const WSTRING profiler_home_path = WStr("DD_DOTNET_TRACER_HOME");
+    // Sets the path to the profiler's home directory, for example:
+    // "C:\Program Files\Datadog .NET Tracer\" or "/opt/datadog/"
+    const WSTRING profiler_home_path = WStr("DD_DOTNET_TRACER_HOME");
 
-// Sets the filename of executables the profiler can attach to.
-// If not defined (default), the profiler will attach to any process.
-// Supports multiple values separated with semi-colons, for example:
-// "MyApp.exe;dotnet.exe"
-const WSTRING include_process_names = WStr("DD_PROFILER_PROCESSES");
+    // Sets the filename of executables the profiler can attach to.
+    // If not defined (default), the profiler will attach to any process.
+    // Supports multiple values separated with semi-colons, for example:
+    // "MyApp.exe;dotnet.exe"
+    const WSTRING include_process_names = WStr("DD_PROFILER_PROCESSES");
 
-// Sets the filename of executables the profiler cannot attach to.
-// If not defined (default), the profiler will attach to any process.
-// Supports multiple values separated with semi-colons, for example:
-// "MyApp.exe;dotnet.exe"
-const WSTRING exclude_process_names = WStr("DD_PROFILER_EXCLUDE_PROCESSES");
+    // Sets the filename of executables the profiler cannot attach to.
+    // If not defined (default), the profiler will attach to any process.
+    // Supports multiple values separated with semi-colons, for example:
+    // "MyApp.exe;dotnet.exe"
+    const WSTRING exclude_process_names = WStr("DD_PROFILER_EXCLUDE_PROCESSES");
 
-// Sets the Agent's host. Default is localhost.
-const WSTRING agent_host = WStr("DD_AGENT_HOST");
+    // Sets the Agent's host. Default is localhost.
+    const WSTRING agent_host = WStr("DD_AGENT_HOST");
 
-// Sets the Agent's port. Default is 8126.
-const WSTRING agent_port = WStr("DD_TRACE_AGENT_PORT");
+    // Sets the Agent's port. Default is 8126.
+    const WSTRING agent_port = WStr("DD_TRACE_AGENT_PORT");
 
-// Sets the "env" tag for every span.
-const WSTRING env = WStr("DD_ENV");
+    // Sets the "env" tag for every span.
+    const WSTRING env = WStr("DD_ENV");
 
-// Sets the default service name for every span.
-// If not set, Tracer will try to determine service name automatically
-// from application name (e.g. entry assembly or IIS application name).
-const WSTRING service_name = WStr("DD_SERVICE");
+    // Sets the default service name for every span.
+    // If not set, Tracer will try to determine service name automatically
+    // from application name (e.g. entry assembly or IIS application name).
+    const WSTRING service_name = WStr("DD_SERVICE");
 
-// Sets the "service_version" tag for every span that belong to the root service (and not an external service).
-const WSTRING service_version = WStr("DD_VERSION");
+    // Sets the "service_version" tag for every span that belong to the root service (and not an external service).
+    const WSTRING service_version = WStr("DD_VERSION");
 
-// Sets a list of integrations to disable. All other integrations will remain
-// enabled. If not set (default), all integrations are enabled. Supports
-// multiple values separated with semi-colons, for example:
-// "ElasticsearchNet;AspNetWebApi2"
-const WSTRING disabled_integrations = WStr("DD_DISABLED_INTEGRATIONS");
+    // Sets a list of integrations to disable. All other integrations will remain
+    // enabled. If not set (default), all integrations are enabled. Supports
+    // multiple values separated with semi-colons, for example:
+    // "ElasticsearchNet;AspNetWebApi2"
+    const WSTRING disabled_integrations = WStr("DD_DISABLED_INTEGRATIONS");
 
-// Sets the path for the profiler's log file.
-// Environment variable DD_TRACE_LOG_DIRECTORY takes precedence over this setting, if set.
-const WSTRING log_path = WStr("DD_TRACE_LOG_PATH");
+    // Sets the path for the profiler's log file.
+    // Environment variable DD_TRACE_LOG_DIRECTORY takes precedence over this setting, if set.
+    const WSTRING log_path = WStr("DD_TRACE_LOG_PATH");
 
-// Sets the directory for the profiler's log file.
-// If set, this setting takes precedence over environment variable DD_TRACE_LOG_PATH.
-// If not set, default is
-// "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows or
-// "/var/log/datadog/dotnet/" on Linux.
-const WSTRING log_directory = WStr("DD_TRACE_LOG_DIRECTORY");
+    // Sets the directory for the profiler's log file.
+    // If set, this setting takes precedence over environment variable DD_TRACE_LOG_PATH.
+    // If not set, default is
+    // "%ProgramData%"\Datadog .NET Tracer\logs\" on Windows or
+    // "/var/log/datadog/dotnet/" on Linux.
+    const WSTRING log_directory = WStr("DD_TRACE_LOG_DIRECTORY");
 
-// Sets whether to disable all JIT optimizations.
-// Default value is false (do not disable all optimizations).
-// https://github.com/dotnet/coreclr/issues/24676
-// https://github.com/dotnet/coreclr/issues/12468
-const WSTRING clr_disable_optimizations = WStr("DD_CLR_DISABLE_OPTIMIZATIONS");
+    // Sets whether to disable all JIT optimizations.
+    // Default value is false (do not disable all optimizations).
+    // https://github.com/dotnet/coreclr/issues/24676
+    // https://github.com/dotnet/coreclr/issues/12468
+    const WSTRING clr_disable_optimizations = WStr("DD_CLR_DISABLE_OPTIMIZATIONS");
 
-// Sets whether to intercept method calls when the caller method is inside a
-// domain-neutral assembly. This is dangerous because the integration assembly
-// Datadog.Trace.ClrProfiler.Managed.dll must also be loaded domain-neutral,
-// otherwise a sharing violation (HRESULT 0x80131401) may occur. This setting should only be
-// enabled when there is only one AppDomain or, when hosting applications in IIS,
-// the user can guarantee that all Application Pools on the system have at most
-// one application.
-// Default is false. Only used in .NET Framework 4.5 and 4.5.1.
-// https://github.com/DataDog/dd-trace-dotnet/pull/671
-const WSTRING domain_neutral_instrumentation = WStr("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION");
+    // Sets whether to intercept method calls when the caller method is inside a
+    // domain-neutral assembly. This is dangerous because the integration assembly
+    // Datadog.Trace.ClrProfiler.Managed.dll must also be loaded domain-neutral,
+    // otherwise a sharing violation (HRESULT 0x80131401) may occur. This setting should only be
+    // enabled when there is only one AppDomain or, when hosting applications in IIS,
+    // the user can guarantee that all Application Pools on the system have at most
+    // one application.
+    // Default is false. Only used in .NET Framework 4.5 and 4.5.1.
+    // https://github.com/DataDog/dd-trace-dotnet/pull/671
+    const WSTRING domain_neutral_instrumentation = WStr("DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION");
 
-// Indicates whether the profiler is running in the context
-// of Azure App Services
-const WSTRING azure_app_services = WStr("DD_AZURE_APP_SERVICES");
+    // Indicates whether the profiler is running in the context
+    // of Azure App Services
+    const WSTRING azure_app_services = WStr("DD_AZURE_APP_SERVICES");
 
-// The app_pool_id in the context of azure app services
-const WSTRING azure_app_services_app_pool_id = WStr("APP_POOL_ID");
+    // The app_pool_id in the context of azure app services
+    const WSTRING azure_app_services_app_pool_id = WStr("APP_POOL_ID");
 
-// The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
-const WSTRING azure_app_services_cli_telemetry_profile_value = WStr("DOTNET_CLI_TELEMETRY_PROFILE");
+    // The DOTNET_CLI_TELEMETRY_PROFILE in the context of azure app services
+    const WSTRING azure_app_services_cli_telemetry_profile_value = WStr("DOTNET_CLI_TELEMETRY_PROFILE");
 
-// Determine whether to instrument calls into netstandard.dll.
-// Default to false for now to avoid the unexpected overhead of additional spans.
-const WSTRING netstandard_enabled = WStr("DD_TRACE_NETSTANDARD_ENABLED");
+    // Determine whether to instrument calls into netstandard.dll.
+    // Default to false for now to avoid the unexpected overhead of additional spans.
+    const WSTRING netstandard_enabled = WStr("DD_TRACE_NETSTANDARD_ENABLED");
 
-// Enable the profiler to dump the IL original code and modification to the log.
-const WSTRING dump_il_rewrite_enabled = WStr("DD_DUMP_ILREWRITE_ENABLED");
+    // Enable the profiler to dump the IL original code and modification to the log.
+    const WSTRING dump_il_rewrite_enabled = WStr("DD_DUMP_ILREWRITE_ENABLED");
 
-// Sets whether to enable JIT inlining
-const WSTRING clr_enable_inlining = WStr("DD_CLR_ENABLE_INLINING");
+    // Sets whether to enable JIT inlining
+    const WSTRING clr_enable_inlining = WStr("DD_CLR_ENABLE_INLINING");
 
-// Sets whether to enable the CallTarget instrumentation mode
-const WSTRING calltarget_enabled = WStr("DD_TRACE_CALLTARGET_ENABLED");
+    // Sets whether to enable the CallTarget instrumentation mode
+    const WSTRING calltarget_enabled = WStr("DD_TRACE_CALLTARGET_ENABLED");
 
 } // namespace environment
 } // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
@@ -7,7 +7,8 @@
 
 #define CheckIfTrue(EXPR)                                                                                              \
     static int sValue = -1;                                                                                            \
-    if (sValue == -1) {                                                                                                \
+    if (sValue == -1)                                                                                                  \
+    {                                                                                                                  \
         const auto envValue = EXPR;                                                                                    \
         sValue = envValue == WStr("1") || envValue == WStr("true") ? 1 : 0;                                            \
     }                                                                                                                  \
@@ -15,7 +16,8 @@
 
 #define CheckIfFalse(EXPR)                                                                                             \
     static int sValue = -1;                                                                                            \
-    if (sValue == -1) {                                                                                                \
+    if (sValue == -1)                                                                                                  \
+    {                                                                                                                  \
         const auto envValue = EXPR;                                                                                    \
         sValue = envValue == WStr("0") || envValue == WStr("false") ? 1 : 0;                                           \
     }                                                                                                                  \
@@ -23,19 +25,26 @@
 
 #define ToBooleanWithDefault(EXPR, DEFAULT)                                                                            \
     static int sValue = -1;                                                                                            \
-    if (sValue == -1) {                                                                                                \
+    if (sValue == -1)                                                                                                  \
+    {                                                                                                                  \
         const auto envValue = EXPR;                                                                                    \
-        if (envValue == WStr("1") || envValue == WStr("true")) {                                                       \
+        if (envValue == WStr("1") || envValue == WStr("true"))                                                         \
+        {                                                                                                              \
             sValue = 1;                                                                                                \
-        } else if (envValue == WStr("0") || envValue == WStr("false")) {                                               \
+        }                                                                                                              \
+        else if (envValue == WStr("0") || envValue == WStr("false"))                                                   \
+        {                                                                                                              \
             sValue = 0;                                                                                                \
-        } else {                                                                                                       \
+        }                                                                                                              \
+        else                                                                                                           \
+        {                                                                                                              \
             sValue = DEFAULT;                                                                                          \
         }                                                                                                              \
     }                                                                                                                  \
     return sValue == 1;
 
-namespace trace {
+namespace trace
+{
 
 bool DisableOptimizations()
 {

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -259,63 +259,63 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL)
 
         switch (flags)
         {
-        case 0:
-            break;
-        case 1:
-            pInstr->m_Arg8 = *(UNALIGNED INT8*) &(pIL[offset]);
-            break;
-        case 2:
-            pInstr->m_Arg16 = *(UNALIGNED INT16*) &(pIL[offset]);
-            break;
-        case 4:
-            pInstr->m_Arg32 = *(UNALIGNED INT32*) &(pIL[offset]);
-            break;
-        case 8:
-            pInstr->m_Arg64 = *(UNALIGNED INT64*) &(pIL[offset]);
-            break;
-        case 1 | OPCODEFLAGS_BranchTarget:
-            pInstr->m_Arg32 = offset + 1 + *(UNALIGNED INT8*) &(pIL[offset]);
-            fBranch = true;
-            break;
-        case 4 | OPCODEFLAGS_BranchTarget:
-            pInstr->m_Arg32 = offset + 4 + *(UNALIGNED INT32*) &(pIL[offset]);
-            fBranch = true;
-            break;
-        case 0 | OPCODEFLAGS_Switch:
-        {
-            if (offset + sizeof(INT32) > m_CodeSize)
-            {
-                return COR_E_INVALIDPROGRAM;
-            }
-
-            unsigned nTargets = *(UNALIGNED INT32*) &(pIL[offset]);
-            pInstr->m_Arg32 = nTargets;
-            offset += sizeof(INT32);
-
-            unsigned base = offset + nTargets * sizeof(INT32);
-
-            for (unsigned iTarget = 0; iTarget < nTargets; iTarget++)
+            case 0:
+                break;
+            case 1:
+                pInstr->m_Arg8 = *(UNALIGNED INT8*) &(pIL[offset]);
+                break;
+            case 2:
+                pInstr->m_Arg16 = *(UNALIGNED INT16*) &(pIL[offset]);
+                break;
+            case 4:
+                pInstr->m_Arg32 = *(UNALIGNED INT32*) &(pIL[offset]);
+                break;
+            case 8:
+                pInstr->m_Arg64 = *(UNALIGNED INT64*) &(pIL[offset]);
+                break;
+            case 1 | OPCODEFLAGS_BranchTarget:
+                pInstr->m_Arg32 = offset + 1 + *(UNALIGNED INT8*) &(pIL[offset]);
+                fBranch = true;
+                break;
+            case 4 | OPCODEFLAGS_BranchTarget:
+                pInstr->m_Arg32 = offset + 4 + *(UNALIGNED INT32*) &(pIL[offset]);
+                fBranch = true;
+                break;
+            case 0 | OPCODEFLAGS_Switch:
             {
                 if (offset + sizeof(INT32) > m_CodeSize)
                 {
                     return COR_E_INVALIDPROGRAM;
                 }
 
-                pInstr = NewILInstr();
-                IfNullRet(pInstr);
-
-                pInstr->m_opcode = CEE_SWITCH_ARG;
-
-                pInstr->m_Arg32 = base + *(UNALIGNED INT32*) &(pIL[offset]);
+                unsigned nTargets = *(UNALIGNED INT32*) &(pIL[offset]);
+                pInstr->m_Arg32 = nTargets;
                 offset += sizeof(INT32);
 
-                InsertBefore(&m_IL, pInstr);
+                unsigned base = offset + nTargets * sizeof(INT32);
+
+                for (unsigned iTarget = 0; iTarget < nTargets; iTarget++)
+                {
+                    if (offset + sizeof(INT32) > m_CodeSize)
+                    {
+                        return COR_E_INVALIDPROGRAM;
+                    }
+
+                    pInstr = NewILInstr();
+                    IfNullRet(pInstr);
+
+                    pInstr->m_opcode = CEE_SWITCH_ARG;
+
+                    pInstr->m_Arg32 = base + *(UNALIGNED INT32*) &(pIL[offset]);
+                    offset += sizeof(INT32);
+
+                    InsertBefore(&m_IL, pInstr);
+                }
+                fBranch = true;
+                break;
             }
-            fBranch = true;
-            break;
-        }
-        default:
-            return COR_E_INVALIDPROGRAM;
+            default:
+                return COR_E_INVALIDPROGRAM;
         }
         offset += size;
     }
@@ -494,32 +494,32 @@ again:
         BYTE flags = s_OpCodeFlags[pInstr->m_opcode];
         switch (flags)
         {
-        case 0:
-            break;
-        case 1:
-            *(UNALIGNED INT8*) &(pIL[offset]) = pInstr->m_Arg8;
-            break;
-        case 2:
-            *(UNALIGNED INT16*) &(pIL[offset]) = pInstr->m_Arg16;
-            break;
-        case 4:
-            *(UNALIGNED INT32*) &(pIL[offset]) = pInstr->m_Arg32;
-            break;
-        case 8:
-            *(UNALIGNED INT64*) &(pIL[offset]) = pInstr->m_Arg64;
-            break;
-        case 1 | OPCODEFLAGS_BranchTarget:
-            fBranch = true;
-            break;
-        case 4 | OPCODEFLAGS_BranchTarget:
-            fBranch = true;
-            break;
-        case 0 | OPCODEFLAGS_Switch:
-            *(UNALIGNED INT32*) &(pIL[offset]) = pInstr->m_Arg32;
-            offset += sizeof(INT32);
-            break;
-        default:
-            return COR_E_INVALIDPROGRAM;
+            case 0:
+                break;
+            case 1:
+                *(UNALIGNED INT8*) &(pIL[offset]) = pInstr->m_Arg8;
+                break;
+            case 2:
+                *(UNALIGNED INT16*) &(pIL[offset]) = pInstr->m_Arg16;
+                break;
+            case 4:
+                *(UNALIGNED INT32*) &(pIL[offset]) = pInstr->m_Arg32;
+                break;
+            case 8:
+                *(UNALIGNED INT64*) &(pIL[offset]) = pInstr->m_Arg64;
+                break;
+            case 1 | OPCODEFLAGS_BranchTarget:
+                fBranch = true;
+                break;
+            case 4 | OPCODEFLAGS_BranchTarget:
+                fBranch = true;
+                break;
+            case 0 | OPCODEFLAGS_Switch:
+                *(UNALIGNED INT32*) &(pIL[offset]) = pInstr->m_Arg32;
+                offset += sizeof(INT32);
+                break;
+            default:
+                return COR_E_INVALIDPROGRAM;
         }
         offset += (flags & OPCODEFLAGS_SizeMask);
     }
@@ -555,40 +555,40 @@ again:
 
                 switch (flags)
                 {
-                case 1 | OPCODEFLAGS_BranchTarget:
-                    // Check if delta is too big to fit into an INT8.
-                    //
-                    // (see #pragma at top of file)
-                    if ((INT8) delta != delta)
-                    {
-                        if (opcode == CEE_LEAVE_S)
+                    case 1 | OPCODEFLAGS_BranchTarget:
+                        // Check if delta is too big to fit into an INT8.
+                        //
+                        // (see #pragma at top of file)
+                        if ((INT8) delta != delta)
                         {
-                            pInstr->m_opcode = CEE_LEAVE;
-                        }
-                        else
-                        {
-                            if (!(opcode >= CEE_BR_S && opcode <= CEE_BLT_UN_S))
+                            if (opcode == CEE_LEAVE_S)
                             {
-                                return COR_E_INVALIDPROGRAM;
+                                pInstr->m_opcode = CEE_LEAVE;
                             }
-
-                            pInstr->m_opcode = opcode - CEE_BR_S + CEE_BR;
-
-                            if (!(pInstr->m_opcode >= CEE_BR && pInstr->m_opcode <= CEE_BLT_UN))
+                            else
                             {
-                                return COR_E_INVALIDPROGRAM;
+                                if (!(opcode >= CEE_BR_S && opcode <= CEE_BLT_UN_S))
+                                {
+                                    return COR_E_INVALIDPROGRAM;
+                                }
+
+                                pInstr->m_opcode = opcode - CEE_BR_S + CEE_BR;
+
+                                if (!(pInstr->m_opcode >= CEE_BR && pInstr->m_opcode <= CEE_BLT_UN))
+                                {
+                                    return COR_E_INVALIDPROGRAM;
+                                }
                             }
+                            fTryAgain = true;
+                            continue;
                         }
-                        fTryAgain = true;
-                        continue;
-                    }
-                    *(UNALIGNED INT8*) &(pIL[pInstr->m_pNext->m_offset - sizeof(INT8)]) = delta;
-                    break;
-                case 4 | OPCODEFLAGS_BranchTarget:
-                    *(UNALIGNED INT32*) &(pIL[pInstr->m_pNext->m_offset - sizeof(INT32)]) = delta;
-                    break;
-                default:
-                    return COR_E_INVALIDPROGRAM;
+                        *(UNALIGNED INT8*) &(pIL[pInstr->m_pNext->m_offset - sizeof(INT8)]) = delta;
+                        break;
+                    case 4 | OPCODEFLAGS_BranchTarget:
+                        *(UNALIGNED INT32*) &(pIL[pInstr->m_pNext->m_offset - sizeof(INT32)]) = delta;
+                        break;
+                    default:
+                        return COR_E_INVALIDPROGRAM;
                 }
             }
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -612,7 +612,7 @@ again:
         BYTE* pCurrent = pBody;
 
         // Here's the tiny header
-        *pCurrent = (BYTE) (CorILMethod_TinyFormat | (codeSize << 2));
+        *pCurrent = (BYTE)(CorILMethod_TinyFormat | (codeSize << 2));
         pCurrent += sizeof(IMAGE_COR_ILMETHOD_TINY);
 
         // And the body

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.cpp
@@ -8,18 +8,20 @@
 
 #undef IfFailRet
 #define IfFailRet(EXPR)                                                                                                \
-    do {                                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
         HRESULT hr = (EXPR);                                                                                           \
-        if (FAILED(hr)) {                                                                                              \
+        if (FAILED(hr))                                                                                                \
+        {                                                                                                              \
             return (hr);                                                                                               \
         }                                                                                                              \
     } while (0)
 
 #undef IfNullRet
 #define IfNullRet(EXPR)                                                                                                \
-    do {                                                                                                               \
-        if ((EXPR) == NULL)                                                                                            \
-            return E_OUTOFMEMORY;                                                                                      \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((EXPR) == NULL) return E_OUTOFMEMORY;                                                                      \
     } while (0)
 
 #define OPCODEFLAGS_SizeMask 0x0F
@@ -105,10 +107,16 @@ static int k_rgnStackPushes[] = {
 };
 
 ILRewriter::ILRewriter(ICorProfilerInfo* pICorProfilerInfo, ICorProfilerFunctionControl* pICorProfilerFunctionControl,
-                       ModuleID moduleID, mdToken tkMethod)
-    : m_pICorProfilerInfo(pICorProfilerInfo), m_pICorProfilerFunctionControl(pICorProfilerFunctionControl),
-      m_moduleId(moduleID), m_tkMethod(tkMethod), m_fGenerateTinyHeader(false), m_pEH(nullptr),
-      m_pOffsetToInstr(nullptr), m_pOutputBuffer(nullptr), m_pIMethodMalloc(nullptr)
+                       ModuleID moduleID, mdToken tkMethod) :
+    m_pICorProfilerInfo(pICorProfilerInfo),
+    m_pICorProfilerFunctionControl(pICorProfilerFunctionControl),
+    m_moduleId(moduleID),
+    m_tkMethod(tkMethod),
+    m_fGenerateTinyHeader(false),
+    m_pEH(nullptr),
+    m_pOffsetToInstr(nullptr),
+    m_pOutputBuffer(nullptr),
+    m_pIMethodMalloc(nullptr)
 {
     m_IL.m_pNext = &m_IL;
     m_IL.m_pPrev = &m_IL;
@@ -119,7 +127,8 @@ ILRewriter::ILRewriter(ICorProfilerInfo* pICorProfilerInfo, ICorProfilerFunction
 ILRewriter::~ILRewriter()
 {
     ILInstr* p = m_IL.m_pNext;
-    while (p != &m_IL) {
+    while (p != &m_IL)
+    {
         ILInstr* t = p->m_pNext;
         delete p;
         p = t;
@@ -128,7 +137,8 @@ ILRewriter::~ILRewriter()
     delete[] m_pOffsetToInstr;
     delete[] m_pOutputBuffer;
 
-    if (m_pIMethodMalloc) {
+    if (m_pIMethodMalloc)
+    {
         m_pIMethodMalloc->Release();
     }
 }
@@ -176,7 +186,7 @@ HRESULT ILRewriter::Import()
 
     IfFailRet(m_pICorProfilerInfo->GetILFunctionBody(m_moduleId, m_tkMethod, &pMethodBytes, nullptr));
 
-    COR_ILMETHOD_DECODER decoder((COR_ILMETHOD*)pMethodBytes);
+    COR_ILMETHOD_DECODER decoder((COR_ILMETHOD*) pMethodBytes);
 
     // Import the header flags
     m_tkLocalVarSig = decoder.GetLocalVarSigTok();
@@ -205,30 +215,36 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL)
 
     bool fBranch = false;
     unsigned offset = 0;
-    while (offset < m_CodeSize) {
+    while (offset < m_CodeSize)
+    {
         unsigned startOffset = offset;
         unsigned opcode = pIL[offset++];
 
-        if (opcode == CEE_PREFIX1) {
-            if (offset >= m_CodeSize) {
+        if (opcode == CEE_PREFIX1)
+        {
+            if (offset >= m_CodeSize)
+            {
                 return COR_E_INVALIDPROGRAM;
             }
             opcode = 0x100 + pIL[offset++];
         }
 
-        if ((CEE_PREFIX7 <= opcode) && (opcode <= CEE_PREFIX2)) {
+        if ((CEE_PREFIX7 <= opcode) && (opcode <= CEE_PREFIX2))
+        {
             // NOTE: CEE_PREFIX2-7 are currently not supported
             return COR_E_INVALIDPROGRAM;
         }
 
-        if (opcode >= CEE_COUNT) {
+        if (opcode >= CEE_COUNT)
+        {
             return COR_E_INVALIDPROGRAM;
         }
 
         BYTE flags = s_OpCodeFlags[opcode];
 
         int size = (flags & OPCODEFLAGS_SizeMask);
-        if (offset + size > m_CodeSize) {
+        if (offset + size > m_CodeSize)
+        {
             return COR_E_INVALIDPROGRAM;
         }
 
@@ -241,42 +257,47 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL)
 
         m_pOffsetToInstr[startOffset] = pInstr;
 
-        switch (flags) {
+        switch (flags)
+        {
         case 0:
             break;
         case 1:
-            pInstr->m_Arg8 = *(UNALIGNED INT8*)&(pIL[offset]);
+            pInstr->m_Arg8 = *(UNALIGNED INT8*) &(pIL[offset]);
             break;
         case 2:
-            pInstr->m_Arg16 = *(UNALIGNED INT16*)&(pIL[offset]);
+            pInstr->m_Arg16 = *(UNALIGNED INT16*) &(pIL[offset]);
             break;
         case 4:
-            pInstr->m_Arg32 = *(UNALIGNED INT32*)&(pIL[offset]);
+            pInstr->m_Arg32 = *(UNALIGNED INT32*) &(pIL[offset]);
             break;
         case 8:
-            pInstr->m_Arg64 = *(UNALIGNED INT64*)&(pIL[offset]);
+            pInstr->m_Arg64 = *(UNALIGNED INT64*) &(pIL[offset]);
             break;
         case 1 | OPCODEFLAGS_BranchTarget:
-            pInstr->m_Arg32 = offset + 1 + *(UNALIGNED INT8*)&(pIL[offset]);
+            pInstr->m_Arg32 = offset + 1 + *(UNALIGNED INT8*) &(pIL[offset]);
             fBranch = true;
             break;
         case 4 | OPCODEFLAGS_BranchTarget:
-            pInstr->m_Arg32 = offset + 4 + *(UNALIGNED INT32*)&(pIL[offset]);
+            pInstr->m_Arg32 = offset + 4 + *(UNALIGNED INT32*) &(pIL[offset]);
             fBranch = true;
             break;
-        case 0 | OPCODEFLAGS_Switch: {
-            if (offset + sizeof(INT32) > m_CodeSize) {
+        case 0 | OPCODEFLAGS_Switch:
+        {
+            if (offset + sizeof(INT32) > m_CodeSize)
+            {
                 return COR_E_INVALIDPROGRAM;
             }
 
-            unsigned nTargets = *(UNALIGNED INT32*)&(pIL[offset]);
+            unsigned nTargets = *(UNALIGNED INT32*) &(pIL[offset]);
             pInstr->m_Arg32 = nTargets;
             offset += sizeof(INT32);
 
             unsigned base = offset + nTargets * sizeof(INT32);
 
-            for (unsigned iTarget = 0; iTarget < nTargets; iTarget++) {
-                if (offset + sizeof(INT32) > m_CodeSize) {
+            for (unsigned iTarget = 0; iTarget < nTargets; iTarget++)
+            {
+                if (offset + sizeof(INT32) > m_CodeSize)
+                {
                     return COR_E_INVALIDPROGRAM;
                 }
 
@@ -285,7 +306,7 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL)
 
                 pInstr->m_opcode = CEE_SWITCH_ARG;
 
-                pInstr->m_Arg32 = base + *(UNALIGNED INT32*)&(pIL[offset]);
+                pInstr->m_Arg32 = base + *(UNALIGNED INT32*) &(pIL[offset]);
                 offset += sizeof(INT32);
 
                 InsertBefore(&m_IL, pInstr);
@@ -299,14 +320,18 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL)
         offset += size;
     }
 
-    if (offset != m_CodeSize) {
+    if (offset != m_CodeSize)
+    {
         return COR_E_INVALIDPROGRAM;
     }
 
-    if (fBranch) {
+    if (fBranch)
+    {
         // Go over all control flow instructions and resolve the targets
-        for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext) {
-            if (s_OpCodeFlags[pInstr->m_opcode] & OPCODEFLAGS_BranchTarget) {
+        for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext)
+        {
+            if (s_OpCodeFlags[pInstr->m_opcode] & OPCODEFLAGS_BranchTarget)
+            {
                 IfFailRet(GetInstrFromOffset(pInstr->m_Arg32, &pInstr->m_pTarget));
             }
         }
@@ -317,24 +342,25 @@ HRESULT ILRewriter::ImportIL(LPCBYTE pIL)
 
 HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH)
 {
-    if (m_pEH != nullptr) {
+    if (m_pEH != nullptr)
+    {
         return COR_E_INVALIDOPERATION;
     }
 
     m_nEH = nEH;
 
-    if (nEH == 0)
-        return S_OK;
+    if (nEH == 0) return S_OK;
 
     IfNullRet(m_pEH = new EHClause[m_nEH]);
-    for (unsigned iEH = 0; iEH < m_nEH; iEH++) {
+    for (unsigned iEH = 0; iEH < m_nEH; iEH++)
+    {
         // If the EH clause is in tiny form, the call to pILEH->EHClause() below
         // will use this as a scratch buffer to expand the EH clause into its fat
         // form.
         COR_ILMETHOD_SECT_EH_CLAUSE_FAT scratch;
 
         const COR_ILMETHOD_SECT_EH_CLAUSE_FAT* ehInfo;
-        ehInfo = (COR_ILMETHOD_SECT_EH_CLAUSE_FAT*)pILEH->EHClause(iEH, &scratch);
+        ehInfo = (COR_ILMETHOD_SECT_EH_CLAUSE_FAT*) pILEH->EHClause(iEH, &scratch);
 
         EHClause* clause = &(m_pEH[iEH]);
         clause->m_Flags = ehInfo->GetFlags();
@@ -352,9 +378,12 @@ HRESULT ILRewriter::ImportEH(const COR_ILMETHOD_SECT_EH* pILEH, unsigned nEH)
         IfFailRet(GetInstrFromOffset(ehInfo->GetHandlerOffset() + ehInfo->GetHandlerLength(), &pInstr));
         clause->m_pHandlerEnd = pInstr->m_pPrev;
 
-        if ((clause->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0) {
+        if ((clause->m_Flags & COR_ILEXCEPTION_CLAUSE_FILTER) == 0)
+        {
             clause->m_ClassToken = ehInfo->GetClassToken();
-        } else {
+        }
+        else
+        {
             IfFailRet(GetInstrFromOffset(ehInfo->GetFilterOffset(), &pInstr));
             clause->m_pFilter = pInstr;
         }
@@ -371,10 +400,12 @@ ILInstr* ILRewriter::NewILInstr()
 
 HRESULT ILRewriter::GetInstrFromOffset(unsigned offset, ILInstr** ppInstr)
 {
-    if (offset <= m_CodeSize) {
+    if (offset <= m_CodeSize)
+    {
         ILInstr* result = m_pOffsetToInstr[offset];
 
-        if (result != nullptr) {
+        if (result != nullptr)
+        {
             *ppInstr = result;
             return S_OK;
         }
@@ -431,21 +462,23 @@ again:
     unsigned offset = 0;
 
     // Go over all instructions and produce code for them
-    for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext) {
+    for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext)
+    {
 
-        if (offset >= maxSize) {
+        if (offset >= maxSize)
+        {
             return COR_E_INDEXOUTOFRANGE;
         }
 
         pInstr->m_offset = offset;
 
         unsigned opcode = pInstr->m_opcode;
-        if (opcode < CEE_COUNT) {
+        if (opcode < CEE_COUNT)
+        {
             // CEE_PREFIX1 refers not to instruction prefixes (like tail.), but to
             // the lead byte of multi-byte opcodes. For now, the only lead byte
             // supported is CEE_PREFIX1 = 0xFE.
-            if (opcode >= 0x100)
-                m_pOutputBuffer[offset++] = CEE_PREFIX1;
+            if (opcode >= 0x100) m_pOutputBuffer[offset++] = CEE_PREFIX1;
 
             // This appears to depend on an implicit conversion from
             // unsigned opcode down to BYTE, to deliberately lose data and have
@@ -453,25 +486,27 @@ again:
             m_pOutputBuffer[offset++] = (opcode & 0xFF);
         }
 
-        if (pInstr->m_opcode >= (sizeof(s_OpCodeFlags) / sizeof(BYTE))) {
+        if (pInstr->m_opcode >= (sizeof(s_OpCodeFlags) / sizeof(BYTE)))
+        {
             return COR_E_INVALIDPROGRAM;
         }
 
         BYTE flags = s_OpCodeFlags[pInstr->m_opcode];
-        switch (flags) {
+        switch (flags)
+        {
         case 0:
             break;
         case 1:
-            *(UNALIGNED INT8*)&(pIL[offset]) = pInstr->m_Arg8;
+            *(UNALIGNED INT8*) &(pIL[offset]) = pInstr->m_Arg8;
             break;
         case 2:
-            *(UNALIGNED INT16*)&(pIL[offset]) = pInstr->m_Arg16;
+            *(UNALIGNED INT16*) &(pIL[offset]) = pInstr->m_Arg16;
             break;
         case 4:
-            *(UNALIGNED INT32*)&(pIL[offset]) = pInstr->m_Arg32;
+            *(UNALIGNED INT32*) &(pIL[offset]) = pInstr->m_Arg32;
             break;
         case 8:
-            *(UNALIGNED INT64*)&(pIL[offset]) = pInstr->m_Arg64;
+            *(UNALIGNED INT64*) &(pIL[offset]) = pInstr->m_Arg64;
             break;
         case 1 | OPCODEFLAGS_BranchTarget:
             fBranch = true;
@@ -480,7 +515,7 @@ again:
             fBranch = true;
             break;
         case 0 | OPCODEFLAGS_Switch:
-            *(UNALIGNED INT32*)&(pIL[offset]) = pInstr->m_Arg32;
+            *(UNALIGNED INT32*) &(pIL[offset]) = pInstr->m_Arg32;
             offset += sizeof(INT32);
             break;
         default:
@@ -490,55 +525,67 @@ again:
     }
     m_IL.m_offset = offset;
 
-    if (fBranch) {
+    if (fBranch)
+    {
         bool fTryAgain = false;
         unsigned switchBase = 0;
 
         // Go over all control flow instructions and resolve the targets
-        for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext) {
+        for (ILInstr* pInstr = m_IL.m_pNext; pInstr != &m_IL; pInstr = pInstr->m_pNext)
+        {
             unsigned opcode = pInstr->m_opcode;
 
-            if (pInstr->m_opcode == CEE_SWITCH) {
+            if (pInstr->m_opcode == CEE_SWITCH)
+            {
                 switchBase = pInstr->m_offset + 1 + sizeof(INT32) * (pInstr->m_Arg32 + 1);
                 continue;
             }
-            if (opcode == CEE_SWITCH_ARG) {
+            if (opcode == CEE_SWITCH_ARG)
+            {
                 // Switch args are special
-                *(UNALIGNED INT32*)&(pIL[pInstr->m_offset]) = pInstr->m_pTarget->m_offset - switchBase;
+                *(UNALIGNED INT32*) &(pIL[pInstr->m_offset]) = pInstr->m_pTarget->m_offset - switchBase;
                 continue;
             }
 
             BYTE flags = s_OpCodeFlags[pInstr->m_opcode];
 
-            if (flags & OPCODEFLAGS_BranchTarget) {
+            if (flags & OPCODEFLAGS_BranchTarget)
+            {
                 int delta = pInstr->m_pTarget->m_offset - pInstr->m_pNext->m_offset;
 
-                switch (flags) {
+                switch (flags)
+                {
                 case 1 | OPCODEFLAGS_BranchTarget:
                     // Check if delta is too big to fit into an INT8.
                     //
                     // (see #pragma at top of file)
-                    if ((INT8)delta != delta) {
-                        if (opcode == CEE_LEAVE_S) {
+                    if ((INT8) delta != delta)
+                    {
+                        if (opcode == CEE_LEAVE_S)
+                        {
                             pInstr->m_opcode = CEE_LEAVE;
-                        } else {
-                            if (!(opcode >= CEE_BR_S && opcode <= CEE_BLT_UN_S)) {
+                        }
+                        else
+                        {
+                            if (!(opcode >= CEE_BR_S && opcode <= CEE_BLT_UN_S))
+                            {
                                 return COR_E_INVALIDPROGRAM;
                             }
 
                             pInstr->m_opcode = opcode - CEE_BR_S + CEE_BR;
 
-                            if (!(pInstr->m_opcode >= CEE_BR && pInstr->m_opcode <= CEE_BLT_UN)) {
+                            if (!(pInstr->m_opcode >= CEE_BR && pInstr->m_opcode <= CEE_BLT_UN))
+                            {
                                 return COR_E_INVALIDPROGRAM;
                             }
                         }
                         fTryAgain = true;
                         continue;
                     }
-                    *(UNALIGNED INT8*)&(pIL[pInstr->m_pNext->m_offset - sizeof(INT8)]) = delta;
+                    *(UNALIGNED INT8*) &(pIL[pInstr->m_pNext->m_offset - sizeof(INT8)]) = delta;
                     break;
                 case 4 | OPCODEFLAGS_BranchTarget:
-                    *(UNALIGNED INT32*)&(pIL[pInstr->m_pNext->m_offset - sizeof(INT32)]) = delta;
+                    *(UNALIGNED INT32*) &(pIL[pInstr->m_pNext->m_offset - sizeof(INT32)]) = delta;
                     break;
                 default:
                     return COR_E_INVALIDPROGRAM;
@@ -547,17 +594,16 @@ again:
         }
 
         // Do the whole thing again if we changed the size of some branch targets
-        if (fTryAgain)
-            goto again;
+        if (fTryAgain) goto again;
     }
 
     unsigned codeSize = offset;
     unsigned totalSize;
     LPBYTE pBody = NULL;
-    if (m_fGenerateTinyHeader) {
+    if (m_fGenerateTinyHeader)
+    {
         // Make sure we can fit in a tiny header
-        if (codeSize >= 64)
-            return E_FAIL;
+        if (codeSize >= 64) return E_FAIL;
 
         totalSize = sizeof(IMAGE_COR_ILMETHOD_TINY) + codeSize;
         pBody = AllocateILMemory(totalSize);
@@ -566,12 +612,14 @@ again:
         BYTE* pCurrent = pBody;
 
         // Here's the tiny header
-        *pCurrent = (BYTE)(CorILMethod_TinyFormat | (codeSize << 2));
+        *pCurrent = (BYTE) (CorILMethod_TinyFormat | (codeSize << 2));
         pCurrent += sizeof(IMAGE_COR_ILMETHOD_TINY);
 
         // And the body
         CopyMemory(pCurrent, m_pOutputBuffer, codeSize);
-    } else {
+    }
+    else
+    {
         // Use FAT header
 
         unsigned alignedCodeSize = (offset + 3) & ~3;
@@ -585,29 +633,31 @@ again:
 
         BYTE* pCurrent = pBody;
 
-        IMAGE_COR_ILMETHOD_FAT* pHeader = (IMAGE_COR_ILMETHOD_FAT*)pCurrent;
+        IMAGE_COR_ILMETHOD_FAT* pHeader = (IMAGE_COR_ILMETHOD_FAT*) pCurrent;
         pHeader->Flags = m_flags | (m_nEH ? CorILMethod_MoreSects : 0) | CorILMethod_FatFormat;
         pHeader->Size = sizeof(IMAGE_COR_ILMETHOD_FAT) / sizeof(DWORD);
         pHeader->MaxStack = m_maxStack;
         pHeader->CodeSize = offset;
         pHeader->LocalVarSigTok = m_tkLocalVarSig;
 
-        pCurrent = (BYTE*)(pHeader + 1);
+        pCurrent = (BYTE*) (pHeader + 1);
 
         CopyMemory(pCurrent, m_pOutputBuffer, codeSize);
         pCurrent += alignedCodeSize;
 
-        if (m_nEH != 0) {
-            IMAGE_COR_ILMETHOD_SECT_FAT* pEH = (IMAGE_COR_ILMETHOD_SECT_FAT*)pCurrent;
+        if (m_nEH != 0)
+        {
+            IMAGE_COR_ILMETHOD_SECT_FAT* pEH = (IMAGE_COR_ILMETHOD_SECT_FAT*) pCurrent;
             pEH->Kind = CorILMethod_Sect_EHTable | CorILMethod_Sect_FatFormat;
-            pEH->DataSize =
-                (unsigned)(sizeof(IMAGE_COR_ILMETHOD_SECT_FAT) + sizeof(IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT) * m_nEH);
+            pEH->DataSize = (unsigned) (sizeof(IMAGE_COR_ILMETHOD_SECT_FAT) +
+                                        sizeof(IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT) * m_nEH);
 
-            pCurrent = (BYTE*)(pEH + 1);
+            pCurrent = (BYTE*) (pEH + 1);
 
-            for (unsigned iEH = 0; iEH < m_nEH; iEH++) {
+            for (unsigned iEH = 0; iEH < m_nEH; iEH++)
+            {
                 EHClause* pSrc = &(m_pEH[iEH]);
-                IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT* pDst = (IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT*)pCurrent;
+                IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT* pDst = (IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT*) pCurrent;
 
                 pDst->Flags = pSrc->m_Flags;
                 pDst->TryOffset = pSrc->m_pTryBegin->m_offset;
@@ -619,7 +669,7 @@ again:
                 else
                     pDst->FilterOffset = pSrc->m_pFilter->m_offset;
 
-                pCurrent = (BYTE*)(pDst + 1);
+                pCurrent = (BYTE*) (pDst + 1);
             }
         }
     }
@@ -632,10 +682,13 @@ again:
 
 HRESULT ILRewriter::SetILFunctionBody(unsigned size, LPBYTE pBody)
 {
-    if (m_pICorProfilerFunctionControl != nullptr) {
+    if (m_pICorProfilerFunctionControl != nullptr)
+    {
         // We're supplying IL for a rejit, so use the rejit mechanism
         IfFailRet(m_pICorProfilerFunctionControl->SetILFunctionBody(size, pBody));
-    } else {
+    }
+    else
+    {
         // "classic-style" instrumentation on first JIT, so use old mechanism
         IfFailRet(m_pICorProfilerInfo->SetILFunctionBody(m_moduleId, m_tkMethod, pBody));
     }
@@ -645,7 +698,8 @@ HRESULT ILRewriter::SetILFunctionBody(unsigned size, LPBYTE pBody)
 
 LPBYTE ILRewriter::AllocateILMemory(unsigned size)
 {
-    if (m_pICorProfilerFunctionControl != nullptr) {
+    if (m_pICorProfilerFunctionControl != nullptr)
+    {
         // We're supplying IL for a rejit, so we can just allocate from
         // the heap
         return new BYTE[size];
@@ -654,15 +708,15 @@ LPBYTE ILRewriter::AllocateILMemory(unsigned size)
     // Else, this is "classic-style" instrumentation on first JIT, and
     // need to use the CLR's IL allocator
 
-    if (FAILED(m_pICorProfilerInfo->GetILFunctionBodyAllocator(m_moduleId, &m_pIMethodMalloc)))
-        return nullptr;
+    if (FAILED(m_pICorProfilerInfo->GetILFunctionBodyAllocator(m_moduleId, &m_pIMethodMalloc))) return nullptr;
 
-    return (LPBYTE)m_pIMethodMalloc->Alloc(size);
+    return (LPBYTE) m_pIMethodMalloc->Alloc(size);
 }
 
 void ILRewriter::DeallocateILMemory(LPBYTE pBody)
 {
-    if (m_pICorProfilerFunctionControl == nullptr) {
+    if (m_pICorProfilerFunctionControl == nullptr)
+    {
         // Old-style instrumentation does not provide a way to free up bytes
         return;
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter.h
@@ -18,14 +18,16 @@ typedef enum
     // special internal instructions
 } OPCODE;
 
-struct ILInstr {
+struct ILInstr
+{
     ILInstr* m_pNext;
     ILInstr* m_pPrev;
 
     unsigned m_opcode;
     unsigned m_offset;
 
-    union {
+    union
+    {
         ILInstr* m_pTarget;
         INT8 m_Arg8;
         INT16 m_Arg16;
@@ -34,21 +36,24 @@ struct ILInstr {
     };
 };
 
-struct EHClause {
+struct EHClause
+{
     CorExceptionFlag m_Flags;
     ILInstr* m_pTryBegin;
     ILInstr* m_pTryEnd;
     ILInstr* m_pHandlerBegin; // First instruction inside the handler
     ILInstr* m_pHandlerEnd;   // Last instruction inside the handler
-    union {
+    union
+    {
         DWORD m_ClassToken; // use for type-based exception handlers
         ILInstr* m_pFilter; // use for filter-based exception handlers
                             // (COR_ILEXCEPTION_CLAUSE_FILTER is set)
     };
 };
 
-class ILRewriter {
-  private:
+class ILRewriter
+{
+private:
     ICorProfilerInfo* m_pICorProfilerInfo;
     ICorProfilerFunctionControl* m_pICorProfilerFunctionControl;
 
@@ -78,7 +83,7 @@ class ILRewriter {
 
     IMethodMalloc* m_pIMethodMalloc;
 
-  public:
+public:
     ILRewriter(ICorProfilerInfo* pICorProfilerInfo, ICorProfilerFunctionControl* pICorProfilerFunctionControl,
                ModuleID moduleID, mdToken tkMethod);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
@@ -47,12 +47,17 @@ void ILRewriterWrapper::LoadInt32(const INT32 value) const
 
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
 
-    if (value >= 0 && value <= 8) {
+    if (value >= 0 && value <= 8)
+    {
         pNewInstr->m_opcode = opcodes[value];
-    } else if (-128 <= value && value <= 127) {
+    }
+    else if (-128 <= value && value <= 127)
+    {
         pNewInstr->m_opcode = CEE_LDC_I4_S;
         pNewInstr->m_Arg8 = static_cast<INT8>(value);
-    } else {
+    }
+    else
+    {
         pNewInstr->m_opcode = CEE_LDC_I4;
         pNewInstr->m_Arg32 = value;
     }
@@ -71,12 +76,17 @@ ILInstr* ILRewriterWrapper::LoadArgument(const UINT16 index) const
 
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
 
-    if (index >= 0 && index <= 3) {
+    if (index >= 0 && index <= 3)
+    {
         pNewInstr->m_opcode = opcodes[index];
-    } else if (index <= 255) {
+    }
+    else if (index <= 255)
+    {
         pNewInstr->m_opcode = CEE_LDARG_S;
         pNewInstr->m_Arg8 = static_cast<UINT8>(index);
-    } else {
+    }
+    else
+    {
         pNewInstr->m_opcode = CEE_LDARG;
         pNewInstr->m_Arg16 = index;
     }
@@ -166,9 +176,11 @@ bool ILRewriterWrapper::ReplaceMethodCalls(const mdMemberRef old_method_ref, con
     bool modified = false;
 
     for (ILInstr* pInstr = m_ILRewriter->GetILList()->m_pNext; pInstr != m_ILRewriter->GetILList();
-         pInstr = pInstr->m_pNext) {
+         pInstr = pInstr->m_pNext)
+    {
         if ((pInstr->m_opcode == CEE_CALL || pInstr->m_opcode == CEE_CALLVIRT) &&
-            pInstr->m_Arg32 == static_cast<INT32>(old_method_ref)) {
+            pInstr->m_Arg32 == static_cast<INT32>(old_method_ref))
+        {
             pInstr->m_opcode = CEE_CALL;
             pInstr->m_Arg32 = new_method_ref;
 
@@ -207,12 +219,17 @@ ILInstr* ILRewriterWrapper::StLocal(unsigned index) const
     };
 
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
-    if (index <= 3) {
+    if (index <= 3)
+    {
         pNewInstr->m_opcode = opcodes[index];
-    } else if (index <= 255) {
+    }
+    else if (index <= 255)
+    {
         pNewInstr->m_opcode = CEE_STLOC_S;
         pNewInstr->m_Arg8 = static_cast<UINT8>(index);
-    } else {
+    }
+    else
+    {
         pNewInstr->m_opcode = CEE_STLOC;
         pNewInstr->m_Arg16 = index;
     }
@@ -230,12 +247,17 @@ ILInstr* ILRewriterWrapper::LoadLocal(unsigned index) const
     };
 
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
-    if (index <= 3) {
+    if (index <= 3)
+    {
         pNewInstr->m_opcode = opcodes[index];
-    } else if (index <= 255) {
+    }
+    else if (index <= 255)
+    {
         pNewInstr->m_opcode = CEE_LDLOC_S;
         pNewInstr->m_Arg8 = static_cast<UINT8>(index);
-    } else {
+    }
+    else
+    {
         pNewInstr->m_opcode = CEE_LDLOC;
         pNewInstr->m_Arg16 = index;
     }
@@ -246,10 +268,13 @@ ILInstr* ILRewriterWrapper::LoadLocal(unsigned index) const
 ILInstr* ILRewriterWrapper::LoadLocalAddress(unsigned index) const
 {
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
-    if (index <= 255) {
+    if (index <= 255)
+    {
         pNewInstr->m_opcode = CEE_LDLOCA_S;
         pNewInstr->m_Arg8 = static_cast<UINT8>(index);
-    } else {
+    }
+    else
+    {
         pNewInstr->m_opcode = CEE_LDLOCA;
         pNewInstr->m_Arg16 = index;
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
@@ -4,15 +4,15 @@
 #include "il_rewriter.h"
 #include "module_metadata.h"
 
-class ILRewriterWrapper {
-  private:
+class ILRewriterWrapper
+{
+private:
     ILRewriter* const m_ILRewriter;
     ILInstr* m_ILInstr;
 
-  public:
+public:
     ILRewriterWrapper(ILRewriter* const il_rewriter) : m_ILRewriter(il_rewriter), m_ILInstr(nullptr)
-    {
-    }
+    {}
 
     ILRewriter* GetILRewriter() const;
     ILInstr* GetCurrentILInstr() const;

--- a/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
@@ -12,7 +12,8 @@ private:
 
 public:
     ILRewriterWrapper(ILRewriter* const il_rewriter) : m_ILRewriter(il_rewriter), m_ILInstr(nullptr)
-    {}
+    {
+    }
 
     ILRewriter* GetILRewriter() const;
     ILInstr* GetCurrentILInstr() const;

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -10,123 +10,135 @@
 
 #include "util.h"
 
-namespace trace {
-
-AssemblyReference::AssemblyReference(const WSTRING& str)
-    : name(GetNameFromAssemblyReferenceString(str)), version(GetVersionFromAssemblyReferenceString(str)),
-      locale(GetLocaleFromAssemblyReferenceString(str)), public_key(GetPublicKeyFromAssemblyReferenceString(str))
+namespace trace
 {
-}
 
-namespace {
+AssemblyReference::AssemblyReference(const WSTRING& str) :
+    name(GetNameFromAssemblyReferenceString(str)),
+    version(GetVersionFromAssemblyReferenceString(str)),
+    locale(GetLocaleFromAssemblyReferenceString(str)),
+    public_key(GetPublicKeyFromAssemblyReferenceString(str))
+{}
 
-WSTRING GetNameFromAssemblyReferenceString(const WSTRING& wstr)
+namespace
 {
-    WSTRING name = wstr;
 
-    auto pos = name.find(WStr(','));
-    if (pos != WSTRING::npos) {
-        name = name.substr(0, pos);
-    }
+    WSTRING GetNameFromAssemblyReferenceString(const WSTRING& wstr)
+    {
+        WSTRING name = wstr;
 
-    // strip spaces
-    pos = name.rfind(WStr(' '));
-    if (pos != WSTRING::npos) {
-        name = name.substr(0, pos);
-    }
-
-    return name;
-}
-
-Version GetVersionFromAssemblyReferenceString(const WSTRING& str)
-{
-    unsigned short major = 0;
-    unsigned short minor = 0;
-    unsigned short build = 0;
-    unsigned short revision = 0;
-
-#ifdef _WIN32
-
-    static auto re = std::wregex(WStr("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
-
-    std::wsmatch match;
-    if (std::regex_search(str, match, re) && match.size() == 5) {
-        WSTRINGSTREAM(match.str(1)) >> major;
-        WSTRINGSTREAM(match.str(2)) >> minor;
-        WSTRINGSTREAM(match.str(3)) >> build;
-        WSTRINGSTREAM(match.str(4)) >> revision;
-    }
-
-#else
-
-    static re2::RE2 re("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)", RE2::Quiet);
-    re2::RE2::FullMatch(ToString(str), re, &major, &minor, &build, &revision);
-
-#endif
-
-    return {major, minor, build, revision};
-}
-
-WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& str)
-{
-    WSTRING locale = WStr("neutral");
-
-#ifdef _WIN32
-
-    static auto re = std::wregex(WStr("Culture=([a-zA-Z0-9]+)"));
-    std::wsmatch match;
-    if (std::regex_search(str, match, re) && match.size() == 2) {
-        locale = match.str(1);
-    }
-
-#else
-
-    static re2::RE2 re("Culture=([a-zA-Z0-9]+)", RE2::Quiet);
-
-    std::string match;
-    if (re2::RE2::FullMatch(ToString(str), re, &match)) {
-        locale = ToWSTRING(match);
-    }
-
-#endif
-
-    return locale;
-}
-
-PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& str)
-{
-    BYTE data[8] = {0};
-
-#ifdef _WIN32
-
-    static auto re = std::wregex(WStr("PublicKeyToken=([a-fA-F0-9]{16})"));
-    std::wsmatch match;
-    if (std::regex_search(str, match, re) && match.size() == 2) {
-        for (int i = 0; i < 8; i++) {
-            auto s = match.str(1).substr(i * 2, 2);
-            unsigned long x;
-            WSTRINGSTREAM(s) >> std::hex >> x;
-            data[i] = BYTE(x);
+        auto pos = name.find(WStr(','));
+        if (pos != WSTRING::npos)
+        {
+            name = name.substr(0, pos);
         }
+
+        // strip spaces
+        pos = name.rfind(WStr(' '));
+        if (pos != WSTRING::npos)
+        {
+            name = name.substr(0, pos);
+        }
+
+        return name;
     }
+
+    Version GetVersionFromAssemblyReferenceString(const WSTRING& str)
+    {
+        unsigned short major = 0;
+        unsigned short minor = 0;
+        unsigned short build = 0;
+        unsigned short revision = 0;
+
+#ifdef _WIN32
+
+        static auto re = std::wregex(WStr("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
+
+        std::wsmatch match;
+        if (std::regex_search(str, match, re) && match.size() == 5)
+        {
+            WSTRINGSTREAM(match.str(1)) >> major;
+            WSTRINGSTREAM(match.str(2)) >> minor;
+            WSTRINGSTREAM(match.str(3)) >> build;
+            WSTRINGSTREAM(match.str(4)) >> revision;
+        }
 
 #else
 
-    static re2::RE2 re("PublicKeyToken=([a-fA-F0-9]{16})");
-    std::string match;
-    if (re2::RE2::FullMatch(ToString(str), re, &match)) {
-        for (int i = 0; i < 8; i++) {
-            auto s = match.substr(i * 2, 2);
-            unsigned long x;
-            std::stringstream(s) >> std::hex >> x;
-            data[i] = BYTE(x);
-        }
-    }
+        static re2::RE2 re("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)", RE2::Quiet);
+        re2::RE2::FullMatch(ToString(str), re, &major, &minor, &build, &revision);
 
 #endif
 
-    return PublicKey(data);
-}
+        return {major, minor, build, revision};
+    }
+
+    WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& str)
+    {
+        WSTRING locale = WStr("neutral");
+
+#ifdef _WIN32
+
+        static auto re = std::wregex(WStr("Culture=([a-zA-Z0-9]+)"));
+        std::wsmatch match;
+        if (std::regex_search(str, match, re) && match.size() == 2)
+        {
+            locale = match.str(1);
+        }
+
+#else
+
+        static re2::RE2 re("Culture=([a-zA-Z0-9]+)", RE2::Quiet);
+
+        std::string match;
+        if (re2::RE2::FullMatch(ToString(str), re, &match))
+        {
+            locale = ToWSTRING(match);
+        }
+
+#endif
+
+        return locale;
+    }
+
+    PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& str)
+    {
+        BYTE data[8] = {0};
+
+#ifdef _WIN32
+
+        static auto re = std::wregex(WStr("PublicKeyToken=([a-fA-F0-9]{16})"));
+        std::wsmatch match;
+        if (std::regex_search(str, match, re) && match.size() == 2)
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                auto s = match.str(1).substr(i * 2, 2);
+                unsigned long x;
+                WSTRINGSTREAM(s) >> std::hex >> x;
+                data[i] = BYTE(x);
+            }
+        }
+
+#else
+
+        static re2::RE2 re("PublicKeyToken=([a-fA-F0-9]{16})");
+        std::string match;
+        if (re2::RE2::FullMatch(ToString(str), re, &match))
+        {
+            for (int i = 0; i < 8; i++)
+            {
+                auto s = match.substr(i * 2, 2);
+                unsigned long x;
+                std::stringstream(s) >> std::hex >> x;
+                data[i] = BYTE(x);
+            }
+        }
+
+#endif
+
+        return PublicKey(data);
+    }
 
 } // namespace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -18,7 +18,8 @@ AssemblyReference::AssemblyReference(const WSTRING& str) :
     version(GetVersionFromAssemblyReferenceString(str)),
     locale(GetLocaleFromAssemblyReferenceString(str)),
     public_key(GetPublicKeyFromAssemblyReferenceString(str))
-{}
+{
+}
 
 namespace
 {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -23,9 +23,11 @@ struct PublicKey
     const BYTE data[kPublicKeySize];
 
     PublicKey() : data{0}
-    {}
+    {
+    }
     PublicKey(const BYTE (&arr)[kPublicKeySize]) : data{arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7]}
-    {}
+    {
+    }
 
     inline bool operator==(const PublicKey& other) const
     {
@@ -60,11 +62,13 @@ struct Version
     const unsigned short revision;
 
     Version() : major(0), minor(0), build(0), revision(0)
-    {}
+    {
+    }
     Version(const unsigned short major, const unsigned short minor, const unsigned short build,
             const unsigned short revision) :
         major(major), minor(minor), build(build), revision(revision)
-    {}
+    {
+    }
 
     inline bool operator==(const Version& other) const
     {
@@ -125,7 +129,8 @@ struct AssemblyReference
     const PublicKey public_key;
 
     AssemblyReference()
-    {}
+    {
+    }
     AssemblyReference(const WSTRING& str);
 
     inline bool operator==(const AssemblyReference& other) const
@@ -151,9 +156,11 @@ public:
     const std::vector<BYTE> data;
 
     MethodSignature()
-    {}
+    {
+    }
     MethodSignature(const std::vector<BYTE>& data) : data(data)
-    {}
+    {
+    }
 
     inline bool operator==(const MethodSignature& other) const
     {
@@ -243,7 +250,8 @@ struct MethodReference
 
     MethodReference() :
         min_version(Version(0, 0, 0, 0)), max_version(Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX))
-    {}
+    {
+    }
 
     MethodReference(const WSTRING& assembly_name, WSTRING type_name, WSTRING method_name, WSTRING action,
                     Version min_version, Version max_version, const std::vector<BYTE>& method_signature,
@@ -256,7 +264,8 @@ struct MethodReference
         min_version(min_version),
         max_version(max_version),
         signature_types(signature_types)
-    {}
+    {
+    }
 
     inline WSTRING get_type_cache_key() const
     {
@@ -285,11 +294,13 @@ struct MethodReplacement
     const MethodReference wrapper_method;
 
     MethodReplacement()
-    {}
+    {
+    }
 
     MethodReplacement(MethodReference caller_method, MethodReference target_method, MethodReference wrapper_method) :
         caller_method(caller_method), target_method(target_method), wrapper_method(wrapper_method)
-    {}
+    {
+    }
 
     inline bool operator==(const MethodReplacement& other) const
     {
@@ -304,11 +315,13 @@ struct Integration
     std::vector<MethodReplacement> method_replacements;
 
     Integration() : integration_name(WStr("")), method_replacements({})
-    {}
+    {
+    }
 
     Integration(WSTRING integration_name, std::vector<MethodReplacement> method_replacements) :
         integration_name(integration_name), method_replacements(method_replacements)
-    {}
+    {
+    }
 
     inline bool operator==(const Integration& other) const
     {
@@ -322,11 +335,13 @@ struct IntegrationMethod
     MethodReplacement replacement;
 
     IntegrationMethod() : integration_name(WStr("")), replacement({})
-    {}
+    {
+    }
 
     IntegrationMethod(WSTRING integration_name, MethodReplacement replacement) :
         integration_name(integration_name), replacement(replacement)
-    {}
+    {
+    }
 
     inline bool operator==(const IntegrationMethod& other) const
     {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -11,26 +11,28 @@
 #undef major
 #undef minor
 
-namespace trace {
+namespace trace
+{
 
 const size_t kPublicKeySize = 8;
 
 // PublicKey represents an Assembly Public Key token, which is an 8 byte binary
 // RSA key.
-struct PublicKey {
+struct PublicKey
+{
     const BYTE data[kPublicKeySize];
 
     PublicKey() : data{0}
-    {
-    }
+    {}
     PublicKey(const BYTE (&arr)[kPublicKeySize]) : data{arr[0], arr[1], arr[2], arr[3], arr[4], arr[5], arr[6], arr[7]}
-    {
-    }
+    {}
 
     inline bool operator==(const PublicKey& other) const
     {
-        for (int i = 0; i < kPublicKeySize; i++) {
-            if (data[i] != other.data[i]) {
+        for (int i = 0; i < kPublicKeySize; i++)
+        {
+            if (data[i] != other.data[i])
+            {
                 return false;
             }
         }
@@ -40,7 +42,8 @@ struct PublicKey {
     inline WSTRING str() const
     {
         std::stringstream ss;
-        for (int i = 0; i < kPublicKeySize; i++) {
+        for (int i = 0; i < kPublicKeySize; i++)
+        {
             ss << std::setfill('0') << std::setw(2) << std::hex << static_cast<int>(data[i]);
         }
         return ToWSTRING(ss.str());
@@ -49,20 +52,19 @@ struct PublicKey {
 
 // Version is an Assembly version in the form Major.Minor.Build.Revision
 // (1.0.0.0)
-struct Version {
+struct Version
+{
     const unsigned short major;
     const unsigned short minor;
     const unsigned short build;
     const unsigned short revision;
 
     Version() : major(0), minor(0), build(0), revision(0)
-    {
-    }
+    {}
     Version(const unsigned short major, const unsigned short minor, const unsigned short build,
-            const unsigned short revision)
-        : major(major), minor(minor), build(build), revision(revision)
-    {
-    }
+            const unsigned short revision) :
+        major(major), minor(minor), build(build), revision(revision)
+    {}
 
     inline bool operator==(const Version& other) const
     {
@@ -78,13 +80,16 @@ struct Version {
 
     inline bool operator<(const Version& other) const
     {
-        if (major < other.major) {
+        if (major < other.major)
+        {
             return true;
         }
-        if (major == other.major && minor < other.minor) {
+        if (major == other.major && minor < other.minor)
+        {
             return true;
         }
-        if (major == other.major && minor == other.minor && build < other.build) {
+        if (major == other.major && minor == other.minor && build < other.build)
+        {
             return true;
         }
         return false;
@@ -92,13 +97,16 @@ struct Version {
 
     inline bool operator>(const Version& other) const
     {
-        if (major > other.major) {
+        if (major > other.major)
+        {
             return true;
         }
-        if (major == other.major && minor > other.minor) {
+        if (major == other.major && minor > other.minor)
+        {
             return true;
         }
-        if (major == other.major && minor == other.minor && build > other.build) {
+        if (major == other.major && minor == other.minor && build > other.build)
+        {
             return true;
         }
         return false;
@@ -109,15 +117,15 @@ struct Version {
 // look like:
 //     Some.Assembly.Name, Version=1.0.0.0, Culture=neutral,
 //     PublicKeyToken=abcdef0123456789
-struct AssemblyReference {
+struct AssemblyReference
+{
     const WSTRING name;
     const Version version;
     const WSTRING locale;
     const PublicKey public_key;
 
     AssemblyReference()
-    {
-    }
+    {}
     AssemblyReference(const WSTRING& str);
 
     inline bool operator==(const AssemblyReference& other) const
@@ -137,16 +145,15 @@ struct AssemblyReference {
 // A MethodSignature is a byte array. The format is:
 // [calling convention, number of parameters, return type, parameter type...]
 // For types see CorElementType
-struct MethodSignature {
-  public:
+struct MethodSignature
+{
+public:
     const std::vector<BYTE> data;
 
     MethodSignature()
-    {
-    }
+    {}
     MethodSignature(const std::vector<BYTE>& data) : data(data)
-    {
-    }
+    {}
 
     inline bool operator==(const MethodSignature& other) const
     {
@@ -160,7 +167,8 @@ struct MethodSignature {
 
     size_t NumberOfTypeArguments() const
     {
-        if (data.size() > 1 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0) {
+        if (data.size() > 1 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0)
+        {
             return data[1];
         }
         return 0;
@@ -168,10 +176,12 @@ struct MethodSignature {
 
     size_t NumberOfArguments() const
     {
-        if (data.size() > 2 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0) {
+        if (data.size() > 2 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0)
+        {
             return data[2];
         }
-        if (data.size() > 1) {
+        if (data.size() > 1)
+        {
             return data[1];
         }
         return 0;
@@ -179,10 +189,12 @@ struct MethodSignature {
 
     bool ReturnTypeIsObject() const
     {
-        if (data.size() > 2 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0) {
+        if (data.size() > 2 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0)
+        {
             return data[3] == ELEMENT_TYPE_OBJECT;
         }
-        if (data.size() > 1) {
+        if (data.size() > 1)
+        {
             return data[2] == ELEMENT_TYPE_OBJECT;
         }
 
@@ -191,10 +203,12 @@ struct MethodSignature {
 
     size_t IndexOfReturnType() const
     {
-        if (data.size() > 2 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0) {
+        if (data.size() > 2 && (CallingConvention() & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0)
+        {
             return 3;
         }
-        if (data.size() > 1) {
+        if (data.size() > 1)
+        {
             return 2;
         }
         return 0;
@@ -203,7 +217,8 @@ struct MethodSignature {
     WSTRING str() const
     {
         std::stringstream ss;
-        for (auto& b : data) {
+        for (auto& b : data)
+        {
             ss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(b);
         }
         return ToWSTRING(ss.str());
@@ -215,7 +230,8 @@ struct MethodSignature {
     }
 };
 
-struct MethodReference {
+struct MethodReference
+{
     const AssemblyReference assembly;
     const WSTRING type_name;
     const WSTRING method_name;
@@ -225,19 +241,22 @@ struct MethodReference {
     const Version max_version;
     const std::vector<WSTRING> signature_types;
 
-    MethodReference()
-        : min_version(Version(0, 0, 0, 0)), max_version(Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX))
-    {
-    }
+    MethodReference() :
+        min_version(Version(0, 0, 0, 0)), max_version(Version(USHRT_MAX, USHRT_MAX, USHRT_MAX, USHRT_MAX))
+    {}
 
     MethodReference(const WSTRING& assembly_name, WSTRING type_name, WSTRING method_name, WSTRING action,
                     Version min_version, Version max_version, const std::vector<BYTE>& method_signature,
-                    const std::vector<WSTRING>& signature_types)
-        : assembly(assembly_name), type_name(type_name), method_name(method_name), action(action),
-          method_signature(method_signature), min_version(min_version), max_version(max_version),
-          signature_types(signature_types)
-    {
-    }
+                    const std::vector<WSTRING>& signature_types) :
+        assembly(assembly_name),
+        type_name(type_name),
+        method_name(method_name),
+        action(action),
+        method_signature(method_signature),
+        min_version(min_version),
+        max_version(max_version),
+        signature_types(signature_types)
+    {}
 
     inline WSTRING get_type_cache_key() const
     {
@@ -259,19 +278,18 @@ struct MethodReference {
     }
 };
 
-struct MethodReplacement {
+struct MethodReplacement
+{
     const MethodReference caller_method;
     const MethodReference target_method;
     const MethodReference wrapper_method;
 
     MethodReplacement()
-    {
-    }
+    {}
 
-    MethodReplacement(MethodReference caller_method, MethodReference target_method, MethodReference wrapper_method)
-        : caller_method(caller_method), target_method(target_method), wrapper_method(wrapper_method)
-    {
-    }
+    MethodReplacement(MethodReference caller_method, MethodReference target_method, MethodReference wrapper_method) :
+        caller_method(caller_method), target_method(target_method), wrapper_method(wrapper_method)
+    {}
 
     inline bool operator==(const MethodReplacement& other) const
     {
@@ -280,18 +298,17 @@ struct MethodReplacement {
     }
 };
 
-struct Integration {
+struct Integration
+{
     const WSTRING integration_name;
     std::vector<MethodReplacement> method_replacements;
 
     Integration() : integration_name(WStr("")), method_replacements({})
-    {
-    }
+    {}
 
-    Integration(WSTRING integration_name, std::vector<MethodReplacement> method_replacements)
-        : integration_name(integration_name), method_replacements(method_replacements)
-    {
-    }
+    Integration(WSTRING integration_name, std::vector<MethodReplacement> method_replacements) :
+        integration_name(integration_name), method_replacements(method_replacements)
+    {}
 
     inline bool operator==(const Integration& other) const
     {
@@ -299,18 +316,17 @@ struct Integration {
     }
 };
 
-struct IntegrationMethod {
+struct IntegrationMethod
+{
     const WSTRING integration_name;
     MethodReplacement replacement;
 
     IntegrationMethod() : integration_name(WStr("")), replacement({})
-    {
-    }
+    {}
 
-    IntegrationMethod(WSTRING integration_name, MethodReplacement replacement)
-        : integration_name(integration_name), replacement(replacement)
-    {
-    }
+    IntegrationMethod(WSTRING integration_name, MethodReplacement replacement) :
+        integration_name(integration_name), replacement(replacement)
+    {}
 
     inline bool operator==(const IntegrationMethod& other) const
     {
@@ -318,12 +334,13 @@ struct IntegrationMethod {
     }
 };
 
-namespace {
+namespace
+{
 
-WSTRING GetNameFromAssemblyReferenceString(const WSTRING& wstr);
-Version GetVersionFromAssemblyReferenceString(const WSTRING& wstr);
-WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& wstr);
-PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& wstr);
+    WSTRING GetNameFromAssemblyReferenceString(const WSTRING& wstr);
+    Version GetVersionFromAssemblyReferenceString(const WSTRING& wstr);
+    WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& wstr);
+    PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& wstr);
 
 } // namespace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -7,17 +7,20 @@
 #include "logging.h"
 #include "util.h"
 
-namespace trace {
+namespace trace
+{
 
 using json = nlohmann::json;
 
 std::vector<Integration> LoadIntegrationsFromEnvironment()
 {
     std::vector<Integration> integrations;
-    for (const auto f : GetEnvironmentValues(environment::integrations_path)) {
+    for (const auto f : GetEnvironmentValues(environment::integrations_path))
+    {
         Debug("Loading integrations from file: ", f);
         auto is = LoadIntegrationsFromFile(f);
-        for (auto& i : is) {
+        for (auto& i : is)
+        {
             integrations.push_back(i);
         }
     }
@@ -28,24 +31,34 @@ std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path)
 {
     std::vector<Integration> integrations;
 
-    try {
+    try
+    {
         std::ifstream stream;
         stream.open(ToString(file_path));
 
-        if (static_cast<bool>(stream)) {
+        if (static_cast<bool>(stream))
+        {
             integrations = LoadIntegrationsFromStream(stream);
-        } else {
+        }
+        else
+        {
             Warn("Failed to load integrations from file ", file_path);
         }
 
         stream.close();
-    } catch (...) {
+    }
+    catch (...)
+    {
         auto ex = std::current_exception();
-        try {
-            if (ex) {
+        try
+        {
+            if (ex)
+            {
                 std::rethrow_exception(ex);
             }
-        } catch (const std::exception& ex) {
+        }
+        catch (const std::exception& ex)
+        {
             Warn("Failed to load integrations: ", ex.what());
         }
     }
@@ -57,30 +70,43 @@ std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream)
 {
     std::vector<Integration> integrations;
 
-    try {
+    try
+    {
         json j;
         // parse the stream
         stream >> j;
 
-        for (auto& el : j) {
+        for (auto& el : j)
+        {
             auto i = IntegrationFromJson(el);
-            if (std::get<1>(i)) {
+            if (std::get<1>(i))
+            {
                 integrations.push_back(std::get<0>(i));
             }
         }
 
         // Debug("Loaded integrations: ", j.dump());
-    } catch (const json::parse_error& e) {
+    }
+    catch (const json::parse_error& e)
+    {
         Warn("Invalid integrations:", e.what());
-    } catch (const json::type_error& e) {
+    }
+    catch (const json::type_error& e)
+    {
         Warn("Invalid integrations:", e.what());
-    } catch (...) {
+    }
+    catch (...)
+    {
         auto ex = std::current_exception();
-        try {
-            if (ex) {
+        try
+        {
+            if (ex)
+            {
                 std::rethrow_exception(ex);
             }
-        } catch (const std::exception& ex) {
+        }
+        catch (const std::exception& ex)
+        {
             Warn("Failed to load integrations: ", ex.what());
         }
     }
@@ -88,137 +114,170 @@ std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream)
     return integrations;
 }
 
-namespace {
-
-std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src)
+namespace
 {
-    if (!src.is_object()) {
-        return std::make_pair<Integration, bool>({}, false);
-    }
 
-    // first get the name, which is required
-    const auto name = ToWSTRING(src.value("name", ""));
-    if (name.empty()) {
-        Warn("Integration name is missing for integration: ", src.dump());
-        return std::make_pair<Integration, bool>({}, false);
-    }
+    std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src)
+    {
+        if (!src.is_object())
+        {
+            return std::make_pair<Integration, bool>({}, false);
+        }
 
-    std::vector<MethodReplacement> replacements;
-    auto arr = src.value("method_replacements", json::array());
-    if (arr.is_array()) {
-        for (auto& el : arr) {
-            auto mr = MethodReplacementFromJson(el);
-            if (std::get<1>(mr)) {
-                replacements.push_back(std::get<0>(mr));
+        // first get the name, which is required
+        const auto name = ToWSTRING(src.value("name", ""));
+        if (name.empty())
+        {
+            Warn("Integration name is missing for integration: ", src.dump());
+            return std::make_pair<Integration, bool>({}, false);
+        }
+
+        std::vector<MethodReplacement> replacements;
+        auto arr = src.value("method_replacements", json::array());
+        if (arr.is_array())
+        {
+            for (auto& el : arr)
+            {
+                auto mr = MethodReplacementFromJson(el);
+                if (std::get<1>(mr))
+                {
+                    replacements.push_back(std::get<0>(mr));
+                }
             }
         }
-    }
-    return std::make_pair<Integration, bool>({name, replacements}, true);
-}
-
-std::pair<MethodReplacement, bool> MethodReplacementFromJson(const json::value_type& src)
-{
-    if (!src.is_object()) {
-        return std::make_pair<MethodReplacement, bool>({}, false);
+        return std::make_pair<Integration, bool>({name, replacements}, true);
     }
 
-    const auto caller = MethodReferenceFromJson(src.value("caller", json::object()), false, false);
-    const auto target = MethodReferenceFromJson(src.value("target", json::object()), true, false);
-    const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()), false, true);
-    return std::make_pair<MethodReplacement, bool>({caller, target, wrapper}, true);
-}
+    std::pair<MethodReplacement, bool> MethodReplacementFromJson(const json::value_type& src)
+    {
+        if (!src.is_object())
+        {
+            return std::make_pair<MethodReplacement, bool>({}, false);
+        }
 
-MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method,
-                                        const bool is_wrapper_method)
-{
-    if (!src.is_object()) {
-        return {};
+        const auto caller = MethodReferenceFromJson(src.value("caller", json::object()), false, false);
+        const auto target = MethodReferenceFromJson(src.value("target", json::object()), true, false);
+        const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()), false, true);
+        return std::make_pair<MethodReplacement, bool>({caller, target, wrapper}, true);
     }
 
-    const auto assembly = ToWSTRING(src.value("assembly", ""));
-    const auto type = ToWSTRING(src.value("type", ""));
-    const auto method = ToWSTRING(src.value("method", ""));
-    auto raw_signature = src.value("signature", json::array());
-
-    const auto eoj = src.end();
-    USHORT min_major = 0;
-    USHORT min_minor = 0;
-    USHORT min_patch = 0;
-    USHORT max_major = USHRT_MAX;
-    USHORT max_minor = USHRT_MAX;
-    USHORT max_patch = USHRT_MAX;
-    std::vector<WSTRING> signature_type_array;
-    WSTRING action = WStr("");
-
-    if (is_target_method) {
-        // these fields only exist in the target definition
-
-        if (src.find("minimum_major") != eoj) {
-            min_major = src["minimum_major"].get<USHORT>();
-        }
-        if (src.find("minimum_minor") != eoj) {
-            min_minor = src["minimum_minor"].get<USHORT>();
-        }
-        if (src.find("minimum_patch") != eoj) {
-            min_patch = src["minimum_patch"].get<USHORT>();
-        }
-        if (src.find("maximum_major") != eoj) {
-            max_major = src["maximum_major"].get<USHORT>();
-        }
-        if (src.find("maximum_minor") != eoj) {
-            max_minor = src["maximum_minor"].get<USHORT>();
-        }
-        if (src.find("maximum_patch") != eoj) {
-            max_patch = src["maximum_patch"].get<USHORT>();
+    MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method,
+                                            const bool is_wrapper_method)
+    {
+        if (!src.is_object())
+        {
+            return {};
         }
 
-        if (src.find("signature_types") != eoj) {
-            // c++ is unable to handle null values in this array
-            // we would need to write out own parsing here for null values
-            auto sig_types = src["signature_types"].get<std::vector<std::string>>();
-            signature_type_array = std::vector<WSTRING>(sig_types.size());
-            for (auto i = sig_types.size() - 1; i < sig_types.size(); i--) {
-                signature_type_array[i] = ToWSTRING(sig_types[i]);
+        const auto assembly = ToWSTRING(src.value("assembly", ""));
+        const auto type = ToWSTRING(src.value("type", ""));
+        const auto method = ToWSTRING(src.value("method", ""));
+        auto raw_signature = src.value("signature", json::array());
+
+        const auto eoj = src.end();
+        USHORT min_major = 0;
+        USHORT min_minor = 0;
+        USHORT min_patch = 0;
+        USHORT max_major = USHRT_MAX;
+        USHORT max_minor = USHRT_MAX;
+        USHORT max_patch = USHRT_MAX;
+        std::vector<WSTRING> signature_type_array;
+        WSTRING action = WStr("");
+
+        if (is_target_method)
+        {
+            // these fields only exist in the target definition
+
+            if (src.find("minimum_major") != eoj)
+            {
+                min_major = src["minimum_major"].get<USHORT>();
+            }
+            if (src.find("minimum_minor") != eoj)
+            {
+                min_minor = src["minimum_minor"].get<USHORT>();
+            }
+            if (src.find("minimum_patch") != eoj)
+            {
+                min_patch = src["minimum_patch"].get<USHORT>();
+            }
+            if (src.find("maximum_major") != eoj)
+            {
+                max_major = src["maximum_major"].get<USHORT>();
+            }
+            if (src.find("maximum_minor") != eoj)
+            {
+                max_minor = src["maximum_minor"].get<USHORT>();
+            }
+            if (src.find("maximum_patch") != eoj)
+            {
+                max_patch = src["maximum_patch"].get<USHORT>();
+            }
+
+            if (src.find("signature_types") != eoj)
+            {
+                // c++ is unable to handle null values in this array
+                // we would need to write out own parsing here for null values
+                auto sig_types = src["signature_types"].get<std::vector<std::string>>();
+                signature_type_array = std::vector<WSTRING>(sig_types.size());
+                for (auto i = sig_types.size() - 1; i < sig_types.size(); i--)
+                {
+                    signature_type_array[i] = ToWSTRING(sig_types[i]);
+                }
             }
         }
-    } else if (is_wrapper_method) {
-        action = ToWSTRING(src.value("action", ""));
-    }
+        else if (is_wrapper_method)
+        {
+            action = ToWSTRING(src.value("action", ""));
+        }
 
-    std::vector<BYTE> signature;
-    if (raw_signature.is_array()) {
-        for (auto& el : raw_signature) {
-            if (el.is_number_unsigned()) {
-                signature.push_back(BYTE(el.get<BYTE>()));
+        std::vector<BYTE> signature;
+        if (raw_signature.is_array())
+        {
+            for (auto& el : raw_signature)
+            {
+                if (el.is_number_unsigned())
+                {
+                    signature.push_back(BYTE(el.get<BYTE>()));
+                }
             }
         }
-    } else if (raw_signature.is_string()) {
-        // load as a hex string
-        std::string str = raw_signature;
-        bool flip = false;
-        char prev = 0;
-        for (auto& c : str) {
-            BYTE b = 0;
-            if ('0' <= c && c <= '9') {
-                b = c - '0';
-            } else if ('a' <= c && c <= 'f') {
-                b = c - 'a' + 10;
-            } else if ('A' <= c && c <= 'F') {
-                b = c - 'A' + 10;
-            } else {
-                // skip any non-hex character
-                continue;
+        else if (raw_signature.is_string())
+        {
+            // load as a hex string
+            std::string str = raw_signature;
+            bool flip = false;
+            char prev = 0;
+            for (auto& c : str)
+            {
+                BYTE b = 0;
+                if ('0' <= c && c <= '9')
+                {
+                    b = c - '0';
+                }
+                else if ('a' <= c && c <= 'f')
+                {
+                    b = c - 'a' + 10;
+                }
+                else if ('A' <= c && c <= 'F')
+                {
+                    b = c - 'A' + 10;
+                }
+                else
+                {
+                    // skip any non-hex character
+                    continue;
+                }
+                if (flip)
+                {
+                    signature.push_back((prev << 4) + b);
+                }
+                flip = !flip;
+                prev = b;
             }
-            if (flip) {
-                signature.push_back((prev << 4) + b);
-            }
-            flip = !flip;
-            prev = b;
         }
+        return MethodReference(assembly, type, method, action, Version(min_major, min_minor, min_patch, 0),
+                               Version(max_major, max_minor, max_patch, USHRT_MAX), signature, signature_type_array);
     }
-    return MethodReference(assembly, type, method, action, Version(min_major, min_minor, min_patch, 0),
-                           Version(max_major, max_minor, max_patch, USHRT_MAX), signature, signature_type_array);
-}
 
 } // namespace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
@@ -10,7 +10,8 @@
 #include "integration.h"
 #include "macros.h"
 
-namespace trace {
+namespace trace
+{
 
 using json = nlohmann::json;
 
@@ -22,12 +23,13 @@ std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path);
 // LoadIntegrationsFromFile loads the integrations from a stream
 std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream);
 
-namespace {
+namespace
+{
 
-std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src);
-std::pair<MethodReplacement, bool> MethodReplacementFromJson(const json::value_type& src);
-MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method,
-                                        const bool is_wrapper_method);
+    std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src);
+    std::pair<MethodReplacement, bool> MethodReplacementFromJson(const json::value_type& src);
+    MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method,
+                                            const bool is_wrapper_method);
 
 } // namespace
 

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.cpp
@@ -9,7 +9,8 @@
 typedef struct stat Stat;
 #endif
 
-namespace trace {
+namespace trace
+{
 
 bool debug_logging_enabled = false;
 bool dump_il_rewrite_enabled = false;
@@ -20,7 +21,8 @@ std::string getPathName(const std::string& s)
 {
     char sep = '/';
     size_t i = s.rfind(sep, s.length());
-    if (i != std::string::npos) {
+    if (i != std::string::npos)
+    {
         return s.substr(0, i);
     }
     return "";
@@ -36,10 +38,12 @@ std::string Logger::GetLogPath(const std::string& file_name_suffix)
     // create directory if missing
     const auto log_path = std::filesystem::path(path);
 
-    if (log_path.has_parent_path()) {
+    if (log_path.has_parent_path())
+    {
         const auto parent_path = log_path.parent_path();
 
-        if (!std::filesystem::exists(parent_path)) {
+        if (!std::filesystem::exists(parent_path))
+        {
             std::filesystem::create_directories(parent_path);
         }
     }
@@ -47,7 +51,8 @@ std::string Logger::GetLogPath(const std::string& file_name_suffix)
     // on linux and osx we use the basic C approach
     const auto log_path = getPathName(path);
     Stat st;
-    if (log_path != "" && stat(log_path.c_str(), &st) != 0) {
+    if (log_path != "" && stat(log_path.c_str(), &st) != 0)
+    {
         mkdir(log_path.c_str(), 0777);
     }
 #endif
@@ -73,9 +78,12 @@ Logger::Logger()
 
     static auto file_name_suffix = "-" + current_process_without_extension + "-" + std::to_string(current_process_id);
 
-    try {
+    try
+    {
         m_fileout = spdlog::rotating_logger_mt("Logger", GetLogPath(file_name_suffix), 1048576 * 5, 10);
-    } catch (...) {
+    }
+    catch (...)
+    {
         std::cerr << "Logger Handler: Error creating native log file." << std::endl;
         m_fileout = spdlog::null_logger_mt("Logger");
     }
@@ -95,7 +103,8 @@ Logger::~Logger()
 
 void Logger::Debug(const std::string& str)
 {
-    if (debug_logging_enabled) {
+    if (debug_logging_enabled)
+    {
         m_fileout->debug(str);
     }
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/logging.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logging.h
@@ -7,21 +7,23 @@
 #include <iostream>
 #include <memory>
 
-namespace trace {
+namespace trace
+{
 
 extern bool debug_logging_enabled;
 extern bool dump_il_rewrite_enabled;
 
-class Logger : public Singleton<Logger> {
+class Logger : public Singleton<Logger>
+{
     friend class Singleton<Logger>;
 
-  private:
+private:
     std::shared_ptr<spdlog::logger> m_fileout;
     static std::string GetLogPath(const std::string& file_name_suffix);
     Logger();
     ~Logger();
 
-  public:
+public:
     void Debug(const std::string& str);
     void Info(const std::string& str);
     void Warn(const std::string& str);
@@ -34,31 +36,37 @@ class Logger : public Singleton<Logger> {
     }
 };
 
-template <typename Arg> std::string LogToString(Arg const& arg)
+template <typename Arg>
+std::string LogToString(Arg const& arg)
 {
     return ToString(arg);
 }
 
-template <typename... Args> std::string LogToString(Args const&... args)
+template <typename... Args>
+std::string LogToString(Args const&... args)
 {
     std::ostringstream oss;
-    int a[] = {0, ((void)(oss << LogToString(args)), 0)...};
+    int a[] = {0, ((void) (oss << LogToString(args)), 0)...};
     return oss.str();
 }
 
-template <typename... Args> void Debug(const Args... args)
+template <typename... Args>
+void Debug(const Args... args)
 {
-    if (debug_logging_enabled) {
+    if (debug_logging_enabled)
+    {
         Logger::Instance()->Debug(LogToString(args...));
     }
 }
 
-template <typename... Args> void Info(const Args... args)
+template <typename... Args>
+void Info(const Args... args)
 {
     Logger::Instance()->Info(LogToString(args...));
 }
 
-template <typename... Args> void Warn(const Args... args)
+template <typename... Args>
+void Warn(const Args... args)
 {
     Logger::Instance()->Warn(LogToString(args...));
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/macros.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/macros.h
@@ -5,25 +5,29 @@
 #include <fstream>
 
 #define RETURN_IF_FAILED(EXPR)                                                                                         \
-    do {                                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
         hr = (EXPR);                                                                                                   \
-        if (FAILED(hr)) {                                                                                              \
+        if (FAILED(hr))                                                                                                \
+        {                                                                                                              \
             return (hr);                                                                                               \
         }                                                                                                              \
     } while (0)
 
 #define RETURN_OK_IF_FAILED(EXPR)                                                                                      \
-    do {                                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
         hr = (EXPR);                                                                                                   \
-        if (FAILED(hr)) {                                                                                              \
+        if (FAILED(hr))                                                                                                \
+        {                                                                                                              \
             return S_OK;                                                                                               \
         }                                                                                                              \
     } while (0)
 
 #define IfFalseRetFAIL(EXPR)                                                                                           \
-    do {                                                                                                               \
-        if ((EXPR) == false)                                                                                           \
-            return E_FAIL;                                                                                             \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if ((EXPR) == false) return E_FAIL;                                                                            \
     } while (0)
 
 #endif // DD_CLR_PROFILER_MACROS_H_

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -24,7 +24,7 @@ HRESULT MetadataBuilder::EmitAssemblyRef(const trace::AssemblyReference& assembl
     else
     {
         assembly_metadata.szLocale = const_cast<WCHAR*>(assembly_ref.locale.c_str());
-        assembly_metadata.cbLocale = (DWORD) (assembly_ref.locale.size());
+        assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
     }
 
     DWORD public_key_size = 8;
@@ -136,13 +136,13 @@ HRESULT MetadataBuilder::StoreWrapperMethodRef(const MethodReplacement& method_r
     {
         // callsite integrations do this path.
         hr = metadata_import_->FindMemberRef(type_ref, method_replacement.wrapper_method.method_name.c_str(),
-                                             signature_data.data(), (DWORD) (signature_data.size()), &member_ref);
+                                             signature_data.data(), (DWORD)(signature_data.size()), &member_ref);
 
         if (hr == HRESULT(0x80131130) /* record not found on lookup */)
         {
             // if memberRef not found, create it by emitting a metadata token
             hr = metadata_emit_->DefineMemberRef(type_ref, method_replacement.wrapper_method.method_name.c_str(),
-                                                 signature_data.data(), (DWORD) (signature_data.size()), &member_ref);
+                                                 signature_data.data(), (DWORD)(signature_data.size()), &member_ref);
         }
 
         if (FAILED(hr))

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.cpp
@@ -6,7 +6,8 @@
 #include "macros.h"
 #include "metadata_builder.h"
 
-namespace trace {
+namespace trace
+{
 
 HRESULT MetadataBuilder::EmitAssemblyRef(const trace::AssemblyReference& assembly_ref) const
 {
@@ -15,16 +16,20 @@ HRESULT MetadataBuilder::EmitAssemblyRef(const trace::AssemblyReference& assembl
     assembly_metadata.usMinorVersion = assembly_ref.version.minor;
     assembly_metadata.usBuildNumber = assembly_ref.version.build;
     assembly_metadata.usRevisionNumber = assembly_ref.version.revision;
-    if (assembly_ref.locale == WStr("neutral")) {
+    if (assembly_ref.locale == WStr("neutral"))
+    {
         assembly_metadata.szLocale = nullptr;
         assembly_metadata.cbLocale = 0;
-    } else {
+    }
+    else
+    {
         assembly_metadata.szLocale = const_cast<WCHAR*>(assembly_ref.locale.c_str());
-        assembly_metadata.cbLocale = (DWORD)(assembly_ref.locale.size());
+        assembly_metadata.cbLocale = (DWORD) (assembly_ref.locale.size());
     }
 
     DWORD public_key_size = 8;
-    if (assembly_ref.public_key == trace::PublicKey()) {
+    if (assembly_ref.public_key == trace::PublicKey())
+    {
         public_key_size = 0;
     }
 
@@ -38,7 +43,8 @@ HRESULT MetadataBuilder::EmitAssemblyRef(const trace::AssemblyReference& assembl
                                                          // flags
                                                          0, &assembly_ref_out);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("DefineAssemblyRef failed");
     }
     return S_OK;
@@ -49,7 +55,8 @@ HRESULT MetadataBuilder::FindWrapperTypeRef(const MethodReplacement& method_repl
     const auto& cache_key = method_replacement.wrapper_method.get_type_cache_key();
     mdTypeRef type_ref = mdTypeRefNil;
 
-    if (metadata_.TryGetWrapperParentTypeRef(cache_key, type_ref)) {
+    if (metadata_.TryGetWrapperParentTypeRef(cache_key, type_ref))
+    {
         // this type was already resolved
         type_ref_out = type_ref;
         return S_OK;
@@ -58,15 +65,19 @@ HRESULT MetadataBuilder::FindWrapperTypeRef(const MethodReplacement& method_repl
     HRESULT hr;
     type_ref = mdTypeRefNil;
 
-    if (metadata_.assemblyName == method_replacement.wrapper_method.assembly.name) {
+    if (metadata_.assemblyName == method_replacement.wrapper_method.assembly.name)
+    {
         // type is defined in this assembly
         hr = metadata_emit_->DefineTypeRefByName(module_, method_replacement.wrapper_method.type_name.c_str(),
                                                  &type_ref);
-    } else {
+    }
+    else
+    {
         // type is defined in another assembly,
         // find a reference to the assembly where type lives
         const auto assembly_ref = FindAssemblyRef(assembly_import_, method_replacement.wrapper_method.assembly.name);
-        if (assembly_ref == mdAssemblyRefNil) {
+        if (assembly_ref == mdAssemblyRefNil)
+        {
             // TODO: emit assembly reference if not found?
             Warn("Assembly reference for", method_replacement.wrapper_method.assembly.name, " not found");
             return E_FAIL;
@@ -76,7 +87,8 @@ HRESULT MetadataBuilder::FindWrapperTypeRef(const MethodReplacement& method_repl
         hr =
             metadata_import_->FindTypeRef(assembly_ref, method_replacement.wrapper_method.type_name.c_str(), &type_ref);
 
-        if (hr == HRESULT(0x80131130) /* record not found on lookup */) {
+        if (hr == HRESULT(0x80131130) /* record not found on lookup */)
+        {
             // if typeRef not found, create a new one by emitting a metadata token
             hr = metadata_emit_->DefineTypeRefByName(assembly_ref, method_replacement.wrapper_method.type_name.c_str(),
                                                      &type_ref);
@@ -96,14 +108,16 @@ HRESULT MetadataBuilder::StoreWrapperMethodRef(const MethodReplacement& method_r
     const auto& cache_key = method_replacement.wrapper_method.get_method_cache_key();
     mdMemberRef member_ref = mdMemberRefNil;
 
-    if (metadata_.TryGetWrapperMemberRef(cache_key, member_ref)) {
+    if (metadata_.TryGetWrapperMemberRef(cache_key, member_ref))
+    {
         // this member was already resolved
         return S_OK;
     }
 
     mdTypeRef type_ref = mdTypeRefNil;
     HRESULT hr = FindWrapperTypeRef(method_replacement, type_ref);
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         // Record that this cache_key failed
         metadata_.SetFailedWrapperMemberKey(cache_key);
         return hr;
@@ -118,18 +132,21 @@ HRESULT MetadataBuilder::StoreWrapperMethodRef(const MethodReplacement& method_r
     // In case of the signature data size is zero we asume we are in a calltarget scenario
     // where we use the TypeRef but not a MemberRef.
 
-    if (signature_data.size() > 0) {
+    if (signature_data.size() > 0)
+    {
         // callsite integrations do this path.
         hr = metadata_import_->FindMemberRef(type_ref, method_replacement.wrapper_method.method_name.c_str(),
-                                             signature_data.data(), (DWORD)(signature_data.size()), &member_ref);
+                                             signature_data.data(), (DWORD) (signature_data.size()), &member_ref);
 
-        if (hr == HRESULT(0x80131130) /* record not found on lookup */) {
+        if (hr == HRESULT(0x80131130) /* record not found on lookup */)
+        {
             // if memberRef not found, create it by emitting a metadata token
             hr = metadata_emit_->DefineMemberRef(type_ref, method_replacement.wrapper_method.method_name.c_str(),
-                                                 signature_data.data(), (DWORD)(signature_data.size()), &member_ref);
+                                                 signature_data.data(), (DWORD) (signature_data.size()), &member_ref);
         }
 
-        if (FAILED(hr)) {
+        if (FAILED(hr))
+        {
             // Record that this cache_key failed
             metadata_.SetFailedWrapperMemberKey(cache_key);
             return hr;

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.h
@@ -31,7 +31,8 @@ public:
         metadata_emit_(metadata_emit),
         assembly_import_(assembly_import),
         assembly_emit_(assembly_emit)
-    {}
+    {
+    }
 
     HRESULT StoreWrapperMethodRef(const MethodReplacement& method_replacement) const;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/metadata_builder.h
@@ -6,10 +6,12 @@
 #include "logging.h"
 #include "module_metadata.h"
 
-namespace trace {
+namespace trace
+{
 
-class MetadataBuilder {
-  private:
+class MetadataBuilder
+{
+private:
     ModuleMetadata& metadata_;
     const mdModule module_ = mdModuleNil;
     const ComPtr<IMetaDataImport2> metadata_import_{};
@@ -19,14 +21,17 @@ class MetadataBuilder {
 
     HRESULT FindWrapperTypeRef(const MethodReplacement& method_replacement, mdTypeRef& type_ref_out) const;
 
-  public:
+public:
     MetadataBuilder(ModuleMetadata& metadata, const mdModule module, ComPtr<IMetaDataImport2> metadata_import,
                     ComPtr<IMetaDataEmit> metadata_emit, ComPtr<IMetaDataAssemblyImport> assembly_import,
-                    ComPtr<IMetaDataAssemblyEmit> assembly_emit)
-        : metadata_(metadata), module_(module), metadata_import_(metadata_import), metadata_emit_(metadata_emit),
-          assembly_import_(assembly_import), assembly_emit_(assembly_emit)
-    {
-    }
+                    ComPtr<IMetaDataAssemblyEmit> assembly_emit) :
+        metadata_(metadata),
+        module_(module),
+        metadata_import_(metadata_import),
+        metadata_emit_(metadata_emit),
+        assembly_import_(assembly_import),
+        assembly_emit_(assembly_emit)
+    {}
 
     HRESULT StoreWrapperMethodRef(const MethodReplacement& method_replacement) const;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/miniutf.hpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/miniutf.hpp
@@ -23,7 +23,8 @@
 
 #include <string>
 
-namespace miniutf {
+namespace miniutf
+{
 
 /*
  * Character-at-a-time encoding. Convert pt to UTF-8/16 and append to out.

--- a/src/Datadog.Trace.ClrProfiler.Native/miniutfdata.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/miniutfdata.h
@@ -932,8 +932,7 @@ static const uint16_t decomp_idx_t2[] = {
 
 int32_t decomp_idx(int32_t codepoint)
 {
-    if (codepoint >= 195102)
-        return 0;
+    if (codepoint >= 195102) return 0;
     return decomp_idx_t2[(decomp_idx_t1[codepoint >> 6] << 6) + (codepoint & 63)];
 }
 static const uint8_t comp_idx_t1[] = {
@@ -1110,8 +1109,7 @@ static const uint16_t comp_idx_t2[] = {
 
 int32_t comp_idx(int32_t codepoint)
 {
-    if (codepoint >= 69939)
-        return 0;
+    if (codepoint >= 69939) return 0;
     return comp_idx_t2[(comp_idx_t1[codepoint >> 5] << 5) + (codepoint & 31)];
 }
 static const uint8_t ccc_t1[] = {
@@ -1383,8 +1381,7 @@ static const uint8_t ccc_t2[] = {
 
 int32_t ccc(int32_t codepoint)
 {
-    if (codepoint >= 119365)
-        return 0;
+    if (codepoint >= 119365) return 0;
     return ccc_t2[(ccc_t1[codepoint >> 6] << 6) + (codepoint & 63)];
 }
 static const int32_t lowercase_offset_values[] = {
@@ -1524,8 +1521,7 @@ static const uint8_t lowercase_offset_t2[] = {
 int32_t lowercase_offset(int32_t codepoint)
 {
     int offset_index;
-    if (codepoint >= 66600)
-        return 0;
+    if (codepoint >= 66600) return 0;
     offset_index = lowercase_offset_t2[(lowercase_offset_t1[codepoint >> 6] << 6) + (codepoint & 63)];
     return lowercase_offset_values[offset_index];
 }

--- a/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
@@ -46,7 +46,8 @@ public:
         module_version_id(module_version_id),
         integrations(integrations),
         corAssemblyProperty(corAssemblyProperty)
-    {}
+    {
+    }
 
     bool TryGetWrapperMemberRef(const WSTRING& keyIn, mdMemberRef& valueOut) const
     {

--- a/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
@@ -11,16 +11,18 @@
 #include "integration.h"
 #include "string.h"
 
-namespace trace {
+namespace trace
+{
 
-class ModuleMetadata {
-  private:
+class ModuleMetadata
+{
+private:
     std::unordered_map<WSTRING, mdMemberRef> wrapper_refs{};
     std::unordered_map<WSTRING, mdTypeRef> wrapper_parent_type{};
     std::unordered_set<WSTRING> failed_wrapper_keys{};
     CallTargetTokens* calltargetTokens = nullptr;
 
-  public:
+public:
     const ComPtr<IMetaDataImport2> metadata_import{};
     const ComPtr<IMetaDataEmit2> metadata_emit{};
     const ComPtr<IMetaDataAssemblyImport> assembly_import{};
@@ -34,18 +36,24 @@ class ModuleMetadata {
     ModuleMetadata(ComPtr<IMetaDataImport2> metadata_import, ComPtr<IMetaDataEmit2> metadata_emit,
                    ComPtr<IMetaDataAssemblyImport> assembly_import, ComPtr<IMetaDataAssemblyEmit> assembly_emit,
                    WSTRING assembly_name, AppDomainID app_domain_id, GUID module_version_id,
-                   std::vector<IntegrationMethod> integrations, AssemblyProperty* corAssemblyProperty)
-        : metadata_import(metadata_import), metadata_emit(metadata_emit), assembly_import(assembly_import),
-          assembly_emit(assembly_emit), assemblyName(assembly_name), app_domain_id(app_domain_id),
-          module_version_id(module_version_id), integrations(integrations), corAssemblyProperty(corAssemblyProperty)
-    {
-    }
+                   std::vector<IntegrationMethod> integrations, AssemblyProperty* corAssemblyProperty) :
+        metadata_import(metadata_import),
+        metadata_emit(metadata_emit),
+        assembly_import(assembly_import),
+        assembly_emit(assembly_emit),
+        assemblyName(assembly_name),
+        app_domain_id(app_domain_id),
+        module_version_id(module_version_id),
+        integrations(integrations),
+        corAssemblyProperty(corAssemblyProperty)
+    {}
 
     bool TryGetWrapperMemberRef(const WSTRING& keyIn, mdMemberRef& valueOut) const
     {
         const auto search = wrapper_refs.find(keyIn);
 
-        if (search != wrapper_refs.end()) {
+        if (search != wrapper_refs.end())
+        {
             valueOut = search->second;
             return true;
         }
@@ -57,7 +65,8 @@ class ModuleMetadata {
     {
         const auto search = wrapper_parent_type.find(keyIn);
 
-        if (search != wrapper_parent_type.end()) {
+        if (search != wrapper_parent_type.end())
+        {
             valueOut = search->second;
             return true;
         }
@@ -69,7 +78,8 @@ class ModuleMetadata {
     {
         const auto search = failed_wrapper_keys.find(key);
 
-        if (search != failed_wrapper_keys.end()) {
+        if (search != failed_wrapper_keys.end())
+        {
             return true;
         }
 
@@ -94,11 +104,13 @@ class ModuleMetadata {
     inline std::vector<MethodReplacement> GetMethodReplacementsForCaller(const trace::FunctionInfo& caller)
     {
         std::vector<MethodReplacement> enabled;
-        for (auto& i : integrations) {
+        for (auto& i : integrations)
+        {
             if ((i.replacement.caller_method.type_name.empty() ||
                  i.replacement.caller_method.type_name == caller.type.name) &&
                 (i.replacement.caller_method.method_name.empty() ||
-                 i.replacement.caller_method.method_name == caller.name)) {
+                 i.replacement.caller_method.method_name == caller.name))
+            {
                 enabled.push_back(i.replacement);
             }
         }
@@ -107,7 +119,8 @@ class ModuleMetadata {
 
     inline CallTargetTokens* GetCallTargetTokens()
     {
-        if (calltargetTokens == nullptr) {
+        if (calltargetTokens == nullptr)
+        {
             calltargetTokens = new CallTargetTokens(this);
         }
         return calltargetTokens;

--- a/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -22,13 +22,15 @@
 #include "string.h" // NOLINT
 #include "util.h"
 
-namespace trace {
+namespace trace
+{
 
 inline WSTRING DatadogLogFilePath(const std::string& file_name_suffix)
 {
     WSTRING directory = GetEnvironmentValue(environment::log_directory);
 
-    if (directory.length() > 0) {
+    if (directory.length() > 0)
+    {
         return directory +
 #ifdef _WIN32
                WStr('\\') +
@@ -40,7 +42,8 @@ inline WSTRING DatadogLogFilePath(const std::string& file_name_suffix)
 
     WSTRING path = GetEnvironmentValue(environment::log_path);
 
-    if (path.length() > 0) {
+    if (path.length() > 0)
+    {
         return path;
     }
 
@@ -50,9 +53,12 @@ inline WSTRING DatadogLogFilePath(const std::string& file_name_suffix)
     const errno_t result = _dupenv_s(&p_program_data, &length, "PROGRAMDATA");
     std::string program_data;
 
-    if (SUCCEEDED(result) && p_program_data != nullptr && length > 0) {
+    if (SUCCEEDED(result) && p_program_data != nullptr && length > 0)
+    {
         program_data = std::string(p_program_data);
-    } else {
+    }
+    else
+    {
         program_data = R"(C:\ProgramData)";
     }
 

--- a/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -1,11 +1,13 @@
 #include "rejit_handler.h"
 
-namespace trace {
+namespace trace
+{
 
 RejitItem::RejitItem(int length, ModuleID* modulesId, mdMethodDef* methodDefs)
 {
     length_ = length;
-    if (length > 0) {
+    if (length > 0)
+    {
         ModuleID* myModulesIds = new ModuleID[length];
         memcpy(myModulesIds, modulesId, length * sizeof(ModuleID));
         moduleIds_ = myModulesIds;
@@ -18,11 +20,13 @@ RejitItem::RejitItem(int length, ModuleID* modulesId, mdMethodDef* methodDefs)
 
 void RejitItem::DeleteArray()
 {
-    if (moduleIds_ != nullptr) {
+    if (moduleIds_ != nullptr)
+    {
         delete[] moduleIds_;
         moduleIds_ = nullptr;
     }
-    if (methodDefs_ != nullptr) {
+    if (methodDefs_ != nullptr)
+    {
         delete[] methodDefs_;
         methodDefs_ = nullptr;
     }
@@ -31,8 +35,8 @@ void RejitItem::DeleteArray()
 void RejitHandlerModuleMethod::AddFunctionId(FunctionID functionId)
 {
     std::lock_guard<std::mutex> guard(functionsIds_lock);
-    auto moduleHandler = (RejitHandlerModule*)module;
-    auto rejitHandler = (RejitHandler*)moduleHandler->GetHandler();
+    auto moduleHandler = (RejitHandlerModule*) module;
+    auto rejitHandler = (RejitHandler*) moduleHandler->GetHandler();
     functionsIds.insert(functionId);
     rejitHandler->_addFunctionToSet(functionId, this);
 }
@@ -47,7 +51,8 @@ RejitHandlerModuleMethod* RejitHandlerModule::GetOrAddMethod(mdMethodDef methodD
     std::lock_guard<std::mutex> guard(methods_lock);
 
     auto find_res = methods.find(methodDef);
-    if (find_res != methods.end()) {
+    if (find_res != methods.end())
+    {
         return find_res->second;
     }
 
@@ -60,7 +65,8 @@ bool RejitHandlerModule::TryGetMethod(mdMethodDef methodDef, RejitHandlerModuleM
     std::lock_guard<std::mutex> guard(methods_lock);
 
     auto find_res = methods.find(methodDef);
-    if (find_res != methods.end()) {
+    if (find_res != methods.end())
+    {
         *methodHandler = find_res->second;
         return true;
     }
@@ -73,7 +79,8 @@ RejitHandlerModuleMethod* RejitHandler::GetModuleMethodFromFunctionId(FunctionID
     {
         std::lock_guard<std::mutex> guard(methodByFunctionId_lock);
         auto find_res = methodByFunctionId.find(functionId);
-        if (find_res != methodByFunctionId.end()) {
+        if (find_res != methodByFunctionId.end())
+        {
             return find_res->second;
         }
     }
@@ -83,7 +90,8 @@ RejitHandlerModuleMethod* RejitHandler::GetModuleMethodFromFunctionId(FunctionID
 
     HRESULT hr = profilerInfo->GetFunctionInfo(functionId, nullptr, &moduleId, &function_token);
 
-    if (FAILED(hr)) {
+    if (FAILED(hr))
+    {
         Warn("RejitHandler::GetModuleMethodFromFunctionId: Call to "
              "ICorProfilerInfo4.GetFunctionInfo() "
              "failed for ",
@@ -103,7 +111,8 @@ RejitHandlerModule* RejitHandler::GetOrAddModule(ModuleID moduleId)
     std::lock_guard<std::mutex> guard(modules_lock);
 
     auto find_res = modules.find(moduleId);
-    if (find_res != modules.end()) {
+    if (find_res != modules.end())
+    {
         return find_res->second;
     }
 
@@ -117,7 +126,8 @@ bool RejitHandler::TryGetModule(ModuleID moduleId, RejitHandlerModule** moduleHa
     std::lock_guard<std::mutex> guard(modules_lock);
 
     auto find_res = modules.find(moduleId);
-    if (find_res != modules.end()) {
+    if (find_res != modules.end())
+    {
         *moduleHandler = find_res->second;
         return true;
     }
@@ -133,14 +143,16 @@ HRESULT RejitHandler::NotifyReJITParameters(ModuleID moduleId, mdMethodDef metho
     auto methodHandler = moduleHandler->GetOrAddMethod(methodId);
     methodHandler->SetFunctionControl(pFunctionControl);
 
-    if (methodHandler->GetMethodDef() == mdMethodDefNil) {
+    if (methodHandler->GetMethodDef() == mdMethodDefNil)
+    {
         Warn("NotifyReJITCompilationStarted: mdMethodDef is missing for "
              "MethodDef: ",
              methodId);
         return S_FALSE;
     }
 
-    if (methodHandler->GetFunctionControl() == nullptr) {
+    if (methodHandler->GetFunctionControl() == nullptr)
+    {
         Warn("NotifyReJITCompilationStarted: ICorProfilerFunctionControl is missing "
              "for "
              "MethodDef: ",
@@ -148,28 +160,32 @@ HRESULT RejitHandler::NotifyReJITParameters(ModuleID moduleId, mdMethodDef metho
         return S_FALSE;
     }
 
-    if (methodHandler->GetFunctionInfo() == nullptr) {
+    if (methodHandler->GetFunctionInfo() == nullptr)
+    {
         Warn("NotifyReJITCompilationStarted: FunctionInfo is missing for "
              "MethodDef: ",
              methodId);
         return S_FALSE;
     }
 
-    if (methodHandler->GetMethodReplacement() == nullptr) {
+    if (methodHandler->GetMethodReplacement() == nullptr)
+    {
         Warn("NotifyReJITCompilationStarted: MethodReplacement is missing for "
              "MethodDef: ",
              methodId);
         return S_FALSE;
     }
 
-    if (moduleHandler->GetModuleId() == 0) {
+    if (moduleHandler->GetModuleId() == 0)
+    {
         Warn("NotifyReJITCompilationStarted: ModuleID is missing for "
              "MethodDef: ",
              methodId);
         return S_FALSE;
     }
 
-    if (moduleHandler->GetModuleMetadata() == nullptr) {
+    if (moduleHandler->GetModuleMetadata() == nullptr)
+    {
         Warn("NotifyReJITCompilationStarted: ModuleMetadata is missing for "
              "MethodDef: ",
              methodId);

--- a/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.cpp
@@ -46,15 +46,15 @@ bool ParseOptionalCustomMods(PCCOR_SIGNATURE* p_sig)
     {
         switch (**p_sig)
         {
-        case ELEMENT_TYPE_CMOD_OPT:
-        case ELEMENT_TYPE_CMOD_REQD:
-            if (!ParseCustomMod(p_sig))
-            {
-                return false;
-            }
-            break;
-        default:
-            return true;
+            case ELEMENT_TYPE_CMOD_OPT:
+            case ELEMENT_TYPE_CMOD_REQD:
+                if (!ParseCustomMod(p_sig))
+                {
+                    return false;
+                }
+                break;
+            default:
+                return true;
         }
     }
 
@@ -211,102 +211,102 @@ bool ParseType(PCCOR_SIGNATURE* p_sig)
 
     switch (cor_element_type)
     {
-    case ELEMENT_TYPE_VOID:
-    case ELEMENT_TYPE_BOOLEAN:
-    case ELEMENT_TYPE_CHAR:
-    case ELEMENT_TYPE_I1:
-    case ELEMENT_TYPE_U1:
-    case ELEMENT_TYPE_I2:
-    case ELEMENT_TYPE_U2:
-    case ELEMENT_TYPE_I4:
-    case ELEMENT_TYPE_U4:
-    case ELEMENT_TYPE_I8:
-    case ELEMENT_TYPE_U8:
-    case ELEMENT_TYPE_R4:
-    case ELEMENT_TYPE_R8:
-    case ELEMENT_TYPE_STRING:
-    case ELEMENT_TYPE_OBJECT:
-        return true;
-
-    case ELEMENT_TYPE_PTR:
-        // Format: PTR CustomMod* VOID
-        // Format: PTR CustomMod* Type
-        if (!ParseOptionalCustomMods(p_sig))
-        {
-            return false;
-        }
-
-        if (**p_sig == ELEMENT_TYPE_VOID)
-        {
-            *p_sig += 1;
+        case ELEMENT_TYPE_VOID:
+        case ELEMENT_TYPE_BOOLEAN:
+        case ELEMENT_TYPE_CHAR:
+        case ELEMENT_TYPE_I1:
+        case ELEMENT_TYPE_U1:
+        case ELEMENT_TYPE_I2:
+        case ELEMENT_TYPE_U2:
+        case ELEMENT_TYPE_I4:
+        case ELEMENT_TYPE_U4:
+        case ELEMENT_TYPE_I8:
+        case ELEMENT_TYPE_U8:
+        case ELEMENT_TYPE_R4:
+        case ELEMENT_TYPE_R8:
+        case ELEMENT_TYPE_STRING:
+        case ELEMENT_TYPE_OBJECT:
             return true;
-        }
-        else
-        {
-            return ParseType(p_sig);
-        }
 
-    case ELEMENT_TYPE_VALUETYPE:
-    case ELEMENT_TYPE_CLASS:
-        // Format: CLASS TypeDefOrRefEncoded
-        // Format: VALUETYPE TypeDefOrRefEncoded
-        return ParseTypeDefOrRefEncoded(p_sig);
+        case ELEMENT_TYPE_PTR:
+            // Format: PTR CustomMod* VOID
+            // Format: PTR CustomMod* Type
+            if (!ParseOptionalCustomMods(p_sig))
+            {
+                return false;
+            }
 
-    case ELEMENT_TYPE_FNPTR:
-        // Format: FNPTR MethodDefSig
-        // Format: FNPTR MethodRefSig
-        return ParseMethod(p_sig);
+            if (**p_sig == ELEMENT_TYPE_VOID)
+            {
+                *p_sig += 1;
+                return true;
+            }
+            else
+            {
+                return ParseType(p_sig);
+            }
 
-    case ELEMENT_TYPE_ARRAY:
-        // Format: ARRAY Type ArrayShape
-        if (!ParseType(p_sig))
-        {
-            return false;
-        }
-        return ParseArrayShape(p_sig);
+        case ELEMENT_TYPE_VALUETYPE:
+        case ELEMENT_TYPE_CLASS:
+            // Format: CLASS TypeDefOrRefEncoded
+            // Format: VALUETYPE TypeDefOrRefEncoded
+            return ParseTypeDefOrRefEncoded(p_sig);
 
-    case ELEMENT_TYPE_SZARRAY:
-        // Format: SZARRAY CustomMod* Type
-        if (!ParseOptionalCustomMods(p_sig))
-        {
-            return false;
-        }
-        return ParseType(p_sig);
+        case ELEMENT_TYPE_FNPTR:
+            // Format: FNPTR MethodDefSig
+            // Format: FNPTR MethodRefSig
+            return ParseMethod(p_sig);
 
-    case ELEMENT_TYPE_GENERICINST:
-        if (**p_sig != ELEMENT_TYPE_VALUETYPE && **p_sig != ELEMENT_TYPE_CLASS)
-        {
-            return false;
-        }
-
-        *p_sig += 1;
-        if (!ParseTypeDefOrRefEncoded(p_sig))
-        {
-            return false;
-        }
-
-        if (!ParseNumber(p_sig, &number))
-        {
-            return false;
-        }
-
-        for (ULONG i = 0; i < number; i++)
-        {
+        case ELEMENT_TYPE_ARRAY:
+            // Format: ARRAY Type ArrayShape
             if (!ParseType(p_sig))
             {
                 return false;
             }
-        }
-        return true;
+            return ParseArrayShape(p_sig);
 
-    case ELEMENT_TYPE_VAR:
-    case ELEMENT_TYPE_MVAR:
-        // Format: VAR Number
-        // Format: MVAR Number
-        return ParseNumber(p_sig, &number);
+        case ELEMENT_TYPE_SZARRAY:
+            // Format: SZARRAY CustomMod* Type
+            if (!ParseOptionalCustomMods(p_sig))
+            {
+                return false;
+            }
+            return ParseType(p_sig);
 
-    default:
-        return false;
+        case ELEMENT_TYPE_GENERICINST:
+            if (**p_sig != ELEMENT_TYPE_VALUETYPE && **p_sig != ELEMENT_TYPE_CLASS)
+            {
+                return false;
+            }
+
+            *p_sig += 1;
+            if (!ParseTypeDefOrRefEncoded(p_sig))
+            {
+                return false;
+            }
+
+            if (!ParseNumber(p_sig, &number))
+            {
+                return false;
+            }
+
+            for (ULONG i = 0; i < number; i++)
+            {
+                if (!ParseType(p_sig))
+                {
+                    return false;
+                }
+            }
+            return true;
+
+        case ELEMENT_TYPE_VAR:
+        case ELEMENT_TYPE_MVAR:
+            // Format: VAR Number
+            // Format: MVAR Number
+            return ParseNumber(p_sig, &number);
+
+        default:
+            return false;
     }
 }
 } // namespace trace

--- a/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.cpp
@@ -1,11 +1,13 @@
 #include "sig_helpers.h"
 
-namespace trace {
+namespace trace
+{
 
 bool ParseNumber(PCCOR_SIGNATURE* p_sig, ULONG* number)
 {
     ULONG result = CorSigUncompressData(*p_sig, number);
-    if (result == -1) {
+    if (result == -1)
+    {
         return false;
     }
 
@@ -18,7 +20,8 @@ bool ParseTypeDefOrRefEncoded(PCCOR_SIGNATURE* p_sig)
     mdToken type_token;
     ULONG result;
     result = CorSigUncompressToken(*p_sig, &type_token);
-    if (result == -1) {
+    if (result == -1)
+    {
         return false;
     }
 
@@ -28,7 +31,8 @@ bool ParseTypeDefOrRefEncoded(PCCOR_SIGNATURE* p_sig)
 
 bool ParseCustomMod(PCCOR_SIGNATURE* p_sig)
 {
-    if (**p_sig == ELEMENT_TYPE_CMOD_OPT || **p_sig == ELEMENT_TYPE_CMOD_REQD) {
+    if (**p_sig == ELEMENT_TYPE_CMOD_OPT || **p_sig == ELEMENT_TYPE_CMOD_REQD)
+    {
         *p_sig += 1;
         return ParseTypeDefOrRefEncoded(p_sig);
     }
@@ -38,11 +42,14 @@ bool ParseCustomMod(PCCOR_SIGNATURE* p_sig)
 
 bool ParseOptionalCustomMods(PCCOR_SIGNATURE* p_sig)
 {
-    while (true) {
-        switch (**p_sig) {
+    while (true)
+    {
+        switch (**p_sig)
+        {
         case ELEMENT_TYPE_CMOD_OPT:
         case ELEMENT_TYPE_CMOD_REQD:
-            if (!ParseCustomMod(p_sig)) {
+            if (!ParseCustomMod(p_sig))
+            {
                 return false;
             }
             break;
@@ -56,16 +63,19 @@ bool ParseOptionalCustomMods(PCCOR_SIGNATURE* p_sig)
 
 bool ParseRetType(PCCOR_SIGNATURE* p_sig)
 {
-    if (!ParseOptionalCustomMods(p_sig)) {
+    if (!ParseOptionalCustomMods(p_sig))
+    {
         return false;
     }
 
-    if (**p_sig == ELEMENT_TYPE_TYPEDBYREF || **p_sig == ELEMENT_TYPE_VOID) {
+    if (**p_sig == ELEMENT_TYPE_TYPEDBYREF || **p_sig == ELEMENT_TYPE_VOID)
+    {
         *p_sig += 1;
         return true;
     }
 
-    if (**p_sig == ELEMENT_TYPE_BYREF) {
+    if (**p_sig == ELEMENT_TYPE_BYREF)
+    {
         *p_sig += 1;
     }
 
@@ -74,16 +84,19 @@ bool ParseRetType(PCCOR_SIGNATURE* p_sig)
 
 bool ParseParam(PCCOR_SIGNATURE* p_sig)
 {
-    if (!ParseOptionalCustomMods(p_sig)) {
+    if (!ParseOptionalCustomMods(p_sig))
+    {
         return false;
     }
 
-    if (**p_sig == ELEMENT_TYPE_TYPEDBYREF) {
+    if (**p_sig == ELEMENT_TYPE_TYPEDBYREF)
+    {
         *p_sig += 1;
         return true;
     }
 
-    if (**p_sig == ELEMENT_TYPE_BYREF) {
+    if (**p_sig == ELEMENT_TYPE_BYREF)
+    {
         *p_sig += 1;
     }
 
@@ -94,28 +107,35 @@ bool ParseMethod(PCCOR_SIGNATURE* p_sig)
 {
     // Format:  [[HASTHIS] [EXPLICITTHIS]] (DEFAULT|VARARG|GENERIC GenParamCount)
     //                    ParamCount RetType Param* [SENTINEL Param+]
-    if (**p_sig == IMAGE_CEE_CS_CALLCONV_GENERIC) {
+    if (**p_sig == IMAGE_CEE_CS_CALLCONV_GENERIC)
+    {
         *p_sig += 1;
 
         ULONG generic_count = 0;
-        if (!ParseNumber(p_sig, &generic_count)) {
+        if (!ParseNumber(p_sig, &generic_count))
+        {
             return false;
         }
     }
 
     ULONG param_count = 0;
-    if (!ParseNumber(p_sig, &param_count)) {
+    if (!ParseNumber(p_sig, &param_count))
+    {
         return false;
     }
 
-    if (!ParseRetType(p_sig)) {
+    if (!ParseRetType(p_sig))
+    {
         return false;
     }
 
     bool sentinel_found = false;
-    for (ULONG i = 0; i < param_count; i++) {
-        if (**p_sig == ELEMENT_TYPE_SENTINEL) {
-            if (sentinel_found) {
+    for (ULONG i = 0; i < param_count; i++)
+    {
+        if (**p_sig == ELEMENT_TYPE_SENTINEL)
+        {
+            if (sentinel_found)
+            {
                 return false;
             }
 
@@ -123,7 +143,8 @@ bool ParseMethod(PCCOR_SIGNATURE* p_sig)
             *p_sig += 1;
         }
 
-        if (!ParseParam(p_sig)) {
+        if (!ParseParam(p_sig))
+        {
             return false;
         }
     }
@@ -135,22 +156,28 @@ bool ParseArrayShape(PCCOR_SIGNATURE* p_sig)
 {
     // Format: Rank NumSizes Size* NumLoBounds LoBound*
     ULONG rank = 0, numsizes = 0, size = 0;
-    if (!ParseNumber(p_sig, &rank) || !ParseNumber(p_sig, &numsizes)) {
+    if (!ParseNumber(p_sig, &rank) || !ParseNumber(p_sig, &numsizes))
+    {
         return false;
     }
 
-    for (ULONG i = 0; i < numsizes; i++) {
-        if (!ParseNumber(p_sig, &size)) {
+    for (ULONG i = 0; i < numsizes; i++)
+    {
+        if (!ParseNumber(p_sig, &size))
+        {
             return false;
         }
     }
 
-    if (!ParseNumber(p_sig, &numsizes)) {
+    if (!ParseNumber(p_sig, &numsizes))
+    {
         return false;
     }
 
-    for (ULONG i = 0; i < numsizes; i++) {
-        if (!ParseNumber(p_sig, &size)) {
+    for (ULONG i = 0; i < numsizes; i++)
+    {
+        if (!ParseNumber(p_sig, &size))
+        {
             return false;
         }
     }
@@ -182,7 +209,8 @@ bool ParseType(PCCOR_SIGNATURE* p_sig)
     ULONG number = 0;
     *p_sig += 1;
 
-    switch (cor_element_type) {
+    switch (cor_element_type)
+    {
     case ELEMENT_TYPE_VOID:
     case ELEMENT_TYPE_BOOLEAN:
     case ELEMENT_TYPE_CHAR:
@@ -203,14 +231,18 @@ bool ParseType(PCCOR_SIGNATURE* p_sig)
     case ELEMENT_TYPE_PTR:
         // Format: PTR CustomMod* VOID
         // Format: PTR CustomMod* Type
-        if (!ParseOptionalCustomMods(p_sig)) {
+        if (!ParseOptionalCustomMods(p_sig))
+        {
             return false;
         }
 
-        if (**p_sig == ELEMENT_TYPE_VOID) {
+        if (**p_sig == ELEMENT_TYPE_VOID)
+        {
             *p_sig += 1;
             return true;
-        } else {
+        }
+        else
+        {
             return ParseType(p_sig);
         }
 
@@ -227,34 +259,41 @@ bool ParseType(PCCOR_SIGNATURE* p_sig)
 
     case ELEMENT_TYPE_ARRAY:
         // Format: ARRAY Type ArrayShape
-        if (!ParseType(p_sig)) {
+        if (!ParseType(p_sig))
+        {
             return false;
         }
         return ParseArrayShape(p_sig);
 
     case ELEMENT_TYPE_SZARRAY:
         // Format: SZARRAY CustomMod* Type
-        if (!ParseOptionalCustomMods(p_sig)) {
+        if (!ParseOptionalCustomMods(p_sig))
+        {
             return false;
         }
         return ParseType(p_sig);
 
     case ELEMENT_TYPE_GENERICINST:
-        if (**p_sig != ELEMENT_TYPE_VALUETYPE && **p_sig != ELEMENT_TYPE_CLASS) {
+        if (**p_sig != ELEMENT_TYPE_VALUETYPE && **p_sig != ELEMENT_TYPE_CLASS)
+        {
             return false;
         }
 
         *p_sig += 1;
-        if (!ParseTypeDefOrRefEncoded(p_sig)) {
+        if (!ParseTypeDefOrRefEncoded(p_sig))
+        {
             return false;
         }
 
-        if (!ParseNumber(p_sig, &number)) {
+        if (!ParseNumber(p_sig, &number))
+        {
             return false;
         }
 
-        for (ULONG i = 0; i < number; i++) {
-            if (!ParseType(p_sig)) {
+        for (ULONG i = 0; i < number; i++)
+        {
+            if (!ParseType(p_sig))
+            {
                 return false;
             }
         }

--- a/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/sig_helpers.h
@@ -2,7 +2,8 @@
 
 #include <corhlpr.h>
 
-namespace trace {
+namespace trace
+{
 
 bool ParseType(PCCOR_SIGNATURE* p_sig);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/stats.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/stats.h
@@ -5,13 +5,15 @@
 
 #include "util.h"
 
-namespace trace {
+namespace trace
+{
 
-class SWStat {
+class SWStat
+{
     std::atomic_ullong* _value;
     std::chrono::steady_clock::time_point _startTime;
 
-  public:
+public:
     SWStat(std::atomic_ullong* value)
     {
         _value = value;
@@ -24,10 +26,11 @@ class SWStat {
     }
 };
 
-class Stats : public Singleton<Stats> {
+class Stats : public Singleton<Stats>
+{
     friend class Singleton<Stats>;
 
-  private:
+private:
     std::atomic_ullong callTargetRequestRejit = {0};
     std::atomic_ullong callTargetRewriter = {0};
     std::atomic_ullong jitInlining = {0};
@@ -46,7 +49,7 @@ class Stats : public Singleton<Stats> {
     std::atomic_uint moduleLoadFinishedCount = {0};
     std::atomic_uint assemblyLoadFinishedCount = {0};
 
-  public:
+public:
     Stats()
     {
         callTargetRequestRejit = 0;

--- a/src/Datadog.Trace.ClrProfiler.Native/string.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.cpp
@@ -6,7 +6,8 @@
 #include "miniutf.hpp"
 #endif
 
-namespace trace {
+namespace trace
+{
 
 std::string ToString(const std::string& str)
 {
@@ -23,18 +24,18 @@ std::string ToString(const uint64_t i)
 std::string ToString(const WSTRING& wstr)
 {
 #ifdef _WIN32
-    if (wstr.empty())
-        return std::string();
+    if (wstr.empty()) return std::string();
 
     std::string tmpStr(tmp_buffer_size, 0);
     int size_needed =
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &tmpStr[0], tmp_buffer_size, NULL, NULL);
-    if (size_needed < tmp_buffer_size) {
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) wstr.size(), &tmpStr[0], tmp_buffer_size, NULL, NULL);
+    if (size_needed < tmp_buffer_size)
+    {
         return tmpStr.substr(0, size_needed);
     }
 
     std::string strTo(size_needed, 0);
-    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
+    WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) wstr.size(), &strTo[0], size_needed, NULL, NULL);
     return strTo;
 #else
     std::u16string ustr(reinterpret_cast<const char16_t*>(wstr.c_str()));
@@ -45,17 +46,17 @@ std::string ToString(const WSTRING& wstr)
 WSTRING ToWSTRING(const std::string& str)
 {
 #ifdef _WIN32
-    if (str.empty())
-        return std::wstring();
+    if (str.empty()) return std::wstring();
 
     std::wstring tmpStr(tmp_buffer_size, 0);
-    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &tmpStr[0], tmp_buffer_size);
-    if (size_needed < tmp_buffer_size) {
+    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int) str.size(), &tmpStr[0], tmp_buffer_size);
+    if (size_needed < tmp_buffer_size)
+    {
         return tmpStr.substr(0, size_needed);
     }
 
     std::wstring wstrTo(size_needed, 0);
-    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstrTo[0], size_needed);
+    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int) str.size(), &wstrTo[0], size_needed);
     return wstrTo;
 #else
     auto ustr = miniutf::to_utf16(str);

--- a/src/Datadog.Trace.ClrProfiler.Native/string.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/string.h
@@ -13,7 +13,8 @@
 #define WStrLen(value) (size_t) std::char_traits<char16_t>::length(value)
 #endif
 
-namespace trace {
+namespace trace
+{
 
 typedef std::basic_string<WCHAR> WSTRING;
 

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -62,7 +62,7 @@ WSTRING GetEnvironmentValue(const WSTRING& name)
 #ifdef _WIN32
     const size_t max_buf_size = 4096;
     WSTRING buf(max_buf_size, 0);
-    auto len = GetEnvironmentVariable(name.data(), buf.data(), (DWORD) (buf.size()));
+    auto len = GetEnvironmentVariable(name.data(), buf.data(), (DWORD)(buf.size()));
     return Trim(buf.substr(0, len));
 #else
     auto cstr = std::getenv(ToString(name).c_str());

--- a/src/Datadog.Trace.ClrProfiler.Native/util.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.cpp
@@ -8,13 +8,17 @@
 #include <string> //NOLINT
 #include <vector>
 
-namespace trace {
+namespace trace
+{
 
-template <typename Out> void Split(const WSTRING& s, wchar_t delim, Out result)
+template <typename Out>
+void Split(const WSTRING& s, wchar_t delim, Out result)
 {
     size_t lpos = 0;
-    for (size_t i = 0; i < s.length(); i++) {
-        if (s[i] == delim) {
+    for (size_t i = 0; i < s.length(); i++)
+    {
+        if (s[i] == delim)
+        {
             *(result++) = s.substr(lpos, (i - lpos));
             lpos = i + 1;
         }
@@ -31,19 +35,22 @@ std::vector<WSTRING> Split(const WSTRING& s, wchar_t delim)
 
 WSTRING Trim(const WSTRING& str)
 {
-    if (str.length() == 0) {
+    if (str.length() == 0)
+    {
         return WStr("");
     }
 
     WSTRING trimmed = str;
 
     auto lpos = trimmed.find_first_not_of(WStr(" \t"));
-    if (lpos != WSTRING::npos && lpos > 0) {
+    if (lpos != WSTRING::npos && lpos > 0)
+    {
         trimmed = trimmed.substr(lpos);
     }
 
     auto rpos = trimmed.find_last_not_of(WStr(" \t"));
-    if (rpos != WSTRING::npos) {
+    if (rpos != WSTRING::npos)
+    {
         trimmed = trimmed.substr(0, rpos + 1);
     }
 
@@ -55,11 +62,12 @@ WSTRING GetEnvironmentValue(const WSTRING& name)
 #ifdef _WIN32
     const size_t max_buf_size = 4096;
     WSTRING buf(max_buf_size, 0);
-    auto len = GetEnvironmentVariable(name.data(), buf.data(), (DWORD)(buf.size()));
+    auto len = GetEnvironmentVariable(name.data(), buf.data(), (DWORD) (buf.size()));
     return Trim(buf.substr(0, len));
 #else
     auto cstr = std::getenv(ToString(name).c_str());
-    if (cstr == nullptr) {
+    if (cstr == nullptr)
+    {
         return WStr("");
     }
     std::string str(cstr);
@@ -71,9 +79,11 @@ WSTRING GetEnvironmentValue(const WSTRING& name)
 std::vector<WSTRING> GetEnvironmentValues(const WSTRING& name, const wchar_t delim)
 {
     std::vector<WSTRING> values;
-    for (auto s : Split(GetEnvironmentValue(name), delim)) {
+    for (auto s : Split(GetEnvironmentValue(name), delim))
+    {
         s = Trim(s);
-        if (!s.empty()) {
+        if (!s.empty())
+        {
             values.push_back(s);
         }
     }
@@ -89,9 +99,10 @@ constexpr char HexMap[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a'
 
 WSTRING HexStr(const void* dataPtr, int len)
 {
-    const unsigned char* data = (unsigned char*)dataPtr;
+    const unsigned char* data = (unsigned char*) dataPtr;
     WSTRING s(len * 2, ' ');
-    for (int i = 0; i < len; ++i) {
+    for (int i = 0; i < len; ++i)
+    {
         s[2 * i] = HexMap[(data[i] & 0xF0) >> 4];
         s[2 * i + 1] = HexMap[data[i] & 0x0F];
     }
@@ -100,10 +111,11 @@ WSTRING HexStr(const void* dataPtr, int len)
 
 WSTRING TokenStr(const mdToken* token)
 {
-    const unsigned char* data = (unsigned char*)token;
+    const unsigned char* data = (unsigned char*) token;
     int len = sizeof(mdToken);
     WSTRING s(len * 2, ' ');
-    for (int i = 0; i < len; i++) {
+    for (int i = 0; i < len; i++)
+    {
         s[(2 * (len - i)) - 2] = HexMap[(data[i] & 0xF0) >> 4];
         s[(2 * (len - i)) - 1] = HexMap[data[i] & 0x0F];
     }

--- a/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -12,9 +12,11 @@
 
 #include "string.h"
 
-namespace trace {
+namespace trace
+{
 
-template <typename Out> void Split(const WSTRING& s, wchar_t delim, Out result);
+template <typename Out>
+void Split(const WSTRING& s, wchar_t delim, Out result);
 
 // Split splits a string by the given delimiter.
 std::vector<WSTRING> Split(const WSTRING& s, wchar_t delim);
@@ -39,26 +41,30 @@ WSTRING HexStr(const void* data, int len);
 // Convert Token to string
 WSTRING TokenStr(const mdToken* token);
 
-template <class Container> bool Contains(const Container& items, const typename Container::value_type& value)
+template <class Container>
+bool Contains(const Container& items, const typename Container::value_type& value)
 {
     return std::find(items.begin(), items.end(), value) != items.end();
 }
 
 // Singleton definition
-class UnCopyable {
-  protected:
+class UnCopyable
+{
+protected:
     UnCopyable(){};
     ~UnCopyable(){};
 
-  private:
+private:
     UnCopyable(const UnCopyable&) = delete;
     UnCopyable(const UnCopyable&&) = delete;
     UnCopyable& operator=(const UnCopyable&) = delete;
     UnCopyable& operator=(const UnCopyable&&) = delete;
 };
 
-template <typename T> class Singleton : public UnCopyable {
-  public:
+template <typename T>
+class Singleton : public UnCopyable
+{
+public:
     static T* Instance()
     {
         static T instance_obj;
@@ -66,17 +72,20 @@ template <typename T> class Singleton : public UnCopyable {
     }
 };
 
-template <typename T> class BlockingQueue : public UnCopyable {
-  private:
+template <typename T>
+class BlockingQueue : public UnCopyable
+{
+private:
     std::queue<T> queue_;
     mutable std::mutex mutex_;
     std::condition_variable condition_;
 
-  public:
+public:
     T pop()
     {
         std::unique_lock<std::mutex> mlock(mutex_);
-        while (queue_.empty()) {
+        while (queue_.empty())
+        {
             condition_.wait(mlock);
         }
         T value = queue_.front();


### PR DESCRIPTION
Older `clang-format` versions doesn't support the `Microsoft` style. 
This PR uses a custom format (with some changes) after an agreement with @gleocadie

@DataDog/apm-dotnet