### PR TITLE
Add better error handling for the Header Tags feature accessing System.Web.HttpResponse.Headers

### DIFF
--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -28,6 +28,8 @@ namespace Datadog.Trace.AspNet
         private readonly string _httpContextScopeKey;
         private readonly string _requestOperationName;
 
+        private static bool CanReadHttpResponseHeaders = true;
+
         /// <summary>
         ///     Initializes a new instance of the <see cref="TracingHttpModule" /> class.
         /// </summary>
@@ -151,10 +153,7 @@ namespace Datadog.Trace.AspNet
                 {
                     try
                     {
-                        if (HttpRuntime.UsingIntegratedPipeline)
-                        {
-                            scope.Span.SetHeaderTags<IHeadersCollection>(app.Context.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-                        }
+                        AddHeaderTagsFromHttpResponse(app.Context, scope);
 
                         scope.Span.SetHttpStatusCode(app.Context.Response.StatusCode, isServer: true);
 
@@ -197,10 +196,7 @@ namespace Datadog.Trace.AspNet
 
                 if (httpContext.Items[_httpContextScopeKey] is Scope scope)
                 {
-                    if (HttpRuntime.UsingIntegratedPipeline)
-                    {
-                        scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-                    }
+                    AddHeaderTagsFromHttpResponse(httpContext, scope);
 
                     if (exception != null && !is404)
                     {
@@ -223,6 +219,27 @@ namespace Datadog.Trace.AspNet
             catch (Exception ex)
             {
                 Log.Error(ex, "Error while clearing the HttpContext");
+            }
+        }
+
+        private static void AddHeaderTagsFromHttpResponse(System.Web.HttpContext httpContext, Scope scope)
+        {
+            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && CanReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTags.IsNullOrEmpty())
+            {
+                try
+                {
+                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                }
+                catch (PlatformNotSupportedException ex)
+                {
+                    // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
+                    Log.Error(ex, "Unable to access response headers when creating header tags. Disabling for the rest of the application lifetime.");
+                    CanReadHttpResponseHeaders = false;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error extracting HTTP headers to create header tags.");
+                }
             }
         }
     }

--- a/src/Datadog.Trace.AspNet/TracingHttpModule.cs
+++ b/src/Datadog.Trace.AspNet/TracingHttpModule.cs
@@ -25,10 +25,10 @@ namespace Datadog.Trace.AspNet
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TracingHttpModule));
 
+        private static bool _canReadHttpResponseHeaders = true;
+
         private readonly string _httpContextScopeKey;
         private readonly string _requestOperationName;
-
-        private static bool CanReadHttpResponseHeaders = true;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="TracingHttpModule" /> class.
@@ -222,9 +222,9 @@ namespace Datadog.Trace.AspNet
             }
         }
 
-        private static void AddHeaderTagsFromHttpResponse(System.Web.HttpContext httpContext, Scope scope)
+        private void AddHeaderTagsFromHttpResponse(System.Web.HttpContext httpContext, Scope scope)
         {
-            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && CanReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTags.IsNullOrEmpty())
+            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTags.IsNullOrEmpty())
             {
                 try
                 {
@@ -234,7 +234,7 @@ namespace Datadog.Trace.AspNet
                 {
                     // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
                     Log.Error(ex, "Unable to access response headers when creating header tags. Disabling for the rest of the application lifetime.");
-                    CanReadHttpResponseHeaders = false;
+                    _canReadHttpResponseHeaders = false;
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -115,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             }
             else
             {
-                HttpContextHelpers.AddHeaderTagsFromHttpResponse(HttpContext.Current, scope);
+                HttpContextHelper.AddHeaderTagsFromHttpResponse(HttpContext.Current, scope);
                 scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true);
                 scope.Dispose();
             }
@@ -125,7 +125,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+            HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -120,7 +120,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 {
                     scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 }
-
+                HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
                 scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true);
                 scope.Dispose();
             }
@@ -130,11 +130,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            if (HttpRuntime.UsingIntegratedPipeline)
-            {
-                scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-            }
-
+            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -115,12 +115,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             }
             else
             {
-                var httpContext = HttpContext.Current;
-                if (httpContext != null && HttpRuntime.UsingIntegratedPipeline)
-                {
-                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-                }
-                HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+                HttpContextHelpers.AddHeaderTagsFromHttpResponse(HttpContext.Current, scope);
                 scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true);
                 scope.Dispose();
             }

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -8,9 +8,9 @@ using System;
 using System.Web;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.ClrProfiler.Integrations;
+using Datadog.Trace.ClrProfiler.Integrations.AspNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
-using Datadog.Trace.Headers;
 using Datadog.Trace.Vendors.Serilog;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
@@ -75,11 +75,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 }
                 else
                 {
-                    if (HttpRuntime.UsingIntegratedPipeline)
-                    {
-                        scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-                    }
-
+                    HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -90,11 +86,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            if (HttpRuntime.UsingIntegratedPipeline)
-            {
-                scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-            }
-
+            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 }
                 else
                 {
-                    HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+                    HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+            HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -363,11 +363,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 if (scope != null)
                 {
-                    if (HttpRuntime.UsingIntegratedPipeline)
-                    {
-                        scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-                    }
-
+                    HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -399,11 +395,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            if (HttpRuntime.UsingIntegratedPipeline)
-            {
-                scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
-            }
-
+            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetMvcIntegration.cs
@@ -363,7 +363,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
                 if (scope != null)
                 {
-                    HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+                    HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
                     scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -395,7 +395,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+            HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -171,7 +171,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
                 {
                     // some fields aren't set till after execution, so populate anything missing
                     UpdateSpan(controllerContext, scope.Span, tags, Enumerable.Empty<KeyValuePair<string, string>>());
-                    HttpContextHelpers.AddHeaderTagsFromHttpResponse(System.Web.HttpContext.Current, scope);
+                    HttpContextHelper.AddHeaderTagsFromHttpResponse(System.Web.HttpContext.Current, scope);
                     scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true);
                     scope.Dispose();
                 }
@@ -348,7 +348,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
 
         private static void OnRequestCompleted(System.Web.HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
-            HttpContextHelpers.AddHeaderTagsFromHttpResponse(httpContext, scope);
+            HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
             scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true);
             scope.Span.Finish(finishTime);
             scope.Dispose();

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -41,8 +41,6 @@ namespace Datadog.Trace.ClrProfiler.Integrations
         private static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(nameof(IntegrationIds.AspNetWebApi2));
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AspNetWebApi2Integration));
 
-        private static bool CanReadResponseHeaders = true;
-
         /// <summary>
         /// Calls the underlying ExecuteAsync and traces the request.
         /// </summary>

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/HttpContextHelper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/HttpContextHelper.cs
@@ -1,3 +1,8 @@
+// <copyright file="HttpContextHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
 #if NETFRAMEWORK
 using System;
 using System.Web;
@@ -7,14 +12,14 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.Integrations.AspNet
 {
-    internal static class HttpContextHelpers
+    internal static class HttpContextHelper
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(HttpContextHelpers));
-        private static bool CanReadHttpResponseHeaders = true;
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(HttpContextHelper));
+        private static bool _canReadHttpResponseHeaders = true;
 
         internal static void AddHeaderTagsFromHttpResponse(System.Web.HttpContext httpContext, Scope scope)
         {
-            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && CanReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTags.IsNullOrEmpty())
+            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTags.IsNullOrEmpty())
             {
                 try
                 {
@@ -24,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.AspNet
                 {
                     // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
                     Log.Error(ex, "Unable to access response headers when creating header tags. Disabling for the rest of the application lifetime.");
-                    CanReadHttpResponseHeaders = false;
+                    _canReadHttpResponseHeaders = false;
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/HttpContextHelpers.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/Integrations/AspNet/HttpContextHelpers.cs
@@ -1,0 +1,37 @@
+#if NETFRAMEWORK
+using System;
+using System.Web;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Headers;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.Integrations.AspNet
+{
+    internal static class HttpContextHelpers
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(HttpContextHelpers));
+        private static bool CanReadHttpResponseHeaders = true;
+
+        internal static void AddHeaderTagsFromHttpResponse(System.Web.HttpContext httpContext, Scope scope)
+        {
+            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && CanReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTags.IsNullOrEmpty())
+            {
+                try
+                {
+                    scope.Span.SetHeaderTags<IHeadersCollection>(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTags, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                }
+                catch (PlatformNotSupportedException ex)
+                {
+                    // Despite the HttpRuntime.UsingIntegratedPipeline check, we can still fail to access response headers, for example when using Sitefinity: "This operation requires IIS integrated pipeline mode"
+                    Log.Error(ex, "Unable to access response headers when creating header tags. Disabling for the rest of the application lifetime.");
+                    CanReadHttpResponseHeaders = false;
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error extracting HTTP headers to create header tags.");
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -302,7 +302,7 @@ namespace Datadog.Trace.DiagnosticListeners
         {
             var settings = tracer.Settings;
 
-            if (!settings.HeaderTags.IsEmpty())
+            if (!settings.HeaderTags.IsNullOrEmpty())
             {
                 try
                 {

--- a/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
+++ b/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
@@ -79,5 +79,7 @@ namespace Datadog.Trace.ExtensionMethods
 
             return dictionary.Count == 0;
         }
+
+        public static bool IsNullOrEmpty<TKey, TValue>(this IDictionary<TKey, TValue> dictionary) => dictionary?.IsEmpty() ?? true;
     }
 }


### PR DESCRIPTION
Fixes `System.PlatformNotSupportedException: This operation requires IIS integrated pipeline mode`

This scenario can occur even when the IIS application is running in the Integrated pipeline mode, which seems to be related to Sitefinity CMS widgets. Without having a reproduction available, this doesn't prevent the bad access from happening. Instead, we have better handling of the scenario:
1. Only attempt to access the System.Web.HttpResponse.Headers field when the application has explicitly configured the `DD_TRACE_HEADER_TAGS`/`TracerSettings.HeaderTags` feature, which avoids the issue in some cases
2. Catch the exception and prevents further field accesses when the exception is observed

@DataDog/apm-dotnet