### PR TITLE
Wait 10 more seconds on runtime metrics tests

### DIFF
--- a/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
+++ b/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
@@ -17,7 +17,7 @@ namespace Samples.RuntimeMetrics
 
             new Thread(GenerateEvents) { IsBackground = true }.Start();
 
-            Thread.Sleep(20000);
+            Thread.Sleep(30000);
         }
 
         private static void GenerateEvents()


### PR DESCRIPTION
We need runtime metrics to be refreshed at least twice to have the contention metrics (because it needs a previous value to compute the variation). Because of the asynchronous initialization of the performance counters, we sometimes miss the first refresh. Wait 10 more seconds for another refresh to prevent that from happening.