### PR TITLE
Add fallback for logs injection for NLog versions < 4.1.0

### DIFF
--- a/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
@@ -13,6 +13,9 @@ namespace Datadog.Trace.Logging
     {
         public ILogEnricher CreateEnricher() => new LogEnricher(this);
 
+        internal static new bool IsLoggerAvailable() =>
+            NLogLogProvider.IsLoggerAvailable() && IsSetObjectAvailable();
+
         protected override OpenMdc GetOpenMdcMethod()
         {
             // This is a copy/paste of the base GetOpenMdcMethod, but calling Set(string, object) instead of Set(string, string)
@@ -43,48 +46,29 @@ namespace Datadog.Trace.Logging
 
             var mdcContextType = FindType("NLog.MappedDiagnosticsContext", "NLog");
             var setMethod = mdcContextType.GetMethod("Set", typeof(string), typeof(object));
+            var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));
+            var valueParam = Expression.Parameter(typeof(object), "value");
+            var setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
+            var removeMethodCall = Expression.Call(null, removeMethod, keyParam);
 
-            if (setMethod != null)
+            var set = Expression
+                .Lambda<Action<string, object>>(setMethodCall, keyParam, valueParam)
+                .Compile();
+            var remove = Expression
+                .Lambda<Action<string>>(removeMethodCall, keyParam)
+                .Compile();
+
+            return (key, value, _) =>
             {
-                var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));
-                var valueParam = Expression.Parameter(typeof(object), "value");
-                var setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
-                var removeMethodCall = Expression.Call(null, removeMethod, keyParam);
+                set(key, value);
+                return new DisposableAction(() => remove(key));
+            };
+        }
 
-                var set = Expression
-                    .Lambda<Action<string, object>>(setMethodCall, keyParam, valueParam)
-                    .Compile();
-                var remove = Expression
-                    .Lambda<Action<string>>(removeMethodCall, keyParam)
-                    .Compile();
-
-                return (key, value, _) =>
-                {
-                    set(key, value);
-                    return new DisposableAction(() => remove(key));
-                };
-            }
-            else
-            {
-                setMethod = mdcContextType.GetMethod("Set", typeof(string), typeof(string));
-                var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));
-                var valueParam = Expression.Parameter(typeof(string), "value");
-                var setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
-                var removeMethodCall = Expression.Call(null, removeMethod, keyParam);
-
-                var set = Expression
-                    .Lambda<Action<string, string>>(setMethodCall, keyParam, valueParam)
-                    .Compile();
-                var remove = Expression
-                    .Lambda<Action<string>>(removeMethodCall, keyParam)
-                    .Compile();
-
-                return (key, value, _) =>
-                {
-                    set(key, value.ToString());
-                    return new DisposableAction(() => remove(key));
-                };
-            }
+        private static bool IsSetObjectAvailable()
+        {
+            var mdcContextType = FindType("NLog.MappedDiagnosticsContext", "NLog");
+            return mdcContextType.GetMethod("Set", typeof(string), typeof(object)) != null;
         }
     }
 }

--- a/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
@@ -43,23 +43,48 @@ namespace Datadog.Trace.Logging
 
             var mdcContextType = FindType("NLog.MappedDiagnosticsContext", "NLog");
             var setMethod = mdcContextType.GetMethod("Set", typeof(string), typeof(object));
-            var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));
-            var valueParam = Expression.Parameter(typeof(object), "value");
-            var setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
-            var removeMethodCall = Expression.Call(null, removeMethod, keyParam);
 
-            var set = Expression
-                .Lambda<Action<string, object>>(setMethodCall, keyParam, valueParam)
-                .Compile();
-            var remove = Expression
-                .Lambda<Action<string>>(removeMethodCall, keyParam)
-                .Compile();
-
-            return (key, value, _) =>
+            if (setMethod != null)
             {
-                set(key, value);
-                return new DisposableAction(() => remove(key));
-            };
+                var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));
+                var valueParam = Expression.Parameter(typeof(object), "value");
+                var setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
+                var removeMethodCall = Expression.Call(null, removeMethod, keyParam);
+
+                var set = Expression
+                    .Lambda<Action<string, object>>(setMethodCall, keyParam, valueParam)
+                    .Compile();
+                var remove = Expression
+                    .Lambda<Action<string>>(removeMethodCall, keyParam)
+                    .Compile();
+
+                return (key, value, _) =>
+                {
+                    set(key, value);
+                    return new DisposableAction(() => remove(key));
+                };
+            }
+            else
+            {
+                setMethod = mdcContextType.GetMethod("Set", typeof(string), typeof(string));
+                var removeMethod = mdcContextType.GetMethod("Remove", typeof(string));
+                var valueParam = Expression.Parameter(typeof(string), "value");
+                var setMethodCall = Expression.Call(null, setMethod, keyParam, valueParam);
+                var removeMethodCall = Expression.Call(null, removeMethod, keyParam);
+
+                var set = Expression
+                    .Lambda<Action<string, string>>(setMethodCall, keyParam, valueParam)
+                    .Compile();
+                var remove = Expression
+                    .Lambda<Action<string>>(removeMethodCall, keyParam)
+                    .Compile();
+
+                return (key, value, _) =>
+                {
+                    set(key, value.ToString());
+                    return new DisposableAction(() => remove(key));
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
We advertise support beginning with NLog 4.0. Until NLog 4.1.0, there is only one Set API in the MappedDiagnosticsContext class: `Set(string, string)`. Our new `CustomNLogLogProvider` requires `Set(string, object)` API, which was introduced in NLog 4.1.0, to use our optimized `LogEnricher` type. Without this API present, we can't use our `CustomNLogLogProvider` type so revise the `IsLoggerAvailable` check to fail when the API is not found.

Note: I discovered this while testing cross-AppDomain calls with the various logging frameworks. I plan to post that PR separately, but I've verified that we find and use the fallback API in this scenario.

@DataDog/apm-dotnet