### PR TITLE
Remove usage of non-builtin types in Attribute named arguments

### DIFF
--- a/src/Datadog.Trace/AppSec/AspNetCore/BlockingMiddleware.cs
+++ b/src/Datadog.Trace/AppSec/AspNetCore/BlockingMiddleware.cs
@@ -94,7 +94,7 @@ namespace Datadog.Trace.AppSec.AspNetCore
             /// <summary>
             /// The components that will make up the application http pipe
             /// </summary>
-            [Duck(Name = "_components", Kind = DuckKind.Field)]
+            [DuckField(Name = "_components")]
             public List<Func<RequestDelegate, RequestDelegate>> Components;
         }
     }

--- a/src/Datadog.Trace/AppSec/EventModel/JsonPropertyIgnoreNullValueAttribute.cs
+++ b/src/Datadog.Trace/AppSec/EventModel/JsonPropertyIgnoreNullValueAttribute.cs
@@ -1,0 +1,23 @@
+// <copyright file="JsonPropertyIgnoreNullValueAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.AppSec.EventModel
+{
+    /// <summary>
+    /// Attribute that allows us to declare JsonProperty attributes with
+    /// NullValueHandling.Ignore, without running into the issue where the
+    /// named argument is a custom type.
+    /// </summary>
+    internal class JsonPropertyIgnoreNullValueAttribute : JsonPropertyAttribute
+    {
+        internal JsonPropertyIgnoreNullValueAttribute(string propertyName)
+            : base(propertyName)
+        {
+            NullValueHandling = NullValueHandling.Ignore;
+        }
+    }
+}

--- a/src/Datadog.Trace/AppSec/EventModel/Service.cs
+++ b/src/Datadog.Trace/AppSec/EventModel/Service.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.AppSec.EventModel
         [JsonProperty("version")]
         public string Version { get; set; }
 
-        [JsonProperty("when", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonPropertyIgnoreNullValue("when")]
         public DateTimeOffset? When { get; set; }
     }
 }

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/IHttpWebRequest.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/IHttpWebRequest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IHttpWebRequest.cs" company="Datadog">
+// <copyright file="IHttpWebRequest.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         /// <summary>
         /// Gets the time the HttpWebRequest was created in Ticks (UTC)
         /// </summary>
-        [Duck(Name = "m_StartTimestamp", Kind = DuckKind.Field)]
+        [DuckField(Name = "m_StartTimestamp")]
         long RequestStartTicks { get; }
     }
 }

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITypedDeliveryHandlerShimAction.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/ITypedDeliveryHandlerShimAction.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ITypedDeliveryHandlerShimAction.cs" company="Datadog">
+// <copyright file="ITypedDeliveryHandlerShimAction.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         /// <summary>
         /// Sets the delivery report handler
         /// </summary>
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         public object Handler { set; }
     }
 }

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IRedisBase.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IRedisBase.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IRedisBase.cs" company="Datadog">
+// <copyright file="IRedisBase.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <summary>
         /// Gets multiplexer data structure
         /// </summary>
-        [Duck(Name = "multiplexer", Kind = DuckKind.Field)]
+        [DuckField(Name = "multiplexer")]
         public MultiplexerData Multiplexer { get; }
     }
 }

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/ITestMethodRunner.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/ITestMethodRunner.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
         /// <summary>
         /// Gets the TestMethodInfo instance
         /// </summary>
-        [Duck(Name = "testMethodInfo", Kind = DuckKind.Field)]
+        [DuckField(Name = "testMethodInfo")]
         ITestMethod TestMethodInfo { get; }
     }
 }

--- a/src/Datadog.Trace/ClrProfiler/InsertFirstInterceptMethodAttribute.cs
+++ b/src/Datadog.Trace/ClrProfiler/InsertFirstInterceptMethodAttribute.cs
@@ -1,0 +1,26 @@
+// <copyright file="InsertFirstInterceptMethodAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Linq;
+
+namespace Datadog.Trace.ClrProfiler
+{
+    /// <summary>
+    /// Attribute that indicates that the decorated method is meant to intercept calls
+    /// to another method. Used to generate the integration definitions file.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class InsertFirstInterceptMethodAttribute : InterceptMethodAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InsertFirstInterceptMethodAttribute"/> class.
+        /// </summary>
+        public InsertFirstInterceptMethodAttribute()
+        {
+            MethodReplacementAction = MethodReplacementActionType.InsertFirst;
+        }
+    }
+}

--- a/src/Datadog.Trace/ClrProfiler/InsertFirstInterceptMethodAttribute.cs
+++ b/src/Datadog.Trace/ClrProfiler/InsertFirstInterceptMethodAttribute.cs
@@ -12,7 +12,6 @@ namespace Datadog.Trace.ClrProfiler
     /// Attribute that indicates that the decorated method is meant to intercept calls
     /// to another method. Used to generate the integration definitions file.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class InsertFirstInterceptMethodAttribute : InterceptMethodAttribute
     {
         /// <summary>

--- a/src/Datadog.Trace/ClrProfiler/InsertFirstInterceptMethodAttribute.cs
+++ b/src/Datadog.Trace/ClrProfiler/InsertFirstInterceptMethodAttribute.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.ClrProfiler
     /// Attribute that indicates that the decorated method is meant to intercept calls
     /// to another method. Used to generate the integration definitions file.
     /// </summary>
-    public class InsertFirstInterceptMethodAttribute : InterceptMethodAttribute
+    internal class InsertFirstInterceptMethodAttribute : InterceptMethodAttribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="InsertFirstInterceptMethodAttribute"/> class.

--- a/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetIntegration.cs
+++ b/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetIntegration.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AspNet
         /// <summary>
         /// Injects a call to HttpApplication to register the HttpModule
         /// </summary>
-        [InterceptMethod(
+        [InsertFirstInterceptMethod(
             Integration = "AspNet",
             CallerAssembly = "System.Web",
             CallerType = "System.Web.Compilation.BuildManager",
@@ -36,8 +36,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AspNet
             TargetType = "System.Web.Compilation.BuildManager",
             TargetMethod = "InvokePreStartInitMethodsCore",
             TargetMinimumVersion = "4",
-            TargetMaximumVersion = "4",
-            MethodReplacementAction = MethodReplacementActionType.InsertFirst)]
+            TargetMaximumVersion = "4")]
         public static void TryLoadHttpModule()
         {
             if (Interlocked.Exchange(ref _firstInitialization, 0) != 1)

--- a/src/Datadog.Trace/ClrProfiler/Integrations/StackExchange.Redis/RedisBatch.cs
+++ b/src/Datadog.Trace/ClrProfiler/Integrations/StackExchange.Redis/RedisBatch.cs
@@ -188,7 +188,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.StackExchange.Redis
             /// <summary>
             /// Multiplexer data structure
             /// </summary>
-            [Duck(Name = "multiplexer", Kind = DuckKind.Field)]
+            [DuckField(Name = "multiplexer")]
             public MultiplexerData Multiplexer;
         }
 

--- a/src/Datadog.Trace/ClrProfiler/InterceptMethodAttribute.cs
+++ b/src/Datadog.Trace/ClrProfiler/InterceptMethodAttribute.cs
@@ -115,6 +115,6 @@ namespace Datadog.Trace.ClrProfiler
         /// <summary>
         /// Gets or sets the <see cref="MethodReplacementActionType">MethodReplacementActionType</see> for this method.
         /// </summary>
-        public MethodReplacementActionType MethodReplacementAction { get; set; } = MethodReplacementActionType.ReplaceTargetMethod;
+        public MethodReplacementActionType MethodReplacementAction { get; protected set; } = MethodReplacementActionType.ReplaceTargetMethod;
     }
 }

--- a/src/Datadog.Trace/DuckTyping/DuckFieldAttribute.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckFieldAttribute.cs
@@ -1,0 +1,21 @@
+// <copyright file="DuckFieldAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.DuckTyping
+{
+    /// <summary>
+    /// Duck attribute where the underlying member is a field
+    /// </summary>
+    public class DuckFieldAttribute : DuckAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DuckFieldAttribute"/> class.
+        /// </summary>
+        public DuckFieldAttribute()
+        {
+            Kind = DuckKind.Field;
+        }
+    }
+}

--- a/src/Datadog.Trace/DuckTyping/README.md
+++ b/src/Datadog.Trace/DuckTyping/README.md
@@ -118,6 +118,20 @@ public class DuckAttribute : Attribute
 }
 
 /// <summary>
+/// Duck attribute where the underlying member is a field
+/// </summary>
+public class DuckFieldAttribute : DuckAttribute
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DuckFieldAttribute"/> class.
+    /// </summary>
+    public DuckFieldAttribute()
+    {
+        Kind = DuckKind.Field;
+    }
+}
+
+/// <summary>
 /// Duck kind
 /// </summary>
 public enum DuckKind
@@ -147,10 +161,10 @@ public interface IMyProxy
     // *** Field binding
     // ***
 
-    [Duck(Name = "_sampleStaticField", Kind = DuckKind.Field)]
+    [DuckField(Name = "_sampleStaticField")]
     string MyStaticField { get; }
 
-    [Duck(Name = "_normalField", Kind = DuckKind.Field)]
+    [DuckField(Name = "_normalField")]
     int NormalFieldWithGetterAndSetter { get; set; }
 
 

--- a/src/Datadog.Trace/Vendors/Newtonsoft.Json/JsonPropertyAttribute.cs
+++ b/src/Datadog.Trace/Vendors/Newtonsoft.Json/JsonPropertyAttribute.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Vendors.Newtonsoft.Json
     /// Instructs the <see cref="JsonSerializer"/> to always serialize the member with the specified name.
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Parameter, AllowMultiple = false)]
-    internal sealed class JsonPropertyAttribute : Attribute
+    internal class JsonPropertyAttribute : Attribute
     {
         // yuck. can't set nullable properties on an attribute in C#
         // have to use this approach to get an unset default state

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/AttributeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/AttributeTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="AttributeTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests
+{
+    public class AttributeTests
+    {
+        /// <summary>
+        /// This test reports instances in the Datadog.Trace.ClrProfiler.Managed and Datadog.Trace
+        /// where attributes use named arguments that are not a built-in type. Using a custom type
+        /// (especially one from the Datadog.Trace assembly) as a named argument can fail with a
+        /// System.Reflection.CustomAttributeFormatException if the owning assembly cannot be found
+        /// in the default load context and other assembly resolve events are registered, in addition
+        /// to the ones added by the Datadog .NET Tracer
+        /// </summary>
+        [Fact]
+        public void AttributesInstantiationsOnlyUseBuiltinTypes()
+        {
+            List<string> invalidAttributeUsages = new();
+            var coreAssembly = typeof(object).Assembly;
+            var managedAssembly = typeof(Instrumentation).Assembly;
+            var types = coreAssembly.GetTypes().Concat(managedAssembly.GetTypes());
+
+            foreach (var type in types)
+            {
+                foreach (var member in type.GetMembers())
+                {
+                    foreach (var attribute in member.CustomAttributes)
+                    {
+                        foreach (var namedArg in attribute.NamedArguments)
+                        {
+                            var argumentType = namedArg.TypedValue.ArgumentType;
+                            if (argumentType.Assembly != coreAssembly)
+                            {
+                                invalidAttributeUsages.Add($"{type.FullName}.{member.Name} => {attribute.AttributeType.FullName}({namedArg.MemberName} : {argumentType.FullName})");
+                            }
+                        }
+                    }
+                }
+            }
+
+            invalidAttributeUsages.Should().BeEmpty();
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/AttributeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/AttributeTests.cs
@@ -26,8 +26,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             List<string> invalidAttributeUsages = new();
             var coreAssembly = typeof(object).Assembly;
+
+            var tracerAssembly = typeof(Tracer).Assembly;
             var managedAssembly = typeof(Instrumentation).Assembly;
-            var types = coreAssembly.GetTypes().Concat(managedAssembly.GetTypes());
+            var types = tracerAssembly.GetTypes().Concat(managedAssembly.GetTypes());
 
             foreach (var type in types)
             {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -31,4 +31,17 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
   </ItemGroup>
+
+  <!-- Bring in Microsoft.AspNetCore.Mvc.Testing packages so we can resolve all type references -->
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3')) ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net5')) ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
+  </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -32,16 +32,9 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
   </ItemGroup>
 
-  <!-- Bring in Microsoft.AspNetCore.Mvc.Testing packages so we can resolve all type references -->
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net5')) ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.0" />
+  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -31,10 +31,4 @@
   <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
   </ItemGroup>
-
-  <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
-  </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckChainingWithExplicitInterfaceTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckChainingWithExplicitInterfaceTests.cs
@@ -94,13 +94,13 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface P_IHostingApplication
         {
-            [Duck(Name = "_diagnostics", Kind = DuckKind.Field)]
+            [DuckField(Name = "_diagnostics")]
             P_IHostingApplicationDiagnostics Diagnostics { get; }
         }
 
         public interface P_IHostingApplicationDiagnostics
         {
-            [Duck(Name = "_logger", Kind = DuckKind.Field)]
+            [DuckField(Name = "_logger")]
             P_ILogger Logger { get; }
         }
 

--- a/test/Datadog.Trace.DuckTyping.Tests/DuckILoggerTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/DuckILoggerTests.cs
@@ -57,13 +57,13 @@ namespace Datadog.Trace.Tests
 
         public interface IHostingApplication
         {
-            [Duck(Name = "_diagnostics", Kind = DuckKind.Field)]
+            [DuckField(Name = "_diagnostics")]
             IHostingApplicationDiagnostics Diagnostics { get; }
         }
 
         public interface IHostingApplicationDiagnostics
         {
-            [Duck(Name = "_logger", Kind = DuckKind.Field)]
+            [DuckField(Name = "_logger")]
             ILogger Logger { get; }
         }
 

--- a/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ExceptionsTests.cs
@@ -133,7 +133,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface IFieldIsReadonlyException
         {
-            [Duck(Name = "_name", Kind = DuckKind.Field)]
+            [DuckField(Name = "_name")]
             string Name { get; set; }
         }
 
@@ -191,7 +191,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface IPropertyOrFieldNotFound2Exception
         {
-            [Duck(Kind = DuckKind.Field)]
+            [DuckField]
             string Name { get; set; }
         }
 
@@ -207,7 +207,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public struct PropertyOrFieldNotFound2ExceptionStruct
         {
-            [Duck(Kind = DuckKind.Field)]
+            [DuckField]
             public string Name;
         }
 
@@ -287,7 +287,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface IStructMembersCannotBeChanged2Exception
         {
-            [Duck(Kind = DuckKind.Field)]
+            [DuckField]
             string Name { get; set; }
         }
 
@@ -580,7 +580,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface IObjectInvalidTypeConversion3Exception
         {
-            [Duck(Kind = DuckKind.Field)]
+            [DuckField]
             int Value { get; }
         }
 

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureDuckType.cs
@@ -7,58 +7,58 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 {
     public interface IObscureDuckType
     {
-        [Duck(Name = "_publicStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyReferenceTypeField")]
         string PublicStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlyReferenceTypeField")]
         string InternalStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlyReferenceTypeField")]
         string ProtectedStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlyReferenceTypeField")]
         string PrivateStaticReadonlyReferenceTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReferenceTypeField")]
         string PublicStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReferenceTypeField")]
         string InternalStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReferenceTypeField")]
         string ProtectedStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReferenceTypeField")]
         string PrivateStaticReferenceTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyReferenceTypeField")]
         string PublicReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_internalReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlyReferenceTypeField")]
         string InternalReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlyReferenceTypeField")]
         string ProtectedReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_privateReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlyReferenceTypeField")]
         string PrivateReadonlyReferenceTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReferenceTypeField")]
         string PublicReferenceTypeField { get; set; }
 
-        [Duck(Name = "_internalReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReferenceTypeField")]
         string InternalReferenceTypeField { get; set; }
 
-        [Duck(Name = "_protectedReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReferenceTypeField")]
         string ProtectedReferenceTypeField { get; set; }
 
-        [Duck(Name = "_privateReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReferenceTypeField")]
         string PrivateReferenceTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureReadonlyErrorDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureReadonlyErrorDuckType.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 {
     public interface IObscureReadonlyErrorDuckType
     {
-        [Duck(Name = "_publicReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyReferenceTypeField")]
         string PublicReadonlyReferenceTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureStaticReadonlyErrorDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureStaticReadonlyErrorDuckType.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 {
     public interface IObscureStaticReadonlyErrorDuckType
     {
-        [Duck(Name = "_publicStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyReferenceTypeField")]
         string PublicStaticReadonlyReferenceTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -7,58 +7,58 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 {
     public abstract class ObscureDuckTypeAbstractClass
     {
-        [Duck(Name = "_publicStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyReferenceTypeField")]
         public abstract string PublicStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlyReferenceTypeField")]
         public abstract string InternalStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlyReferenceTypeField")]
         public abstract string ProtectedStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlyReferenceTypeField")]
         public abstract string PrivateStaticReadonlyReferenceTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReferenceTypeField")]
         public abstract string PublicStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReferenceTypeField")]
         public abstract string InternalStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReferenceTypeField")]
         public abstract string ProtectedStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReferenceTypeField")]
         public abstract string PrivateStaticReferenceTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyReferenceTypeField")]
         public abstract string PublicReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_internalReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlyReferenceTypeField")]
         public abstract string InternalReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlyReferenceTypeField")]
         public abstract string ProtectedReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_privateReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlyReferenceTypeField")]
         public abstract string PrivateReadonlyReferenceTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReferenceTypeField")]
         public abstract string PublicReferenceTypeField { get; set; }
 
-        [Duck(Name = "_internalReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReferenceTypeField")]
         public abstract string InternalReferenceTypeField { get; set; }
 
-        [Duck(Name = "_protectedReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReferenceTypeField")]
         public abstract string ProtectedReferenceTypeField { get; set; }
 
-        [Duck(Name = "_privateReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReferenceTypeField")]
         public abstract string PrivateReferenceTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -7,58 +7,58 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 {
     public class ObscureDuckTypeVirtualClass
     {
-        [Duck(Name = "_publicStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyReferenceTypeField")]
         public virtual string PublicStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlyReferenceTypeField")]
         public virtual string InternalStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlyReferenceTypeField")]
         public virtual string ProtectedStaticReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlyReferenceTypeField")]
         public virtual string PrivateStaticReadonlyReferenceTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReferenceTypeField")]
         public virtual string PublicStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReferenceTypeField")]
         public virtual string InternalStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReferenceTypeField")]
         public virtual string ProtectedStaticReferenceTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReferenceTypeField")]
         public virtual string PrivateStaticReferenceTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyReferenceTypeField")]
         public virtual string PublicReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_internalReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlyReferenceTypeField")]
         public virtual string InternalReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlyReferenceTypeField")]
         public virtual string ProtectedReadonlyReferenceTypeField { get; }
 
-        [Duck(Name = "_privateReadonlyReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlyReferenceTypeField")]
         public virtual string PrivateReadonlyReferenceTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReferenceTypeField")]
         public virtual string PublicReferenceTypeField { get; set; }
 
-        [Duck(Name = "_internalReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReferenceTypeField")]
         public virtual string InternalReferenceTypeField { get; set; }
 
-        [Duck(Name = "_protectedReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReferenceTypeField")]
         public virtual string ProtectedReferenceTypeField { get; set; }
 
-        [Duck(Name = "_privateReferenceTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReferenceTypeField")]
         public virtual string PrivateReferenceTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IDummyFieldObject.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IDummyFieldObject.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 {
     public interface IDummyFieldObject
     {
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         int MagicNumber { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureDuckType.cs
@@ -7,58 +7,58 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 {
     public interface IObscureDuckType
     {
-        [Duck(Name = "_publicStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlySelfTypeField")]
         IDummyFieldObject PublicStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlySelfTypeField")]
         IDummyFieldObject InternalStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlySelfTypeField")]
         IDummyFieldObject ProtectedStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlySelfTypeField")]
         IDummyFieldObject PrivateStaticReadonlySelfTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticSelfTypeField")]
         IDummyFieldObject PublicStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticSelfTypeField")]
         IDummyFieldObject InternalStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticSelfTypeField")]
         IDummyFieldObject ProtectedStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticSelfTypeField")]
         IDummyFieldObject PrivateStaticSelfTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlySelfTypeField")]
         IDummyFieldObject PublicReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_internalReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlySelfTypeField")]
         IDummyFieldObject InternalReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlySelfTypeField")]
         IDummyFieldObject ProtectedReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_privateReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlySelfTypeField")]
         IDummyFieldObject PrivateReadonlySelfTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicSelfTypeField")]
         IDummyFieldObject PublicSelfTypeField { get; set; }
 
-        [Duck(Name = "_internalSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalSelfTypeField")]
         IDummyFieldObject InternalSelfTypeField { get; set; }
 
-        [Duck(Name = "_protectedSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedSelfTypeField")]
         IDummyFieldObject ProtectedSelfTypeField { get; set; }
 
-        [Duck(Name = "_privateSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateSelfTypeField")]
         IDummyFieldObject PrivateSelfTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureReadonlyErrorDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureReadonlyErrorDuckType.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 {
     public interface IObscureReadonlyErrorDuckType
     {
-        [Duck(Name = "_publicReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlySelfTypeField")]
         IDummyFieldObject PublicReadonlySelfTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureStaticReadonlyErrorDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureStaticReadonlyErrorDuckType.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 {
     public interface IObscureStaticReadonlyErrorDuckType
     {
-        [Duck(Name = "_publicStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlySelfTypeField")]
         IDummyFieldObject PublicStaticReadonlySelfTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -7,58 +7,58 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 {
     public abstract class ObscureDuckTypeAbstractClass
     {
-        [Duck(Name = "_publicStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlySelfTypeField")]
         public abstract IDummyFieldObject PublicStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlySelfTypeField")]
         public abstract IDummyFieldObject InternalStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlySelfTypeField")]
         public abstract IDummyFieldObject ProtectedStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlySelfTypeField")]
         public abstract IDummyFieldObject PrivateStaticReadonlySelfTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticSelfTypeField")]
         public abstract IDummyFieldObject PublicStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticSelfTypeField")]
         public abstract IDummyFieldObject InternalStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticSelfTypeField")]
         public abstract IDummyFieldObject ProtectedStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticSelfTypeField")]
         public abstract IDummyFieldObject PrivateStaticSelfTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlySelfTypeField")]
         public abstract IDummyFieldObject PublicReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_internalReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlySelfTypeField")]
         public abstract IDummyFieldObject InternalReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlySelfTypeField")]
         public abstract IDummyFieldObject ProtectedReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_privateReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlySelfTypeField")]
         public abstract IDummyFieldObject PrivateReadonlySelfTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicSelfTypeField")]
         public abstract IDummyFieldObject PublicSelfTypeField { get; set; }
 
-        [Duck(Name = "_internalSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalSelfTypeField")]
         public abstract IDummyFieldObject InternalSelfTypeField { get; set; }
 
-        [Duck(Name = "_protectedSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedSelfTypeField")]
         public abstract IDummyFieldObject ProtectedSelfTypeField { get; set; }
 
-        [Duck(Name = "_privateSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateSelfTypeField")]
         public abstract IDummyFieldObject PrivateSelfTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -7,58 +7,58 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 {
     public class ObscureDuckTypeVirtualClass
     {
-        [Duck(Name = "_publicStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlySelfTypeField")]
         public virtual IDummyFieldObject PublicStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlySelfTypeField")]
         public virtual IDummyFieldObject InternalStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlySelfTypeField")]
         public virtual IDummyFieldObject ProtectedStaticReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlySelfTypeField")]
         public virtual IDummyFieldObject PrivateStaticReadonlySelfTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticSelfTypeField")]
         public virtual IDummyFieldObject PublicStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticSelfTypeField")]
         public virtual IDummyFieldObject InternalStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticSelfTypeField")]
         public virtual IDummyFieldObject ProtectedStaticSelfTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticSelfTypeField")]
         public virtual IDummyFieldObject PrivateStaticSelfTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlySelfTypeField")]
         public virtual IDummyFieldObject PublicReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_internalReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlySelfTypeField")]
         public virtual IDummyFieldObject InternalReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlySelfTypeField")]
         public virtual IDummyFieldObject ProtectedReadonlySelfTypeField { get; }
 
-        [Duck(Name = "_privateReadonlySelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlySelfTypeField")]
         public virtual IDummyFieldObject PrivateReadonlySelfTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicSelfTypeField")]
         public virtual IDummyFieldObject PublicSelfTypeField { get; set; }
 
-        [Duck(Name = "_internalSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalSelfTypeField")]
         public virtual IDummyFieldObject InternalSelfTypeField { get; set; }
 
-        [Duck(Name = "_protectedSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedSelfTypeField")]
         public virtual IDummyFieldObject ProtectedSelfTypeField { get; set; }
 
-        [Duck(Name = "_privateSelfTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateSelfTypeField")]
         public virtual IDummyFieldObject PrivateSelfTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureDuckType.cs
@@ -7,72 +7,72 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 {
     public interface IObscureDuckType
     {
-        [Duck(Name = "_publicStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyValueTypeField")]
         int PublicStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlyValueTypeField")]
         int InternalStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlyValueTypeField")]
         int ProtectedStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlyValueTypeField")]
         int PrivateStaticReadonlyValueTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticValueTypeField")]
         int PublicStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticValueTypeField")]
         int InternalStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticValueTypeField")]
         int ProtectedStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticValueTypeField")]
         int PrivateStaticValueTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyValueTypeField")]
         int PublicReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_internalReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlyValueTypeField")]
         int InternalReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlyValueTypeField")]
         int ProtectedReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_privateReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlyValueTypeField")]
         int PrivateReadonlyValueTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicValueTypeField")]
         int PublicValueTypeField { get; set; }
 
-        [Duck(Name = "_internalValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalValueTypeField")]
         int InternalValueTypeField { get; set; }
 
-        [Duck(Name = "_protectedValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedValueTypeField")]
         int ProtectedValueTypeField { get; set; }
 
-        [Duck(Name = "_privateValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateValueTypeField")]
         int PrivateValueTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicStaticNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticNullableIntField")]
         int? PublicStaticNullableIntField { get; set; }
 
-        [Duck(Name = "_privateStaticNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticNullableIntField")]
         int? PrivateStaticNullableIntField { get; set; }
 
-        [Duck(Name = "_publicNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicNullableIntField")]
         int? PublicNullableIntField { get; set; }
 
-        [Duck(Name = "_privateNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateNullableIntField")]
         int? PrivateNullableIntField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureReadonlyErrorDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureReadonlyErrorDuckType.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 {
     public interface IObscureReadonlyErrorDuckType
     {
-        [Duck(Name = "_publicReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyValueTypeField")]
         int PublicReadonlyValueTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureStaticReadonlyErrorDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureStaticReadonlyErrorDuckType.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 {
     public interface IObscureStaticReadonlyErrorDuckType
     {
-        [Duck(Name = "_publicStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyValueTypeField")]
         int PublicStaticReadonlyValueTypeField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -7,72 +7,72 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 {
     public abstract class ObscureDuckTypeAbstractClass
     {
-        [Duck(Name = "_publicStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyValueTypeField")]
         public abstract int PublicStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlyValueTypeField")]
         public abstract int InternalStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlyValueTypeField")]
         public abstract int ProtectedStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlyValueTypeField")]
         public abstract int PrivateStaticReadonlyValueTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticValueTypeField")]
         public abstract int PublicStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticValueTypeField")]
         public abstract int InternalStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticValueTypeField")]
         public abstract int ProtectedStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticValueTypeField")]
         public abstract int PrivateStaticValueTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyValueTypeField")]
         public abstract int PublicReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_internalReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlyValueTypeField")]
         public abstract int InternalReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlyValueTypeField")]
         public abstract int ProtectedReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_privateReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlyValueTypeField")]
         public abstract int PrivateReadonlyValueTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicValueTypeField")]
         public abstract int PublicValueTypeField { get; set; }
 
-        [Duck(Name = "_internalValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalValueTypeField")]
         public abstract int InternalValueTypeField { get; set; }
 
-        [Duck(Name = "_protectedValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedValueTypeField")]
         public abstract int ProtectedValueTypeField { get; set; }
 
-        [Duck(Name = "_privateValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateValueTypeField")]
         public abstract int PrivateValueTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicStaticNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticNullableIntField")]
         public abstract int? PublicStaticNullableIntField { get; set; }
 
-        [Duck(Name = "_privateStaticNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticNullableIntField")]
         public abstract int? PrivateStaticNullableIntField { get; set; }
 
-        [Duck(Name = "_publicNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicNullableIntField")]
         public abstract int? PublicNullableIntField { get; set; }
 
-        [Duck(Name = "_privateNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateNullableIntField")]
         public abstract int? PrivateNullableIntField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -7,72 +7,72 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 {
     public class ObscureDuckTypeVirtualClass
     {
-        [Duck(Name = "_publicStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticReadonlyValueTypeField")]
         public virtual int PublicStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_internalStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticReadonlyValueTypeField")]
         public virtual int InternalStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_protectedStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticReadonlyValueTypeField")]
         public virtual int ProtectedStaticReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_privateStaticReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticReadonlyValueTypeField")]
         public virtual int PrivateStaticReadonlyValueTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticValueTypeField")]
         public virtual int PublicStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_internalStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalStaticValueTypeField")]
         public virtual int InternalStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_protectedStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedStaticValueTypeField")]
         public virtual int ProtectedStaticValueTypeField { get; set; }
 
-        [Duck(Name = "_privateStaticValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticValueTypeField")]
         public virtual int PrivateStaticValueTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicReadonlyValueTypeField")]
         public virtual int PublicReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_internalReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalReadonlyValueTypeField")]
         public virtual int InternalReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_protectedReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedReadonlyValueTypeField")]
         public virtual int ProtectedReadonlyValueTypeField { get; }
 
-        [Duck(Name = "_privateReadonlyValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateReadonlyValueTypeField")]
         public virtual int PrivateReadonlyValueTypeField { get; }
 
         // *
 
-        [Duck(Name = "_publicValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicValueTypeField")]
         public virtual int PublicValueTypeField { get; set; }
 
-        [Duck(Name = "_internalValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_internalValueTypeField")]
         public virtual int InternalValueTypeField { get; set; }
 
-        [Duck(Name = "_protectedValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_protectedValueTypeField")]
         public virtual int ProtectedValueTypeField { get; set; }
 
-        [Duck(Name = "_privateValueTypeField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateValueTypeField")]
         public virtual int PrivateValueTypeField { get; set; }
 
         // *
 
-        [Duck(Name = "_publicStaticNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicStaticNullableIntField")]
         public virtual int? PublicStaticNullableIntField { get; set; }
 
-        [Duck(Name = "_privateStaticNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateStaticNullableIntField")]
         public virtual int? PrivateStaticNullableIntField { get; set; }
 
-        [Duck(Name = "_publicNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_publicNullableIntField")]
         public virtual int? PublicNullableIntField { get; set; }
 
-        [Duck(Name = "_privateNullableIntField", Kind = DuckKind.Field)]
+        [DuckField(Name = "_privateNullableIntField")]
         public virtual int? PrivateNullableIntField { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/IDummyFieldObject.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/IDummyFieldObject.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
 {
     public interface IDummyFieldObject
     {
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         int MagicNumber { get; set; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/DummyFieldStruct.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/DummyFieldStruct.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
     [DuckCopy]
     public struct DummyFieldStruct
     {
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         public int MagicNumber;
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/IDummyFieldObject.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/IDummyFieldObject.cs
@@ -7,7 +7,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
 {
     public interface IDummyFieldObject
     {
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         int MagicNumber { get; set; }
 
         ITypesTuple this[ITypesTuple index] { get; set; }

--- a/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ITypesTuple.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ITypesTuple.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ITypesTuple.cs" company="Datadog">
+// <copyright file="ITypesTuple.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,10 +9,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
 {
     public interface ITypesTuple
     {
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         Type ProxyDefinitionType { get; }
 
-        [Duck(Kind = DuckKind.Field)]
+        [DuckField]
         Type TargetType { get; }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/StructTests.cs
@@ -88,7 +88,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface IPrivateDuckChainingTarget
         {
-            [Duck(Kind = DuckKind.Field)]
+            [DuckField]
             IPrivateTarget ChainingTestField { get; }
 
             IPrivateTarget ChainingTest { get; }
@@ -98,7 +98,7 @@ namespace Datadog.Trace.DuckTyping.Tests
 
         public interface IPrivateTarget
         {
-            [Duck(Kind = DuckKind.Field)]
+            [DuckField]
             public string Name { get; }
         }
 

--- a/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
+++ b/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
@@ -395,6 +395,10 @@ namespace Datadog.Trace.DuckTyping
     {
         public DuckCopyAttribute() { }
     }
+    public class DuckFieldAttribute : Datadog.Trace.DuckTyping.DuckAttribute
+    {
+        public DuckFieldAttribute() { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.All, AllowMultiple=false)]
     public class DuckIgnoreAttribute : System.Attribute
     {

--- a/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
+++ b/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
@@ -395,6 +395,10 @@ namespace Datadog.Trace.DuckTyping
     {
         public DuckCopyAttribute() { }
     }
+    public class DuckFieldAttribute : Datadog.Trace.DuckTyping.DuckAttribute
+    {
+        public DuckFieldAttribute() { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Field | System.AttributeTargets.All, AllowMultiple=false)]
     public class DuckIgnoreAttribute : System.Attribute
     {

--- a/test/benchmarks/Benchmarks.Trace/DuckTyping/DuckTypeValueTypeFieldBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/DuckTyping/DuckTypeValueTypeFieldBenchmark.cs
@@ -174,30 +174,30 @@ namespace Benchmarks.Trace.DuckTyping
 
         public interface IObscureDuckType
         {
-            [Duck(Name = "_publicStaticValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_publicStaticValueTypeField")]
             int PublicStaticValueTypeField { get; set; }
 
-            [Duck(Name = "_internalStaticValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_internalStaticValueTypeField")]
             int InternalStaticValueTypeField { get; set; }
 
-            [Duck(Name = "_protectedStaticValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_protectedStaticValueTypeField")]
             int ProtectedStaticValueTypeField { get; set; }
 
-            [Duck(Name = "_privateStaticValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_privateStaticValueTypeField")]
             int PrivateStaticValueTypeField { get; set; }
 
             // *
 
-            [Duck(Name = "_publicValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_publicValueTypeField")]
             int PublicValueTypeField { get; set; }
 
-            [Duck(Name = "_internalValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_internalValueTypeField")]
             int InternalValueTypeField { get; set; }
 
-            [Duck(Name = "_protectedValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_protectedValueTypeField")]
             int ProtectedValueTypeField { get; set; }
 
-            [Duck(Name = "_privateValueTypeField", Kind = DuckKind.Field)]
+            [DuckField(Name = "_privateValueTypeField")]
             int PrivateValueTypeField { get; set; }
 
             string ToString();


### PR DESCRIPTION
To workaround an issue discovered in Azure Functions, remove all usages of named arguments in Attributes that are not built-in types. This means removing arguments that use our own custom enums, but keeping arguments that use `string`, etc. While rare, the failing scenario occurs when the corelib attempts to create the `Attribute` object from the metadata but the assembly that gets resolved from the default load context (or one of its handlers) does not resolve to the same assembly as the one we expected, causing type equality to fail.

Note: This workaround is only required for attributes that will be instantiated from metadata, like `DuckAttribute`, but it is easier to maintain a broader rule that we can always revisit later.

Specific changes include:
- Replacing all usages of `[Duck(Kind = DuckKind.Field)]` with a new attribute `[DuckField]`
- Replacing the one usage of `[InterceptMethod(MethodReplacementAction = MethodReplacementActionType.InsertFirst)]` with `[InsertFirstInterceptMethod]`
- Adding a unit test to continuously maintain this coding guideline

@DataDog/apm-dotnet