### PR TITLE
Fix throughput tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -957,12 +957,15 @@ stages:
         path: $(System.DefaultWorkingDirectory)/arm64
 
     - script: |
+        mv win-x64/*.dll ./
+        rmdir win-x64
         cd $(System.DefaultWorkingDirectory)/build/crank
         chmod +x ./run.sh
         ./run.sh
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet
+
 - stage: coverage
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]


### PR DESCRIPTION
Throughput tests on Windows have been broken for a week, for no apparent reason. 

I think something must have changed in the way the `DownloadPipelineArtifact` task runs, as the native windows dll is now being unexpectedly downloaded to a `win-64` sub-folder. 

The fix here is to move it back to where it should be

@DataDog/apm-dotnet