### PR TITLE
Fixes environment values in the logs on non windows platforms

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -9,31 +9,31 @@
 namespace trace
 {
 
-inline WSTRING env_vars_to_display[]{environment::tracing_enabled,
-                                     environment::debug_enabled,
-                                     environment::calltarget_enabled,
-                                     environment::profiler_home_path,
-                                     environment::integrations_path,
-                                     environment::include_process_names,
-                                     environment::exclude_process_names,
-                                     environment::agent_host,
-                                     environment::agent_port,
-                                     environment::env,
-                                     environment::service_name,
-                                     environment::service_version,
-                                     environment::disabled_integrations,
-                                     environment::log_path,
-                                     environment::log_directory,
-                                     environment::clr_disable_optimizations,
-                                     environment::clr_enable_inlining,
-                                     environment::domain_neutral_instrumentation,
-                                     environment::dump_il_rewrite_enabled,
-                                     environment::netstandard_enabled,
-                                     environment::azure_app_services,
-                                     environment::azure_app_services_app_pool_id,
-                                     environment::azure_app_services_cli_telemetry_profile_value};
+const WSTRING env_vars_to_display[]{environment::tracing_enabled,
+                                    environment::debug_enabled,
+                                    environment::calltarget_enabled,
+                                    environment::profiler_home_path,
+                                    environment::integrations_path,
+                                    environment::include_process_names,
+                                    environment::exclude_process_names,
+                                    environment::agent_host,
+                                    environment::agent_port,
+                                    environment::env,
+                                    environment::service_name,
+                                    environment::service_version,
+                                    environment::disabled_integrations,
+                                    environment::log_path,
+                                    environment::log_directory,
+                                    environment::clr_disable_optimizations,
+                                    environment::clr_enable_inlining,
+                                    environment::domain_neutral_instrumentation,
+                                    environment::dump_il_rewrite_enabled,
+                                    environment::netstandard_enabled,
+                                    environment::azure_app_services,
+                                    environment::azure_app_services_app_pool_id,
+                                    environment::azure_app_services_cli_telemetry_profile_value};
 
-inline WSTRING skip_assembly_prefixes[]{
+const WSTRING skip_assembly_prefixes[]{
     WStr("Datadog.Trace"),
     WStr("MessagePack"),
     WStr("Microsoft.AI"),
@@ -58,18 +58,18 @@ inline WSTRING skip_assembly_prefixes[]{
     WStr("Newtonsoft"),
 };
 
-inline WSTRING skip_assemblies[]{WStr("mscorlib"),
-                                 WStr("netstandard"),
-                                 WStr("System.Configuration"),
-                                 WStr("Microsoft.AspNetCore.Razor.Language"),
-                                 WStr("Microsoft.AspNetCore.Mvc.RazorPages"),
-                                 WStr("Anonymously Hosted DynamicMethods Assembly"),
-                                 WStr("ISymWrapper")};
+const WSTRING skip_assemblies[]{WStr("mscorlib"),
+                                WStr("netstandard"),
+                                WStr("System.Configuration"),
+                                WStr("Microsoft.AspNetCore.Razor.Language"),
+                                WStr("Microsoft.AspNetCore.Mvc.RazorPages"),
+                                WStr("Anonymously Hosted DynamicMethods Assembly"),
+                                WStr("ISymWrapper")};
 
-inline WSTRING managed_profiler_full_assembly_version =
+const WSTRING managed_profiler_full_assembly_version =
     WStr("Datadog.Trace.ClrProfiler.Managed, Version=1.27.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
-inline WSTRING calltarget_modification_action = WStr("CallTargetModification");
+const WSTRING calltarget_modification_action = WStr("CallTargetModification");
 
 } // namespace trace
 


### PR DESCRIPTION
This PR fixes environment values in the logs on non windows platforms.


#### Before this PR:
```bash
07/07/21 03:32:22.127 PM [78326|1189725] [info] Datadog CLR Profiler 1.27.1 on macOS (amd64)
07/07/21 03:32:22.128 PM [78326|1189725] [debug] Initialize
07/07/21 03:32:22.128 PM [78326|1189725] [debug] Interface ICorProfilerInfo6 found.
07/07/21 03:32:22.128 PM [78326|1189725] [info] Environment variables:
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
07/07/21 03:32:22.128 PM [78326|1189725] [info]   =
```

#### After this PR:
```bash
07/07/21 03:36:05.620 PM [79042|1194748] [info] Datadog CLR Profiler 1.27.1 on macOS (amd64)
07/07/21 03:36:05.620 PM [79042|1194748] [debug] Initialize
07/07/21 03:36:05.620 PM [79042|1194748] [debug] Interface ICorProfilerInfo6 found.
07/07/21 03:36:05.620 PM [79042|1194748] [info] Environment variables:
07/07/21 03:36:05.620 PM [79042|1194748] [info]   DD_TRACE_ENABLED=
07/07/21 03:36:05.620 PM [79042|1194748] [info]   DD_TRACE_DEBUG=1
07/07/21 03:36:05.620 PM [79042|1194748] [info]   DD_TRACE_CALLTARGET_ENABLED=
07/07/21 03:36:05.620 PM [79042|1194748] [info]   DD_DOTNET_TRACER_HOME=/dd-tracer
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_INTEGRATIONS=/dd-tracer/integrations.json
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_PROFILER_PROCESSES=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_PROFILER_EXCLUDE_PROCESSES=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_AGENT_HOST=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_TRACE_AGENT_PORT=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_ENV=tony_mac2
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_SERVICE=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_VERSION=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_DISABLED_INTEGRATIONS=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_TRACE_LOG_PATH=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_TRACE_LOG_DIRECTORY=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_CLR_DISABLE_OPTIMIZATIONS=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_CLR_ENABLE_INLINING=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_TRACE_DOMAIN_NEUTRAL_INSTRUMENTATION=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_DUMP_ILREWRITE_ENABLED=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_TRACE_NETSTANDARD_ENABLED=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DD_AZURE_APP_SERVICES=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   APP_POOL_ID=
07/07/21 03:36:05.621 PM [79042|1194748] [info]   DOTNET_CLI_TELEMETRY_PROFILE=
```



@DataDog/apm-dotnet