### PR TITLE
Add instrumentation for Begin/EndGetResponse to WebRequest

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -4705,6 +4705,101 @@
         "target": {
           "assembly": "System",
           "type": "System.Net.HttpWebRequest",
+          "method": "BeginGetRequestStream",
+          "signature_types": [
+            "System.IAsyncResult",
+            "System.AsyncCallback",
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetRequestStream_Integration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Net.Requests",
+          "type": "System.Net.HttpWebRequest",
+          "method": "BeginGetRequestStream",
+          "signature_types": [
+            "System.IAsyncResult",
+            "System.AsyncCallback",
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetRequestStream_Integration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System",
+          "type": "System.Net.HttpWebRequest",
+          "method": "BeginGetResponse",
+          "signature_types": [
+            "System.IAsyncResult",
+            "System.AsyncCallback",
+            "System.Object"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetResponse_Integration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System",
+          "type": "System.Net.HttpWebRequest",
+          "method": "EndGetResponse",
+          "signature_types": [
+            "System.Net.WebResponse",
+            "System.IAsyncResult"
+          ],
+          "minimum_major": 4,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 4,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_EndGetResponse_Integration",
+          "action": "CallTargetModification"
+        }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System",
+          "type": "System.Net.HttpWebRequest",
           "method": "GetRequestStream",
           "signature_types": [
             "System.IO.Stream"

--- a/integrations.json
+++ b/integrations.json
@@ -4719,7 +4719,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetRequestStream_Integration",
           "action": "CallTargetModification"
         }
@@ -4743,7 +4743,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetRequestStream_Integration",
           "action": "CallTargetModification"
         }
@@ -4767,7 +4767,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_BeginGetResponse_Integration",
           "action": "CallTargetModification"
         }
@@ -4790,7 +4790,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest.HttpWebRequest_EndGetResponse_Integration",
           "action": "CallTargetModification"
         }

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="HttpWebRequest_BeginGetRequestStream_Integration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Net;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ExtensionMethods;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
+{
+    /// <summary>
+    /// CallTarget integration for HttpWebRequest.BeginGetRequestStream
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = WebRequestCommon.NetFrameworkAssembly,
+        TypeName = WebRequestCommon.HttpWebRequestTypeName,
+        MethodName = MethodName,
+        ReturnTypeName = ClrNames.IAsyncResult,
+        ParameterTypeNames = new[] { ClrNames.AsyncCallback, ClrNames.Object },
+        MinimumVersion = WebRequestCommon.Major4,
+        MaximumVersion = WebRequestCommon.Major4,
+        IntegrationName = WebRequestCommon.IntegrationName)]
+    [InstrumentMethod(
+        AssemblyName = WebRequestCommon.NetCoreAssembly,
+        TypeName = WebRequestCommon.HttpWebRequestTypeName,
+        MethodName = MethodName,
+        ReturnTypeName = ClrNames.IAsyncResult,
+        ParameterTypeNames = new[] { ClrNames.AsyncCallback, ClrNames.Object },
+        MinimumVersion = WebRequestCommon.Major4,
+        MaximumVersion = WebRequestCommon.Major5,
+        IntegrationName = WebRequestCommon.IntegrationName)]
+    public class HttpWebRequest_BeginGetRequestStream_Integration
+    {
+        private const string MethodName = "BeginGetRequestStream";
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="callback">The AsyncCallback delegate</param>
+        /// <param name="state">An object containing state information for this asynchronous request</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, AsyncCallback callback, object state)
+        {
+            if (instance is HttpWebRequest request && WebRequestCommon.IsTracingEnabled(request))
+            {
+                var tracer = Tracer.Instance;
+
+                if (tracer.Settings.IsIntegrationEnabled(WebRequestCommon.IntegrationId))
+                {
+                    var spanContext = ScopeFactory.CreateHttpSpanContext(tracer, WebRequestCommon.IntegrationId);
+
+                    if (spanContext != null)
+                    {
+                        // Add distributed tracing headers to the HTTP request.
+                        // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
+                        // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
+                        // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
+                        SpanContextPropagator.Instance.Inject(spanContext, request.Headers.Wrap());
+                    }
+                }
+            }
+
+            return CallTargetState.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="HttpWebRequest_BeginGetResponse_Integration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Net;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.ExtensionMethods;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
+{
+    /// <summary>
+    /// CallTarget integration for HttpWebRequest.BeginGetResponse
+    /// We only instrument .NET Framework - .NET Core uses an HttpClient
+    /// internally, which is already instrumented
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = WebRequestCommon.NetFrameworkAssembly,
+        TypeName = WebRequestCommon.HttpWebRequestTypeName,
+        MethodName = MethodName,
+        ReturnTypeName = ClrNames.IAsyncResult,
+        ParameterTypeNames = new[] { ClrNames.AsyncCallback, ClrNames.Object },
+        MinimumVersion = WebRequestCommon.Major4,
+        MaximumVersion = WebRequestCommon.Major4,
+        IntegrationName = WebRequestCommon.IntegrationName)]
+    public class HttpWebRequest_BeginGetResponse_Integration
+    {
+        private const string MethodName = "BeginGetResponse";
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="callback">The AsyncCallback delegate</param>
+        /// <param name="state">An object containing state information for this asynchronous request</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, AsyncCallback callback, object state)
+        {
+            if (instance is HttpWebRequest request && WebRequestCommon.IsTracingEnabled(request))
+            {
+                var tracer = Tracer.Instance;
+
+                // We may have already set headers
+                if (request.Headers.Get(HttpHeaderNames.TraceId) is null)
+                {
+                    var spanContext = ScopeFactory.CreateHttpSpanContext(tracer, WebRequestCommon.IntegrationId);
+
+                    if (spanContext != null)
+                    {
+                        // Add distributed tracing headers to the HTTP request.
+                        // We don't want to set an active scope now, because it's possible that EndGetResponse will never be called.
+                        // Instead, we generate a spancontext and inject it in the headers. EndGetResponse will fetch them and create an active scope with the right id.
+                        SpanContextPropagator.Instance.Inject(spanContext, request.Headers.Wrap());
+                    }
+                }
+            }
+
+            return CallTargetState.GetDefault();
+        }
+    }
+}

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -1,0 +1,90 @@
+﻿// <copyright file="HttpWebRequest_EndGetResponse_Integration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Net;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.ExtensionMethods;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
+{
+    /// <summary>
+    /// CallTarget integration for HttpWebRequest.GetResponse
+    /// We only instrument .NET Framework - .NET Core uses an HttpClient
+    /// internally, which is already instrumented
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = WebRequestCommon.NetFrameworkAssembly,
+        TypeName = WebRequestCommon.HttpWebRequestTypeName,
+        MethodName = MethodName,
+        ReturnTypeName = WebRequestCommon.WebResponseTypeName,
+        ParameterTypeNames = new[] { ClrNames.IAsyncResult },
+        MinimumVersion = WebRequestCommon.Major4,
+        MaximumVersion = WebRequestCommon.Major4,
+        IntegrationName = WebRequestCommon.IntegrationName)]
+    public class HttpWebRequest_EndGetResponse_Integration
+    {
+        private const string MethodName = "EndGetResponse";
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TReturn">Type of the return value</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="returnValue">Task of HttpResponse message instance</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        public static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, CallTargetState state)
+            where TTarget : IHttpWebRequest, IDuckType
+        {
+            if (instance.Instance is HttpWebRequest request && WebRequestCommon.IsTracingEnabled(request))
+            {
+                // Get the time the HttpWebRequest was created
+                DateTime startTime;
+                if (Stopwatch.IsHighResolution)
+                {
+                    var elapsedTicks = Stopwatch.GetTimestamp() - instance.RequestStartTicks;
+                    // ReSharper disable once PossibleLossOfFraction
+                    startTime = DateTime.UtcNow.AddSeconds(-elapsedTicks / Stopwatch.Frequency);
+                }
+                else
+                {
+                    startTime = new DateTime(instance.RequestStartTicks, DateTimeKind.Utc);
+                }
+
+                // Check if any headers were injected by a previous call
+                var existingSpanId = SpanContextPropagator.Instance.Extract(request.Headers.Wrap())?.SpanId;
+
+                Scope scope = null;
+
+                try
+                {
+                    scope = ScopeFactory.CreateOutboundHttpScope(Tracer.Instance, request.Method, request.RequestUri, WebRequestCommon.IntegrationId, out var tags, existingSpanId, startTime);
+
+                    if (scope is not null)
+                    {
+                        if (returnValue is HttpWebResponse response)
+                        {
+                            scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false);
+                        }
+
+                        scope.DisposeWithException(exception);
+                    }
+                }
+                catch
+                {
+                    scope?.Dispose();
+                    throw;
+                }
+            }
+
+            return new CallTargetReturn<TReturn>(returnValue);
+        }
+    }
+}

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/IHttpWebRequest.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/IHttpWebRequest.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="IHttpWebRequest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
+{
+    /// <summary>
+    /// Duck type interface for HttpWebRequest
+    /// </summary>
+    public interface IHttpWebRequest
+    {
+        /// <summary>
+        /// Gets the time the HttpWebRequest was created in Ticks (UTC)
+        /// </summary>
+        [Duck(Name = "m_StartTimestamp", Kind = DuckKind.Field)]
+        long RequestStartTicks { get; }
+    }
+}

--- a/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -87,6 +87,20 @@ namespace Datadog.Trace.ClrProfiler
         /// <param name="spanId">The span ID</param>
         /// <returns>A new pre-populated scope.</returns>
         public static Scope CreateOutboundHttpScope(Tracer tracer, string httpMethod, Uri requestUri, IntegrationInfo integrationId, out HttpTags tags, ulong? spanId = null)
+            => CreateOutboundHttpScope(tracer, httpMethod, requestUri, integrationId, out tags, spanId, startTime: null);
+
+        /// <summary>
+        /// Creates a scope for outbound http requests and populates some common details.
+        /// </summary>
+        /// <param name="tracer">The tracer instance to use to create the new scope.</param>
+        /// <param name="httpMethod">The HTTP method used by the request.</param>
+        /// <param name="requestUri">The URI requested by the request.</param>
+        /// <param name="integrationId">The id of the integration creating this scope.</param>
+        /// <param name="tags">The tags associated to the scope</param>
+        /// <param name="spanId">The span ID</param>
+        /// <param name="startTime">The start time that should be applied to the span</param>
+        /// <returns>A new pre-populated scope.</returns>
+        internal static Scope CreateOutboundHttpScope(Tracer tracer, string httpMethod, Uri requestUri, IntegrationInfo integrationId, out HttpTags tags, ulong? spanId, DateTimeOffset? startTime)
         {
             tags = null;
 
@@ -114,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler
                 tags = new HttpTags();
 
                 string serviceName = tracer.Settings.GetServiceName(tracer, ServiceName);
-                scope = tracer.StartActiveWithTags(OperationName, tags: tags, serviceName: serviceName, spanId: spanId);
+                scope = tracer.StartActiveWithTags(OperationName, tags: tags, serviceName: serviceName, spanId: spanId, startTime: startTime);
 
                 var span = scope.Span;
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var (ignoreAsync, expectedSpanCount) = (EnvironmentHelper.IsCoreClr(), enableCallTarget) switch
             {
                 (false, false) => (true, 28), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
-                _ => (false, 73)
+                _ => (false, 74)
             };
 
             const string expectedOperationName = "http.request";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -19,26 +19,33 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        [Fact]
+        [Theory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void RenamesService()
+        [InlineData(false)]
+        [InlineData(true)]
+        public void RenamesService(bool enableCallTarget)
         {
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 71 : 27; // .NET Framework automatic instrumentation doesn't cover Async / TaskAsync operations
+            SetCallTargetSettings(enableCallTarget);
 
-            var ignoreAsync = EnvironmentHelper.IsCoreClr() ? string.Empty : "IgnoreAsync ";
+            var (ignoreAsync, expectedSpanCount) = (EnvironmentHelper.IsCoreClr(), enableCallTarget) switch
+            {
+                (false, false) => (true, 28), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
+                _ => (false, 73)
+            };
 
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "my-custom-client";
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();
+            var extraArgs = ignoreAsync ? "IgnoreAsync " : string.Empty;
 
             Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"{ignoreAsync}Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"{extraArgs}Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetCallTargetSettings(enableCallTarget);
 
-            int expectedSpanCount = 25;
+            int expectedSpanCount = enableCallTarget ? 45 : 25; // CallSite insturmentation doesn't instrument async requests
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "Samples.WebRequest.NetFramework20-http-client";
 

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,26 +32,29 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetCallTargetSettings(enableCallTarget);
 
-            int expectedSpanCount = EnvironmentHelper.IsCoreClr() ? 71 : 27; // .NET Framework automatic instrumentation doesn't cover Async / TaskAsync operations
-
-            var ignoreAsync = EnvironmentHelper.IsCoreClr() ? string.Empty : "IgnoreAsync ";
+            var (ignoreAsync, expectedSpanCount) = (EnvironmentHelper.IsCoreClr(), enableCallTarget) switch
+            {
+                (false, false) => (true, 28), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
+                _ => (false, 73)
+            };
 
             const string expectedOperationName = "http.request";
             const string expectedServiceName = "Samples.WebRequest-http-client";
 
             int agentPort = TcpPortProvider.GetOpenPort();
             int httpPort = TcpPortProvider.GetOpenPort();
+            var extraArgs = ignoreAsync ? "IgnoreAsync " : string.Empty;
 
             Output.WriteLine($"Assigning port {agentPort} for the agentPort.");
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"{ignoreAsync}Port={httpPort}"))
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent.Port, arguments: $"{extraArgs}Port={httpPort}"))
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
-                Assert.Equal(expectedSpanCount, spans.Count);
+                spans.Should().HaveCount(expectedSpanCount);
 
                 foreach (var span in spans)
                 {

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var (ignoreAsync, expectedSpanCount) = (EnvironmentHelper.IsCoreClr(), enableCallTarget) switch
             {
                 (false, false) => (true, 28), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
-                _ => (false, 73)
+                _ => (false, 74)
             };
 
             const string expectedOperationName = "http.request";

--- a/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -45,6 +45,8 @@ namespace Samples.WebRequest
                 Console.WriteLine("Stopping HTTP listener.");
                 listener.Stop();
             }
+
+            await Tracer.Instance.ForceFlushAsync();
         }
 
         public static HttpListener StartHttpListenerWithPortResilience(string port, int retries = 5)

--- a/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
@@ -423,20 +423,9 @@ namespace Samples.WebRequest
                     }
 
                     await Task.Factory.FromAsync(
-                        beginMethod: (callback, state) => request.BeginGetResponse(callback, state),
-                        endMethod: iar =>
-                        {
-                            var req = (HttpWebRequest)iar.AsyncState;
-                            var response = req.EndGetResponse(iar);
-
-                            response.Close();
-
-                            Console.WriteLine("Received response for request.Begin/EndGetResponse()");
-                            _allDone.Set();
-                        },
+                        beginMethod: request.BeginGetResponse,
+                        endMethod: request.EndGetResponse,
                         state: request);
-
-                    _allDone.WaitOne();
                 }
             }
         }

--- a/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
+++ b/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
 
@@ -11,6 +12,7 @@ namespace Samples.WebRequest
     public static class RequestHelpers
     {
         private static readonly Encoding Utf8 = Encoding.UTF8;
+        private static readonly AutoResetEvent _allDone = new(false);
 
         public static async Task SendWebClientRequests(bool tracingDisabled, string url, string requestContent)
         {
@@ -357,6 +359,58 @@ namespace Samples.WebRequest
 
                     request.GetResponse().Close();
                     Console.WriteLine("Received response for request.GetRequestStream()/GetResponse()");
+                }
+
+                using (Tracer.Instance.StartActive("BeginGetRequestStream"))
+                {
+                    // Create separate request objects since .NET Core asserts only one response per request
+                    HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("BeginGetRequestStream", url));
+                    request.Method = "POST";
+
+                    if (tracingDisabled)
+                    {
+                        request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                    }
+
+                    request.BeginGetRequestStream(
+                        iar =>
+                        {
+                            var req = (HttpWebRequest)iar.AsyncState;
+                            var stream = req.EndGetRequestStream(iar);
+                            stream.Write(new byte[1], 0, 1);
+
+                            request.GetResponse()
+                                   .Close();
+
+                            Console.WriteLine("Received response for request.Begin/EndGetRequestStream()/GetResponse()");
+                            _allDone.Set();
+                        }, request);
+
+                    _allDone.WaitOne();
+                }
+
+                using (Tracer.Instance.StartActive("BeginGetResponse"))
+                {
+                    // Create separate request objects since .NET Core asserts only one response per request
+                    HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("BeginGetResponseAsync", url));
+                    if (tracingDisabled)
+                    {
+                        request.Headers.Add(HttpHeaderNames.TracingEnabled, "false");
+                    }
+
+                    request.BeginGetResponse(
+                        iar =>
+                        {
+                            var req = (HttpWebRequest)iar.AsyncState;
+                            var response = req.EndGetResponse(iar);
+
+                            response.Close();
+
+                            Console.WriteLine("Received response for request.Begin/EndGetResponse()");
+                            _allDone.Set();
+                        }, request);
+
+                    _allDone.WaitOne();
                 }
             }
         }


### PR DESCRIPTION
Adds instrumentation for 3 more methods in `HttpWebRequest`:

* `BeginGetRequestStream` (.NET Core and .NET Framework) - ensures distributed headers are added if `BeginGetRequestStream` is used (instead of `GetRequestStream()`)
* `BeginGetResponse` (.NET Framework only) - ensures distributed headers are added when using this instead of `GetResponse` or `GetResponseAsync`
* `EndGetResponse` (.NET Framework only) - creates the outgoing http span when `Begin/EndGetResponse` pattern is used. 

We don't need to instrument the latter two methods in .NET Core, as .NET Core uses an `HttpClient` under the covers to make the request, which we already instrument.

One of the challenges is that we can't rely on `EndGetResponse` _definitely_ being called just because `BeginGetResponse` is. Also, there are difficulties with the execution context flow. The copy-on-write semantics appear to cause an issue where if we close a span on a child execution context, it doesn't get closed on the parent. 

To work around the issue (and generally to be safer), we start and end the span in `EndGetResponse`, using the `HttpWebRequest` field `m_StartTimeStamp` as a proxy for the request "start time". _Technically_, this is set when the `HttpWebRequest` is _created_, not when we start fetching the response, but I think it's unlikely that this will result in a significant disparity with the "true" duration, and it drastically simplifies the solution.

Tests wise, this means we now also generate spans for the async WebClient paths on .NET Framework (CallTarget only).

Relates to #701 

@DataDog/apm-dotnet