### PR TITLE
Fixes native regex usage on non windows platforms.

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -51,6 +51,11 @@ namespace
         unsigned short build = 0;
         unsigned short revision = 0;
 
+        if (str.empty())
+        {
+            return {major, minor, build, revision};
+        }
+
 #ifdef _WIN32
 
         static auto re = std::wregex(WStr("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
@@ -67,7 +72,7 @@ namespace
 #else
 
         static re2::RE2 re("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)", RE2::Quiet);
-        re2::RE2::FullMatch(ToString(str), re, &major, &minor, &build, &revision);
+        re2::RE2::PartialMatch(ToString(str), re, &major, &minor, &build, &revision);
 
 #endif
 
@@ -77,6 +82,11 @@ namespace
     WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& str)
     {
         WSTRING locale = WStr("neutral");
+
+        if (str.empty())
+        {
+            return locale;
+        }
 
 #ifdef _WIN32
 
@@ -92,7 +102,7 @@ namespace
         static re2::RE2 re("Culture=([a-zA-Z0-9]+)", RE2::Quiet);
 
         std::string match;
-        if (re2::RE2::FullMatch(ToString(str), re, &match))
+        if (re2::RE2::PartialMatch(ToString(str), re, &match))
         {
             locale = ToWSTRING(match);
         }
@@ -105,6 +115,11 @@ namespace
     PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& str)
     {
         BYTE data[8] = {0};
+
+        if (str.empty())
+        {
+            return PublicKey(data);
+        }
 
 #ifdef _WIN32
 
@@ -125,7 +140,7 @@ namespace
 
         static re2::RE2 re("PublicKeyToken=([a-fA-F0-9]{16})");
         std::string match;
-        if (re2::RE2::FullMatch(ToString(str), re, &match))
+        if (re2::RE2::PartialMatch(ToString(str), re, &match))
         {
             for (int i = 0; i < 8; i++)
             {


### PR DESCRIPTION
Currently the regex parsing on non windows platform is failing due incorrect usage. This PR fixes that.


@DataDog/apm-dotnet