### PR TITLE
don't include code analyzer when publishing projects

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net45' ">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)Datadog.Trace.Tools.Analyzers\Datadog.Trace.Tools.Analyzers.csproj" OutputItemType="Analyzer" PrivateAssets="All" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)Datadog.Trace.Tools.Analyzers\Datadog.Trace.Tools.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Don't include the analyzer (added in #1325) when publishing projects. This makes the analyzer dlls and all the `System.*` it depends on to be included in the tracer home directory, the MSI installer, installed in the GAC, etc.

See https://github.com/dotnet/roslyn/issues/18093#issuecomment-405702631