### PR TITLE
Split Windows regression tests and integration tests to save drive space

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -213,7 +213,7 @@ stages:
           testResultsFormat: VSTest
           testResultsFiles: build_data/results/**/*.trx
         condition: succeededOrFailed()
-        
+
     - job: native
       steps:
       - template: steps/install-dotnet.yml
@@ -254,7 +254,7 @@ stages:
           testResultsFormat: VSTest
           testResultsFiles: build_data/results/**/*.trx
         condition: succeededOrFailed()
-        
+
 
 
 - stage: unit_tests_linux
@@ -292,7 +292,7 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
-      
+
     - task: PublishPipelineArtifact@1
       inputs:
         targetPath: 'build_data/results/'
@@ -339,10 +339,22 @@ stages:
     timeoutInMinutes: 100
     strategy:
       matrix:
-        x64:
+        x64_integration:
           platform: x64
-        x86:
+          target: BuildAndRunWindowsIntegrationTests
+          requiresCosmos: true
+        x86_interation:
           platform: x86
+          target: BuildAndRunWindowsIntegrationTests
+          requiresCosmos: true
+        x64_regression:
+          platform: x64
+          target: BuildAndRunWindowsRegressionTests
+          requiresCosmos: false
+        x86_regression:
+          platform: x86
+          target: BuildAndRunWindowsRegressionTests
+          requiresCosmos: false
 
     steps:
     - template: steps/install-dotnet-sdks.yml
@@ -355,9 +367,10 @@ stages:
         Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
         Start-CosmosDbEmulator -Timeout 300
       displayName: 'Start CosmosDB Emulator'
+      condition: eq(variables.requiresCosmos, true)
       workingDirectory: $(Pipeline.Workspace)
 
-    - script: build.cmd BuildAndRunWindowsIntegrationTests --PrintDriveSpace --code-coverage
+    - script: build.cmd $(target) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
 
     - task: PublishTestResults@2
@@ -366,7 +379,7 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
-      
+
     - task: PublishPipelineArtifact@1
       inputs:
         targetPath: 'build_data/results/'
@@ -955,7 +968,7 @@ stages:
 
       steps:
       - template: steps/restore-working-directory.yml
-    
+
       - task: DownloadPipelineArtifact@2
         inputs:
           patterns: '**/coverage.cobertura.xml'
@@ -967,7 +980,7 @@ stages:
           targetdir: '$(Build.SourcesDirectory)\coveragereport'
           sourcedirs: '$(Build.SourcesDirectory);..'
           reporttypes: 'Cobertura'
-     
+
       - task: PublishCodeCoverageResults@1
         inputs:
           codeCoverageTool: 'Cobertura'

--- a/Datadog.Trace.proj
+++ b/Datadog.Trace.proj
@@ -10,6 +10,7 @@
     <CsharpUnitTestProject Include="test\**\*.Tests.csproj"/>
     <CsharpIntegrationTestProject Include="test\*.IntegrationTests\*.IntegrationTests.csproj"/>
     <CsharpIntegrationTestRegressionProject Include="test\tests-applications\regression\*.IntegrationTests.csproj" />
+    <RazorPagesProject Include="test/test-applications/**/Samples.AspNetCoreRazorPages.csproj" />
     <ExcludeExpenseItDemoProject Remove="test/test-applications/regression/**/ExpenseItDemo*.csproj" />
     <ExcludeEF6DemoProject Remove="test/test-applications/regression/**/EntityFramework6x*.csproj" />
     <ExcludeLegacyRedisProject Remove="test/test-applications/regression/**/StackExchange.Redis.AssemblyConflict.LegacyProject.csproj" />
@@ -50,7 +51,7 @@
 
   <!-- Used by CompileIntegrationTests-->
   <Target Name="BuildCsharpIntegrationTests">
-    <MSBuild Targets="Build" Projects="@(CsharpIntegrationTestProject);@(CsharpIntegrationTestRegressionProject);@(ExcludeExpenseItDemoProject);@(ExcludeEF6DemoProject);@(ExcludeLegacyRedisProject)">
+    <MSBuild Targets="Build" Projects="@(RazorPagesProject);@(CsharpIntegrationTestProject);@(CsharpIntegrationTestRegressionProject);@(ExcludeExpenseItDemoProject);@(ExcludeEF6DemoProject);@(ExcludeLegacyRedisProject)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -182,7 +182,7 @@ partial class Build : NukeBuild
 
     Target BuildAndRunWindowsRegressionTests => _ => _
         .Requires(() => IsWin)
-        .Description("Builds and runs the Windows (non-IIS) integration tests")
+        .Description("Builds and runs the Windows regression tests")
         .DependsOn(BuildWindowsRegressionIntegrationTests)
         .DependsOn(RunWindowsRegressionTests);
 

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -159,11 +159,19 @@ partial class Build : NukeBuild
         .DependsOn(CompileDependencyLibs)
         .DependsOn(CompileManagedTestHelpers)
         .DependsOn(CreatePlatformlessSymlinks)
+        .DependsOn(CompileSamples)
+        .DependsOn(PublishIisSamples)
+        .DependsOn(CompileIntegrationTests);
+
+    Target BuildWindowsRegressionIntegrationTests => _ => _
+        .Unlisted()
+        .Requires(() => IsWin)
+        .Description("Builds the integration tests for Windows")
+        .DependsOn(CompileManagedTestHelpers)
+        .DependsOn(CreatePlatformlessSymlinks)
         .DependsOn(CompileRegressionDependencyLibs)
         .DependsOn(CompileRegressionSamples)
         .DependsOn(CompileFrameworkReproductions)
-        .DependsOn(CompileSamples)
-        .DependsOn(PublishIisSamples)
         .DependsOn(CompileIntegrationTests);
 
     Target BuildAndRunWindowsIntegrationTests => _ => _
@@ -171,6 +179,12 @@ partial class Build : NukeBuild
         .Description("Builds and runs the Windows (non-IIS) integration tests")
         .DependsOn(BuildWindowsIntegrationTests)
         .DependsOn(RunWindowsIntegrationTests);
+
+    Target BuildAndRunWindowsRegressionTests => _ => _
+        .Requires(() => IsWin)
+        .Description("Builds and runs the Windows (non-IIS) integration tests")
+        .DependsOn(BuildWindowsRegressionIntegrationTests)
+        .DependsOn(RunWindowsRegressionTests);
 
     Target BuildAndRunWindowsIisIntegrationTests => _ => _
         .Requires(() => IsWin)

--- a/build/_build/Projects.cs
+++ b/build/_build/Projects.cs
@@ -16,7 +16,7 @@
 
     public const string ApplicationWithLog4Net = "ApplicationWithLog4Net";
     public const string EntityFramework6xMdTokenLookupFailure = "EntityFramework6x.MdTokenLookupFailure";
-    
+
     public const string RunnerTool = "Datadog.Trace.Tools.Runner.Tool";
     public const string StandaloneTool = "Datadog.Trace.Tools.Runner.Standalone";
 }


### PR DESCRIPTION
The `RunOnWindows` tests and `SmokeTests` tests are actually independent (currently) so we can save drive space by splitting them into two jobs, one which builds the regression/smoke tests, another which builds the samples. 

That saves us ~2GB in both jobs, which should stave off drive space issues for a while

> The integration tests have a direct dependency on the AspNetCoreRazor pages app for diagnostic source testing, so made that explicit in the proj file

@DataDog/apm-dotnet