### PR TITLE
Don't add the sampling priority header if empty (other overload)

### DIFF
--- a/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/src/Datadog.Trace/SpanContextPropagator.cs
@@ -107,7 +107,10 @@ namespace Datadog.Trace
 
             var samplingPriority = (int?)(context.TraceContext?.SamplingPriority ?? context.SamplingPriority);
 
-            setter(carrier, HttpHeaderNames.SamplingPriority, samplingPriority?.ToString(InvariantCulture));
+            if (samplingPriority != null)
+            {
+                setter(carrier, HttpHeaderNames.SamplingPriority, samplingPriority?.ToString(InvariantCulture));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Follow up from #1644