### PR TITLE
Filter now applied to the samples when compiling

### DIFF
--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -698,7 +698,7 @@ partial class Build
                 {
                     _ when exclude.Contains(projectPath) => false,
                     _ when projectPath.ToString().Contains("Samples.OracleMDA") => false,
-                    _ when !string.IsNullOrWhiteSpace(Filter) => projectPath.ToString().Contains(Filter),
+                    _ when !string.IsNullOrWhiteSpace(SampleName) => projectPath.ToString().Contains(SampleName),
                      _ => true,
                 }
             );
@@ -928,6 +928,7 @@ partial class Build
                         "Samples.AspNetCoreMvc31" => Framework == TargetFramework.NETCOREAPP3_1,
                         var name when projectsToSkip.Contains(name) => false,
                         var name when multiApiProjects.Contains(name) => false,
+                        _ when !string.IsNullOrWhiteSpace(SampleName) => project?.Name?.Contains(SampleName) ?? false,
                         _ => true,
                     };
                 });

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -698,7 +698,8 @@ partial class Build
                 {
                     _ when exclude.Contains(projectPath) => false,
                     _ when projectPath.ToString().Contains("Samples.OracleMDA") => false,
-                    _ => true,
+                    _ when !string.IsNullOrWhiteSpace(Filter) => projectPath.ToString().Contains(Filter),
+                     _ => true,
                 }
             );
 


### PR DESCRIPTION
If you're just working on one sample, you can now use the filter just to compile that sample:

```
c:\code\dd-trace-dotnet
>build CompileSamples -Filter Cosmos

...

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:01.55

═══════════════════════════════════════
Target             Status      Duration
───────────────────────────────────────
CompileSamples     Executed        0:02
───────────────────────────────────────
Total                              0:02
═══════════════════════════════════════

Build succeeded on 02/08/2021 17:57:06. ＼（＾ᴗ＾）／
```

Complete sample rebuild takes ~3 minutes on my machine, so it can make a big difference.


@DataDog/apm-dotnet