### PR TITLE
Add support for db client split by instance.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/ScopeDBFactory.cs
@@ -73,7 +73,16 @@ namespace Datadog.Trace.ClrProfiler
                     return null;
                 }
 
-                string serviceName = tracer.Settings.GetServiceName(tracer, _dbTypeName);
+                string serviceName;
+
+                if (tracer.Settings.DbClientSplitByInscance)
+                {
+                    serviceName = command.Connection.Database;
+                }
+                else
+                {
+                    serviceName = tracer.Settings.GetServiceName(tracer, _dbTypeName);
+                }
 
                 var tags = new SqlTags();
                 scope = tracer.StartActiveWithTags(_operationName, tags: tags, serviceName: serviceName);

--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -334,6 +334,11 @@ namespace Datadog.Trace.Configuration
         public const string KafkaCreateConsumerScopeEnabled = "DD_TRACE_KAFKA_CREATE_CONSUMER_SCOPE_ENABLED";
 
         /// <summary>
+        /// Configuration key to enable db spans get assigned the instance name as the service name.
+        /// </summary>
+        public const string DbClientSplitByInscance = "DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE";
+
+        /// <summary>
         /// String format patterns used to match integration-specific configuration keys.
         /// </summary>
         public static class Integrations

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -217,7 +217,7 @@ namespace Datadog.Trace.Configuration
 
             DbClientSplitByInscance = source?.GetBool(ConfigurationKeys.DbClientSplitByInscance) ??
                                         // Default value
-                                        false;    
+                                        false;
         }
 
         /// <summary>

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -214,6 +214,10 @@ namespace Datadog.Trace.Configuration
 
             KafkaCreateConsumerScopeEnabled = source?.GetBool(ConfigurationKeys.KafkaCreateConsumerScopeEnabled)
                                            ?? true; // default
+
+            DbClientSplitByInscance = source?.GetBool(ConfigurationKeys.DbClientSplitByInscance) ??
+                                        // Default value
+                                        false;    
         }
 
         /// <summary>
@@ -417,6 +421,11 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether the diagnostic log at startup is enabled
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether db spans get assigned the instance name as the service name.
+        /// </summary>
+        public bool DbClientSplitByInscance { get; set; }
 
         /// <summary>
         /// Gets or sets the comma separated list of url patterns to skip tracing.


### PR DESCRIPTION
Fixes #1571

Changes proposed in this pull request:

Add Support for DD_TRACE_DB_CLIENT_SPLIT_BY_INSTANCE

@DataDog/apm-dotnet