### PR TITLE
Disable S3 upload step in the consolidated pipeline

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -735,99 +735,99 @@ stages:
       displayName: Uploading runner standalone osx-x64 artifact
       artifact: runner-standalone-osx-x64
 
-- stage: upload_to_s3
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
-  dependsOn: [package_windows, build_linux, build_arm64]
-  jobs:
-  - job: s3_upload
+#- stage: upload_to_s3
+#  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+#  dependsOn: [package_windows, build_linux, build_arm64]
+#  jobs:
+#  - job: s3_upload
 
-    pool:
-      vmImage: ubuntu-18.04
+#    pool:
+#      vmImage: ubuntu-18.04
 
-    steps:
+#    steps:
 
-    - script: |
-        mkdir s3_upload
-      displayName: create s3_upload folder
+#    - script: |
+#        mkdir s3_upload
+#      displayName: create s3_upload folder
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download x64 Windows MSI
-      inputs:
-        artifact: windows-msi-x64
-        patterns: '**/*x64.msi'
-        path: s3_upload
+#    - task: DownloadPipelineArtifact@2
+#      displayName: Download x64 Windows MSI
+#      inputs:
+#        artifact: windows-msi-x64
+#        patterns: '**/*x64.msi'
+#        path: s3_upload
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux-packages
-      inputs:
-        artifact: linux-packages-debian
-        patterns: '**/*amd64.deb'
-        path: s3_upload
+#    - task: DownloadPipelineArtifact@2
+#      displayName: Download linux-packages
+#      inputs:
+#        artifact: linux-packages-debian
+#        patterns: '**/*amd64.deb'
+#        path: s3_upload
 
-    # for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
-    # to datadog-dotnet-apm-{version}-{tag}-amd64.deb (i.e. add the prerelease tag)
-    # by copying most of the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
-    - script: |
-        MSI_NAME=$(ls s3_upload/*.msi)
-        PACKAGE_NAME=${MSI_NAME::-8}
-        echo Renaming deb package to $PACKAGE_NAME-amd64.deb
-        mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
-      displayName: Rename deb package name to match MSI name
+#    # for prerelease versions, rename datadog-dotnet-apm-{version}-amd64.deb
+#    # to datadog-dotnet-apm-{version}-{tag}-amd64.deb (i.e. add the prerelease tag)
+#    # by copying most of the filename from datadog-dotnet-apm-{version}-{tag}-x64.msi
+#    - script: |
+#        MSI_NAME=$(ls s3_upload/*.msi)
+#        PACKAGE_NAME=${MSI_NAME::-8}
+#        echo Renaming deb package to $PACKAGE_NAME-amd64.deb
+#        mv s3_upload/*.deb $PACKAGE_NAME-amd64.deb
+#      displayName: Rename deb package name to match MSI name
 
-    # Create index.txt file with the following format:
-    # BRANCH_NAME
-    # SHA
-    # ARTIFACT WILDCARD (datadog-dotnet-apm-vX.X.X-*)
-    # COMMIT AUTHOR
-    # Note: For the branch name, normalize 'refs/heads/<branch>' to '<branch>' and 'refs/tags/<tag_name>' to 'tags/<tag_name>'
-    - script: |
-        INDEX_FILE=$(pwd)/s3_upload/index.txt
-        echo $(Build.SourceBranch) | sed 's/refs\/heads\///g' | sed 's/refs\/tags\//tags\//g' >> $INDEX_FILE
-        git rev-parse HEAD >> $INDEX_FILE
-        pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
-        git show -s --format='%ae' HEAD >> $INDEX_FILE
-        echo Generated index.txt file:
-        cat $INDEX_FILE
-      displayName: Write index.txt
+#    # Create index.txt file with the following format:
+#    # BRANCH_NAME
+#    # SHA
+#    # ARTIFACT WILDCARD (datadog-dotnet-apm-vX.X.X-*)
+#    # COMMIT AUTHOR
+#    # Note: For the branch name, normalize 'refs/heads/<branch>' to '<branch>' and 'refs/tags/<tag_name>' to 'tags/<tag_name>'
+#    - script: |
+#        INDEX_FILE=$(pwd)/s3_upload/index.txt
+#        echo $(Build.SourceBranch) | sed 's/refs\/heads\///g' | sed 's/refs\/tags\//tags\//g' >> $INDEX_FILE
+#        git rev-parse HEAD >> $INDEX_FILE
+#        pushd s3_upload && name=$(ls *.deb) && echo "${name::-9}*" >> $INDEX_FILE && popd
+#        git show -s --format='%ae' HEAD >> $INDEX_FILE
+#        echo Generated index.txt file:
+#        cat $INDEX_FILE
+#      displayName: Write index.txt
 
-    - script: tree s3_upload
-      displayName: 'tree s3_upload'
+#    - script: tree s3_upload
+#      displayName: 'tree s3_upload'
 
-    - script: |
-        sudo apt-get install -y unzip python3-setuptools
-        curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-        unzip awscli-bundle.zip
-        sudo python3 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
-        aws --version
-      displayName: Install AWS CLI
+#    - script: |
+#        sudo apt-get install -y unzip python3-setuptools
+#        curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
+#        unzip awscli-bundle.zip
+#        sudo python3 ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws
+#        aws --version
+#      displayName: Install AWS CLI
 
-    - script: aws configure set aws_access_key_id $SECRET
-      displayName: Authenticate aws_access_key_id
-      env:
-        SECRET: $(AWS_ACCESS_KEY_ID)
+#    - script: aws configure set aws_access_key_id $SECRET
+#      displayName: Authenticate aws_access_key_id
+#      env:
+#        SECRET: $(AWS_ACCESS_KEY_ID)
 
-    - script: aws configure set aws_secret_access_key $SECRET
-      displayName: Authenticate aws_secret_access_key
-      env:
-        SECRET: $(AWS_SECRET_ACCESS_KEY)
+#    - script: aws configure set aws_secret_access_key $SECRET
+#      displayName: Authenticate aws_secret_access_key
+#      env:
+#        SECRET: $(AWS_SECRET_ACCESS_KEY)
 
-    # by default, run this step on master branch only.
-    # use "push_artifacts_to_s3" to override:
-    #   "true": run this step
-    #   "false": do NOT run this step
-    #   else: run this stage if branch is master
+#    # by default, run this step on master branch only.
+#    # use "push_artifacts_to_s3" to override:
+#    #   "true": run this step
+#    #   "false": do NOT run this step
+#    #   else: run this stage if branch is master
 
-    - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
-      displayName: Upload deb, MSI, index.txt to s3
-      condition: >
-        and(
-          succeeded(),
-          ne(variables['push_artifacts_to_s3'], 'false'),
-          or(
-            eq(variables['push_artifacts_to_s3'], 'true'),
-            eq(variables.isMainBranch, true)
-          )
-        )
+#    - script: aws s3 cp s3_upload s3://datadog-reliability-env/dotnet/ --recursive
+#      displayName: Upload deb, MSI, index.txt to s3
+#      condition: >
+#        and(
+#          succeeded(),
+#          ne(variables['push_artifacts_to_s3'], 'false'),
+#          or(
+#            eq(variables['push_artifacts_to_s3'], 'true'),
+#            eq(variables.isMainBranch, true)
+#          )
+#        )
 
 
 

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.452
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31423.177
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native", "src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.vcxproj", "{91B6272F-5780-4C94-8071-DBBA7B4F67F3}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -229,6 +229,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".azure-pipelines", ".azure-
 		.azure-pipelines\packages.yml = .azure-pipelines\packages.yml
 		.azure-pipelines\runner.yml = .azure-pipelines\runner.yml
 		.azure-pipelines\setup_tracer.ps1 = .azure-pipelines\setup_tracer.ps1
+		.azure-pipelines\ultimate-pipeline.yml = .azure-pipelines\ultimate-pipeline.yml
 		.azure-pipelines\unit-tests.yml = .azure-pipelines\unit-tests.yml
 	EndProjectSection
 EndProject
@@ -720,6 +721,18 @@ Global
 		{B4AE8B0F-C2B2-41DF-88BB-D97E267D8964}.Release|x64.Build.0 = Release|Any CPU
 		{B4AE8B0F-C2B2-41DF-88BB-D97E267D8964}.Release|x86.ActiveCfg = Release|Any CPU
 		{B4AE8B0F-C2B2-41DF-88BB-D97E267D8964}.Release|x86.Build.0 = Release|Any CPU
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|Any CPU.Build.0 = Debug|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x64.ActiveCfg = Debug|x64
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x64.Build.0 = Debug|x64
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x86.ActiveCfg = Debug|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x86.Build.0 = Debug|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|Any CPU.ActiveCfg = Release|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|Any CPU.Build.0 = Release|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x64.ActiveCfg = Release|x64
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x64.Build.0 = Release|x64
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x86.ActiveCfg = Release|x86
+		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x86.Build.0 = Release|x86
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1729F17-99A5-45AF-AB38-72FA6ECCE609}.Debug|x64.ActiveCfg = Debug|Any CPU
@@ -1680,18 +1693,6 @@ Global
 		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Release|x64.Build.0 = Release|x64
 		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Release|x86.ActiveCfg = Release|x86
 		{BF1E5BA6-C0E5-4472-9D5D-2622231DD275}.Release|x86.Build.0 = Release|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|Any CPU.ActiveCfg = Debug|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|Any CPU.Build.0 = Debug|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x64.ActiveCfg = Debug|x64
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x64.Build.0 = Debug|x64
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x86.ActiveCfg = Debug|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Debug|x86.Build.0 = Debug|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|Any CPU.ActiveCfg = Release|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|Any CPU.Build.0 = Release|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x64.ActiveCfg = Release|x64
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x64.Build.0 = Release|x64
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x86.ActiveCfg = Release|x86
-		{99A62CCF-8E7F-4D57-8383-D38C371C8087}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Currently, the consolidated pipeline generates invalid artifacts. Until that's fixed, only the Packages pipeline must be used to upload to S3.