### PR TITLE
Clear metadata when an appdomain unloads

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -110,6 +110,8 @@ public:
 
     HRESULT STDMETHODCALLTYPE JITCompilationStarted(FunctionID function_id, BOOL is_safe_to_block) override;
 
+    HRESULT STDMETHODCALLTYPE AppDomainShutdownFinished(AppDomainID appDomainId, HRESULT hrStatus) override;
+
     HRESULT STDMETHODCALLTYPE Shutdown() override;
 
     HRESULT STDMETHODCALLTYPE ProfilerDetachSucceeded() override;


### PR DESCRIPTION
We keep some metadata to know in which appdomains the tracer has been loaded. Unfortunately we don't clear that metadata when an appdomain is unloaded, so if a new appdomain is created with the same id then the tracer won't be loaded.

This scenario occasionally occurs in the MultiDomainHost tests.