### PR TITLE
Using stream instead of strings to send appsec data to agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.playlist
 
 # https://github.com/VerifyTests/Verify
 *.received.*

--- a/integrations.json
+++ b/integrations.json
@@ -228,6 +228,33 @@
     ]
   },
   {
+    "name": "AspNetCore",
+    "method_replacements": [
+      {
+        "caller": {},
+        "target": {
+          "assembly": "Microsoft.AspNetCore.Http",
+          "type": "Microsoft.AspNetCore.Builder.ApplicationBuilder",
+          "method": "Build",
+          "signature_types": [
+            "System.Void"
+          ],
+          "minimum_major": 2,
+          "minimum_minor": 0,
+          "minimum_patch": 0,
+          "maximum_major": 6,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace.ClrProfiler.Managed, Version=1.28.2.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.AspNetCoreMiddlewareIntegration",
+          "action": "CallTargetModification"
+        }
+      }
+    ]
+  },
+  {
     "name": "AspNetWebApi2",
     "method_replacements": [
       {

--- a/src/Datadog.Trace/Agent/IApiRequest.cs
+++ b/src/Datadog.Trace/Agent/IApiRequest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading.Tasks;
 using Datadog.Trace.Abstractions;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Agent
 {
@@ -15,6 +16,6 @@ namespace Datadog.Trace.Agent
 
         Task<IApiResponse> PostAsync(ArraySegment<byte> traces);
 
-        Task<IApiResponse> PostAsJsonAsync(IEvent events);
+        Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer);
     }
 }

--- a/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -55,28 +55,32 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        public async Task<IApiResponse> PostAsJsonAsync(IEvent events)
+        public async Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
         {
             _request.Method = "POST";
             _request.ContentType = "application/json";
 
-            using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
+            using (var ms = new MemoryStream())
             {
-                using var streamWriter = new StreamWriter(requestStream);
-                var json = JsonConvert.SerializeObject(events);
-                streamWriter.Write(json);
-            }
+                using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
+                {
+                    using (var writer = new JsonTextWriter(new StreamWriter(requestStream)))
+                    {
+                        serializer.Serialize(writer, events);
 
-            try
-            {
-                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
-                return new ApiWebResponse(httpWebResponse);
-            }
-            catch (WebException exception)
-                when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
-            {
-                // If the exception is caused by an error status code, ignore it and let the caller handle the result
-                return new ApiWebResponse((HttpWebResponse)exception.Response);
+                        try
+                        {
+                            var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
+                            return new ApiWebResponse(httpWebResponse);
+                        }
+                        catch (WebException exception)
+                            when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
+                        {
+                            // If the exception is caused by an error status code, ignore it and let the caller handle the result
+                            return new ApiWebResponse((HttpWebResponse)exception.Response);
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -5,6 +5,7 @@
 
 #if NETCOREAPP
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -29,14 +30,25 @@ namespace Datadog.Trace.Agent.Transports
             _request.Headers.Add(name, value);
         }
 
-        public async Task<IApiResponse> PostAsJsonAsync(IEvent events)
+        public async Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
         {
-            var json = JsonConvert.SerializeObject(events);
-            using var content = new System.Net.Http.StringContent(json);
-            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-            _request.Content = content;
-            var response = await _client.SendAsync(_request).ConfigureAwait(false);
-            return new HttpClientResponse(response);
+            var ms = new MemoryStream();
+            {
+                var sw = new StreamWriter(ms, leaveOpen: true);
+                using (var content = new StreamContent(ms))
+                {
+                    using (JsonWriter writer = new JsonTextWriter(sw) { CloseOutput = true })
+                    {
+                        serializer.Serialize(writer, events);
+                        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                        _request.Content = content;
+                        await writer.FlushAsync();
+                        ms.Seek(0, SeekOrigin.Begin);
+                        var response = await _client.SendAsync(_request).ConfigureAwait(false);
+                        return new HttpClientResponse(response);
+                    }
+                }
+            }
         }
 
         public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)

--- a/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -47,6 +47,7 @@ namespace Datadog.Trace.Agent.Transports
             using (JsonWriter writer = new JsonTextWriter(sw))
             {
                 serializer.Serialize(writer, events);
+                await writer.FlushAsync();
                 var buffer = memoryStream.GetBuffer();
                 return await PostSegmentAsync(new ArraySegment<byte>(buffer, 0, (int)memoryStream.Length)).ConfigureAwait(false);
             }

--- a/src/Datadog.Trace/AppSec/Agent/AgentWriter.cs
+++ b/src/Datadog.Trace/AppSec/Agent/AgentWriter.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Abstractions;
 using Datadog.Trace.AppSec.Transports;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.AppSec.Agent

--- a/src/Datadog.Trace/AppSec/Security.cs
+++ b/src/Datadog.Trace/AppSec/Security.cs
@@ -200,7 +200,7 @@ namespace Datadog.Trace.AppSec
             }
             else
             {
-                Log.Warning("AppSec could not start because of unsupported process architecture {ProcessArchitecture}", frameworkDescription.ProcessArchitecture);
+                Log.Warning($"AppSec could not start because the current environment is not supported. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help. Host information: {{ operating_system:{frameworkDescription.OSPlatform} }}, arch:{{ {frameworkDescription.ProcessArchitecture} }}, runtime_infos: {{ {frameworkDescription.ProductVersion} }}");
             }
 
             return osSupported && archSupported;

--- a/src/Datadog.Trace/AppSec/Security.cs
+++ b/src/Datadog.Trace/AppSec/Security.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Datadog.Trace.Agent;
 using Datadog.Trace.AppSec.Agent;
 using Datadog.Trace.AppSec.EventModel;
 using Datadog.Trace.AppSec.Transport;
@@ -30,7 +31,7 @@ namespace Datadog.Trace.AppSec
         private static object _globalInstanceLock = new();
 
         private readonly IPowerWaf _powerWaf;
-        private readonly IAgentWriter _agentWriter;
+        private readonly Datadog.Trace.AppSec.Agent.IAgentWriter _agentWriter;
         private readonly InstrumentationGateway _instrumentationGateway;
         private readonly ConcurrentDictionary<Guid, Action> toExecute = new();
 
@@ -42,7 +43,7 @@ namespace Datadog.Trace.AppSec
         {
         }
 
-        private Security(InstrumentationGateway instrumentationGateway = null, IPowerWaf powerWaf = null, IAgentWriter agentWriter = null)
+        private Security(InstrumentationGateway instrumentationGateway = null, IPowerWaf powerWaf = null, Datadog.Trace.AppSec.Agent.IAgentWriter agentWriter = null)
         {
             try
             {
@@ -61,7 +62,7 @@ namespace Datadog.Trace.AppSec
                     _powerWaf = powerWaf ?? PowerWaf.Initialize();
                     if (_powerWaf != null)
                     {
-                        _agentWriter = agentWriter ?? new AgentWriter();
+                        _agentWriter = agentWriter ?? new Datadog.Trace.AppSec.Agent.AgentWriter();
                         _instrumentationGateway.InstrumentationGatewayEvent += InstrumentationGatewayInstrumentationGatewayEvent;
                     }
                     else

--- a/test/Datadog.Trace.Security.IntegrationTests/MockTracerAgentAppSecWrapper.cs
+++ b/test/Datadog.Trace.Security.IntegrationTests/MockTracerAgentAppSecWrapper.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var appSecUrl = ctx.Value.Request.Url.AbsoluteUri.Contains("appsec");
             if (appSecUrl)
             {
-                var sr = new StreamReader(ctx.Value.Request.InputStream);
+                using var sr = new StreamReader(ctx.Value.Request.InputStream);
                 string content = sr.ReadToEnd();
                 var intake = JsonConvert.DeserializeObject<Intake>(content, new IntakeConverter());
                 events.AddRange(intake.Events);

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -92,16 +92,7 @@ namespace Benchmarks.Trace
                 _realRequest.AddHeader(name, value);
             }
 
-            public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)
-            {
-                using (var requestStream = Stream.Null)
-                {
-                    await requestStream.WriteAsync(traces.Array, traces.Offset, traces.Count).ConfigureAwait(false);
-                }
-
-                return new FakeApiResponse();
-            }
-            public  Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
+            public Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
             {
                 using (var requestStream = Stream.Null)
                 {
@@ -110,6 +101,16 @@ namespace Benchmarks.Trace
                     streamWriter.Write(json);
                 }
                 return Task.FromResult<IApiResponse>(new FakeApiResponse());
+            }
+
+            public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)
+            {
+                using (var requestStream = Stream.Null)
+                {
+                    await requestStream.WriteAsync(traces.Array, traces.Offset, traces.Count).ConfigureAwait(false);
+                }
+
+                return new FakeApiResponse();
             }
         }
 

--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -92,17 +92,6 @@ namespace Benchmarks.Trace
                 _realRequest.AddHeader(name, value);
             }
 
-            public Task<IApiResponse> PostAsJsonAsync(IEvent events)
-            {
-                using (var requestStream = Stream.Null)
-                {
-                    using var streamWriter = new StreamWriter(requestStream);
-                    var json = JsonConvert.SerializeObject(events);
-                    streamWriter.Write(json);
-                }
-                return Task.FromResult<IApiResponse>(new FakeApiResponse());
-            }
-
             public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)
             {
                 using (var requestStream = Stream.Null)
@@ -111,6 +100,16 @@ namespace Benchmarks.Trace
                 }
 
                 return new FakeApiResponse();
+            }
+            public  Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
+            {
+                using (var requestStream = Stream.Null)
+                {
+                    using var streamWriter = new StreamWriter(requestStream);
+                    var json = JsonConvert.SerializeObject(events);
+                    streamWriter.Write(json);
+                }
+                return Task.FromResult<IApiResponse>(new FakeApiResponse());
             }
         }
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

- Using streams instead of strings before sending app sec events (for serializing and filling request stream)
- Taking into account transport strategy in case HttpStreamRequest is wanted
- Fixing integrations.json where asp.net core middleware integration disappears
- Logging wrong response codes 
- Using one json serializer for all requests


@DataDog/apm-dotnet