### PR TITLE
CIApp - Removes version from the test.framework tag

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             MethodInfo testMethod = testMethodInfo.MethodInfo;
             object[] testMethodArguments = testMethodInfo.Arguments;
 
-            string testFramework = "MSTestV2 " + type.Assembly.GetName().Version;
+            string testFramework = "MSTestV2";
             string testSuite = testMethodInfo.TestClassName;
             string testName = testMethodInfo.TestMethodName;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                 return null;
             }
 
-            string testFramework = "NUnit " + targetType?.Assembly?.GetName().Version;
+            string testFramework = "NUnit";
             string fullName = currentTest.FullName;
             string composedTestName = currentTest.Name;
 

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 
             AssemblyName testInvokerAssemblyName = targetType.Assembly.GetName();
 
-            string testFramework = "xUnit " + testInvokerAssemblyName.Version.ToString();
+            string testFramework = "xUnit";
 
             Scope scope = Common.TestTracer.StartActive("xunit.test", serviceName: Common.TestTracer.DefaultServiceName);
             Span span = scope.Span;


### PR DESCRIPTION
This PR removes the version string from the `test.framework` span tag.


@DataDog/apm-dotnet