### PR TITLE
Fix arm64 tar suffix

### DIFF
--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -430,10 +430,6 @@ partial class Build
                 var gzip = GZip.Value;
                 var packageName = "datadog-dotnet-apm";
 
-                var suffix = RuntimeInformation.ProcessArchitecture == Architecture.X64
-                    ? string.Empty
-                    : RuntimeInformation.ProcessArchitecture.ToString().ToLower();
-
                 var workingDirectory = ArtifactsDirectory / $"linux-{LinuxArchitectureIdentifier}";
                 EnsureCleanDirectory(workingDirectory);
 
@@ -459,6 +455,11 @@ partial class Build
                 }
 
                 gzip($"-f {packageName}.tar", workingDirectory: workingDirectory);
+
+
+                var suffix = RuntimeInformation.ProcessArchitecture == Architecture.X64
+                    ? string.Empty
+                    : $".{RuntimeInformation.ProcessArchitecture.ToString().ToLower()}";
 
                 var versionedName = IsAlpine
                     ? $"{packageName}-{Version}-musl{suffix}.tar.gz"


### PR DESCRIPTION
The arm64 tar.gz artifact is missing a '.'.

* `datadog-dotnet-apm-1.28.0arm64.tar.gz` (before)
* `datadog-dotnet-apm-1.28.0.arm64.tar.gz` (after)

@DataDog/apm-dotnet