### PR TITLE
Add additional logs injection fallback for NLog 1.x

### DIFF
--- a/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/CustomNLogLogProvider.cs
@@ -9,6 +9,20 @@ using Datadog.Trace.Logging.LogProviders;
 
 namespace Datadog.Trace.Logging
 {
+    /// <summary>
+    /// <para>
+    /// Log provider that performs more efficient logs injection by adding a custom type
+    /// into the NLog MDC which can later be rendered with the properties of the active
+    /// Datadog scope.
+    /// </para>
+    ///
+    /// <para>
+    /// Note: This logger is intended to be used when the application uses NLog &gt;= 4.1.
+    /// When the application uses NLog versions older than 4.1, use
+    /// <see cref="FallbackNLogLogProvider"/> which utilizes the original
+    /// Set(string, string) API to perform logs injection.
+    /// </para>
+    /// </summary>
     internal class CustomNLogLogProvider : NLogLogProvider, ILogProviderWithEnricher
     {
         public ILogEnricher CreateEnricher() => new LogEnricher(this);

--- a/src/Datadog.Trace/Logging/FallbackNLogLogProvider.cs
+++ b/src/Datadog.Trace/Logging/FallbackNLogLogProvider.cs
@@ -10,9 +10,18 @@ using Datadog.Trace.Logging.LogProviders;
 namespace Datadog.Trace.Logging
 {
     /// <summary>
-    /// Log provider for all versions of NLog lower than 4.1. This is required
-    /// because the built-in NLogLogProvider does not have the required interface
-    /// for NLog 1.0.
+    /// <para>
+    /// Log provider that enhances the built-in LibLog NLogLogProvider by adding
+    /// MDC support for NLog 1.0. The built-in NLogLogProvider only looked for
+    /// API's present on NLog 2.0 and newer.
+    /// </para>
+    ///
+    /// <para>
+    /// Note: This logger is intended to be used when the application uses NLog &lt; 4.1.
+    /// When the application uses NLog versions 4.1 and newer, use
+    /// <see cref="CustomNLogLogProvider"/> which utilizes the Set(string, object)
+    /// API to perform logs injection more efficiently.
+    /// </para>
     /// </summary>
     internal class FallbackNLogLogProvider : NLogLogProvider
     {

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -271,12 +271,18 @@ namespace Datadog.Trace.Logging
                     CustomLog4NetLogProvider.IsLoggerAvailable,
                     () => new CustomLog4NetLogProvider()));
 
-            // Register the custom NLog provider
+            // Register the custom NLog providers
             LogProvider.LogProviderResolvers.Insert(
                 0,
                 Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
                     CustomNLogLogProvider.IsLoggerAvailable,
                     () => new CustomNLogLogProvider()));
+
+            LogProvider.LogProviderResolvers.Insert(
+                1,
+                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
+                    FallbackNLogLogProvider.IsLoggerAvailable,
+                    () => new FallbackNLogLogProvider()));
 
             // Register the custom Serilog provider
             LogProvider.LogProviderResolvers.Insert(

--- a/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
+++ b/src/Datadog.Trace/Logging/LibLogScopeEventSubscriber.cs
@@ -264,32 +264,32 @@ namespace Datadog.Trace.Logging
             //  - NLog
             //  - Log4net
 
-            // Register the custom log4net provider
-            LogProvider.LogProviderResolvers.Insert(
-                0,
-                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
-                    CustomLog4NetLogProvider.IsLoggerAvailable,
-                    () => new CustomLog4NetLogProvider()));
-
-            // Register the custom NLog providers
-            LogProvider.LogProviderResolvers.Insert(
-                0,
-                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
-                    CustomNLogLogProvider.IsLoggerAvailable,
-                    () => new CustomNLogLogProvider()));
-
-            LogProvider.LogProviderResolvers.Insert(
-                1,
-                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
-                    FallbackNLogLogProvider.IsLoggerAvailable,
-                    () => new FallbackNLogLogProvider()));
-
             // Register the custom Serilog provider
             LogProvider.LogProviderResolvers.Insert(
                 0,
                 Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
                     CustomSerilogLogProvider.IsLoggerAvailable,
                     () => new CustomSerilogLogProvider()));
+
+            // Register the custom NLog providers
+            LogProvider.LogProviderResolvers.Insert(
+                1,
+                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
+                    CustomNLogLogProvider.IsLoggerAvailable,
+                    () => new CustomNLogLogProvider()));
+
+            LogProvider.LogProviderResolvers.Insert(
+                2,
+                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
+                    FallbackNLogLogProvider.IsLoggerAvailable,
+                    () => new FallbackNLogLogProvider()));
+
+            // Register the custom log4net provider
+            LogProvider.LogProviderResolvers.Insert(
+                3,
+                Tuple.Create<LogProvider.IsLoggerAvailable, LogProvider.CreateLogProvider>(
+                    CustomLog4NetLogProvider.IsLoggerAvailable,
+                    () => new CustomLog4NetLogProvider()));
         }
 
         private void SetDefaultValues()


### PR DESCRIPTION
This PR is based on the work from #1607, so that must be merged first.

The previous PR allows logs injection to fallback on LibLog's built-in log provider for NLog for versions < 4.0.0. However, the built-in log provider only looks for the MDC class `NLog.MappedDiagnosticsContext` to find the `Set`/`Remove` API's. These API's were introduced in NLog 2.x, so the lookup fails on NLog 1.x. This PR introduces a new custom NLog log provider to add a fallback path to search on the type `NLog.MDC` for the methods, which is the predecessor of the `NLog.MappedDiagnosticsContext` class.

Result: We no longer throw an unhandled exception when an application enables logs injection when using NLog 1.x.

@DataDog/apm-dotnet