### PR TITLE
fix "PrepareRelease msi" command

### DIFF
--- a/build/tools/PrepareRelease/Program.cs
+++ b/build/tools/PrepareRelease/Program.cs
@@ -43,9 +43,7 @@ namespace PrepareRelease
             {
                 Environment.SetEnvironmentVariable("SOLUTION_DIR", solutionDir);
 
-                var outputDir = Path.Combine(solutionDir, "src", "bin", "windows-tracer-home");
-                Environment.SetEnvironmentVariable("OUTPUT_DIR", outputDir);
-
+                var outputDir = Path.Combine(solutionDir, "bin", "tracer-home");
                 var publishBatch = Path.Combine(solutionDir, "build", "tools", "PrepareRelease", "publish-all.bat");
                 ExecuteCommand(publishBatch);
 

--- a/build/tools/PrepareRelease/publish-all.bat
+++ b/build/tools/PrepareRelease/publish-all.bat
@@ -1,3 +1,1 @@
-PUSHD %SOLUTION_DIR%
-build.cmd Clean BuildTracerHome
-POPD
+%SOLUTION_DIR%\build.cmd Clean BuildTracerHome

--- a/build/tools/PrepareRelease/publish-all.bat
+++ b/build/tools/PrepareRelease/publish-all.bat
@@ -1,2 +1,3 @@
-RMDIR "%OUTPUT_DIR%" /S /Q
-dotnet msbuild "%SOLUTION_DIR%\Datadog.Trace.proj" /t:PublishManagedProfilerOnDisk /p:Configuration=Release;TracerHomeDirectory=%OUTPUT_DIR%
+PUSHD %SOLUTION_DIR%
+build.cmd Clean BuildTracerHome
+POPD


### PR DESCRIPTION
- use `nuke` target `BuildTracerHome` because `msbuild` target `PublishManagedProfilerOnDisk` no longer exists in `Datadog.Trace.proj`
- update the output folder to `bin/tracer-home`

Fixes an issue introduced in #1513 which caused `PrepareRelease.exe msi` to fail.