### PR TITLE
Cache native AssemblyReference instances

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -136,7 +136,7 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
     // *** Ensure profiler assembly ref
     if (profilerAssemblyRef == mdAssemblyRefNil)
     {
-        const AssemblyReference assemblyReference = trace::AssemblyReference(managed_profiler_full_assembly_version);
+        const AssemblyReference assemblyReference = trace::AssemblyReference::GetFromCache(managed_profiler_full_assembly_version);
         ASSEMBLYMETADATA assembly_metadata{};
 
         assembly_metadata.usMajorVersion = assemblyReference.version.major;

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -136,7 +136,7 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
     // *** Ensure profiler assembly ref
     if (profilerAssemblyRef == mdAssemblyRefNil)
     {
-        const AssemblyReference assemblyReference = managed_profiler_full_assembly_version;
+        const AssemblyReference assemblyReference = trace::AssemblyReference(managed_profiler_full_assembly_version);
         ASSEMBLYMETADATA assembly_metadata{};
 
         assembly_metadata.usMajorVersion = assemblyReference.version.major;

--- a/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -136,7 +136,7 @@ HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
     // *** Ensure profiler assembly ref
     if (profilerAssemblyRef == mdAssemblyRefNil)
     {
-        const AssemblyReference assemblyReference = trace::AssemblyReference::GetFromCache(managed_profiler_full_assembly_version);
+        const AssemblyReference assemblyReference = *trace::AssemblyReference::GetFromCache(managed_profiler_full_assembly_version);
         ASSEMBLYMETADATA assembly_metadata{};
 
         assembly_metadata.usMajorVersion = assemblyReference.version.major;

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -47,6 +47,7 @@ private:
 
     // Cor assembly properties
     AssemblyProperty corAssemblyProperty{};
+    AssemblyReference* managed_profiler_assembly_reference;
 
     //
     // OpCodes helper

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -16,7 +16,9 @@
 namespace trace
 {
 
-    std::unordered_map<WSTRING, std::unique_ptr<AssemblyReference>> m_assemblyReferenceCache;
+std::mutex m_assemblyReferenceCacheMutex;
+std::unordered_map<WSTRING, std::unique_ptr<AssemblyReference>> m_assemblyReferenceCache;
+
 
 AssemblyReference::AssemblyReference(const WSTRING& str) :
     name(GetNameFromAssemblyReferenceString(str)),
@@ -28,6 +30,7 @@ AssemblyReference::AssemblyReference(const WSTRING& str) :
 
 AssemblyReference* AssemblyReference::GetFromCache(const WSTRING& str)
 {
+    std::lock_guard<std::mutex> guard(m_assemblyReferenceCacheMutex);
     auto findRes = m_assemblyReferenceCache.find(str);
     if (findRes != m_assemblyReferenceCache.end())
     {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -8,10 +8,15 @@
 #endif
 #include <sstream>
 
+#include <unordered_map>
+
 #include "util.h"
+#include "logger.h"
 
 namespace trace
 {
+
+    std::unordered_map<WSTRING, std::unique_ptr<AssemblyReference>> m_assemblyReferenceCache;
 
 AssemblyReference::AssemblyReference(const WSTRING& str) :
     name(GetNameFromAssemblyReferenceString(str)),
@@ -19,6 +24,18 @@ AssemblyReference::AssemblyReference(const WSTRING& str) :
     locale(GetLocaleFromAssemblyReferenceString(str)),
     public_key(GetPublicKeyFromAssemblyReferenceString(str))
 {
+}
+
+AssemblyReference* AssemblyReference::GetFromCache(const WSTRING& str)
+{
+    auto findRes = m_assemblyReferenceCache.find(str);
+    if (findRes != m_assemblyReferenceCache.end())
+    {
+        return findRes->second.get();
+    }
+    AssemblyReference* aref = new AssemblyReference(str);
+    m_assemblyReferenceCache[str] = std::unique_ptr<AssemblyReference>(aref);
+    return aref;
 }
 
 namespace

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -145,6 +145,8 @@ struct AssemblyReference
                         WStr(", PublicKeyToken=") + public_key.str();
         return ss;
     }
+
+    static AssemblyReference* GetFromCache(const WSTRING& str);
 };
 
 // A MethodSignature is a byte array. The format is:
@@ -256,7 +258,7 @@ struct MethodReference
     MethodReference(const WSTRING& assembly_name, WSTRING type_name, WSTRING method_name, WSTRING action,
                     Version min_version, Version max_version, const std::vector<BYTE>& method_signature,
                     const std::vector<WSTRING>& signature_types) :
-        assembly(assembly_name),
+        assembly(*AssemblyReference::GetFromCache(assembly_name)),
         type_name(type_name),
         method_name(method_name),
         action(action),


### PR DESCRIPTION
Currently the profiler Initialization method is creating `AssemblyReferences` for each item in the `integrations.json` and each `AssemblyReference` calls the `regex` library 3 times (`GetVersionFromAssemblyReferenceString`, `GetLocaleFromAssemblyReferenceString`, `GetPublicKeyFromAssemblyReferenceString`).

Because our integrations are contained in a single assembly, this PR uses a `AssemblyReference` cache as an optimization.

#### Initialization time in milliseconds in a sample application:

![image](https://user-images.githubusercontent.com/69803/128393022-a071a8cb-2762-4e6d-b174-dad255bf7f71.png)



@DataDog/apm-dotnet