### PR TITLE
Add support for NestedTypes and GenericParameters to EnsureTypeVisibility

### DIFF
--- a/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -13,4 +13,9 @@
     <DefineConstants>$(DefineConstants);INTERFACE_DEFAULTS</DefineConstants>
   </PropertyGroup>
 
+  <!-- For testing edge case duck typing scenarios (ILogger)-->
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+  </ItemGroup>
+
 </Project>

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckChainingWithExplicitInterfaceTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckChainingWithExplicitInterfaceTests.cs
@@ -1,0 +1,113 @@
+// <copyright file="DuckChainingWithExplicitInterfaceTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+#pragma warning disable SA1302 // Interface names should begin with I
+
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class DuckChainingWithExplicitInterfaceTests
+    {
+        [Fact]
+        public void NormalTest()
+        {
+            var targetObject = new T_HostingApplication();
+            var proxyObject = targetObject.DuckCast<P_IHostingApplication>();
+
+            var logger = proxyObject.Diagnostics.Logger;
+            var disposable = logger.BeginScope<object>(new object());
+
+            disposable.Should().BeOfType<T_DisposableObject>();
+        }
+
+        public class T_HostingApplication
+        {
+            private T_HostingApplicationDiagnostics _diagnostics;
+
+            public T_HostingApplication()
+            {
+                _diagnostics = new T_HostingApplicationDiagnostics();
+            }
+        }
+
+        internal class T_HostingApplicationDiagnostics
+        {
+            private readonly T_ILogger _logger;
+
+            public T_HostingApplicationDiagnostics()
+            {
+                _logger = new T_Logger<T_InternalObject>();
+            }
+        }
+
+        public interface T_ILogger
+        {
+            IDisposable BeginScope<TState>(TState state);
+        }
+
+        public interface T_ILogger<out TCategoryName> : T_ILogger
+        {
+        }
+
+        public class T_Logger<T> : T_ILogger<T>
+        {
+            private readonly T_ILogger _logger;
+
+            public T_Logger()
+            {
+                _logger = new T_Logger();
+            }
+
+            IDisposable T_ILogger.BeginScope<TState>(TState state)
+            {
+                return _logger.BeginScope(state);
+            }
+        }
+
+        public class T_Logger : T_ILogger
+        {
+            IDisposable T_ILogger.BeginScope<TState>(TState state)
+            {
+                return new T_DisposableObject();
+            }
+        }
+
+        internal class T_InternalObject
+        {
+        }
+
+        private class T_DisposableObject : IDisposable
+        {
+            public void Dispose()
+            {
+                // .
+            }
+        }
+
+        // ***
+
+        public interface P_IHostingApplication
+        {
+            [Duck(Name = "_diagnostics", Kind = DuckKind.Field)]
+            P_IHostingApplicationDiagnostics Diagnostics { get; }
+        }
+
+        public interface P_IHostingApplicationDiagnostics
+        {
+            [Duck(Name = "_logger", Kind = DuckKind.Field)]
+            P_ILogger Logger { get; }
+        }
+
+        public interface P_ILogger
+        {
+            [Duck(ExplicitInterfaceTypeName = "*")]
+            IDisposable BeginScope<TState>(TState state);
+        }
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfacePrivateTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfacePrivateTests.cs
@@ -1,0 +1,177 @@
+// <copyright file="DuckExplicitInterfacePrivateTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class DuckExplicitInterfacePrivateTests
+    {
+        [Fact]
+        public void PrivateNormalTest()
+        {
+            var targetObject = new PrivateTargetObject();
+            var proxy = targetObject.DuckCast<IProxyDefinition>();
+
+            proxy.SayHi().Should().Be("Hello World");
+            proxy.SayHiWithWildcard().Should().Be("Hello World (*)");
+        }
+
+        [Fact]
+        public void PrivateGenericTest()
+        {
+            var targetObject = new PrivateTargetGenericObject();
+            var proxy = targetObject.DuckCast<IPrivateGenericProxyDefinition>();
+
+            proxy.Sum(1, 1).Should().Be(2);
+            proxy.Sum(1.0f, 1.0f).Should().Be(2.0f);
+        }
+
+        [Fact]
+        public void PrivateNormalGenericInstanceTest()
+        {
+            var targetObject = new PrivateTargetObject<object>();
+            var proxy = targetObject.DuckCast<IProxyDefinition>();
+
+            proxy.SayHi().Should().Be("Hello World");
+            proxy.SayHiWithWildcard().Should().Be("Hello World (*)");
+        }
+
+        [Fact]
+        public void PrivateGenericWithGenericInstanceTest()
+        {
+            var targetObject = new PrivateTargetGenericObject<object>();
+            var proxy = targetObject.DuckCast<IPrivateGenericProxyDefinition>();
+
+            proxy.Sum(1, 1).Should().Be(2);
+            proxy.Sum(1.0f, 1.0f).Should().Be(2.0f);
+        }
+
+        [Fact]
+        public void PrivateNormalGenericPrivateInstanceTest()
+        {
+            var targetObject = new PrivateTargetObject<PrivateObject>();
+            var proxy = targetObject.DuckCast<IProxyDefinition>();
+
+            proxy.SayHi().Should().Be("Hello World");
+            proxy.SayHiWithWildcard().Should().Be("Hello World (*)");
+        }
+
+        [Fact]
+        public void PrivateGenericWithGenericPrivateInstanceTest()
+        {
+            var targetObject = new PrivateTargetGenericObject<PrivateObject>();
+            var proxy = targetObject.DuckCast<IPrivateGenericProxyDefinition>();
+
+            proxy.Sum(1, 1).Should().Be(2);
+            proxy.Sum(1.0f, 1.0f).Should().Be(2.0f);
+        }
+
+        public interface ITarget
+        {
+            string SayHi();
+
+            string SayHiWithWildcard();
+        }
+
+        public interface ITarget<out TCategoryName> : ITarget
+        {
+        }
+
+        public interface IGenericTarget
+        {
+            T Sum<T>(T a, T b);
+        }
+
+        public interface IGenericTarget<out TCategoryName> : IGenericTarget
+        {
+        }
+
+        public interface IProxyDefinition
+        {
+            [Duck(ExplicitInterfaceTypeName = "Datadog.Trace.DuckTyping.Tests.DuckExplicitInterfacePrivateTests+ITarget")]
+            string SayHi();
+
+            [Duck(ExplicitInterfaceTypeName = "*")]
+            string SayHiWithWildcard();
+        }
+
+        public interface IPrivateGenericProxyDefinition
+        {
+            [Duck(ExplicitInterfaceTypeName = "*", GenericParameterTypeNames = new string[] { "System.Int32" })]
+            int Sum(int a, int b);
+
+            [Duck(ExplicitInterfaceTypeName = "*", GenericParameterTypeNames = new string[] { "System.Single" })]
+            float Sum(float a, float b);
+        }
+
+        private class PrivateTargetObject : ITarget
+        {
+            string ITarget.SayHi()
+            {
+                return "Hello World";
+            }
+
+            string ITarget.SayHiWithWildcard()
+            {
+                return "Hello World (*)";
+            }
+        }
+
+        private class PrivateTargetObject<TInstance> : ITarget<TInstance>
+        {
+            string ITarget.SayHi()
+            {
+                return "Hello World";
+            }
+
+            string ITarget.SayHiWithWildcard()
+            {
+                return "Hello World (*)";
+            }
+        }
+
+        private class PrivateTargetGenericObject : IGenericTarget
+        {
+            T IGenericTarget.Sum<T>(T a, T b)
+            {
+                if (a is int aInt && b is int bInt)
+                {
+                    return (T)(object)(aInt + bInt);
+                }
+                else if (a is float aFloat && b is float bFloat)
+                {
+                    return (T)(object)(aFloat + bFloat);
+                }
+
+                return default;
+            }
+        }
+
+        private class PrivateTargetGenericObject<TInstance> : IGenericTarget<TInstance>
+        {
+            T IGenericTarget.Sum<T>(T a, T b)
+            {
+                if (a is int aInt && b is int bInt)
+                {
+                    return (T)(object)(aInt + bInt);
+                }
+                else if (a is float aFloat && b is float bFloat)
+                {
+                    return (T)(object)(aFloat + bFloat);
+                }
+
+                return default;
+            }
+        }
+
+        private class PrivateObject
+        {
+        }
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfaceTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckExplicitInterfaceTests.cs
@@ -32,6 +32,46 @@ namespace Datadog.Trace.DuckTyping.Tests
             proxy.Sum(1.0f, 1.0f).Should().Be(2.0f);
         }
 
+        [Fact]
+        public void NormalGenericInstanceTest()
+        {
+            var targetObject = new TargetObject<object>();
+            var proxy = targetObject.DuckCast<IProxyDefinition>();
+
+            proxy.SayHi().Should().Be("Hello World");
+            proxy.SayHiWithWildcard().Should().Be("Hello World (*)");
+        }
+
+        [Fact]
+        public void GenericWithGenericInstanceTest()
+        {
+            var targetObject = new TargetGenericObject<object>();
+            var proxy = targetObject.DuckCast<IGenericProxyDefinition>();
+
+            proxy.Sum(1, 1).Should().Be(2);
+            proxy.Sum(1.0f, 1.0f).Should().Be(2.0f);
+        }
+
+        [Fact]
+        public void NormalGenericPrivateInstanceTest()
+        {
+            var targetObject = new TargetObject<PrivateObject>();
+            var proxy = targetObject.DuckCast<IProxyDefinition>();
+
+            proxy.SayHi().Should().Be("Hello World");
+            proxy.SayHiWithWildcard().Should().Be("Hello World (*)");
+        }
+
+        [Fact]
+        public void GenericWithGenericPrivateInstanceTest()
+        {
+            var targetObject = new TargetGenericObject<PrivateObject>();
+            var proxy = targetObject.DuckCast<IGenericProxyDefinition>();
+
+            proxy.Sum(1, 1).Should().Be(2);
+            proxy.Sum(1.0f, 1.0f).Should().Be(2.0f);
+        }
+
         public class TargetObject : ITarget
         {
             string ITarget.SayHi()
@@ -62,6 +102,36 @@ namespace Datadog.Trace.DuckTyping.Tests
             }
         }
 
+        public class TargetObject<TInstance> : ITarget<TInstance>
+        {
+            string ITarget.SayHi()
+            {
+                return "Hello World";
+            }
+
+            string ITarget.SayHiWithWildcard()
+            {
+                return "Hello World (*)";
+            }
+        }
+
+        public class TargetGenericObject<TInstance> : IGenericTarget<TInstance>
+        {
+            T IGenericTarget.Sum<T>(T a, T b)
+            {
+                if (a is int aInt && b is int bInt)
+                {
+                    return (T)(object)(aInt + bInt);
+                }
+                else if (a is float aFloat && b is float bFloat)
+                {
+                    return (T)(object)(aFloat + bFloat);
+                }
+
+                return default;
+            }
+        }
+
         public interface ITarget
         {
             string SayHi();
@@ -69,9 +139,17 @@ namespace Datadog.Trace.DuckTyping.Tests
             string SayHiWithWildcard();
         }
 
+        public interface ITarget<out TCategoryName> : ITarget
+        {
+        }
+
         public interface IGenericTarget
         {
             T Sum<T>(T a, T b);
+        }
+
+        public interface IGenericTarget<out TCategoryName> : IGenericTarget
+        {
         }
 
         public interface IProxyDefinition
@@ -87,6 +165,10 @@ namespace Datadog.Trace.DuckTyping.Tests
         {
             [Duck(ExplicitInterfaceTypeName = "*")]
             T Sum<T>(T a, T b);
+        }
+
+        private class PrivateObject
+        {
         }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckILoggerTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckILoggerTests.cs
@@ -1,0 +1,77 @@
+// <copyright file="DuckILoggerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+
+#if !NETFRAMEWORK
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Datadog.Trace.DuckTyping;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting.Internal;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class DuckILoggerTests
+    {
+        [Fact]
+        public void CanCallBeginScope()
+        {
+            var webHost = typeof(WebHostOptions).Assembly.GetType("Microsoft.AspNetCore.Hosting.Internal.WebHost");
+            var hostingApplication = typeof(DuckILoggerTests)
+                                    .GetMethod(nameof(CreateHostingApplication))
+                                    ?.MakeGenericMethod(webHost)
+                                    .Invoke(this, null);
+
+            var proxy = hostingApplication.DuckCast<IHostingApplication>();
+
+            proxy.Should().NotBeNull();
+
+            var logger = proxy.Diagnostics.Logger;
+            logger.Should().NotBeNull();
+            var disposable = logger.BeginScope(new DatadogLoggingScope());
+            disposable.Should().NotBeNull();
+        }
+
+        public object CreateHostingApplication<TWebHost>()
+        {
+            return new HostingApplication(
+                application: context => Task.CompletedTask,
+                logger: new Logger<TWebHost>(new LoggerFactory()),
+                new DiagnosticListener("ILoggerDuckTypingTests"),
+                httpContextFactory: new HttpContextFactory(Options.Create(new FormOptions())));
+        }
+
+        public class DatadogLoggingScope
+        {
+        }
+
+        public interface IHostingApplication
+        {
+            [Duck(Name = "_diagnostics", Kind = DuckKind.Field)]
+            IHostingApplicationDiagnostics Diagnostics { get; }
+        }
+
+        public interface IHostingApplicationDiagnostics
+        {
+            [Duck(Name = "_logger", Kind = DuckKind.Field)]
+            ILogger Logger { get; }
+        }
+
+        public interface ILogger
+        {
+            [Duck(ExplicitInterfaceTypeName = "*")]
+            IDisposable BeginScope<TState>(TState state);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
The `ILogger` instrumentation implementation in #1549 highlighted a case in the duck typing library that we weren't handling. If a duck-typed target is a generic, and has a non-public type as the generic argument the duck typing call would fail.

This PR adds support for non-public nested types and generic arguments.
It's tested with the specific example we encountered for `ILogger`. I've kept the additional exploratory tests @tonyredondo wrote initially too. 

@DataDog/apm-dotnet 