### PR TITLE
Fix throughtput/crank pipeline.

### DIFF
--- a/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -40,18 +40,19 @@ namespace Samples.AspNetCoreSimpleController
 
         private static bool IsProfilerAttached()
         {
-            var instrumentationType = Type.GetType("Datadog.Trace.ClrProfiler.Instrumentation", throwOnError: false);
-
-            if (instrumentationType == null)
+            Assembly managedAssembly = typeof(Datadog.Trace.ClrProfiler.Instrumentation).Assembly;
+            Type nativeMethodsType = managedAssembly.GetType("Datadog.Trace.ClrProfiler.NativeMethods");
+            MethodInfo profilerAttachedMethodInfo = nativeMethodsType.GetMethod("IsProfilerAttached");
+            try
             {
-                return false;
+                return (bool)profilerAttachedMethodInfo.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
             }
 
-            var property = instrumentationType.GetProperty("ProfilerAttached");
-
-            var isAttached = property?.GetValue(null) as bool?;
-
-            return isAttached ?? false;
+            return false;
         }
     }
 }

--- a/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Properties/launchSettings.json
+++ b/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Properties/launchSettings.json
@@ -9,7 +9,7 @@
       "environmentVariables": {
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "COR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
-        
+
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)profiler-lib\\Datadog.Trace.ClrProfiler.Native.dll",
 

--- a/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -5,4 +5,8 @@
     <Platforms>x64;x86;AnyCPU</Platforms>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.ClrProfiler.Managed\Datadog.Trace.ClrProfiler.Managed.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
- Includes the project reference to the crank sample project to avoid the error trying to locate the managed assembly.

Due the crank pipeline does not use the home folder artifact but manually copies the native build to each crank agent, we need to add the managed profiler reference to the sample project, that way we ensure the required managed assemblies will be found at runtime.

@DataDog/apm-dotnet