### PR TITLE
Small build improvements

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -940,7 +940,7 @@ stages:
               --destination-path "$(Build.SourceVersion)" \
               --source "$(Build.ArtifactStagingDirectory)"
           displayName: Upload blobs to Azure
-          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
@@ -955,7 +955,7 @@ stages:
             az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "index.txt" --name "index.txt"
             az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "sha.txt" --name "sha.txt"
           displayName: Upload indexes to Azure
-          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -940,7 +940,7 @@ stages:
               --destination-path "$(Build.SourceVersion)" \
               --source "$(Build.ArtifactStagingDirectory)"
           displayName: Upload blobs to Azure
-#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
@@ -955,7 +955,7 @@ stages:
             az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "index.txt" --name "index.txt"
             az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "sha.txt" --name "sha.txt"
           displayName: Upload indexes to Azure
-#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -940,7 +940,7 @@ stages:
               --destination-path "$(Build.SourceVersion)" \
               --source "$(Build.ArtifactStagingDirectory)"
           displayName: Upload blobs to Azure
-#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
@@ -955,7 +955,7 @@ stages:
             az storage blob upload --container-name 'apm-dotnet-ci-artifiacts-master' --file "index.txt" --name "index.txt"
             az storage blob upload --container-name 'apm-dotnet-ci-artifiacts-master' --file "sha.txt" --name "sha.txt"
           displayName: Upload indexes to Azure
-#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -564,6 +564,7 @@ stages:
         TestAllPackageVersions: true
         publishTargetFramework: net5.0
         baseImage: debian
+        COMPOSE_PROJECT_NAME: ddtrace_$(Build.BuildNumber)
 
       pool:
         name: Arm64

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -862,18 +862,13 @@ stages:
           )
         )
 
-
-
-
-- stage: upload_to_feed
+- stage: upload_to_azure
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool]
   jobs:
     - job: upload
-
       pool:
         vmImage: ubuntu-18.04
-
       steps:
 
         - task: DownloadPipelineArtifact@2
@@ -925,7 +920,47 @@ stages:
           displayName: Publish release artifacts
           artifact: $(tracer_version)-release-artifacts
 
-        # We don't include the MSI artifacts as they're not signed
+        # We don't include the MSIs in the artifact upload as they're
+        # not signed, but we do include them in the push to Azure
+        - task: DownloadPipelineArtifact@2
+          displayName: Download x64 MSI
+          inputs:
+            artifact: windows-msi-x64
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download x86 MSI
+          inputs:
+            artifact: windows-msi-x86
+            path: $(Build.ArtifactStagingDirectory)
+
+        - bash: |
+            az storage blob upload-batch \
+              --destination 'apm-dotnet-ci-artifiacts-master' \
+              --destination-path "$(Build.SourceVersion)" \
+              --source "$(Build.ArtifactStagingDirectory)"
+          displayName: Upload blobs to Azure
+#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+          env:
+            AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
+            AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
+
+        - bash: ls "$(Build.ArtifactStagingDirectory)" > index.txt
+          displayName: Write file list to index.txt
+
+        - bash: echo "$(Build.SourceVersion)" > sha.txt
+          displayName: Write commit hash to sha.txt
+
+        - bash: |
+            az storage blob upload --container-name 'apm-dotnet-ci-artifiacts-master' --file "index.txt" --name "index.txt"
+            az storage blob upload --container-name 'apm-dotnet-ci-artifiacts-master' --file "sha.txt" --name "sha.txt"
+          displayName: Upload indexes to Azure
+#          condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
+          env:
+            AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
+            AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
+
+
 
 - stage: throughput
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -936,7 +936,7 @@ stages:
 
         - bash: |
             az storage blob upload-batch \
-              --destination 'apm-dotnet-ci-artifiacts-master' \
+              --destination "$(AZURE_STORAGE_CONTAINER_NAME)" \
               --destination-path "$(Build.SourceVersion)" \
               --source "$(Build.ArtifactStagingDirectory)"
           displayName: Upload blobs to Azure
@@ -952,8 +952,8 @@ stages:
           displayName: Write commit hash to sha.txt
 
         - bash: |
-            az storage blob upload --container-name 'apm-dotnet-ci-artifiacts-master' --file "index.txt" --name "index.txt"
-            az storage blob upload --container-name 'apm-dotnet-ci-artifiacts-master' --file "sha.txt" --name "sha.txt"
+            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "index.txt" --name "index.txt"
+            az storage blob upload --container-name "$(AZURE_STORAGE_CONTAINER_NAME)" --file "sha.txt" --name "sha.txt"
           displayName: Upload indexes to Azure
           condition: and(succeeded(), eq(variables.isMainBranch, true), ne(variables['isNgenTestBuild'], 'True'))
           env:

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -890,9 +890,9 @@ partial class Build
                 "NLog10LogsInjection.NullReferenceException",
                 "Sandbox.ManualTracing",
                 "StackExchange.Redis.AssemblyConflict.LegacyProject",
-                "MismatchedTracerVersions"
                 "Samples.OracleMDA", // We don't test these yet
-                "Samples.OracleMDA.Core" // We don't test these yet
+                "Samples.OracleMDA.Core", // We don't test these yet
+                "MismatchedTracerVersions",
             };
 
             // These sample projects are built using RestoreAndBuildSamplesForPackageVersions

--- a/build/_build/Build.Utilities.cs
+++ b/build/_build/Build.Utilities.cs
@@ -145,12 +145,20 @@ partial class Build
                 }
             }
 
-            Logger.Info($"Running sample '{SampleName}'");
-
-            var project = Solution.GetProject(SampleName)?.Path;
-            if (project is null)
+            string project = Solution.GetProject(SampleName)?.Path;
+            if (project is not null)
             {
-                throw new Exception($"Could not find project in solution with name '{SampleName}'");
+                Logger.Info($"Running sample '{SampleName}'");
+            }
+            else if(System.IO.File.Exists(SampleName))
+            {
+                project = SampleName;
+                Logger.Info($"Running project '{SampleName}'");
+            }
+            else
+            {
+                throw new Exception($"Could not find project in solution with name '{SampleName}', " +
+                                                    "and no project file with the provided path exists");
             }
 
             DotNetBuild(s => s


### PR DESCRIPTION
* Allow running an arbitrary dotnet sample app from Nuke (similar to using dd-trace, but automatically uses the build output)
* Automatically build the "multiPackageProject" list from PackageVersionsGeneratorDefinitions.json. Reduces the re-builds we do, and better than manually maintaining this list
