### PR TITLE
Fix ARM64 Integration tests

### DIFF
--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -1055,7 +1055,7 @@ partial class Build
             var filter = (string.IsNullOrEmpty(Filter), IsArm64) switch
             {
                 (true, false) => "Category!=LinuxUnsupported",
-                (true, true) => "(Category!=ArmUnsupported)&(Category!=LinuxUnsupported",
+                (true, true) => "(Category!=ArmUnsupported)&(Category!=LinuxUnsupported)",
                 _ => Filter
             };
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,6 +301,7 @@ services:
       - MYSQL_HOST=mysql
       - MYSQL_PORT=3306
       - RABBITMQ_HOST=rabbitmq
+      - AWS_SQS_HOST=aws_sqs:9324
     depends_on:
       - servicestackredis
       - stackexchangeredis
@@ -310,6 +311,7 @@ services:
       - postgres
       - mysql
       - rabbitmq
+      - aws_sqs
 
   StartDependencies.ARM64:
     image: andrewlock/wait-for-dependencies
@@ -322,6 +324,7 @@ services:
       - postgres
       - mysql
       - rabbitmq
+      - aws_sqs
     environment:
       - TIMEOUT_LENGTH=120
-    command: servicestackredis:6379 stackexchangeredis:6379 elasticsearch7_arm64:9200 sqledge:1433 mongo:27017 postgres:5432 mysql:3306 rabbitmq:5672
+    command: servicestackredis:6379 stackexchangeredis:6379 elasticsearch7_arm64:9200 sqledge:1433 mongo:27017 postgres:5432 mysql:3306 rabbitmq:5672 aws_sqs:9324


### PR DESCRIPTION
ARM64 integration tests have not been running due to a typo in the test filter

`Exception filtering tests: Incorrect format for TestCaseFilter Error: Missing ')'. Specify the correct format and try again. Note that the incorrect format can lead to no test getting executed.`

@DataDog/apm-dotnet