### PR TITLE
Small CI fixes

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -303,9 +303,9 @@ stages:
     strategy:
       matrix:
         x64:
-          buildPlatform: x64
+          platform: x64
         x86:
-          buildPlatform: x86
+          platform: x86
 
     steps:
     - template: steps/install-dotnet-sdks.yml
@@ -337,15 +337,15 @@ stages:
     strategy:
       matrix:
         x64:
-          buildPlatform: x64
+          platform: x64
           enable32bit: false
         x86:
-          buildPlatform: x86
+          platform: x86
           enable32bit: true
     pool:
       vmImage: windows-2019
     variables:
-      relativeMsiOutputDirectory: $(relativeArtifacts)/$(buildPlatform)/en-us
+      relativeMsiOutputDirectory: $(relativeArtifacts)/$(platform)/en-us
 
     steps:
 
@@ -355,7 +355,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download MSI
       inputs:
-        artifact: windows-msi-$(buildPlatform)
+        artifact: windows-msi-$(platform)
         patterns: '**/*.msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -23,6 +23,7 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
+  ContinuousIntegrationBuild: true
   dotnetCoreSdk5Version: 5.0.103
   relativeTracerHome: /src/bin/windows-tracer-home
   relativeArtifacts: /src/bin/artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ driver_build:
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_x64:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\build\_build\gitlab.bat
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ContinuousIntegrationBuild=true -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_x64:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\build\_build\gitlab.bat
     - mkdir artifacts
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
     - remove-item -recurse -force build-out\${CI_JOB_ID}


### PR DESCRIPTION
- Set ContinuousIntegrationBuild=true in GitLab to enable deterministic builds
- Set ContinuousIntegrationBuild=true in consolidated pipeline
- Rename platform -> buildPlatform so we actually test against x86
