### PR TITLE
Fix flaky Kafka test

### DIFF
--- a/test/test-applications/integrations/Samples.Kafka/TopicHelpers.cs
+++ b/test/test-applications/integrations/Samples.Kafka/TopicHelpers.cs
@@ -32,6 +32,8 @@ namespace Samples.Kafka
                             ReplicationFactor = replicationFactor
                         }
                     });
+
+                    Console.WriteLine($"Topic created");
                     return true;
                 }
                 catch (CreateTopicsException e)


### PR DESCRIPTION
In Confluent.Kafka 1.5.3, attempting to consume from a non-existent topic throws an exception. Catching the exception isn't enough, as it causes the consumer to no longer consume, even if the topic exists later. In other versions of the library, this returns a `null` result, so no spans are generated, and the consumer is unaffected.

In the sample app, there was a race condition, whereby if the topic hadn't completely finished being created while doing our initial "warmup" consumes, the consumer would fail completely, meaning later consumes that should generate spans would never happen.

As a workaround, we use a separate consumer for the initial "manual" consumes, to give time for the topic to be ready. To ensure the fix works, we also _explicitly_ consume against a non-existent topic, to ensure we are handling those errors correctly. 

> Note, I tried converting this test to snapshot testing, but the actual number of spans is indeterminate, as we can get multiple consume spans for a single message, which makes snapshot testing difficult.

@DataDog/apm-dotnet