### PR TITLE
Add support for a temporary NGEN pipeline

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -30,6 +30,7 @@ steps:
         --env NugetPackageDirectory=/project/$(relativeNugetPackageDirectory) \
         --env tracerHome=/project/$(relativeTracerHome) \
         --env artifacts=/project/$(relativeArtifacts) \
+        --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }} \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}
   displayName: Run '${{ parameters.command }}' in Docker

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -629,6 +629,7 @@ stages:
           condition: succeededOrFailed()
 
 - stage: benchmarks
+  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: build_windows  
   jobs:
 
@@ -658,7 +659,7 @@ stages:
         script: 'Start-Sleep -s 120'
 
 - stage: dotnet_tool
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [build_windows, build_linux, build_arm64, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone
@@ -767,7 +768,7 @@ stages:
       displayName: Add $(dotnetToolTag) build tag
 
 - stage: upload_to_s3
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [package_windows, build_linux, build_arm64]
   jobs:
   - job: s3_upload
@@ -926,6 +927,7 @@ stages:
         # We don't include the MSI artifacts as they're not signed
 
 - stage: throughput
+  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [build_linux, build_arm64, build_windows]
   jobs:
 
@@ -965,7 +967,7 @@ stages:
         DD_SERVICE: dd-trace-dotnet
 
 - stage: coverage
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]
   jobs:
     - job: Windows

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -963,6 +963,7 @@ stages:
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
+
 - stage: coverage
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,6 +209,8 @@ services:
     image: datadog-iis-loaderoptimizationregkey
     ports:
     - "8080:80"
+    environment:
+      - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-0}
 
   IntegrationTests:
     build:
@@ -226,6 +228,7 @@ services:
       - artifacts=/project/${relativeArtifacts:-src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-default}
+      - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-0}
       - MONGO_HOST=mongo
       - SERVICESTACK_REDIS_HOST=servicestackredis:6379
       - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
@@ -291,6 +294,7 @@ services:
       - artifacts=/project/${relativeArtifacts:-src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-debian}
+      - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-0}
       - MONGO_HOST=mongo
       - SERVICESTACK_REDIS_HOST=servicestackredis:6379
       - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379


### PR DESCRIPTION
To help with NGEN testing while it's experimental, this updates the consolidated pipeline to pass the `DD_CLR_ENABLE_NGEN` environment variable where necessary. To reduce the load on hosted agents, it also disables some of the stages (e.g. benchmarks/throughput) through (slightly annoying) conditionals. 

Once NGEN "graduates" we can revert the changes in this commit.

I've also set up a parallel [ngen-pipeline](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build?definitionId=58&_a=summary) in Azure Devops that uses the ultimate-pipeline, but with some things overriden:

* `push_artifacts_to_s3=false`
* `isNgenTestBuild=true`
* `DD_CLR_ENABLE_NGEN=true`
* Triggers are overriden to _not_ run on PR builds, only on pushes to `master`
