### PR TITLE
Improve error handling for performance counters

### DIFF
--- a/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -54,14 +53,6 @@ namespace Datadog.Trace.RuntimeMetrics
             // That's because performance counters may rely on wmiApSrv being started,
             // and the windows service manager only allows one service at a time to be starting: https://docs.microsoft.com/en-us/windows/win32/services/service-startup
             _initializationTask = Task.Run(InitializePerformanceCounters);
-            _initializationTask.ContinueWith(
-                t =>
-                {
-                    Log.Error(t.Exception, "An error occured while initializing the performance counters");
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
         }
 
         public Task WaitForInitialization() => _initializationTask;
@@ -77,7 +68,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
         public void Refresh()
         {
-            if (!_initializationTask.IsCompleted)
+            if (_initializationTask.Status != TaskStatus.RanToCompletion)
             {
                 return;
             }
@@ -120,17 +111,30 @@ namespace Datadog.Trace.RuntimeMetrics
 
         protected virtual void InitializePerformanceCounters()
         {
-            _memoryCategory = new PerformanceCounterCategory(MemoryCategoryName);
+            try
+            {
+                _memoryCategory = new PerformanceCounterCategory(MemoryCategoryName);
 
-            var instanceName = GetInstanceName();
-            _fullInstanceName = instanceName.Item2;
-            _instanceName = instanceName.Item1;
+                var instanceName = GetInstanceName();
+                _fullInstanceName = instanceName.Item2;
+                _instanceName = instanceName.Item1;
 
-            _gen0Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 0 heap size", _instanceName);
-            _gen1Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 1 heap size", _instanceName);
-            _gen2Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 2 heap size", _instanceName);
-            _lohSize = new PerformanceCounterWrapper(MemoryCategoryName, "Large Object Heap size", _instanceName);
-            _contentionCount = new PerformanceCounterWrapper(ThreadingCategoryName, "Total # of Contentions", _instanceName);
+                _gen0Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 0 heap size", _instanceName);
+                _gen1Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 1 heap size", _instanceName);
+                _gen2Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 2 heap size", _instanceName);
+                _lohSize = new PerformanceCounterWrapper(MemoryCategoryName, "Large Object Heap size", _instanceName);
+                _contentionCount = new PerformanceCounterWrapper(ThreadingCategoryName, "Total # of Contentions", _instanceName);
+            }
+            catch (UnauthorizedAccessException ex) when (ex.Message.Contains("'Global'"))
+            {
+                Log.Error(ex, "The process does not have sufficient permissions to read performance counters. Please refer to https://docs.datadoghq.com/tracing/runtime_metrics/dotnet/#additional-permissions-for-iis to learn how to grant those permissions.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occured while initializing the performance counters");
+                throw;
+            }
         }
 
         private void TryUpdateGauge(string path, PerformanceCounterWrapper counter)

--- a/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -127,6 +127,9 @@ namespace Datadog.Trace.RuntimeMetrics
             }
             catch (UnauthorizedAccessException ex) when (ex.Message.Contains("'Global'"))
             {
+                // Catching error UnauthorizedAccessException: Access to the registry key 'Global' is denied.
+                // The 'Global' part seems consistent across localizations
+
                 Log.Error(ex, "The process does not have sufficient permissions to read performance counters. Please refer to https://docs.datadoghq.com/tracing/runtime_metrics/dotnet/#additional-permissions-for-iis to learn how to grant those permissions.");
                 throw;
             }


### PR DESCRIPTION
Log a specific error message when permissions are insufficient to read performance counters.

Also disable performance counters when initialization failed.