### PR TITLE
Fix PInvokes to the native lib on non windows os.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs
@@ -72,6 +72,15 @@ namespace Datadog.Trace.ClrProfiler
                 // ignore
             }
 
+            try
+            {
+                Log.Information($"IsProfilerAttached: {NativeMethods.IsProfilerAttached()}");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, ex.Message);
+            }
+
 #if !NETFRAMEWORK
             try
             {

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -583,6 +583,75 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         CallTarget_RequestRejitForModule(module_id, module_metadata, filtered_integrations);
     }
 
+#ifndef _WIN32
+    // Fix PInvokeMap (Non windows only)
+    if (module_info.assembly.name == managed_profiler_name)
+    {
+        Info("ModuleLoadFinished: ", managed_profiler_name," - Fix PInvoke maps");
+
+        // We are in the right module, so we try to load the mdTypeDef from the target type name.
+        mdTypeDef nativeMethodsTypeDef = mdTypeDefNil;
+        auto foundType = FindTypeDefByName(nonwindows_nativemethods_type,
+                                           module_metadata->assemblyName, metadata_import, nativeMethodsTypeDef);
+        if (foundType)
+        {
+            // Define the actual profiler file path as a ModuleRef
+            WSTRING native_profiler_file = GetProfilerFilePath();
+            mdModuleRef profiler_ref;
+            hr = metadata_emit->DefineModuleRef(native_profiler_file.c_str(), &profiler_ref);
+            if (SUCCEEDED(hr))
+            {
+                // Enumerate all methods inside the native methods type with the PInvokes
+                Enumerator<mdMethodDef> enumMethods = Enumerator<mdMethodDef>(
+                    [metadata_import, nativeMethodsTypeDef](HCORENUM* ptr, mdMethodDef arr[], ULONG max, ULONG* cnt) -> HRESULT
+                    {
+                        return metadata_import->EnumMethods(ptr, nativeMethodsTypeDef, arr, max, cnt);
+                    }, [metadata_import](HCORENUM ptr) -> void { metadata_import->CloseEnum(ptr); });
+
+                EnumeratorIterator<mdMethodDef> enumIterator = enumMethods.begin();
+                while (enumIterator != enumMethods.end())
+                {
+                    auto methodDef = *enumIterator;
+
+                    // Get the current PInvoke map to extract the flags and the entrypoint name
+                    DWORD pdwMappingFlags;
+                    WCHAR importName[kNameMaxSize]{};
+                    DWORD importNameLength = 0;
+                    mdModuleRef importModule;
+                    hr = metadata_import->GetPinvokeMap(methodDef, &pdwMappingFlags, importName, kNameMaxSize,
+                                                        &importNameLength, &importModule);
+                    if (SUCCEEDED(hr))
+                    {
+                        // Delete the current PInvoke map
+                        hr = metadata_emit->DeletePinvokeMap(methodDef);
+                        if (SUCCEEDED(hr))
+                        {
+                            // Define a new PInvoke map with the new ModuleRef of the actual profiler file path
+                            hr = metadata_emit->DefinePinvokeMap(methodDef, pdwMappingFlags,
+                                                                 WSTRING(importName).c_str(), profiler_ref);
+                            if (FAILED(hr))
+                            {
+                                Warn("ModuleLoadFinished: DefinePinvokeMap failed");
+                                return hr;
+                            }
+                        }
+                        else
+                        {
+                            Warn("ModuleLoadFinished: DeletePinvokeMap failed");
+                        }
+                    }
+
+                    enumIterator = ++enumIterator;
+                }
+            }
+            else
+            {
+                Warn("ModuleLoadFinished: Native Profiler DefineModuleRef failed");
+            }
+        }
+    }
+#endif
+
     return S_OK;
 }
 
@@ -1007,6 +1076,29 @@ bool CorProfiler::IsAttached() const
 //
 // Helper methods
 //
+WSTRING CorProfiler::GetProfilerFilePath()
+{
+    WSTRING native_profiler_file;
+#ifdef BIT64
+    native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_64"));
+    Debug("GetProfilerFilePath: CORECLR_PROFILER_PATH_64 defined as: ", native_profiler_file);
+    if (native_profiler_file == WStr(""))
+    {
+        native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
+        Debug("GetProfilerFilePath: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
+    }
+#else // BIT64
+    native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_32"));
+    Debug("GetProfilerFilePath: CORECLR_PROFILER_PATH_32 defined as: ", native_profiler_file);
+    if (native_profiler_file == WStr(""))
+    {
+        native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
+        Debug("GetProfilerFilePath: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
+    }
+#endif // BIT64
+    return native_profiler_file;
+}
+
 HRESULT CorProfiler::ProcessReplacementCalls(ModuleMetadata* module_metadata, const FunctionID function_id,
                                              const ModuleID module_id, const mdToken function_token,
                                              const FunctionInfo& caller,
@@ -2106,27 +2198,9 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
 #ifdef _WIN32
     WSTRING native_profiler_file = WStr("DATADOG.TRACE.CLRPROFILER.NATIVE.DLL");
 #else // _WIN32
-
-#ifdef BIT64
-    WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_64"));
-    Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_64 defined as: ", native_profiler_file);
-    if (native_profiler_file == WStr(""))
-    {
-        native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
-        Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
-    }
-#else // BIT64
-    WSTRING native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH_32"));
-    Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH_32 defined as: ", native_profiler_file);
-    if (native_profiler_file == WStr(""))
-    {
-        native_profiler_file = GetEnvironmentValue(WStr("CORECLR_PROFILER_PATH"));
-        Debug("GenerateVoidILStartupMethod: Linux: CORECLR_PROFILER_PATH defined as: ", native_profiler_file);
-    }
-#endif // BIT64
-    Debug("GenerateVoidILStartupMethod: Linux: Setting the PInvoke native profiler library path to ",
+    WSTRING native_profiler_file = GetProfilerFilePath();
+    Debug("GenerateVoidILStartupMethod: Setting the PInvoke native profiler library path to ",
           native_profiler_file);
-
 #endif // _WIN32
 
     mdModuleRef profiler_ref;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -62,6 +62,7 @@ private:
     //
     // Helper methods
     //
+    WSTRING GetProfilerFilePath();
     bool GetWrapperMethodRef(ModuleMetadata* module_metadata, ModuleID module_id,
                              const MethodReplacement& method_replacement, mdMemberRef& wrapper_method_ref,
                              mdTypeRef& wrapper_type_ref);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -62,7 +62,7 @@ private:
     //
     // Helper methods
     //
-    WSTRING GetProfilerFilePath();
+    WSTRING GetCoreCLRProfilerPath();
     bool GetWrapperMethodRef(ModuleMetadata* module_metadata, ModuleID module_id,
                              const MethodReplacement& method_replacement, mdMemberRef& wrapper_method_ref,
                              mdTypeRef& wrapper_type_ref);

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -34,7 +34,6 @@ const WSTRING env_vars_to_display[]{environment::tracing_enabled,
                                     environment::azure_app_services_cli_telemetry_profile_value};
 
 const WSTRING skip_assembly_prefixes[]{
-    WStr("Datadog.Trace"),
     WStr("MessagePack"),
     WStr("Microsoft.AI"),
     WStr("Microsoft.ApplicationInsights"),
@@ -68,6 +67,10 @@ const WSTRING skip_assemblies[]{WStr("mscorlib"),
 
 const WSTRING managed_profiler_full_assembly_version =
     WStr("Datadog.Trace.ClrProfiler.Managed, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+
+const WSTRING managed_profiler_name = WStr("Datadog.Trace.ClrProfiler.Managed");
+
+const WSTRING nonwindows_nativemethods_type = WStr("Datadog.Trace.ClrProfiler.NativeMethods+NonWindows");
 
 const WSTRING calltarget_modification_action = WStr("CallTargetModification");
 

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -34,14 +34,12 @@ const WSTRING env_vars_to_display[]{environment::tracing_enabled,
                                     environment::azure_app_services_cli_telemetry_profile_value};
 
 const WSTRING skip_assembly_prefixes[]{
-    WStr("MessagePack"),
     WStr("Microsoft.AI"),
     WStr("Microsoft.ApplicationInsights"),
     WStr("Microsoft.Build"),
     WStr("Microsoft.CSharp"),
     WStr("Microsoft.Extensions"),
     WStr("Microsoft.Web.Compilation.Snapshots"),
-    WStr("Sigil"),
     WStr("System.Core"),
     WStr("System.Console"),
     WStr("System.Collections"),
@@ -54,7 +52,6 @@ const WSTRING skip_assembly_prefixes[]{
     WStr("System.Text"),
     WStr("System.Threading"),
     WStr("System.Xml"),
-    WStr("Newtonsoft"),
 };
 
 const WSTRING skip_assemblies[]{WStr("mscorlib"),


### PR DESCRIPTION
This PR fixes PInvokes to the native lib on non windows os by rewriting the PInvokeMaps from the `Datadog.Trace.ClrProfiler.NativeMethods+NonWindows` type.

#### Before:
```log
2021-07-17 00:13:43.328 +02:00 [DBG] Logger retrieved for: Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace.ClrProfiler.Managed, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.458 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Tracer, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.460 +02:00 [DBG] Logger retrieved for: Datadog.Trace.TracingProcessManager, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.469 +02:00 [DBG] Logger retrieved for: Datadog.Trace.PlatformHelpers.AzureAppServices, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.563 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Agent.Api, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.563 +02:00 [DBG] Creating new Api
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.568 +02:00 [DBG] Logger retrieved for: Datadog.Trace.PlatformHelpers.ContainerMetadata, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.569 +02:00 [DBG] Logger retrieved for: Datadog.Trace.FrameworkDescription, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.572 +02:00 [INF] Using HttpClientRequestFactory for trace transport.
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.638 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Agent.AgentWriter, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.669 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Agent.MovingAverageKeepRateCalculator, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.721 +02:00 [DBG] Sending 0 traces to the DD agent
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.739 +02:00 [DBG] Logger retrieved for: Datadog.Trace.ClrProfiler.CallTarget.Handlers.IntegrationOptions`2[[Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.HttpClientHandler.HttpClientHandlerIntegration, Datadog.Trace.ClrProfiler.Managed, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb],[System.Net.Http.HttpClientHandler, System.Net.Http, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]], Datadog.Trace.ClrProfiler.Managed, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[48930 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:13:43.741 +02:00 [ERR] Unable to load shared library 'Datadog.Trace.ClrProfiler.Native' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(libDatadog.Trace.ClrProfiler.Native, 1): image not found
System.DllNotFoundException: Unable to load shared library 'Datadog.Trace.ClrProfiler.Native' or one of its dependencies. In order to help diagnose loading problems, consider setting the DYLD_PRINT_LIBRARIES environment variable: dlopen(libDatadog.Trace.ClrProfiler.Native, 1): image not found
   at Datadog.Trace.ClrProfiler.NativeMethods.NonWindows.IsProfilerAttached()
   at Datadog.Trace.ClrProfiler.NativeMethods.IsProfilerAttached() in /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/src/Datadog.Trace.ClrProfiler.Managed/NativeMethods.cs:line 23
   at Datadog.Trace.ClrProfiler.Instrumentation.Initialize() in /Users/tony.redondo/repos/github/DataDog/dd-trace-dotnet/src/Datadog.Trace.ClrProfiler.Managed/Instrumentation.cs:line 77
```

#### After:
```log
2021-07-17 00:07:11.884 +02:00 [DBG] Logger retrieved for: Datadog.Trace.ClrProfiler.Instrumentation, Datadog.Trace.ClrProfiler.Managed, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.008 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Tracer, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.009 +02:00 [DBG] Logger retrieved for: Datadog.Trace.TracingProcessManager, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.017 +02:00 [DBG] Logger retrieved for: Datadog.Trace.PlatformHelpers.AzureAppServices, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.107 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Agent.Api, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.107 +02:00 [DBG] Creating new Api
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.112 +02:00 [DBG] Logger retrieved for: Datadog.Trace.PlatformHelpers.ContainerMetadata, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.113 +02:00 [DBG] Logger retrieved for: Datadog.Trace.FrameworkDescription, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.116 +02:00 [INF] Using HttpClientRequestFactory for trace transport.
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.182 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Agent.AgentWriter, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.212 +02:00 [DBG] Logger retrieved for: Datadog.Trace.Agent.MovingAverageKeepRateCalculator, Datadog.Trace, Version=1.28.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb
{ MachineName: ".", Process: "[47953 dotnet]", AppDomain: "[1 dotnet]", TracerVersion: "1.28.1.0" }
2021-07-17 00:07:12.256 +02:00 [INF] IsProfilerAttached: True
```
@DataDog/apm-dotnet