### PR TITLE
Utilize lower-overhead CustomSerilogLogProvider for older LogContext.PushProperties API when LogContext.Push API is not present

### DIFF
--- a/src/Datadog.Trace/Logging/CustomSerilogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/CustomSerilogLogProvider.cs
@@ -6,30 +6,47 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Datadog.Trace.Logging.LogProviders;
 
 namespace Datadog.Trace.Logging
 {
     internal class CustomSerilogLogProvider : SerilogLogProvider, ILogProviderWithEnricher
     {
+        private static ConditionalWeakTable<object, object> _enricherToArrayConditionalWeakTable;
         private static Func<object, IDisposable> _pushMethod;
+        private static Func<object, IDisposable> _openContext;
 
         public CustomSerilogLogProvider()
         {
-            _pushMethod = GetPush();
+            _enricherToArrayConditionalWeakTable = new();
+
+            var logEnricherType = GetLogEnricherType();
+            if (GetPushMethodInfo() != null)
+            {
+                _openContext = _pushMethod = GeneratePushDelegate(GetPushMethodInfo(), logEnricherType);
+            }
+            else
+            {
+                _pushMethod = GeneratePushDelegate(GetPushPropertiesMethodInfo(), logEnricherType.MakeArrayType());
+                _openContext = (enricher) =>
+                {
+                    // Use a conditional weak table to cache a map between the enricher and an array of size 1 containing the enricher,
+                    // since the API requires an argument of type ILogEventEnricher[]
+                    object properties = _enricherToArrayConditionalWeakTable.GetValue(key: enricher, createValueCallback: ConditionalWeakTableCallback);
+                    return _pushMethod(properties);
+                };
+            }
         }
 
-        public IDisposable OpenContext(object enricher)
-        {
-            return _pushMethod(enricher);
-        }
+        public IDisposable OpenContext(object enricher) => _openContext(enricher);
 
         public ILogEnricher CreateEnricher() => new SerilogEnricher(this);
 
         internal static Type GetLogEnricherType() => Type.GetType("Serilog.Core.ILogEventEnricher, Serilog");
 
         internal static new bool IsLoggerAvailable() =>
-            SerilogLogProvider.IsLoggerAvailable() && GetPushMethodInfo() != null;
+            SerilogLogProvider.IsLoggerAvailable() && (GetPushMethodInfo() != null || GetPushPropertiesMethodInfo() != null);
 
         private static MethodInfo GetPushMethodInfo()
         {
@@ -37,18 +54,31 @@ namespace Datadog.Trace.Logging
             return ndcContextType?.GetMethod("Push", GetLogEnricherType());
         }
 
-        private static Func<object, IDisposable> GetPush()
+        private static MethodInfo GetPushPropertiesMethodInfo()
         {
-            var pushPropertyMethod = GetPushMethodInfo();
+            var ndcContextType = FindType("Serilog.Context.LogContext", new[] { "Serilog", "Serilog.FullNetFx" });
+            return ndcContextType?.GetMethod("PushProperties", GetLogEnricherType().MakeArrayType());
+        }
+
+        private static Func<object, IDisposable> GeneratePushDelegate(MethodInfo methodInfo, Type argumentTargetType)
+        {
             var enricherParam = Expression.Parameter(typeof(object), "enricher");
-            var castEnricherParam = Expression.Convert(enricherParam, GetLogEnricherType());
-            var pushMethodCall = Expression.Call(null, pushPropertyMethod, castEnricherParam);
+            var castEnricherParam = Expression.Convert(enricherParam, argumentTargetType);
+            var pushMethodCall = Expression.Call(null, methodInfo, castEnricherParam);
+
             var push = Expression.Lambda<Func<object, IDisposable>>(
                     pushMethodCall,
                     enricherParam)
                 .Compile();
 
             return push;
+        }
+
+        private static object ConditionalWeakTableCallback(object key)
+        {
+            var array = Array.CreateInstance(GetLogEnricherType(), 1);
+            array.SetValue(key, 0);
+            return array;
         }
     }
 }

--- a/src/Datadog.Trace/Logging/CustomSerilogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/CustomSerilogLogProvider.cs
@@ -14,7 +14,6 @@ namespace Datadog.Trace.Logging
     internal class CustomSerilogLogProvider : SerilogLogProvider, ILogProviderWithEnricher
     {
         private static Func<object, IDisposable> _pushMethod;
-        private static NoOpDisposable _cachedDisposable;
         private readonly bool _wrapEnricher;
 
         public CustomSerilogLogProvider()
@@ -33,8 +32,8 @@ namespace Datadog.Trace.Logging
             else
             {
                 _wrapEnricher = false;
-                _cachedDisposable = new NoOpDisposable();
-                _pushMethod = (enricher) => { return _cachedDisposable; };
+                IDisposable cachedDisposable = new NoOpDisposable();
+                _pushMethod = (enricher) => { return cachedDisposable; };
             }
         }
 


### PR DESCRIPTION
This PR is an optimization of #1558. That previous PR uses the slow LibLog fallback for all Serilog versions where `LogContext.Push` is not present. This PR adds an optimization when `LogContext.PushProperties` is present by using the faster Enricher method, which requires us to wrap the enricher inside of an array.

## Performance Measurements
Newer versions of Serilog **(unchanged)**: `LogContext.Push(ILogEventEnricher)` vs `LogContext.PushProperty(string, object, bool)` -- using Serilog 2.10.0
|       CurrentLogProvider |     Toolchain |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |-------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| CustomSerilogLogProvider |        net472 | 6.010 μs | 0.1181 μs | 0.2330 μs | 0.6027 |     - |     - |    2.8 KB |
|       SerilogLogProvider |        net472 | 7.939 μs | 0.1571 μs | 0.2303 μs | 1.1139 |     - |     - |   5.17 KB |
|                          |               |          |           |           |        |       |       |           |
| CustomSerilogLogProvider | netcoreapp3.1 | 5.041 μs | 0.0493 μs | 0.0437 μs | 0.0381 |     - |     - |   2.61 KB |
|       SerilogLogProvider | netcoreapp3.1 | 7.350 μs | 0.1103 μs | 0.0978 μs | 0.0839 |     - |     - |    5.6 KB |

Older versions of Serilog **(changed)**: `LogContext.PushProperties(ILogEventEnricher[])` vs `LogContext.PushProperty(string, object, bool)` -- using Serilog 2.0.0
|       CurrentLogProvider |     Toolchain |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------- |-------------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
| CustomSerilogLogProvider |        net472 |  7.404 μs | 0.1424 μs | 0.1851 μs | 0.8240 |     - |     - |   3.82 KB |
|       SerilogLogProvider |        net472 | 12.412 μs | 0.1865 μs | 0.1653 μs | 1.4496 |     - |     - |   6.71 KB |
|                          |               |           |           |           |        |       |       |           |
| CustomSerilogLogProvider | netcoreapp3.1 |  6.038 μs | 0.1191 μs | 0.1958 μs | 0.0534 |     - |     - |   3.62 KB |
|       SerilogLogProvider | netcoreapp3.1 |  9.053 μs | 0.1771 μs | 0.3455 μs | 0.1068 |     - |     - |   7.23 KB |

@DataDog/apm-dotnet