### PR TITLE
Fix MockTracerAgent listener thread not closing

### DIFF
--- a/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.TestHelpers
 
         public void Dispose()
         {
-            _listener?.Stop();
+            _listener?.Abort();
             _cancellationTokenSource.Cancel();
             _udpClient?.Close();
         }


### PR DESCRIPTION
As noted elsewhere, `listener.GetContext()` doesn't throw on .NET Core when the listener is stopped, which means the thread never ends. `GetContextAsync()` _does_ throw however, so refactored to use a task based approach instead. 

Without this, the Rider test process hangs after running integration tests.
