### PR TITLE
Initialize performance counters asynchronously

### DIFF
--- a/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/PerformanceCountersListenerTests.cs
@@ -4,9 +4,14 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Vendors.StatsdClient;
+using FluentAssertions;
 using Moq;
+using Moq.Protected;
 using Xunit;
 
 namespace Datadog.Trace.Tests.RuntimeMetrics
@@ -14,11 +19,13 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
     public class PerformanceCountersListenerTests
     {
         [Fact]
-        public void PushEvents()
+        public async Task PushEvents()
         {
             var statsd = new Mock<IDogStatsd>();
 
             using var listener = new PerformanceCountersListener(statsd.Object);
+
+            await listener.WaitForInitialization();
 
             listener.Refresh();
 
@@ -44,6 +51,53 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
             statsd.Verify(s => s.Counter(MetricsNames.ContentionCount, It.IsAny<double>(), 1, null), Times.Once);
 
             statsd.VerifyNoOtherCalls();
+        }
+
+        [Fact]
+        public void AsynchronousInitialization()
+        {
+            var barrier = new Barrier(2);
+            void Callback()
+            {
+                barrier.SignalAndWait();
+                barrier.SignalAndWait();
+            }
+
+            var statsd = new Mock<IDogStatsd>();
+
+            using var listener = new TestPerformanceCounterListener(statsd.Object, Callback);
+
+            // The first SignalAndWait will deadlock if InitializePerformanceCounters is not called asynchronously
+            barrier.SignalAndWait();
+
+            listener.WaitForInitialization().IsCompleted.Should().BeFalse();
+
+            // Initialization is still pending, make sure Refresh doesn't throw
+            listener.Refresh();
+
+            // Nothing should have been pushed to statsd since counters are not initialized
+            statsd.VerifyNoOtherCalls();
+
+            // All done, free the thread and cleanup
+            barrier.SignalAndWait();
+        }
+
+        private class TestPerformanceCounterListener : PerformanceCountersListener
+        {
+            private readonly Action _callback;
+
+            public TestPerformanceCounterListener(IDogStatsd statsd, Action callback)
+                : base(statsd)
+            {
+                _callback = callback;
+            }
+
+            protected override void InitializePerformanceCounters()
+            {
+                _callback();
+
+                base.InitializePerformanceCounters();
+            }
         }
     }
 }

--- a/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
+++ b/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
@@ -6,17 +6,21 @@ namespace Samples.RuntimeMetrics
 {
     internal static class Program
     {
+        private static readonly object SyncRoot = new object();
+
         private static void Main()
         {
             // Force the tracer to be loaded
             _ = WebRequest.CreateHttp("http://localhost/");
 
-            new Thread(ThrowExceptions) { IsBackground = true }.Start();
+            Monitor.Enter(SyncRoot);
+
+            new Thread(GenerateEvents) { IsBackground = true }.Start();
 
             Thread.Sleep(20000);
         }
 
-        private static void ThrowExceptions()
+        private static void GenerateEvents()
         {
             while (true)
             {
@@ -28,7 +32,8 @@ namespace Samples.RuntimeMetrics
                 {
                 }
 
-                Thread.Sleep(500);
+                // Sleep for 500ms while creating contention
+                Monitor.TryEnter(SyncRoot, 500);                
             }
         }
     }


### PR DESCRIPTION
Solves a deadlock when using runtime metrics in a Windows service.

That's because performance counters may rely on wmiApSrv being started, and the windows service manager only allows one service at a time to be starting: https://docs.microsoft.com/en-us/windows/win32/services/service-startup

(thanks @lowleveldesign on the help for finding the appropriate bit of documentation)