### PR TITLE
Crank native profiler fix

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -959,6 +959,10 @@ stages:
     - script: |
         mv win-x64/*.dll ./
         rmdir win-x64
+        test ! -s "integrations.json" && echo "integrations.json does not exist" && exit 1
+        test ! -s "Datadog.Trace.ClrProfiler.Native.dll" && echo "Datadog.Trace.ClrProfiler.Native.dll does not exist" && exit 1
+        test ! -s "Datadog.Trace.ClrProfiler.Native.so" && echo "Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
+        test ! -s "arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "arm64/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/build/crank
         chmod +x ./run.sh
         ./run.sh

--- a/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -2,6 +2,9 @@ imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
   - /var/opt/crank/variables.yml
 
+variables:
+  commit_hash: 0
+
 jobs:
   server:
     source:
@@ -73,20 +76,20 @@ profiles:
           - "{{ windowsEndpoint }}"
         environmentVariables:
           COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\Datadog.Trace.ClrProfiler.Native.dll"
+          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\Datadog.Trace.ClrProfiler.Native.dll"
           CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\Datadog.Trace.ClrProfiler.Native.dll"
-          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}"
-          DD_INTEGRATIONS: "{{ windowsProfilerPath }}\\integrations.json"
+          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\Datadog.Trace.ClrProfiler.Native.dll"
+          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}"
+          DD_INTEGRATIONS: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\integrations.json"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_DEBUG: 0
         options:
           requiredOperatingSystem: windows
           requiredArchitecture: x64
           buildFiles:
-          - "../../integrations.json;{{ windowsProfilerPath }}"
-          - "../../Datadog.Trace.ClrProfiler.Native.dll;{{ windowsProfilerPath }}"
-          - "../../Datadog.Trace.ClrProfiler.Native.pdb;{{ windowsProfilerPath }}"
+          - "../../integrations.json;{{ windowsProfilerPath }}\\{{ commit_hash }}"
+          - "../../Datadog.Trace.ClrProfiler.Native.dll;{{ windowsProfilerPath }}\\{{ commit_hash }}"
+          - "../../Datadog.Trace.ClrProfiler.Native.pdb;{{ windowsProfilerPath }}\\{{ commit_hash }}"
       load:
         endpoints:
           - http://localhost:5010

--- a/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -103,19 +103,19 @@ profiles:
           - "{{ linuxEndpoint }}"
         environmentVariables:
           COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ linuxProfilerPath }}/Datadog.Trace.ClrProfiler.Native.so"
+          COR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/Datadog.Trace.ClrProfiler.Native.so"
           CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/Datadog.Trace.ClrProfiler.Native.so"
-          DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}"
-          DD_INTEGRATIONS: "{{ linuxProfilerPath }}/integrations.json"
+          CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/Datadog.Trace.ClrProfiler.Native.so"
+          DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}"
+          DD_INTEGRATIONS: "{{ linuxProfilerPath }}/{{ commit_hash }}/integrations.json"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_DEBUG: 0
         options:
           requiredOperatingSystem: linux
           requiredArchitecture: x64
           buildFiles:
-          - "../../integrations.json;{{ linuxProfilerPath }}"
-          - "../../Datadog.Trace.ClrProfiler.Native.so;{{ linuxProfilerPath }}"
+          - "../../integrations.json;{{ linuxProfilerPath }}/{{ commit_hash }}"
+          - "../../Datadog.Trace.ClrProfiler.Native.so;{{ linuxProfilerPath }}/{{ commit_hash }}"
       load:
         endpoints:
           - http://localhost:5010
@@ -129,19 +129,19 @@ profiles:
           - "{{ linuxArm64Endpoint }}"
         environmentVariables:
           COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/Datadog.Trace.ClrProfiler.Native.so"
+          COR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/Datadog.Trace.ClrProfiler.Native.so"
           CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/Datadog.Trace.ClrProfiler.Native.so"
-          DD_DOTNET_TRACER_HOME: "{{ linuxArm64ProfilerPath }}"
-          DD_INTEGRATIONS: "{{ linuxArm64ProfilerPath }}/integrations.json"
+          CORECLR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/Datadog.Trace.ClrProfiler.Native.so"
+          DD_DOTNET_TRACER_HOME: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}"
+          DD_INTEGRATIONS: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/integrations.json"
           DD_AGENT_HOST: "{{ controllerIp }}"
           DD_TRACE_DEBUG: 0
         options:
           requiredOperatingSystem: linux
           requiredArchitecture: arm64
           buildFiles:
-          - "../../integrations.json;{{ linuxArm64ProfilerPath }}"
-          - "../../arm64/Datadog.Trace.ClrProfiler.Native.so;{{ linuxArm64ProfilerPath }}"
+          - "../../integrations.json;{{ linuxArm64ProfilerPath }}/{{ commit_hash }}"
+          - "../../arm64/Datadog.Trace.ClrProfiler.Native.so;{{ linuxArm64ProfilerPath }}/{{ commit_hash }}"
       load:
         endpoints:
           - http://localhost:5010

--- a/build/crank/run.sh
+++ b/build/crank/run.sh
@@ -23,29 +23,29 @@ repository="--application.source.repository $repo"
 commit="--application.source.branchOrCommit #$commit_sha"
 
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --output baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --output baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="baseline_windows.json"
 rm baseline_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario callsite --profile windows --output callsite_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=callsite --property profile=windows --property arch=x64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario callsite --profile windows --output callsite_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=callsite --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="callsite_windows.json"
 rm callsite_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile windows --output calltarget_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=windows --property arch=x64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile windows --output calltarget_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_windows.json"
 rm calltarget_windows.json
 
 
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --output baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --output baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="baseline_linux.json"
 rm baseline_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario callsite --profile linux --output callsite_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=callsite --property profile=linux --property arch=x64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario callsite --profile linux --output callsite_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=callsite --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="callsite_linux.json"
 rm callsite_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux --output calltarget_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux --property arch=x64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux --output calltarget_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_linux.json"
 rm calltarget_linux.json
 

--- a/build/crank/run.sh
+++ b/build/crank/run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -eo pipefail
+
 sha="$(git rev-parse HEAD)"
 echo "sha=$sha"
 echo "SYSTEM_PULLREQUEST_SOURCECOMMITID=$SYSTEM_PULLREQUEST_SOURCECOMMITID"

--- a/build/crank/run.sh
+++ b/build/crank/run.sh
@@ -51,10 +51,10 @@ rm calltarget_linux.json
 
 
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --output baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --output baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="baseline_linux_arm64.json"
 rm baseline_linux_arm64.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --output calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --output calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_linux_arm64.json"
 rm calltarget_linux_arm64.json

--- a/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -17,7 +17,7 @@ namespace Samples.AspNetCoreSimpleController
                 if (!isAttached)
                 {
                     Console.WriteLine("Error: Profiler is required and is not loaded.");
-                    Environment.Exit(-1);
+                    Environment.Exit(1);
                     return;
                 }
             }


### PR DESCRIPTION
This PR fixes the crank stage native profiler issue by using different folders based on the commit hash.


@DataDog/apm-dotnet