### PR TITLE
Update test spans from Crank runs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1066,6 +1066,7 @@ stages:
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
+        DD_ENV: CI
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -101,17 +101,18 @@ namespace Datadog.Trace.Tools.Runner.Crank
                         }
 
                         var duration = (maxTimeStamp - minTimeStamp);
+                        string suite = $"Crank.{fileName}";
 
                         Span span = tracer.StartSpan("crank.test", startTime: minTimeStamp);
 
                         span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                         span.Type = SpanTypes.Test;
-                        span.ResourceName = $"{fileName}/{jobItem.Key}";
+                        span.ResourceName = $"{suite}/{jobItem.Key}";
                         CIEnvironmentValues.DecorateSpan(span);
 
                         span.SetTag(TestTags.Name, jobItem.Key);
                         span.SetTag(TestTags.Type, TestTags.TypeBenchmark);
-                        span.SetTag(TestTags.Suite, $"Crank.{fileName}");
+                        span.SetTag(TestTags.Suite, suite);
                         span.SetTag(TestTags.Framework, $"Crank");
                         span.SetTag(TestTags.Status, result.ReturnCode == 0 ? TestTags.StatusPass : TestTags.StatusFail);
 
@@ -143,7 +144,6 @@ namespace Datadog.Trace.Tools.Runner.Crank
                                 }
                             }
 
-                            string suite = fileName;
                             if (!string.IsNullOrEmpty(scenario))
                             {
                                 suite = scenario;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -101,18 +101,17 @@ namespace Datadog.Trace.Tools.Runner.Crank
                         }
 
                         var duration = (maxTimeStamp - minTimeStamp);
-                        string suite = $"Crank.{fileName}";
 
                         Span span = tracer.StartSpan("crank.test", startTime: minTimeStamp);
 
                         span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
                         span.Type = SpanTypes.Test;
-                        span.ResourceName = $"{suite}/{jobItem.Key}";
+                        span.ResourceName = $"{fileName}/{jobItem.Key}";
                         CIEnvironmentValues.DecorateSpan(span);
 
                         span.SetTag(TestTags.Name, jobItem.Key);
                         span.SetTag(TestTags.Type, TestTags.TypeBenchmark);
-                        span.SetTag(TestTags.Suite, suite);
+                        span.SetTag(TestTags.Suite, $"Crank.{fileName}");
                         span.SetTag(TestTags.Framework, $"Crank");
                         span.SetTag(TestTags.Status, result.ReturnCode == 0 ? TestTags.StatusPass : TestTags.StatusFail);
 
@@ -144,6 +143,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
                                 }
                             }
 
+                            string suite = fileName;
                             if (!string.IsNullOrEmpty(scenario))
                             {
                                 suite = scenario;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -159,7 +159,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
                                 }
                             }
 
-                            span.SetTag(TestTags.Suite, suite);
+                            span.SetTag(TestTags.Suite, $"Crank.{suite}");
                             span.SetTag(TestTags.Name, testName);
                             span.ResourceName = $"{suite}/{testName}";
                         }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
 
                         span.SetTag(TestTags.Name, jobItem.Key);
                         span.SetTag(TestTags.Type, TestTags.TypeBenchmark);
-                        span.SetTag(TestTags.Suite, fileName);
+                        span.SetTag(TestTags.Suite, $"Crank.{fileName}");
                         span.SetTag(TestTags.Framework, $"Crank");
                         span.SetTag(TestTags.Status, result.ReturnCode == 0 ? TestTags.StatusPass : TestTags.StatusFail);
 


### PR DESCRIPTION
Changes crank spans in the following ways:
- Sets tag `env=ci`
- Add `Crank.` prefix to the "Test Suite". For example, `calltarget.linux_arm64.arm64` will become `Crank.calltarget.linux_arm64.arm64`

@DataDog/apm-dotnet