### PR TITLE
Add a public ForceFlushAsync API on the Tracer

### DIFF
--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -377,7 +377,7 @@ namespace Datadog.Trace
         /// To be called when the appdomain or the process is about to be killed in a non-graceful way.
         /// </summary>
         /// <returns>Task used to track the async flush operation</returns>
-        public Task ForceFlush() => FlushAsync();
+        public Task ForceFlushAsync() => FlushAsync();
 
         /// <summary>
         /// Writes the specified <see cref="Span"/> collection to the agent writer.

--- a/src/Datadog.Trace/Tracer.cs
+++ b/src/Datadog.Trace/Tracer.cs
@@ -373,6 +373,13 @@ namespace Datadog.Trace
         }
 
         /// <summary>
+        /// Forces the tracer to immediately flush pending traces and send them to the agent.
+        /// To be called when the appdomain or the process is about to be killed in a non-graceful way.
+        /// </summary>
+        /// <returns>Task used to track the async flush operation</returns>
+        public Task ForceFlush() => FlushAsync();
+
+        /// <summary>
         /// Writes the specified <see cref="Span"/> collection to the agent writer.
         /// </summary>
         /// <param name="trace">The <see cref="Span"/> collection to write.</param>

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -425,7 +425,7 @@ namespace Datadog.Trace.Tests
 
             var tracer = new Tracer(settings, agent.Object, Mock.Of<ISampler>(), Mock.Of<IScopeManager>(), Mock.Of<IDogStatsd>());
 
-            await tracer.ForceFlush();
+            await tracer.ForceFlushAsync();
 
             agent.Verify(a => a.FlushTracesAsync(), Times.Once);
         }

--- a/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/test/Datadog.Trace.Tests/TracerTests.cs
@@ -23,6 +23,7 @@ using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -410,6 +411,23 @@ namespace Datadog.Trace.Tests
 
             // Runtime id should be a UUID
             Guid.TryParse(runtimeId, out _).Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ForceFlush()
+        {
+            var agent = new Mock<IAgentWriter>();
+
+            var settings = new TracerSettings
+            {
+                StartupDiagnosticLogEnabled = false
+            };
+
+            var tracer = new Tracer(settings, agent.Object, Mock.Of<ISampler>(), Mock.Of<IScopeManager>(), Mock.Of<IDogStatsd>());
+
+            await tracer.ForceFlush();
+
+            agent.Verify(a => a.FlushTracesAsync(), Times.Once);
         }
 
 #if NET452


### PR DESCRIPTION
To be used when the process or appdomain is about to get killed in a non-graceful manner.

Note: 
 - I did not make the old `Tracer.FlushAsync` public because the name does not properly convey the information that this API shouldn't be used under normal circumstances
 - I did not delete the old `Tracer.FlushAsync` because that would be a breaking change (used in `Datadog.Trace.ClrProfiler.Managed`)