### PR TITLE
CI tweaks

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -735,7 +735,7 @@ stages:
       displayName: Uploading runner standalone osx-x64 artifact
       artifact: runner-standalone-osx-x64
 
-- stage: upload
+- stage: upload_to_s3
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [package_windows, build_linux]
   jobs:
@@ -831,6 +831,87 @@ stages:
 
 
 
+
+- stage: upload_to_feed
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool]
+  jobs:
+    - job: upload
+
+      pool:
+        vmImage: ubuntu-18.04
+
+      steps:
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download NuGet packages
+          inputs:
+            artifact: nuget-packages
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download x64 MSI
+          inputs:
+            artifact: windows-msi-x64
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download x86 MSI
+          inputs:
+            artifact: windows-msi-x86
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download Windows tracer home
+          inputs:
+            artifact: windows-tracer-home.zip
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Debian packages
+          inputs:
+            artifact: linux-packages-debian
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Alpine packages
+          inputs:
+            artifact: linux-packages-alpine
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Arm64 packages
+          inputs:
+            artifact: linux-packages-arm64
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download runner dotnet tool
+          inputs:
+            artifact: runner-dotnet-tool
+            patterns: "*.nupkg"
+            path: $(Build.ArtifactStagingDirectory)
+
+        # set the version from the package name
+        - bash: |
+            ls "$(Build.ArtifactStagingDirectory)"
+            MSI_NAME=$(ls $(Build.ArtifactStagingDirectory)/*-x64.msi)
+            VERSION_NUMBER=${MSI_NAME:19:-8}
+            echo "detected version: $VERSION_NUMBER"
+            echo "##vso[task.setvariable variable=tracer_version]$VERSION_NUMBER"
+          displayName: Extract version number
+
+        # Publish a Universal Package
+        - task: UniversalPackages@0
+          displayName: Publish to Feed
+          inputs:
+            command: publish
+            publishDirectory: '$(Build.ArtifactStagingDirectory)'
+            vstsFeedPublish: 'dd-trace-dotnet/Main'
+            vstsFeedPackagePublish: 'dd-trace-dotnet'
+            packagePublishDescription: 'The output artifacts from the consolidated pipeline'
+            versionOption: custom
+            versionPublish: "$(tracer_version)-ci-$(Build.BuildId)-$(Build.SourceBranchName)"
 - stage: throughput
   dependsOn: [build_linux, build_windows]
   jobs:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -83,23 +83,11 @@ stages:
     strategy:
       matrix:
         debian:
-          matrixName: debian
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
           baseImage: debian
         alpine:
-          matrixName: alpine
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
           baseImage: alpine
-        arm64:
-          matrixName: arm64
-          poolName: Arm64
-          vmImage:
-          baseImage: debian
     pool:
-      name: $(poolName)
-      vmImage: $(vmImage)
+      vmImage: ubuntu-18.04
 
     steps:
     - template: steps/run-in-docker.yml
@@ -111,21 +99,43 @@ stages:
 
     - publish: $(tracerHome)
       displayName: Uploading linux tracer home artifact
-      artifact: linux-tracer-home-$(matrixName)
+      artifact: linux-tracer-home-$(baseImage)
 
     - publish: $(artifacts)/linux-x64
-      condition: ne(variables['matrixName'], 'arm64')
       displayName: Upload linux-x64 packages
-      artifact: linux-packages-$(matrixName)
-
-    - publish: $(artifacts)/linux-arm64
-      condition: eq(variables['matrixName'], 'arm64')
-      displayName: Upload linux-arm64 packages
-      artifact: linux-packages-$(matrixName)
+      artifact: linux-packages-$(baseImage)
 
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
-      artifact: build-linux-$(matrixName)-working-directory
+      artifact: build-linux-$(baseImage)-working-directory
+
+- stage: build_arm64
+  dependsOn: []
+  jobs:
+  - job: build
+    dependsOn: []
+    pool:
+      name: Arm64
+
+    steps:
+    - template: steps/run-in-docker.yml
+      parameters:
+        build: true
+        target: builder
+        baseImage: debian
+        command: "Clean BuildTracerHome ZipTracerHome"
+
+    - publish: $(tracerHome)
+      displayName: Uploading linux tracer home artifact
+      artifact: linux-tracer-home-arm64
+
+    - publish: $(artifacts)/linux-arm64
+      displayName: Upload linux-arm64 packages
+      artifact: linux-packages-arm64
+
+    - publish: $(System.DefaultWorkingDirectory)
+      displayName: Upload working directory after the build
+      artifact: build-linux-arm64-working-directory
 
 - stage: build_macos
   condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
@@ -254,28 +264,16 @@ stages:
     strategy:
       matrix:
         debian:
-          matrixName: debian
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
           baseImage: debian
         alpine:
-          matrixName: alpine
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
           baseImage: alpine
-        arm64:
-          matrixName: arm64
-          poolName: Arm64
-          vmImage:
-          baseImage: debian
     pool:
-      name: $(poolName)
-      vmImage: $(vmImage)
+      vmImage: ubuntu-18.04
 
     steps:
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(matrixName)-working-directory
+        artifact: build-linux-$(baseImage)-working-directory
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -293,6 +291,36 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+- stage: unit_tests_arm64
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  dependsOn: [build_arm64]
+  jobs:
+    - job: test
+      pool:
+        name: Arm64
+
+      steps:
+        - template: steps/restore-working-directory.yml
+          parameters:
+            artifact: build-linux-arm64-working-directory
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: debian
+            command: "BuildAndRunManagedUnitTests"
+
+        - publish: build_data
+          artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
+          condition: succeededOrFailed()
+
+        - task: PublishTestResults@2
+          displayName: publish test results
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: build_data/results/**/*.trx
+          condition: succeededOrFailed()
 
 - stage: integration_tests_windows
   condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
@@ -414,82 +442,33 @@ stages:
         debian_netcoreapp2_1:
           publishTargetFramework: netcoreapp2.1
           baseImage: debian
-          matrixName: debian
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         debian_netcoreapp3_0:
           publishTargetFramework: netcoreapp3.0
           baseImage: debian
-          matrixName: debian
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         debian_netcoreapp3_1:
           publishTargetFramework: netcoreapp3.1
           baseImage: debian
-          matrixName: debian
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         debian_net5_0:
           publishTargetFramework: net5.0
           baseImage: debian
-          matrixName: debian
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         alpine_netcoreapp2_1:
           publishTargetFramework: netcoreapp2.1
           baseImage: alpine
-          matrixName: alpine
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         alpine_netcoreapp3_0:
           publishTargetFramework: netcoreapp3.0
           baseImage: alpine
-          matrixName: alpine
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         alpine_netcoreapp3_1:
           publishTargetFramework: netcoreapp3.1
           baseImage: alpine
-          matrixName: alpine
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
         alpine_net5_0:
           publishTargetFramework: net5.0
           baseImage: alpine
-          matrixName: alpine
-          poolName: Azure Pipelines
-          vmImage: ubuntu-18.04
-          dockerComposeTask: NukeIntegrationTests
-          dockerComposeDependenciesTask: StartDependencies
-        arm64_net5_0:
-          publishTargetFramework: net5.0
-          baseImage: debian
-          matrixName: arm64
-          poolName: Arm64
-          vmImage:
-          dockerComposeTask: NukeIntegrationTests.ARM64
-          dockerComposeDependenciesTask: StartDependencies.ARM64
 
     variables:
       TestAllPackageVersions: true
 
     pool:
-      name: $(poolName)
-      vmImage: $(vmImage)
+      vmImage: ubuntu-18.04
 
     steps:
     # Doing a clean of obj files _before_ restore to remove build output from previous runs
@@ -504,7 +483,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(matrixName)-working-directory
+        artifact: build-linux-$(baseImage)-working-directory
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -516,13 +495,13 @@ stages:
       displayName: docker-compose build NukeIntegrationTests
       inputs:
         containerregistrytype: Container Registry
-        dockerComposeCommand: build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) $(dockerComposeTask)
+        dockerComposeCommand: build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) NukeIntegrationTests
 
     - task: DockerCompose@0
       displayName: docker-compose start dependencies
       inputs:
         containerregistrytype: Container Registry
-        dockerComposeCommand: run --rm $(dockerComposeDependenciesTask)
+        dockerComposeCommand: run --rm StartDependencies
 
     - task: DockerCompose@0
       displayName: docker-compose run NukeIntegrationTests
@@ -531,7 +510,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           framework=$(publishTargetFramework)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) $(dockerComposeTask)
+        dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) NukeIntegrationTests
 
     - task: DockerCompose@0
       displayName: docker-compose stop services
@@ -541,7 +520,7 @@ stages:
       condition: succeededOrFailed()
 
     - publish: build_data
-      artifact: profiler-logs_integration_tests_linux_$(matrixName)_$(publishTargetFramework)_$(System.JobAttempt)
+      artifact: profiler-logs_integration_tests_linux_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
       condition: succeededOrFailed()
 
     - task: PublishTestResults@2
@@ -550,6 +529,79 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
+
+- stage: integration_tests_arm64
+  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  dependsOn: [build_arm64]
+  jobs:
+    - job: Test
+      variables:
+        TestAllPackageVersions: true
+        publishTargetFramework: net5.0
+        baseImage: debian
+
+      pool:
+        name: Arm64
+
+      steps:
+        # Doing a clean of obj files _before_ restore to remove build output from previous runs
+        # Can't do a full clean, as otherwise restore-working-directory fails
+        # Only necessary for ARM64, but shouldn't cause any harm on others
+        # Can't ifdef it as depends on a matrix variable
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: $(baseImage)
+            command: "CleanObjFiles"
+
+        - template: steps/restore-working-directory.yml
+          parameters:
+            artifact: build-linux-arm64-working-directory
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: $(baseImage)
+            command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
+
+        - task: DockerCompose@0
+          displayName: docker-compose build NukeIntegrationTests
+          inputs:
+            containerregistrytype: Container Registry
+            dockerComposeCommand: build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) NukeIntegrationTests.ARM64
+
+        - task: DockerCompose@0
+          displayName: docker-compose start dependencies
+          inputs:
+            containerregistrytype: Container Registry
+            dockerComposeCommand: run --rm StartDependencies.ARM64
+
+        - task: DockerCompose@0
+          displayName: docker-compose run NukeIntegrationTests
+          inputs:
+            containerregistrytype: Container Registry
+            dockerComposeFileArgs: |
+              baseImage=$(baseImage)
+              framework=$(publishTargetFramework)
+            dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) NukeIntegrationTests.ARM64
+
+        - task: DockerCompose@0
+          displayName: docker-compose stop services
+          inputs:
+            containerregistrytype: Container Registry
+            dockerComposeCommand: down
+          condition: succeededOrFailed()
+
+        - publish: build_data
+          artifact: profiler-logs_integration_tests_linux_arm64_$(publishTargetFramework)_$(System.JobAttempt)
+          condition: succeededOrFailed()
+
+        - task: PublishTestResults@2
+          displayName: publish test results
+          inputs:
+            testResultsFormat: VSTest
+            testResultsFiles: build_data/results/**/*.trx
+          condition: succeededOrFailed()
 
 - stage: benchmarks
   condition: and(succeeded(), ne(variables['skip_benchmarks'], 'true'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -890,7 +890,7 @@ stages:
 
         - publish: "$(Build.ArtifactStagingDirectory)"
           displayName: Publish release artifacts
-          artifact: $(VERSION_NUMBER)-release-artifacts
+          artifact: $(tracer_version)-release-artifacts
         
         # We don't include the MSI artifacts as they're not signed
         - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -849,6 +849,50 @@ stages:
             artifact: nuget-packages
             path: $(Build.ArtifactStagingDirectory)
 
+        # set the version from the package name
+        - bash: |
+            NUGET_NAME=$(basename $(Build.ArtifactStagingDirectory)/Datadog.Trace.OpenTracing.*.nupkg)
+            VERSION_NUMBER=${NUGET_NAME:26:-6}
+            echo "detected version: $VERSION_NUMBER"
+            echo "##vso[task.setvariable variable=tracer_version]$VERSION_NUMBER"
+          displayName: Extract version number
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Alpine packages
+          inputs:
+            artifact: linux-packages-alpine
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Debian packages
+          inputs:
+            artifact: linux-packages-debian
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Arm64 packages
+          inputs:
+            artifact: linux-packages-arm64
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download Windows tracer home
+          inputs:
+            artifact: windows-tracer-home.zip
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download runner dotnet tool
+          inputs:
+            artifact: runner-dotnet-tool
+            patterns: "*.nupkg"
+            path: $(Build.ArtifactStagingDirectory)
+
+        - publish: "$(Build.ArtifactStagingDirectory)"
+          displayName: Publish release artifacts
+          artifact: $(VERSION_NUMBER)-release-artifacts
+        
+        # We don't include the MSI artifacts as they're not signed
         - task: DownloadPipelineArtifact@2
           displayName: Download x64 MSI
           inputs:
@@ -860,46 +904,6 @@ stages:
           inputs:
             artifact: windows-msi-x86
             path: $(Build.ArtifactStagingDirectory)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download Windows tracer home
-          inputs:
-            artifact: windows-tracer-home.zip
-            path: $(Build.ArtifactStagingDirectory)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download linux Debian packages
-          inputs:
-            artifact: linux-packages-debian
-            path: $(Build.ArtifactStagingDirectory)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download linux Alpine packages
-          inputs:
-            artifact: linux-packages-alpine
-            path: $(Build.ArtifactStagingDirectory)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download linux Arm64 packages
-          inputs:
-            artifact: linux-packages-arm64
-            path: $(Build.ArtifactStagingDirectory)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download runner dotnet tool
-          inputs:
-            artifact: runner-dotnet-tool
-            patterns: "*.nupkg"
-            path: $(Build.ArtifactStagingDirectory)
-
-        # set the version from the package name
-        - bash: |
-            ls "$(Build.ArtifactStagingDirectory)"
-            MSI_NAME=$(basename $(Build.ArtifactStagingDirectory)/*-x64.msi)
-            VERSION_NUMBER=${MSI_NAME:19:-8}
-            echo "detected version: $VERSION_NUMBER"
-            echo "##vso[task.setvariable variable=tracer_version]$VERSION_NUMBER"
-          displayName: Extract version number
 
         # Publish a Universal Package
         - task: UniversalPackages@0

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -39,8 +39,7 @@ variables:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
   # For scheduled builds, only run benchmarks and crank (and deps).
-  # Allow forcing a benchmark/throughput run using run_benchmarks_only=true
-  benchmarksOnly: ${{ or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['run_benchmarks_only'], 'true')) }} # only works if you have a main branch
+  isScheduledBuild: ${{ eq(variables['Build.Reason'], 'Schedule') }} # only works if you have a main branch
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:
@@ -138,7 +137,7 @@ stages:
       artifact: build-linux-arm64-working-directory
 
 - stage: build_macos
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: []
   jobs:
   - job: build
@@ -161,7 +160,7 @@ stages:
       artifact: build-macos-working-directory
 
 - stage: package_windows
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -191,7 +190,7 @@ stages:
         artifact: nuget-packages
 
 - stage: unit_tests_windows
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -230,7 +229,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_macos
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_macos
   jobs:
   - job: managed
@@ -257,7 +256,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_linux
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_linux]
   jobs:
   - job: test
@@ -293,7 +292,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: unit_tests_arm64
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_arm64]
   jobs:
     - job: test
@@ -323,7 +322,7 @@ stages:
           condition: succeededOrFailed()
 
 - stage: integration_tests_windows
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -362,7 +361,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_windows_iis
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_windows, package_windows]
   jobs:
   - job: Windows_IIS
@@ -433,7 +432,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_linux
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_linux]
   jobs:
   - job: Test
@@ -531,7 +530,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_arm64
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_arm64]
   jobs:
     - job: Test
@@ -604,7 +603,6 @@ stages:
           condition: succeededOrFailed()
 
 - stage: benchmarks
-  condition: and(succeeded(), ne(variables['skip_benchmarks'], 'true'))
   dependsOn: build_windows
   jobs:
 
@@ -633,7 +631,7 @@ stages:
         script: 'Start-Sleep -s 120'
 
 - stage: dotnet_tool
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_windows, build_linux, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone
@@ -738,7 +736,7 @@ stages:
       artifact: runner-standalone-osx-x64
 
 - stage: upload
-  condition: and(succeeded(), eq(variables['benchmarksOnly'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [package_windows, build_linux]
   jobs:
   - job: s3_upload
@@ -834,7 +832,6 @@ stages:
 
 
 - stage: throughput
-  condition: and(succeeded(), ne(variables['skip_benchmarks'], 'true'))
   dependsOn: [build_linux, build_windows]
   jobs:
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -895,7 +895,7 @@ stages:
         # set the version from the package name
         - bash: |
             ls "$(Build.ArtifactStagingDirectory)"
-            MSI_NAME=$(ls $(Build.ArtifactStagingDirectory)/*-x64.msi)
+            MSI_NAME=$(basename $(Build.ArtifactStagingDirectory)/*-x64.msi)
             VERSION_NUMBER=${MSI_NAME:19:-8}
             echo "detected version: $VERSION_NUMBER"
             echo "##vso[task.setvariable variable=tracer_version]$VERSION_NUMBER"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -632,7 +632,7 @@ stages:
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [build_windows, build_linux, build_macos]
+  dependsOn: [build_windows, build_linux, build_arm64, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone
 
@@ -737,7 +737,7 @@ stages:
 
 - stage: upload_to_s3
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [package_windows, build_linux]
+  dependsOn: [package_windows, build_linux, build_arm64]
   jobs:
   - job: s3_upload
 
@@ -913,7 +913,7 @@ stages:
             versionOption: custom
             versionPublish: "$(tracer_version)-ci-$(Build.BuildId)-$(Build.SourceBranchName)"
 - stage: throughput
-  dependsOn: [build_linux, build_windows]
+  dependsOn: [build_linux, build_arm64, build_windows]
   jobs:
 
   #### Linux

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -347,7 +347,7 @@ stages:
     - powershell: |
         Write-Host "Starting CosmosDB Emulator"
         Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
-        Start-CosmosDbEmulator
+        Start-CosmosDbEmulator -Timeout 300
       displayName: 'Start CosmosDB Emulator'
       workingDirectory: $(Pipeline.Workspace)
 

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -356,7 +356,7 @@ partial class Build
            EnsureCleanDirectory(outputDir);
            MoveFile(
                DDTracerHomeDirectory / fileName,
-               outputDir / architecture);
+               outputDir / fileName);
        });
 
     Target BuildMsi => _ => _

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -730,6 +730,7 @@ partial class Build
                 // .DisableRestore()
                 .EnableNoDependencies()
                 .SetConfiguration(BuildConfiguration)
+                .SetTargetPlatform(Platform)
                 .SetProperty("DeployOnBuild", true)
                 .SetProperty("PublishProfile", publishProfile)
                 .SetMaxCpuCount(null)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -65,11 +65,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: ExpectedOperationName);
                 spans.Count.Should().BeGreaterOrEqualTo(expectedSpanCount, $"Expecting at least {expectedSpanCount} spans, only received {spans.Count}");
 
-                Console.WriteLine($"spans.Count: {spans.Count}");
+                Output.WriteLine($"spans.Count: {spans.Count}");
 
                 foreach (var span in spans)
                 {
-                    Console.WriteLine(span);
+                    Output.WriteLine(span.ToString());
                 }
 
                 var dbTags = 0;


### PR DESCRIPTION
A few minor changes:

* Split out the ARM64 builds so graviton issues doesn't block everything else. Also cleans up link strategy matrix
* Increase startup timeout to cosmosdb emulator to try and reduce failures
* Don't use Console.Writeline in xunit as clutters the build log
* Remove `run_benchmarks_only` variable - you can already choose which stages to run from the AzDo UI, so this was added complexity
* Add an Azure Devops "Universal Packages" [feed that contains all the build output](https://dev.azure.com/datadoghq/dd-trace-dotnet/_packaging?_a=feed&feed=Main). I _thought_ this would be useful for doing releases (among other things) but it turns out [you can't download from the web, you have to use the Azure CLI](https://docs.microsoft.com/en-us/azure/devops/artifacts/quickstarts/universal-packages?view=azure-devops#download-a-universal-package) 🤨 

~Given the issues with downloading Universal Packages I wonder if I should create a similar package as a standard build artifact for the pipeline. Should make it easier for releases? And if so, maybe I shouldn't include the MSIs, so that we don't accidentally include the unsigned versions?~ Decided this was a good idea, so went for it. We now get a `VERSION-release-artifiacts` artifact which bundles everything together, to make doing releases easier (and thanks to the name, it's the first artifact in the list). Note that this _doesn't_ include the MSI artifacts, so that we don't accidentally use them in place of the signed MSI ones. TBD on the signed NuGet packages I think. 

![image](https://user-images.githubusercontent.com/18755388/124115869-32e01e00-da66-11eb-9d09-0f0184a7ec4d.png)


@DataDog/apm-dotnet