### PR TITLE
Add new options to dd-trace tool

### DIFF
--- a/src/Datadog.Trace.Tools.Runner/Options.cs
+++ b/src/Datadog.Trace.Tools.Runner/Options.cs
@@ -38,8 +38,17 @@ namespace Datadog.Trace.Tools.Runner
         [Option("agent-url", Required = false, HelpText = "Datadog trace agent url.")]
         public string AgentUrl { get; set; }
 
+        [Option("agent-host", Required = false, HelpText = "Datadog trace agent hostname.")]
+        public string AgentHost { get; set; }
+
+        [Option("agent-port", Required = false, HelpText = "Datadog trace agent port.")]
+        public string AgentPort { get; set; }
+
         [Option("tracer-home", Required = false, HelpText = "Sets the tracer home folder path.")]
         public string TracerHomeFolder { get; set; }
+
+        [Option("env-vars", Required = false, HelpText = "Sets environment variables to the target command.")]
+        public string EnvironmentValues { get; set; }
 
         [Option("crank-import", HelpText = "Import crank Json results file.")]
         public string CrankImportFile { get; set; }

--- a/src/Datadog.Trace.Tools.Runner/Properties/launchSettings.json
+++ b/src/Datadog.Trace.Tools.Runner/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Datadog.Trace.Tools.Runner": {
       "commandName": "Project",
-      "commandLineArgs": "--crank-import=\"C:\\temp\\crank\\results.json\""
+      "commandLineArgs": "--agent-host=agenthost --dd-env=ci --env-vars=myVar1=myValue1,myVar2=myValue2 -- dotnet --info"
     }
   }
 }

--- a/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -119,6 +119,31 @@ namespace Datadog.Trace.Tools.Runner
                 envVars["DD_TRACE_AGENT_URL"] = options.AgentUrl;
             }
 
+            if (!string.IsNullOrWhiteSpace(options.AgentHost))
+            {
+                envVars["DD_AGENT_HOST"] = options.AgentHost;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.AgentPort))
+            {
+                envVars["DD_TRACE_AGENT_PORT"] = options.AgentPort;
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.EnvironmentValues))
+            {
+                foreach (var keyValue in options.EnvironmentValues.Split(','))
+                {
+                    if (!string.IsNullOrWhiteSpace(keyValue))
+                    {
+                        var kvArray = keyValue.Split('=');
+                        if (kvArray.Length == 2)
+                        {
+                            envVars[kvArray[0]] = kvArray[1];
+                        }
+                    }
+                }
+            }
+
             return envVars;
         }
 


### PR DESCRIPTION
This PR adds 3 new options to `dd-trace` command to set: `agent-host`, `agent-port` and custom `env-vars`.


@DataDog/apm-dotnet