### PR TITLE
Read performance counter values from environment variables in AAS

### DIFF
--- a/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -1,4 +1,4 @@
-// <copyright file="AzurePerformanceCountersListener.cs" company="Datadog">
+// <copyright file="AzureAppServicePerformanceCounters.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -12,7 +12,7 @@ using Datadog.Trace.Vendors.StatsdClient;
 
 namespace Datadog.Trace.RuntimeMetrics
 {
-    internal class AzurePerformanceCountersListener : IRuntimeMetricsListener
+    internal class AzureAppServicePerformanceCounters : IRuntimeMetricsListener
     {
         internal const string EnvironmentVariableName = "WEBSITE_COUNTERS_CLR";
 
@@ -22,7 +22,7 @@ namespace Datadog.Trace.RuntimeMetrics
         private int? _previousGen1Count;
         private int? _previousGen2Count;
 
-        public AzurePerformanceCountersListener(IDogStatsd statsd)
+        public AzureAppServicePerformanceCounters(IDogStatsd statsd)
         {
             _statsd = statsd;
         }

--- a/src/Datadog.Trace/RuntimeMetrics/AzurePerformanceCountersListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/AzurePerformanceCountersListener.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#if NETFRAMEWORK
+
 using System;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -79,3 +81,5 @@ namespace Datadog.Trace.RuntimeMetrics
         }
     }
 }
+
+#endif

--- a/src/Datadog.Trace/RuntimeMetrics/AzurePerformanceCountersListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/AzurePerformanceCountersListener.cs
@@ -1,0 +1,81 @@
+// <copyright file="AzurePerformanceCountersListener.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.RuntimeMetrics
+{
+    internal class AzurePerformanceCountersListener : IRuntimeMetricsListener
+    {
+        internal const string EnvironmentVariableName = "WEBSITE_COUNTERS_CLR";
+
+        private readonly IDogStatsd _statsd;
+
+        private int? _previousGen0Count;
+        private int? _previousGen1Count;
+        private int? _previousGen2Count;
+
+        public AzurePerformanceCountersListener(IDogStatsd statsd)
+        {
+            _statsd = statsd;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void Refresh()
+        {
+            var rawValue = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariableName);
+            var value = JsonConvert.DeserializeObject<PerformanceCountersValue>(rawValue);
+
+            _statsd.Gauge(MetricsNames.Gen0HeapSize, value.Gen0Size);
+            _statsd.Gauge(MetricsNames.Gen1HeapSize, value.Gen1Size);
+            _statsd.Gauge(MetricsNames.Gen2HeapSize, value.Gen2Size);
+            _statsd.Gauge(MetricsNames.LohSize, value.LohSize);
+
+            var gen0 = GC.CollectionCount(0);
+            var gen1 = GC.CollectionCount(1);
+            var gen2 = GC.CollectionCount(2);
+
+            if (_previousGen0Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen0CollectionsCount, gen0 - _previousGen0Count.Value);
+            }
+
+            if (_previousGen1Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen1CollectionsCount, gen1 - _previousGen1Count.Value);
+            }
+
+            if (_previousGen2Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen2CollectionsCount, gen2 - _previousGen2Count.Value);
+            }
+
+            _previousGen0Count = gen0;
+            _previousGen1Count = gen1;
+            _previousGen2Count = gen2;
+        }
+
+        private class PerformanceCountersValue
+        {
+            [JsonProperty("gen0HeapSize")]
+            public int Gen0Size { get; set; }
+
+            [JsonProperty("gen1HeapSize")]
+            public int Gen1Size { get; set; }
+
+            [JsonProperty("gen2HeapSize")]
+            public int Gen2Size { get; set; }
+
+            [JsonProperty("largeObjectHeapSize")]
+            public int LohSize { get; set; }
+        }
+    }
+}

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Datadog.Trace.Logging;
+using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -144,7 +145,7 @@ namespace Datadog.Trace.RuntimeMetrics
 #if NETCOREAPP
             return new RuntimeEventListener(statsd, delay);
 #elif NETFRAMEWORK
-            return new PerformanceCountersListener(statsd);
+            return AzureAppServices.Metadata.IsRelevant ? new AzurePerformanceCountersListener(statsd) : new PerformanceCountersListener(statsd);
 #else
             return null;
 #endif

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.RuntimeMetrics
 #if NETCOREAPP
             return new RuntimeEventListener(statsd, delay);
 #elif NETFRAMEWORK
-            return AzureAppServices.Metadata.IsRelevant ? new AzurePerformanceCountersListener(statsd) : new PerformanceCountersListener(statsd);
+            return AzureAppServices.Metadata.IsRelevant ? new AzureAppServicePerformanceCounters(statsd) : new PerformanceCountersListener(statsd);
 #else
             return null;
 #endif

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         public void PushEvents()
         {
             Environment.SetEnvironmentVariable(
-                AzurePerformanceCountersListener.EnvironmentVariableName,
+                AzureAppServicePerformanceCounters.EnvironmentVariableName,
                 "{\"bytesInAllHeaps\": 8069304,\"gcHandles\": 6796,\"gen0Collections\": 108,\"gen1Collections\": 76,\"gen2Collections\": 16,\"inducedGC\": 0,\"pinnedObjects\": 20,\"committedBytes\": 17788928,\"reservedBytes\": 50319360,\"timeInGC\": 99342447,\"timeInGCBase\": 385095681,\"allocatedBytes\": 761378928,\"gen0HeapSize\": 8388608,\"gen1HeapSize\": 1448968,\"gen2HeapSize\": 3857504,\"largeObjectHeapSize\": 2762832,\"currentAssemblies\": 104,\"currentClassesLoaded\": 177389,\"exceptionsThrown\": 913,\"appDomains\": 10,\"appDomainsUnloaded\": 8}");
 
             const double expectedGen0HeapSize = 8388608;
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
             var statsd = new Mock<IDogStatsd>();
 
-            using var listener = new AzurePerformanceCountersListener(statsd.Object);
+            using var listener = new AzureAppServicePerformanceCounters(statsd.Object);
 
             listener.Refresh();
 

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -1,0 +1,57 @@
+// <copyright file="AzurePerformanceCountersListenerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.Vendors.StatsdClient;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.RuntimeMetrics
+{
+    public class AzurePerformanceCountersListenerTests
+    {
+        [Fact]
+        public void PushEvents()
+        {
+            Environment.SetEnvironmentVariable(
+                AzurePerformanceCountersListener.EnvironmentVariableName,
+                "{\"bytesInAllHeaps\": 8069304,\"gcHandles\": 6796,\"gen0Collections\": 108,\"gen1Collections\": 76,\"gen2Collections\": 16,\"inducedGC\": 0,\"pinnedObjects\": 20,\"committedBytes\": 17788928,\"reservedBytes\": 50319360,\"timeInGC\": 99342447,\"timeInGCBase\": 385095681,\"allocatedBytes\": 761378928,\"gen0HeapSize\": 8388608,\"gen1HeapSize\": 1448968,\"gen2HeapSize\": 3857504,\"largeObjectHeapSize\": 2762832,\"currentAssemblies\": 104,\"currentClassesLoaded\": 177389,\"exceptionsThrown\": 913,\"appDomains\": 10,\"appDomainsUnloaded\": 8}");
+
+            const double expectedGen0HeapSize = 8388608;
+            const double expectedGen1HeapSize = 1448968;
+            const double expectedGen2HeapSize = 3857504;
+            const double expectedLohHeapSize = 2762832;
+
+            var statsd = new Mock<IDogStatsd>();
+
+            using var listener = new AzurePerformanceCountersListener(statsd.Object);
+
+            listener.Refresh();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, expectedGen0HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, expectedGen1HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, expectedGen2HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, expectedLohHeapSize, 1, null), Times.Once);
+
+            statsd.VerifyNoOtherCalls();
+            statsd.Invocations.Clear();
+
+            listener.Refresh();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, expectedGen0HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, expectedGen1HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, expectedGen2HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, expectedLohHeapSize, 1, null), Times.Once);
+
+            // Those metrics aren't pushed the first time (differential count)
+            statsd.Verify(s => s.Increment(MetricsNames.Gen0CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Increment(MetricsNames.Gen1CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+
+            statsd.VerifyNoOtherCalls();
+        }
+    }
+}

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#if NETFRAMEWORK
+
 using System;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -55,3 +57,5 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
         }
     }
 }
+
+#endif


### PR DESCRIPTION
In AAS, the IIS application pool process does not have sufficient permissions to read performance counters. However, the values are pushed [as environment variables](https://docs.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#performance-counters).

Unfortunately, "contention count" is missing.