### PR TITLE
Ducktype - Explicit interface method implementation support

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckAttribute.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckAttribute.cs
@@ -59,5 +59,10 @@ namespace Datadog.Trace.DuckTyping
         /// Gets or sets the parameter type names of the target method (optional / used to disambiguation)
         /// </summary>
         public string[] ParameterTypeNames { get; set; }
+
+        /// <summary>
+        /// Gets or sets the explicit interface type name
+        /// </summary>
+        public string ExplicitInterfaceTypeName { get; set; }
     }
 }

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -554,8 +554,20 @@ namespace Datadog.Trace.DuckTyping
             MethodInfo[] allTargetMethods = targetType.GetMethods(DuckAttribute.DefaultFlags);
             foreach (MethodInfo candidateMethod in allTargetMethods)
             {
+                string name = proxyMethodDuckAttribute.Name;
+
+                // If there is an explicit interface type name we add it to the name
+                if (!string.IsNullOrEmpty(proxyMethodDuckAttribute.ExplicitInterfaceTypeName))
+                {
+                    string interfaceTypeName = proxyMethodDuckAttribute.ExplicitInterfaceTypeName;
+                    // Nested types are separated with a "." on explicit implementation.
+                    interfaceTypeName = interfaceTypeName.Replace("+", ".");
+
+                    name = interfaceTypeName + "." + name;
+                }
+
                 // We omit target methods with different names.
-                if (candidateMethod.Name != proxyMethodDuckAttribute.Name)
+                if (candidateMethod.Name != name)
                 {
                     continue;
                 }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfaceTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfaceTests.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             var proxy = targetObject.DuckCast<IProxyDefinition>();
 
             proxy.SayHi().Should().Equals("Hello World");
+            proxy.SayHiWithWildcard().Should().Equals("Hello World (*)");
         }
 
         public class TargetObject : ITarget
@@ -27,17 +28,27 @@ namespace Datadog.Trace.DuckTyping.Tests
             {
                 return "Hello World";
             }
+
+            string ITarget.SayHiWithWildcard()
+            {
+                return "Hello World (*)";
+            }
         }
 
         public interface ITarget
         {
             string SayHi();
+
+            string SayHiWithWildcard();
         }
 
         public interface IProxyDefinition
         {
             [Duck(ExplicitInterfaceTypeName = "Datadog.Trace.DuckTyping.Tests.DuckExplicitInterfaceTests+ITarget")]
             string SayHi();
+
+            [Duck(ExplicitInterfaceTypeName = "*")]
+            string SayHiWithWildcard();
         }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfaceTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfaceTests.cs
@@ -1,0 +1,43 @@
+// <copyright file="DuckExplicitInterfaceTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class DuckExplicitInterfaceTests
+    {
+        [Fact]
+        public void NormalTest()
+        {
+            var targetObject = new TargetObject();
+            var proxy = targetObject.DuckCast<IProxyDefinition>();
+
+            proxy.SayHi().Should().Equals("Hello World");
+        }
+
+        public class TargetObject : ITarget
+        {
+            string ITarget.SayHi()
+            {
+                return "Hello World";
+            }
+        }
+
+        public interface ITarget
+        {
+            string SayHi();
+        }
+
+        public interface IProxyDefinition
+        {
+            [Duck(ExplicitInterfaceTypeName = "Datadog.Trace.DuckTyping.Tests.DuckExplicitInterfaceTests+ITarget")]
+            string SayHi();
+        }
+    }
+}


### PR DESCRIPTION
This PR enables support for proxy a target instance with explicit interface method implementations.

@DataDog/apm-dotnet