### PR TITLE
Fix native leak in TypeInfo

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -490,7 +490,7 @@ mdToken CallTargetTokens::GetCurrentTypeRef(const TypeInfo* currentType, bool& i
                 return cType->id;
             }
 
-            cType = const_cast<TypeInfo*>(cType->parent_type);
+            cType = const_cast<TypeInfo*>(cType->parent_type.get());
         }
 
         isValueType = false;

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -209,12 +209,12 @@ ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id)
 TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token)
 {
     mdToken parent_token = mdTokenNil;
-    TypeInfo* parentTypeInfo = nullptr;
+    std::shared_ptr<TypeInfo> parentTypeInfo;
     mdToken parent_type_token = mdTokenNil;
     WCHAR type_name[kNameMaxSize]{};
     DWORD type_name_len = 0;
     DWORD type_flags;
-    TypeInfo* extendsInfo = nullptr;
+    std::shared_ptr<TypeInfo> extendsInfo = nullptr;
     mdToken type_extends = mdTokenNil;
     bool type_valueType = false;
     bool type_isGeneric = false;
@@ -231,12 +231,12 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
             metadata_import->GetNestedClassProps(token, &parent_type_token);
             if (parent_type_token != mdTokenNil)
             {
-                parentTypeInfo = new TypeInfo(GetTypeInfo(metadata_import, parent_type_token));
+                parentTypeInfo = std::shared_ptr<TypeInfo>(new TypeInfo(GetTypeInfo(metadata_import, parent_type_token)));
             }
 
             if (type_extends != mdTokenNil)
             {
-                extendsInfo = new TypeInfo(GetTypeInfo(metadata_import, type_extends));
+                extendsInfo = std::shared_ptr<TypeInfo>(new TypeInfo(GetTypeInfo(metadata_import, type_extends)));
                 type_valueType =
                     extendsInfo->name == WStr("System.ValueType") || extendsInfo->name == WStr("System.Enum");
             }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -209,7 +209,7 @@ ModuleInfo GetModuleInfo(ICorProfilerInfo4* info, const ModuleID& module_id)
 TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdToken& token)
 {
     mdToken parent_token = mdTokenNil;
-    std::shared_ptr<TypeInfo> parentTypeInfo;
+    std::shared_ptr<TypeInfo> parentTypeInfo = nullptr;
     mdToken parent_type_token = mdTokenNil;
     WCHAR type_name[kNameMaxSize]{};
     DWORD type_name_len = 0;
@@ -231,12 +231,12 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
             metadata_import->GetNestedClassProps(token, &parent_type_token);
             if (parent_type_token != mdTokenNil)
             {
-                parentTypeInfo = std::shared_ptr<TypeInfo>(new TypeInfo(GetTypeInfo(metadata_import, parent_type_token)));
+                parentTypeInfo = std::make_shared<TypeInfo>(GetTypeInfo(metadata_import, parent_type_token));
             }
 
             if (type_extends != mdTokenNil)
             {
-                extendsInfo = std::shared_ptr<TypeInfo>(new TypeInfo(GetTypeInfo(metadata_import, type_extends)));
+                extendsInfo = std::make_shared<TypeInfo>(GetTypeInfo(metadata_import, type_extends));
                 type_valueType =
                     extendsInfo->name == WStr("System.ValueType") || extendsInfo->name == WStr("System.Enum");
             }

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -338,10 +338,10 @@ struct TypeInfo
     const WSTRING name;
     const mdTypeSpec type_spec;
     const ULONG32 token_type;
-    const TypeInfo* extend_from;
+    std::shared_ptr<TypeInfo> extend_from;
     const bool valueType;
     const bool isGeneric;
-    const TypeInfo* parent_type;
+    std::shared_ptr<TypeInfo> parent_type;
 
     TypeInfo() :
         id(0),
@@ -354,8 +354,8 @@ struct TypeInfo
         parent_type(nullptr)
     {
     }
-    TypeInfo(mdToken id, WSTRING name, mdTypeSpec type_spec, ULONG32 token_type, const TypeInfo* extend_from,
-             bool valueType, bool isGeneric, const TypeInfo* parent_type) :
+    TypeInfo(mdToken id, WSTRING name, mdTypeSpec type_spec, ULONG32 token_type, std::shared_ptr<TypeInfo> extend_from,
+             bool valueType, bool isGeneric, std::shared_ptr<TypeInfo> parent_type) :
         id(id),
         name(name),
         type_spec(type_spec),


### PR DESCRIPTION
`TypeInfo` instance holds 2 pointers  but they are never freed when the object goes out of scope.

Changes proposed in this pull request:

Use `std::shared_ptr/std::make_shared` to automate and simplify the memory management of this type.



@DataDog/apm-dotnet