### PR TITLE
Add ASP.NET Core on IIS Express tests

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -108,6 +108,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/home/shutdown";
             _iisFixture.TryStartIis(this, classicMode);
+            _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = nameof(AspNetMvc4Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")
                       + (classicMode ? ".Classic" : ".Integrated")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc4Tests.cs
@@ -107,7 +107,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/home/shutdown";
-            _iisFixture.TryStartIis(this, classicMode);
             _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = nameof(AspNetMvc4Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5Tests.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/home/shutdown";
-            _iisFixture.TryStartIis(this, classicMode);
+            _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = nameof(AspNetMvc5Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")
                       + (classicMode ? ".Classic" : ".Integrated")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebApi2Tests.cs
@@ -107,7 +107,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/home/shutdown";
-            _iisFixture.TryStartIis(this, classicMode);
+            _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = nameof(AspNetWebApi2Tests)
                       + (enableCallTarget ? ".CallSite" : ".CallTarget")
                       + (classicMode ? ".Classic" : ".Integrated")

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/account/login?shutdown=1";
-            _iisFixture.TryStartIis(this, classicMode: false);
+            _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
         }
 
         [Theory]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
@@ -1,0 +1,70 @@
+// <copyright file="AspNetCoreIisMvc21Tests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP2_1
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    // Note that ASP.NET Core 2.1 does not support in-process hosting
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc21TestsOutOfProcess : AspNetCoreIisMvc21Tests
+    {
+        public AspNetCoreIisMvc21TestsOutOfProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc21TestsOutOfProcessWithFeatureFlag : AspNetCoreIisMvc21Tests
+    {
+        public AspNetCoreIisMvc21TestsOutOfProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreIisMvc21Tests : AspNetCoreIisMvcTestBase
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        protected AspNetCoreIisMvc21Tests(IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc21", fixture, output, inProcess, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName(nameof(AspNetCoreIisMvc21Tests));
+            _iisFixture = fixture;
+            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            // We actually sometimes expect 2, but waiting for 1 is good enough
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
@@ -49,6 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
         [Theory]
         [Trait("Category", "EndToEnd")]
+        [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
         public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
@@ -65,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
         [Theory]
         [Trait("Category", "EndToEnd")]
+        [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
         public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
@@ -1,0 +1,86 @@
+// <copyright file="AspNetCoreIisMvc30Tests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_0
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc30TestsInProcess : AspNetCoreIisMvc30Tests
+    {
+        public AspNetCoreIisMvc30TestsInProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc30TestsInProcessWithFeatureFlag : AspNetCoreIisMvc30Tests
+    {
+        public AspNetCoreIisMvc30TestsInProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc30TestsOutOfProcess : AspNetCoreIisMvc30Tests
+    {
+        public AspNetCoreIisMvc30TestsOutOfProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc30TestsOutOfProcessWithFeatureFlag : AspNetCoreIisMvc30Tests
+    {
+        public AspNetCoreIisMvc30TestsOutOfProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreIisMvc30Tests : AspNetCoreIisMvcTestBase
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        protected AspNetCoreIisMvc30Tests(IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc30", fixture, output, inProcess, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName(nameof(AspNetCoreIisMvc30Tests));
+            _iisFixture = fixture;
+            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            // We actually sometimes expect 2, but waiting for 1 is good enough
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
@@ -65,6 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
         [Theory]
         [Trait("Category", "EndToEnd")]
+        [Trait("Category", "LinuxUnsupported")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(Data))]
         public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
@@ -1,0 +1,86 @@
+// <copyright file="AspNetCoreIisMvc31Tests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP3_1
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc31TestsInProcess : AspNetCoreIisMvc31Tests
+    {
+        public AspNetCoreIisMvc31TestsInProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc31TestsInProcessWithFeatureFlag : AspNetCoreIisMvc31Tests
+    {
+        public AspNetCoreIisMvc31TestsInProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc31TestsOutOfProcess : AspNetCoreIisMvc31Tests
+    {
+        public AspNetCoreIisMvc31TestsOutOfProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc31TestsOutOfProcessWithFeatureFlag : AspNetCoreIisMvc31Tests
+    {
+        public AspNetCoreIisMvc31TestsOutOfProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreIisMvc31Tests : AspNetCoreIisMvcTestBase
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        protected AspNetCoreIisMvc31Tests(IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc31", fixture, output, inProcess, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName(nameof(AspNetCoreIisMvc31Tests));
+            _iisFixture = fixture;
+            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            // We actually sometimes expect 2, but waiting for 1 is good enough
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
             SetServiceVersion("1.0.0");
 
-            SetCallTargetSettings(inProcess);
+            SetCallTargetSettings(true);
             if (enableRouteTemplateResourceNames)
             {
                 SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -1,0 +1,65 @@
+﻿// <copyright file="AspNetCoreIisMvcTestBase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NETCOREAPP
+
+using System.Runtime.InteropServices;
+using Datadog.Trace.Configuration;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    [UsesVerify]
+    public abstract class AspNetCoreIisMvcTestBase : TestHelper, IClassFixture<IisFixture>
+    {
+        private readonly bool _inProcess;
+        private readonly bool _enableRouteTemplateResourceNames;
+
+        protected AspNetCoreIisMvcTestBase(string sampleName, IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
+            : base(sampleName, output)
+        {
+            _inProcess = inProcess;
+            _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
+            SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
+
+            SetServiceVersion("1.0.0");
+
+            SetCallTargetSettings(inProcess);
+            if (enableRouteTemplateResourceNames)
+            {
+                SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
+            }
+
+            Fixture = fixture;
+        }
+
+        protected IisFixture Fixture { get; }
+
+        public static TheoryData<string, int> Data() => new()
+        {
+            { "/", 200 },
+            { "/delay/0", 200 },
+            { "/api/delay/0", 200 },
+            { "/not-found", 404 },
+            { "/status-code/203", 203 },
+            { "/status-code/500", 500 },
+            { "/bad-request", 500 },
+            { "/status-code/402", 402 },
+            { "/ping", 200 },
+            { "/branch/ping", 200 },
+            { "/branch/not-found", 404 },
+        };
+
+        protected string GetTestName(string testName)
+        {
+            return testName
+                 + (_inProcess ? ".InProcess" : ".OutOfProcess")
+                 + (_enableRouteTemplateResourceNames ? ".WithFF" : ".NoFF")
+                 + (RuntimeInformation.ProcessArchitecture == Architecture.X64 ? ".X64" : ".X86"); // assume that arm is the same
+        }
+    }
+}
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21Tests.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 #if NETCOREAPP2_1
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
 using System.Net;
 using System.Threading.Tasks;
 using VerifyXunit;
@@ -12,12 +14,44 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
-    public class AspNetCoreMvc21Tests : AspNetCoreMvcTestBase
+    public class AspNetCoreMvc21TestsCallsite : AspNetCoreMvc21Tests
+    {
+        public AspNetCoreMvc21TestsCallsite(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc21TestsCallsiteWithFeatureFlag : AspNetCoreMvc21Tests
+    {
+        public AspNetCoreMvc21TestsCallsiteWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc21TestsCallTarget : AspNetCoreMvc21Tests
+    {
+        public AspNetCoreMvc21TestsCallTarget(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc21TestsCallTargetWithFeatureFlag : AspNetCoreMvc21Tests
+    {
+        public AspNetCoreMvc21TestsCallTargetWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreMvc21Tests : AspNetCoreMvcTestBase
     {
         private readonly string _testName;
 
-        public AspNetCoreMvc21Tests(ITestOutputHelper output, AspNetCoreTestFixture fixture)
-            : base("AspNetCoreMvc21", fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
+        protected AspNetCoreMvc21Tests(AspNetCoreTestFixture fixture, ITestOutputHelper output, bool enableCallTarget, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc21", fixture, output, enableCallTarget, enableRouteTemplateResourceNames)
         {
             _testName = GetTestName(nameof(AspNetCoreMvc21Tests));
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 #if NETCOREAPP3_0
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
 using System.Net;
 using System.Threading.Tasks;
 using VerifyXunit;
@@ -12,12 +14,44 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
-    public class AspNetCoreMvc30Tests : AspNetCoreMvcTestBase
+    public class AspNetCoreMvc30TestsCallsite : AspNetCoreMvc30Tests
+    {
+        public AspNetCoreMvc30TestsCallsite(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc30TestsCallsiteWithFeatureFlag : AspNetCoreMvc30Tests
+    {
+        public AspNetCoreMvc30TestsCallsiteWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc30TestsCallTarget : AspNetCoreMvc30Tests
+    {
+        public AspNetCoreMvc30TestsCallTarget(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc30TestsCallTargetWithFeatureFlag : AspNetCoreMvc30Tests
+    {
+        public AspNetCoreMvc30TestsCallTargetWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreMvc30Tests : AspNetCoreMvcTestBase
     {
         private readonly string _testName;
 
-        public AspNetCoreMvc30Tests(ITestOutputHelper output, AspNetCoreTestFixture fixture)
-            : base("AspNetCoreMvc30", fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
+        protected AspNetCoreMvc30Tests(AspNetCoreTestFixture fixture, ITestOutputHelper output, bool enableCallTarget, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc30", fixture, output, enableCallTarget, enableRouteTemplateResourceNames)
         {
             _testName = GetTestName(nameof(AspNetCoreMvc30Tests));
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc30Tests.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 #if NETCOREAPP3_0
+using System.Net;
 using System.Threading.Tasks;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,19 +14,32 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
     public class AspNetCoreMvc30Tests : AspNetCoreMvcTestBase
     {
-        public AspNetCoreMvc30Tests(ITestOutputHelper output)
-            : base("AspNetCoreMvc30", output, serviceVersion: "1.0.0")
+        private readonly string _testName;
+
+        public AspNetCoreMvc30Tests(ITestOutputHelper output, AspNetCoreTestFixture fixture)
+            : base("AspNetCoreMvc30", fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
         {
-            // EnableDebugMode();
+            _testName = GetTestName(nameof(AspNetCoreMvc30Tests));
         }
 
-        [Fact]
+        [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public async Task MeetsAllAspNetCoreMvcExpectations()
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
         {
-            // No package versions are relevant because this is built-in
-            await RunTraceTestOnSelfHosted(string.Empty);
+            await Fixture.TryStartApp(this, Output);
+
+            var spans = await Fixture.WaitForSpans(Output, path);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseTypeName(_testName);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -4,7 +4,9 @@
 // </copyright>
 
 #if NETCOREAPP3_1
+using System.Net;
 using System.Threading.Tasks;
+using VerifyXunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -12,19 +14,32 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
     public class AspNetCoreMvc31Tests : AspNetCoreMvcTestBase
     {
-        public AspNetCoreMvc31Tests(ITestOutputHelper output)
-            : base("AspNetCoreMvc31", output, serviceVersion: "1.0.0")
+        private readonly string _testName;
+
+        public AspNetCoreMvc31Tests(ITestOutputHelper output, AspNetCoreTestFixture fixture)
+            : base("AspNetCoreMvc31", fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
         {
-            // EnableDebugMode();
+            _testName = GetTestName(nameof(AspNetCoreMvc31Tests));
         }
 
-        [Fact]
+        [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public async Task MeetsAllAspNetCoreMvcExpectations()
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
         {
-            // No package versions are relevant because this is built-in
-            await RunTraceTestOnSelfHosted(string.Empty);
+            await Fixture.TryStartApp(this, Output);
+
+            var spans = await Fixture.WaitForSpans(Output, path);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseTypeName(_testName);
         }
     }
 }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc31Tests.cs
@@ -4,6 +4,8 @@
 // </copyright>
 
 #if NETCOREAPP3_1
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
 using System.Net;
 using System.Threading.Tasks;
 using VerifyXunit;
@@ -12,12 +14,44 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
-    public class AspNetCoreMvc31Tests : AspNetCoreMvcTestBase
+    public class AspNetCoreMvc31TestsCallsite : AspNetCoreMvc31Tests
+    {
+        public AspNetCoreMvc31TestsCallsite(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc31TestsCallsiteWithFeatureFlag : AspNetCoreMvc31Tests
+    {
+        public AspNetCoreMvc31TestsCallsiteWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc31TestsCallTarget : AspNetCoreMvc31Tests
+    {
+        public AspNetCoreMvc31TestsCallTarget(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc31TestsCallTargetWithFeatureFlag : AspNetCoreMvc31Tests
+    {
+        public AspNetCoreMvc31TestsCallTargetWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreMvc31Tests : AspNetCoreMvcTestBase
     {
         private readonly string _testName;
 
-        public AspNetCoreMvc31Tests(ITestOutputHelper output, AspNetCoreTestFixture fixture)
-            : base("AspNetCoreMvc31", fixture, output, enableCallTarget: false, enableRouteTemplateResourceNames: false)
+        protected AspNetCoreMvc31Tests(AspNetCoreTestFixture fixture, ITestOutputHelper output, bool enableCallTarget, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc31", fixture, output, enableCallTarget, enableRouteTemplateResourceNames)
         {
             _testName = GetTestName(nameof(AspNetCoreMvc31Tests));
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -2,25 +2,26 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
-
+#if NETCOREAPP
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using VerifyXunit;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 {
-    public abstract class AspNetCoreMvcTestBase : TestHelper
+    [UsesVerify]
+    public abstract class AspNetCoreMvcTestBase : TestHelper, IClassFixture<AspNetCoreMvcTestBase.AspNetCoreTestFixture>
     {
-        protected const string TopLevelOperationName = "aspnet_core.request";
-
         protected const string HeaderName1WithMapping = "datadog-header-name";
         protected const string HeaderName1UpperWithMapping = "DATADOG-HEADER-NAME";
         protected const string HeaderTagName1WithMapping = "datadog-header-tag";
@@ -30,155 +31,163 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         protected const string HeaderName3 = "Server";
         protected const string HeaderValue3 = "Kestrel";
 
-        protected AspNetCoreMvcTestBase(string sampleAppName, ITestOutputHelper output, string serviceVersion)
-            : base(sampleAppName, output)
+        private readonly bool _enableCallTarget;
+        private readonly bool _enableRouteTemplateResourceNames;
+
+        protected AspNetCoreMvcTestBase(string sampleName, AspNetCoreTestFixture fixture, ITestOutputHelper output, bool enableCallTarget, bool enableRouteTemplateResourceNames)
+            : base(sampleName, output)
         {
-            ServiceVersion = serviceVersion;
-            HttpClient = new HttpClient();
-            HttpClient.DefaultRequestHeaders.Add(HeaderName1WithMapping, HeaderValue1);
-            HttpClient.DefaultRequestHeaders.Add(HeaderName2, HeaderValue2);
+            _enableCallTarget = enableCallTarget;
+            _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
             SetEnvironmentVariable(ConfigurationKeys.HeaderTags, $"{HeaderName1UpperWithMapping}:{HeaderTagName1WithMapping},{HeaderName2},{HeaderName3}");
             SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
 
-            SetServiceVersion(ServiceVersion);
+            SetServiceVersion("1.0.0");
 
-            CreateTopLevelExpectation(url: "/", httpMethod: "GET", httpStatus: "200", resourceUrl: "Home/Index", serviceVersion: ServiceVersion);
-            CreateTopLevelExpectation(url: "/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "delay/{seconds}", serviceVersion: ServiceVersion);
-            CreateTopLevelExpectation(url: "/api/delay/0", httpMethod: "GET", httpStatus: "200", resourceUrl: "api/delay/{seconds}", serviceVersion: ServiceVersion);
-            CreateTopLevelExpectation(url: "/not-found", httpMethod: "GET", httpStatus: "404", resourceUrl: "/not-found", serviceVersion: ServiceVersion);
-            CreateTopLevelExpectation(url: "/status-code/203", httpMethod: "GET", httpStatus: "203", resourceUrl: "status-code/{statusCode}", serviceVersion: ServiceVersion);
+            SetCallTargetSettings(enableCallTarget);
+            if (enableRouteTemplateResourceNames)
+            {
+                SetEnvironmentVariable(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "true");
+            }
 
-            CreateTopLevelExpectation(
-                url: "/status-code/500",
-                httpMethod: "GET",
-                httpStatus: "500",
-                resourceUrl: "status-code/{statusCode}",
-                serviceVersion: ServiceVersion,
-                additionalCheck: span =>
-                                 {
-                                     var failures = new List<string>();
-
-                                     if (span.Error == 0)
-                                     {
-                                         failures.Add($"Expected Error flag set within {span.Resource}");
-                                     }
-
-                                     if (SpanExpectation.GetTag(span, Tags.ErrorType) != null)
-                                     {
-                                         failures.Add($"Did not expect exception type within {span.Resource}");
-                                     }
-
-                                     var errorMessage = SpanExpectation.GetTag(span, Tags.ErrorMsg);
-
-                                     if (errorMessage != "The HTTP response has status code 500.")
-                                     {
-                                         failures.Add($"Expected specific error message within {span.Resource}. Found \"{errorMessage}\"");
-                                     }
-
-                                     return failures;
-                                 });
-
-            CreateTopLevelExpectation(
-                url: "/bad-request",
-                httpMethod: "GET",
-                httpStatus: "500",
-                resourceUrl: "bad-request",
-                serviceVersion: ServiceVersion,
-                additionalCheck: span =>
-                {
-                    var failures = new List<string>();
-
-                    if (span.Error == 0)
-                    {
-                        failures.Add($"Expected Error flag set within {span.Resource}");
-                    }
-
-                    if (SpanExpectation.GetTag(span, Tags.ErrorType) != "System.Exception")
-                    {
-                        failures.Add($"Expected specific exception within {span.Resource}");
-                    }
-
-                    var errorMessage = SpanExpectation.GetTag(span, Tags.ErrorMsg);
-
-                    if (errorMessage != "This was a bad request.")
-                    {
-                        failures.Add($"Expected specific error message within {span.Resource}. Found \"{errorMessage}\"");
-                    }
-
-                    return failures;
-                });
-
-            CreateTopLevelExpectation(
-                url: "/status-code/402",
-                httpMethod: "GET",
-                httpStatus: "402",
-                resourceUrl: "status-code/{statusCode}",
-                serviceVersion: ServiceVersion,
-                additionalCheck: span =>
-                {
-                    var failures = new List<string>();
-
-                    if (span.Error == 0)
-                    {
-                        failures.Add($"Expected Error flag set within {span.Resource}");
-                    }
-
-                    var errorMessage = SpanExpectation.GetTag(span, Tags.ErrorMsg);
-
-                    if (errorMessage != "The HTTP response has status code 402.")
-                    {
-                        failures.Add($"Expected specific error message within {span.Resource}. Found \"{errorMessage}\"");
-                    }
-
-                    return failures;
-                });
+            Fixture = fixture;
         }
 
-        public string ServiceVersion { get; }
+        protected AspNetCoreTestFixture Fixture { get; }
 
-        protected HttpClient HttpClient { get; }
-
-        protected List<AspNetCoreMvcSpanExpectation> Expectations { get; set; } = new List<AspNetCoreMvcSpanExpectation>();
-
-        public async Task RunTraceTestOnSelfHosted(string packageVersion)
+        public static TheoryData<string, int> Data() => new()
         {
-            var agentPort = TcpPortProvider.GetOpenPort();
-            var aspNetCorePort = TcpPortProvider.GetOpenPort();
+            { "/", 200 },
+            { "/delay/0", 200 },
+            { "/api/delay/0", 200 },
+            { "/not-found", 404 },
+            { "/status-code/203", 203 },
+            { "/status-code/500", 500 },
+            { "/bad-request", 500 },
+            { "/status-code/402", 402 },
+        };
 
-            using (var agent = new MockTracerAgent(agentPort))
-            using (var process = StartSample(agent.Port, arguments: null, packageVersion: packageVersion, aspNetCorePort: aspNetCorePort))
+        protected string GetTestName(string testName)
+        {
+            return testName
+                 + (_enableCallTarget ? ".CallTarget" : ".CallSite")
+                 + (_enableRouteTemplateResourceNames ? ".WithFF" : ".NoFF")
+                 + (RuntimeInformation.ProcessArchitecture == Architecture.X64 ? ".X64" : ".X86"); // assume that arm is the same
+        }
+
+        public sealed class AspNetCoreTestFixture : IDisposable
+        {
+            private readonly HttpClient _httpClient;
+            private Process _process;
+
+            public AspNetCoreTestFixture()
             {
-                agent.SpanFilters.Add(IsNotServerLifeCheck);
+                _httpClient = new HttpClient();
+                _httpClient.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
+                _httpClient.DefaultRequestHeaders.Add(HeaderName1WithMapping, HeaderValue1);
+                _httpClient.DefaultRequestHeaders.Add(HeaderName2, HeaderValue2);
+            }
 
+            public MockTracerAgent Agent { get; private set; }
+
+            public int HttpPort { get; private set; }
+
+            public async Task TryStartApp(TestHelper helper, ITestOutputHelper output)
+            {
+                if (_process is not null)
+                {
+                    return;
+                }
+
+                lock (this)
+                {
+                    if (_process is null)
+                    {
+                        var initialAgentPort = TcpPortProvider.GetOpenPort();
+                        HttpPort = TcpPortProvider.GetOpenPort();
+
+                        Agent = new MockTracerAgent(initialAgentPort);
+                        Agent.SpanFilters.Add(IsNotServerLifeCheck);
+                        output.WriteLine($"Starting aspnetcore sample, agentPort: {Agent.Port}, samplePort: {HttpPort}");
+                        _process = helper.StartSample(Agent.Port, arguments: null, packageVersion: string.Empty, aspNetCorePort: HttpPort);
+                    }
+                }
+
+                await EnsureServerStarted(output);
+            }
+
+            public void Dispose()
+            {
+                lock (this)
+                {
+                    if (_process is not null)
+                    {
+                        try
+                        {
+                            if (!_process.HasExited)
+                            {
+                                // Try shutting down gracefully
+                                SubmitRequest(output: null, "/shutdown").GetAwaiter().GetResult();
+
+                                if (!_process.WaitForExit(5000))
+                                {
+                                    _process.Kill();
+                                }
+
+                                _process.Kill();
+                            }
+                        }
+                        catch
+                        {
+                            // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
+                        }
+
+                        _process.Dispose();
+                    }
+                }
+
+                Agent?.Dispose();
+            }
+
+            public async Task<IImmutableList<MockTracerAgent.Span>> WaitForSpans(ITestOutputHelper output, string path)
+            {
+                var testStart = DateTime.UtcNow;
+
+                await SubmitRequest(output, path);
+                return Agent.WaitForSpans(count: 1, minDateTime: testStart, returnAllOperations: true);
+            }
+
+            private async Task EnsureServerStarted(ITestOutputHelper output)
+            {
                 var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 
-                process.OutputDataReceived += (sender, args) =>
+                _process.OutputDataReceived += (sender, args) =>
                 {
                     if (args.Data != null)
                     {
-                        if (args.Data.Contains("Now listening on:") || args.Data.Contains("Unable to start Kestrel"))
+                        if (args.Data.Contains("Webserver started"))
                         {
                             wh.Set();
                         }
 
-                        Output.WriteLine($"[webserver][stdout] {args.Data}");
+                        output.WriteLine($"[webserver][stdout] {args.Data}");
                     }
                 };
-                process.BeginOutputReadLine();
+                _process.BeginOutputReadLine();
 
-                process.ErrorDataReceived += (sender, args) =>
+                _process.ErrorDataReceived += (sender, args) =>
                 {
                     if (args.Data != null)
                     {
-                        Output.WriteLine($"[webserver][stderr] {args.Data}");
+                        output.WriteLine($"[webserver][stderr] {args.Data}");
                     }
                 };
 
-                process.BeginErrorReadLine();
+                _process.BeginErrorReadLine();
 
                 wh.WaitOne(5000);
 
-                var maxMillisecondsToWait = 15_000;
+                var maxMillisecondsToWait = 30_000;
                 var intervalMilliseconds = 500;
                 var intervals = maxMillisecondsToWait / intervalMilliseconds;
                 var serverReady = false;
@@ -188,7 +197,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                 {
                     try
                     {
-                        serverReady = await SubmitRequest(aspNetCorePort, "/alive-check") == HttpStatusCode.OK;
+                        serverReady = await SubmitRequest(output, "/alive-check") == HttpStatusCode.OK;
                     }
                     catch
                     {
@@ -207,98 +216,27 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                 {
                     throw new Exception("Couldn't verify the application is ready to receive requests.");
                 }
+            }
 
-                var testStart = DateTime.Now;
-
-                var paths = Expectations.Select(e => e.OriginalUri).ToArray();
-                await SubmitRequests(aspNetCorePort, paths);
-
-                var spans =
-                    agent.WaitForSpans(
-                              Expectations.Count,
-                              operationName: TopLevelOperationName,
-                              minDateTime: testStart)
-                         .OrderBy(s => s.Start)
-                         .ToList();
-
-                if (!process.HasExited)
+            private bool IsNotServerLifeCheck(MockTracerAgent.Span span)
+            {
+                var url = SpanExpectation.GetTag(span, Tags.HttpUrl);
+                if (url == null)
                 {
-                    // Try shutting down gracefully
-                    await SubmitRequest(aspNetCorePort, "/shutdown");
-
-                    if (!process.WaitForExit(5000))
-                    {
-                        process.Kill();
-                    }
+                    return true;
                 }
 
-                SpanTestHelpers.AssertExpectationsMet(Expectations, spans);
-            }
-        }
-
-        protected void CreateTopLevelExpectation(
-            string url,
-            string httpMethod,
-            string httpStatus,
-            string resourceUrl,
-            string serviceVersion,
-            Func<MockTracerAgent.Span, List<string>> additionalCheck = null)
-        {
-            var resourceName = $"{httpMethod.ToUpper()} {resourceUrl}";
-
-            var expectation = new AspNetCoreMvcSpanExpectation(
-                                  EnvironmentHelper.FullSampleName,
-                                  serviceVersion,
-                                  TopLevelOperationName,
-                                  resourceName,
-                                  httpStatus,
-                                  httpMethod)
-            {
-                OriginalUri = url,
-            };
-
-            expectation.RegisterDelegateExpectation(additionalCheck);
-
-            _ = HeaderTagName1WithMapping.TryConvertToNormalizedHeaderTagName(out string normalizedHeaderTagName1WithMapping);
-            expectation.RegisterTagExpectation(normalizedHeaderTagName1WithMapping, HeaderValue1);
-
-            // For successful requests, assert that a header tag is present in both the request and response, with the prefixes "http.request.headers" and "http.response.headers", respectively
-            _ = HeaderName2.TryConvertToNormalizedHeaderTagName(out string normalizedHeaderTagName2);
-            expectation.RegisterTagExpectation($"{SpanContextPropagator.HttpRequestHeadersTagPrefix}.{normalizedHeaderTagName2}", HeaderValue2);
-            expectation.RegisterTagExpectation($"{SpanContextPropagator.HttpResponseHeadersTagPrefix}.{normalizedHeaderTagName2}", HeaderValue2, when: (span) => span.Resource != "GET /not-found" && span.Resource != "GET bad-request");
-
-            // Assert that a response header tag is set on successful requests and failing requests
-            _ = HeaderName3.TryConvertToNormalizedHeaderTagName(out string normalizedHeaderTagName3);
-            expectation.RegisterTagExpectation($"{SpanContextPropagator.HttpResponseHeadersTagPrefix}.{normalizedHeaderTagName3}", HeaderValue3, when: (span) => span.Resource != "GET bad-request");
-
-            Expectations.Add(expectation);
-        }
-
-        protected async Task SubmitRequests(int aspNetCorePort, string[] paths)
-        {
-            foreach (var path in paths)
-            {
-                await SubmitRequest(aspNetCorePort, path);
-            }
-        }
-
-        protected async Task<HttpStatusCode> SubmitRequest(int aspNetCorePort, string path)
-        {
-            HttpResponseMessage response = await HttpClient.GetAsync($"http://localhost:{aspNetCorePort}{path}");
-            string responseText = await response.Content.ReadAsStringAsync();
-            Output.WriteLine($"[http] {response.StatusCode} {responseText}");
-            return response.StatusCode;
-        }
-
-        private bool IsNotServerLifeCheck(MockTracerAgent.Span span)
-        {
-            var url = SpanExpectation.GetTag(span, Tags.HttpUrl);
-            if (url == null)
-            {
-                return true;
-            }
-
             return !url.Contains("alive-check") && !url.Contains("shutdown");
+            }
+
+            private async Task<HttpStatusCode> SubmitRequest(ITestOutputHelper output, string path)
+            {
+                HttpResponseMessage response = await _httpClient.GetAsync($"http://localhost:{HttpPort}{path}");
+                string responseText = await response.Content.ReadAsStringAsync();
+                output?.WriteLine($"[http] {response.StatusCode} {responseText}");
+                return response.StatusCode;
+            }
         }
     }
 }
+#endif

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -65,6 +65,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
             { "/status-code/500", 500 },
             { "/bad-request", 500 },
             { "/status-code/402", 402 },
+            { "/ping", 200 },
+            { "/branch/ping", 200 },
+            { "/branch/not-found", 404 },
         };
 
         protected string GetTestName(string testName)

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -28,6 +28,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,69 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -48,6 +48,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -49,6 +49,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,47 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc21Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,71 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,71 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc30Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IIS.Core.IISHttpContextOfT`1.ProcessRequestAsync(),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.InProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,71 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,71 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.IISIntegration.IISMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreIisMvc31Tests.OutOfProcess.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -28,6 +28,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& sc
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,49 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& sc
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -49,6 +49,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,71 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,70 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -49,6 +49,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -50,6 +50,7 @@ at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
 at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,71 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Internal.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeActionMethodAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeNextActionFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Rethrow(ActionExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeNextResourceFilter()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Rethrow(ResourceExecutedContext context)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Internal.ResourceInvoker.InvokeAsync()
+at Microsoft.AspNetCore.Builder.RouterMiddleware.Invoke(HttpContext httpContext)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,51 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc21Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,53 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc21,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Sco
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Sco
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,51 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,51 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc30),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc30),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc30),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc30Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc30,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc30),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Sco
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -29,6 +29,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Sco
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallSite.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,51 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -30,6 +30,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,51 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.NoFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X64.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=__statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMvc31),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_api_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: api,
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.ApiController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -51,6 +51,7 @@ at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineA
 at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
 at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
 at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
 at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
       error.type: System.Exception,
       http.method: GET,

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_bad-request_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,72 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMvc31),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException()
+at lambda_method(Closure , Object , Object[] )
+at Microsoft.Extensions.Internal.ObjectMethodExecutor.Execute(Object target, Object[] parameters)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor.SyncActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, Object controller, Object[] arguments)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Logged|12_1(ControllerActionInvoker invoker)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.InvokeFilterPipelineAsync()
+at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Logged|17_1(ResourceInvoker invoker)
+at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
+at Microsoft.AspNetCore.Builder.Extensions.MapMiddleware.Invoke(HttpContext context)
+at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_branch_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_delay_0_statusCode=OK.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMvc31),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_not-found_statusCode=NotFound.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_ping_statusCode=OK.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_203_statusCode=NonAuthoritativeInformation.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_402_statusCode=PaymentRequired.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/Snapshots/AspNetCoreMvc31Tests.CallTarget.WithFF.X86.MeetsAllAspNetCoreMvcExpectations_path=_status-code_500_statusCode=InternalServerError.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMvc31,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMvc31),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisAppType.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisAppType.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="IisAppType.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public enum IisAppType
+    {
+        /// <summary>
+        /// ASP.NET app using the Clr4IntegratedAppPool app pool
+        /// </summary>
+        AspNetIntegrated,
+
+        /// <summary>
+        /// ASP.NET app using the Clr4ClassicAppPool app pool
+        /// </summary>
+        AspNetClassic,
+
+        /// <summary>
+        /// ASP.NET Core using in-process hosting model and the UnmanagedClassicAppPool app pool
+        /// </summary>
+        AspNetCoreInProcess,
+
+        /// <summary>
+        /// ASP.NET Core using out-of-process hosting model and the UnmanagedClassicAppPool app pool
+        /// </summary>
+        AspNetCoreOutOfProcess,
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/IisFixture.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public string ShutdownPath { get; set; }
 
-        public void TryStartIis(TestHelper helper, bool classicMode)
+        public void TryStartIis(TestHelper helper, IisAppType appType)
         {
             lock (this)
             {
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     Agent = new MockTracerAgent(initialAgentPort);
 
                     HttpPort = TcpPortProvider.GetOpenPort();
-                    _iisExpress = helper.StartIISExpress(Agent.Port, HttpPort, classicMode);
+                    _iisExpress = helper.StartIISExpress(Agent.Port, HttpPort, appType);
                 }
             }
         }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -168,21 +168,50 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public (Process Process, string ConfigFile) StartIISExpress(int traceAgentPort, int iisPort, bool classicMode)
+        public (Process Process, string ConfigFile) StartIISExpress(int traceAgentPort, int iisPort, IisAppType appType)
         {
             // get full paths to integration definitions
             IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
 
-            var iisExpress = EnvironmentHelper.GetSampleExecutionSource();
+            var iisExpress = EnvironmentHelper.GetIisExpressPath();
+
+            var appPool = appType switch
+            {
+                IisAppType.AspNetClassic => "Clr4ClassicAppPool",
+                IisAppType.AspNetIntegrated => "Clr4IntegratedAppPool",
+                IisAppType.AspNetCoreInProcess => "UnmanagedClassicAppPool",
+                IisAppType.AspNetCoreOutOfProcess => "UnmanagedClassicAppPool",
+                _ => throw new InvalidOperationException($"Unknown {nameof(IisAppType)} '{appType}'"),
+            };
+
+            var appPath = appType switch
+            {
+                IisAppType.AspNetClassic => EnvironmentHelper.GetSampleProjectDirectory(),
+                IisAppType.AspNetIntegrated => EnvironmentHelper.GetSampleProjectDirectory(),
+                IisAppType.AspNetCoreInProcess => EnvironmentHelper.GetSampleApplicationOutputDirectory(),
+                IisAppType.AspNetCoreOutOfProcess => EnvironmentHelper.GetSampleApplicationOutputDirectory(),
+                _ => throw new InvalidOperationException($"Unknown {nameof(IisAppType)} '{appType}'"),
+            };
 
             var configTemplate = File.ReadAllText("applicationHost.config");
 
             var newConfig = Path.GetTempFileName();
 
             configTemplate = configTemplate
-                            .Replace("[PATH]", EnvironmentHelper.GetSampleProjectDirectory())
+                            .Replace("[PATH]", appPath)
                             .Replace("[PORT]", iisPort.ToString())
-                            .Replace("[POOL]", classicMode ? "Clr4ClassicAppPool" : "Clr4IntegratedAppPool");
+                            .Replace("[POOL]", appPool);
+
+            var isAspNetCore = appType == IisAppType.AspNetCoreInProcess || appType == IisAppType.AspNetCoreOutOfProcess;
+            if (isAspNetCore)
+            {
+                var hostingModel = appType == IisAppType.AspNetCoreInProcess ? "inprocess" : "outofprocess";
+                configTemplate = configTemplate
+                                .Replace("[RELATIVE_SAMPLE_PATH]", $".\\{EnvironmentHelper.GetSampleApplicationFileName()}")
+                                .Replace("[HOSTING_MODEL]", hostingModel);
+            }
+
+            // If running a .NET Core app, need to set
 
             File.WriteAllText(newConfig, configTemplate);
 
@@ -202,7 +231,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 arguments: string.Join(" ", args),
                 redirectStandardInput: true,
                 traceAgentPort: traceAgentPort,
-                processToProfile: iisExpress);
+                processToProfile: appType == IisAppType.AspNetCoreOutOfProcess ? "dotnet.exe" : iisExpress);
 
             var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -207,6 +207,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 var hostingModel = appType == IisAppType.AspNetCoreInProcess ? "inprocess" : "outofprocess";
                 configTemplate = configTemplate
+                                .Replace("[DOTNET]", EnvironmentHelper.GetDotnetExe())
                                 .Replace("[RELATIVE_SAMPLE_PATH]", $".\\{EnvironmentHelper.GetSampleApplicationFileName()}")
                                 .Replace("[HOSTING_MODEL]", hostingModel);
             }

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TestHelper.cs
@@ -212,8 +212,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                 .Replace("[HOSTING_MODEL]", hostingModel);
             }
 
-            // If running a .NET Core app, need to set
-
             File.WriteAllText(newConfig, configTemplate);
 
             var args = new[]

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/applicationHost.config
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/applicationHost.config
@@ -1021,7 +1021,7 @@
         <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" responseBufferLimit="0" />
         <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
       </handlers>
-      <aspNetCore processPath="dotnet" arguments="[RELATIVE_SAMPLE_PATH]" stdoutLogEnabled="false" stdoutLogFile=".\stdout" hostingModel="[HOSTING_MODEL]" />
+      <aspNetCore processPath="[DOTNET]" arguments="[RELATIVE_SAMPLE_PATH]" stdoutLogEnabled="false" stdoutLogFile=".\stdout" hostingModel="[HOSTING_MODEL]" />
     </system.webServer>
   </location>
 </configuration>

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/applicationHost.config
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/applicationHost.config
@@ -118,6 +118,7 @@
         <section name="rewriteMaps" overrideModeDefault="Allow" />
       </sectionGroup>
       <section name="webSocket" overrideModeDefault="Deny" />
+      <section name="aspNetCore" overrideModeDefault="Allow" />
     </sectionGroup>
   </configSections>
 
@@ -248,6 +249,8 @@
       <add name="ManagedEngineV4.0_32bit" image="%windir%\Microsoft.NET\Framework\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness32" />
       <add name="ManagedEngineV4.0_64bit" image="%windir%\Microsoft.NET\Framework64\v4.0.30319\webengine4.dll" preCondition="integratedMode,runtimeVersionv4.0,bitness64" />
       <add name="ApplicationInitializationModule" image="%IIS_BIN%\warmup.dll" />
+      <add name="AspNetCoreModule" image="%IIS_BIN%\aspnetcore.dll" />
+      <add name="AspNetCoreModuleV2" image="%IIS_BIN%\ASP.NET Core Module\V2\aspnetcorev2.dll" />
     </globalModules>
 
     <httpCompression directory="%TEMP%">
@@ -921,6 +924,8 @@
         <add name="UrlRoutingModule-4.0" type="System.Web.Routing.UrlRoutingModule" preCondition="managedHandler,runtimeVersionv4.0" />
         <add name="ScriptModule-4.0" type="System.Web.Handlers.ScriptModule, System.Web.Extensions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" preCondition="managedHandler,runtimeVersionv4.0" />
         <add name="ServiceModel" type="System.ServiceModel.Activation.HttpModule, System.ServiceModel, Version=3.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" preCondition="managedHandler,runtimeVersionv2.0" />
+        <add name="AspNetCoreModule" lockItem="true" />
+        <add name="AspNetCoreModuleV2" lockItem="true" />
       </modules>
       <handlers accessPolicy="Read, Script">
         <!--                <add name="WebDAV" path="*" verb="PROPFIND,PROPPATCH,MKCOL,PUT,COPY,DELETE,MOVE,LOCK,UNLOCK" modules="WebDAVModule" resourceType="Unspecified" requireAccess="None" /> -->
@@ -1016,6 +1021,7 @@
         <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="GET,HEAD,POST,DEBUG" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" responseBufferLimit="0" />
         <add name="StaticFile" path="*" verb="*" modules="StaticFileModule,DefaultDocumentModule,DirectoryListingModule" resourceType="Either" requireAccess="Read" />
       </handlers>
+      <aspNetCore processPath="dotnet" arguments="[RELATIVE_SAMPLE_PATH]" stdoutLogEnabled="false" stdoutLogFile=".\stdout" hostingModel="[HOSTING_MODEL]" />
     </system.webServer>
   </location>
 </configuration>

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -296,6 +296,13 @@ namespace Datadog.Trace.TestHelpers
 
         public string GetSampleApplicationPath(string packageVersion = "", string framework = "")
         {
+            var appFileName = GetSampleApplicationFileName();
+            var sampleAppPath = Path.Combine(GetSampleApplicationOutputDirectory(packageVersion: packageVersion, framework: framework), appFileName);
+            return sampleAppPath;
+        }
+
+        public string GetSampleApplicationFileName()
+        {
             string extension = "exe";
 
             if (IsCoreClr() || _samplesDirectory.Contains("aspnet"))
@@ -303,9 +310,7 @@ namespace Datadog.Trace.TestHelpers
                 extension = "dll";
             }
 
-            var appFileName = $"{FullSampleName}.{extension}";
-            var sampleAppPath = Path.Combine(GetSampleApplicationOutputDirectory(packageVersion: packageVersion, framework: framework), appFileName);
-            return sampleAppPath;
+            return $"{FullSampleName}.{extension}";
         }
 
         public string GetTestCommandForSampleApplicationPath(string packageVersion = "", string framework = "")
@@ -321,11 +326,11 @@ namespace Datadog.Trace.TestHelpers
 
             if (_samplesDirectory.Contains("aspnet"))
             {
-                executor = $"C:\\Program Files{(Environment.Is64BitProcess ? string.Empty : " (x86)")}\\IIS Express\\iisexpress.exe";
+                executor = GetIisExpressPath();
             }
             else if (IsCoreClr())
             {
-                executor = EnvironmentTools.IsWindows() ? "dotnet.exe" : "dotnet";
+                executor = GetDotnetExe();
             }
             else
             {
@@ -341,38 +346,39 @@ namespace Datadog.Trace.TestHelpers
             return executor;
         }
 
+        public string GetIisExpressPath()
+            => $"C:\\Program Files{(Environment.Is64BitProcess ? string.Empty : " (x86)")}\\IIS Express\\iisexpress.exe";
+
         public string GetDotNetTest()
         {
-            if (EnvironmentTools.IsWindows())
+            if (EnvironmentTools.IsWindows() && !IsCoreClr())
             {
-                if (!IsCoreClr())
+                string filePattern = @"C:\Program Files (x86)\Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe";
+                List<Tuple<string, string>> lstTuple = new List<Tuple<string, string>>
                 {
-                    string filePattern = @"C:\Program Files (x86)\Microsoft Visual Studio\{0}\{1}\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe";
-                    List<Tuple<string, string>> lstTuple = new List<Tuple<string, string>>
-                    {
-                        Tuple.Create("2019", "Enterprise"),
-                        Tuple.Create("2019", "Professional"),
-                        Tuple.Create("2019", "Community"),
-                        Tuple.Create("2017", "Enterprise"),
-                        Tuple.Create("2017", "Professional"),
-                        Tuple.Create("2017", "Community"),
-                    };
+                    Tuple.Create("2019", "Enterprise"),
+                    Tuple.Create("2019", "Professional"),
+                    Tuple.Create("2019", "Community"),
+                    Tuple.Create("2017", "Enterprise"),
+                    Tuple.Create("2017", "Professional"),
+                    Tuple.Create("2017", "Community"),
+                };
 
-                    foreach (Tuple<string, string> tuple in lstTuple)
+                foreach (Tuple<string, string> tuple in lstTuple)
+                {
+                    var tryPath = string.Format(filePattern, tuple.Item1, tuple.Item2);
+                    if (File.Exists(tryPath))
                     {
-                        var tryPath = string.Format(filePattern, tuple.Item1, tuple.Item2);
-                        if (File.Exists(tryPath))
-                        {
-                            return tryPath;
-                        }
+                        return tryPath;
                     }
                 }
-
-                return "dotnet.exe";
             }
 
-            return "dotnet";
+            return GetDotnetExe();
         }
+
+        public string GetDotnetExe()
+            => EnvironmentTools.IsWindows() ? "dotnet.exe" : "dotnet";
 
         public string GetSampleProjectDirectory()
         {

--- a/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -378,7 +378,16 @@ namespace Datadog.Trace.TestHelpers
         }
 
         public string GetDotnetExe()
-            => EnvironmentTools.IsWindows() ? "dotnet.exe" : "dotnet";
+            => (EnvironmentTools.IsWindows(), Environment.Is64BitProcess) switch
+            {
+                (true, true) => "dotnet.exe",
+                (true, false) => Environment.GetEnvironmentVariable("DOTNET_EXE_32") ??
+                                 Path.Combine(
+                                     Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                                     "dotnet",
+                                     "dotnet.exe"),
+                _ =>  "dotnet",
+            };
 
         public string GetSampleProjectDirectory()
         {

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc21/Shared/PingMiddleware.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc21/Shared/PingMiddleware.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Samples.AspNetCoreMvc.Shared
+{
+    public class PingMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public PingMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public Task Invoke(HttpContext context)
+        {
+            if (context.Request.Path.StartsWithSegments("/ping"))
+            {
+                return context.Response.WriteAsync("pong");
+            }
+
+            return _next(context);
+        }
+    }
+}

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc21/Startup.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc21/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Samples.AspNetCoreMvc.Shared;
 
 namespace Samples.AspNetCoreMvc
 {
@@ -42,6 +43,9 @@ namespace Samples.AspNetCoreMvc
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.UseMiddleware<PingMiddleware>();
+            app.Map("/branch", x => x.UseMiddleware<PingMiddleware>());
 
             app.Map("/shutdown", builder =>
             {

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc21/web.config
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc21/web.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <handlers>
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+      </handlers>
+
+      <!-- Set in applicationHost.config instead -->
+      <!-- <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\stdout" hostingModel="%LAUNCHER_HOSTING_MODEL%" /> -->
+    </system.webServer>
+  </location>
+</configuration>

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc30/Samples.AspNetCoreMvc30.csproj
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc30/Samples.AspNetCoreMvc30.csproj
@@ -15,5 +15,9 @@
     <Compile Include="..\Samples.AspNetCoreMvc21\Shared\**\*.*" Link="Shared\%(RecursiveDir)%(Filename)%(Extension)" />
     <Content Include="..\Samples.AspNetCoreMvc21\Views\**\*.*" Link="Views\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="Always" />
+  </ItemGroup>
 
 </Project>

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc30/Startup.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc30/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Samples.AspNetCoreMvc.Shared;
 
 namespace Samples.AspNetCoreMvc
 {
@@ -30,6 +31,9 @@ namespace Samples.AspNetCoreMvc
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.UseMiddleware<PingMiddleware>();
+            app.Map("/branch", x => x.UseMiddleware<PingMiddleware>());
 
             app.Map("/shutdown", builder =>
             {

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -16,4 +16,7 @@
     <Content Include="..\Samples.AspNetCoreMvc21\Views\**\*.*" Link="Views\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="Always" />
+  </ItemGroup>
 </Project>

--- a/test/test-applications/integrations/Samples.AspNetCoreMvc31/Startup.cs
+++ b/test/test-applications/integrations/Samples.AspNetCoreMvc31/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Samples.AspNetCoreMvc.Shared;
 
 namespace Samples.AspNetCoreMvc
 {
@@ -30,6 +31,9 @@ namespace Samples.AspNetCoreMvc
             {
                 app.UseDeveloperExceptionPage();
             }
+
+            app.UseMiddleware<PingMiddleware>();
+            app.Map("/branch", x => x.UseMiddleware<PingMiddleware>());
 
             app.Map("/shutdown", builder =>
             {


### PR DESCRIPTION
Some clean-up and extension of existing ASP.NET Core tests:
* Add snapshots for ASP.NET Core integration tests
* Add additional test cases for middleware-only and map-branch (Note that _Datadog.Trace.IntegrationTests_ already has additional diagnostic source tests that cover additional scenarios)
* Add tests for CallTarget and RouteTemplateResourceNames flag (previously was only testing Call Site)

Also, more importantly, adds integration tests for ASP.NET Core on IIS (express)
* Refactor IIS fixture to run in one of 4 modes - integrated/classic/aspnet core in-process/aspnet core out-of-process
* Add aspnetcore module to applicationhost.config
* Add snapshots for ASP.NET Core on IIS in Call Site
* Only running snapshots on CallTarget currently, to save cycles etc, and don't see that being a problem as we support CallTarget as the default + we're running callsite in the non-iis versions anyway

Requires #1580 to be merged first

@DataDog/apm-dotnet