### PR TITLE
Ignore empty values when parsing headers

### DIFF
--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -238,6 +238,11 @@ namespace Datadog.Trace
 
             foreach (string headerValue in headerValues)
             {
+                if (string.IsNullOrWhiteSpace(headerValue))
+                {
+                    continue;
+                }
+
                 if (ulong.TryParse(headerValue, NumberStyles, InvariantCulture, out var result))
                 {
                     return result;
@@ -262,6 +267,11 @@ namespace Datadog.Trace
 
             foreach (string headerValue in headerValues)
             {
+                if (string.IsNullOrWhiteSpace(headerValue))
+                {
+                    continue;
+                }
+
                 if (ulong.TryParse(headerValue, NumberStyles, InvariantCulture, out var result))
                 {
                     return result;
@@ -287,6 +297,11 @@ namespace Datadog.Trace
 
             foreach (string headerValue in headerValues)
             {
+                if (string.IsNullOrWhiteSpace(headerValue))
+                {
+                    continue;
+                }
+
                 if (int.TryParse(headerValue, out var result))
                 {
                     if (MinimumSamplingPriority <= result && result <= MaximumSamplingPriority)
@@ -317,6 +332,11 @@ namespace Datadog.Trace
 
             foreach (string headerValue in headerValues)
             {
+                if (string.IsNullOrWhiteSpace(headerValue))
+                {
+                    continue;
+                }
+
                 if (int.TryParse(headerValue, out var result))
                 {
                     if (MinimumSamplingPriority <= result && result <= MaximumSamplingPriority)


### PR DESCRIPTION
There has been one case of customer seeing a lot of warning logs because of an empty `x-datadog-sampling-priority`. While the provenance of this header is unclear, we can save ourselves a lot of trouble if we ignore empty values instead of treating them as invalid.