### PR TITLE
Native profiler Initialize callback optimization

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.cpp
@@ -306,58 +306,6 @@ mdAssemblyRef FindAssemblyRef(const ComPtr<IMetaDataAssemblyImport>& assembly_im
     return mdAssemblyRefNil;
 }
 
-std::vector<Integration> FilterIntegrationsByName(const std::vector<Integration>& integrations,
-                                                  const std::vector<WSTRING>& disabled_integration_names)
-{
-    std::vector<Integration> enabled;
-
-    for (auto& i : integrations)
-    {
-        bool disabled = false;
-        for (auto& disabled_integration : disabled_integration_names)
-        {
-            if (i.integration_name == disabled_integration)
-            {
-                // this integration is disabled, skip it
-                disabled = true;
-                break;
-            }
-        }
-
-        if (!disabled)
-        {
-            enabled.push_back(i);
-        }
-    }
-
-    return enabled;
-}
-
-std::vector<IntegrationMethod> FlattenIntegrations(const std::vector<Integration>& integrations,
-                                                   bool is_calltarget_enabled)
-{
-    std::vector<IntegrationMethod> flattened;
-
-    for (auto& i : integrations)
-    {
-        for (auto& mr : i.method_replacements)
-        {
-            const auto isCallTargetIntegration = mr.wrapper_method.action == calltarget_modification_action;
-
-            if (is_calltarget_enabled && isCallTargetIntegration)
-            {
-                flattened.emplace_back(i.integration_name, mr);
-            }
-            else if (!is_calltarget_enabled && !isCallTargetIntegration)
-            {
-                flattened.emplace_back(i.integration_name, mr);
-            }
-        }
-    }
-
-    return flattened;
-}
-
 std::vector<IntegrationMethod> FilterIntegrationsByCaller(const std::vector<IntegrationMethod>& integration_methods,
                                                           const AssemblyInfo assembly)
 {

--- a/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/clr_helpers.h
@@ -516,15 +516,6 @@ TypeInfo GetTypeInfo(const ComPtr<IMetaDataImport2>& metadata_import, const mdTo
 
 mdAssemblyRef FindAssemblyRef(const ComPtr<IMetaDataAssemblyImport>& assembly_import, const WSTRING& assembly_name);
 
-// FilterIntegrationsByName removes integrations whose names are specified in
-// disabled_integration_names
-std::vector<Integration> FilterIntegrationsByName(const std::vector<Integration>& integrations,
-                                                  const std::vector<WSTRING>& disabled_integration_names);
-
-// FlattenIntegrations flattens integrations to per method structures
-std::vector<IntegrationMethod> FlattenIntegrations(const std::vector<Integration>& integrations,
-                                                   bool is_calltarget_enabled);
-
 // FilterIntegrationsByCaller removes any integrations which have a caller and
 // its not set to the module
 std::vector<IntegrationMethod> FilterIntegrationsByCaller(const std::vector<IntegrationMethod>& integration_methods,

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.h
@@ -311,26 +311,6 @@ struct MethodReplacement
     }
 };
 
-struct Integration
-{
-    const WSTRING integration_name;
-    std::vector<MethodReplacement> method_replacements;
-
-    Integration() : integration_name(WStr("")), method_replacements({})
-    {
-    }
-
-    Integration(WSTRING integration_name, std::vector<MethodReplacement> method_replacements) :
-        integration_name(integration_name), method_replacements(method_replacements)
-    {
-    }
-
-    inline bool operator==(const Integration& other) const
-    {
-        return integration_name == other.integration_name && method_replacements == other.method_replacements;
-    }
-};
-
 struct IntegrationMethod
 {
     const WSTRING integration_name;

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -14,9 +14,9 @@ using json = nlohmann::json;
 
 void LoadIntegrationsFromEnvironment(std::vector<IntegrationMethod>& integrationMethods, const bool isCallTargetEnabled,
                                      const bool isNetstandardEnabled,
-                                     const std::vector<WSTRING> disabledIntegrationNames)
+                                     const std::vector<WSTRING>& disabledIntegrationNames)
 {
-    for (const WSTRING filePath : GetEnvironmentValues(environment::integrations_path))
+    for (const WSTRING& filePath : GetEnvironmentValues(environment::integrations_path))
     {
         Logger::Debug("Loading integrations from file: ", filePath);
         LoadIntegrationsFromFile(filePath, integrationMethods, isCallTargetEnabled, isNetstandardEnabled,
@@ -26,7 +26,7 @@ void LoadIntegrationsFromEnvironment(std::vector<IntegrationMethod>& integration
 
 void LoadIntegrationsFromFile(const WSTRING& file_path, std::vector<IntegrationMethod>& integrationMethods,
                               const bool isCallTargetEnabled, const bool isNetstandardEnabled,
-                              const std::vector<WSTRING> disabledIntegrationNames)
+                              const std::vector<WSTRING>& disabledIntegrationNames)
 {
     try
     {
@@ -63,7 +63,7 @@ void LoadIntegrationsFromFile(const WSTRING& file_path, std::vector<IntegrationM
 
 void LoadIntegrationsFromStream(std::istream& stream, std::vector<IntegrationMethod>& integrationMethods,
                                 const bool isCallTargetEnabled, const bool isNetstandardEnabled,
-                                const std::vector<WSTRING> disabledIntegrationNames)
+                                const std::vector<WSTRING>& disabledIntegrationNames)
 {
     try
     {
@@ -73,7 +73,7 @@ void LoadIntegrationsFromStream(std::istream& stream, std::vector<IntegrationMet
 
         integrationMethods.reserve(j.size());
 
-        for (auto& el : j)
+        for (const auto& el : j)
         {
             IntegrationFromJson(el, integrationMethods, isCallTargetEnabled, isNetstandardEnabled,
                                 disabledIntegrationNames);
@@ -110,7 +110,7 @@ namespace
 
     void IntegrationFromJson(const json::value_type& src, std::vector<IntegrationMethod>& integrationMethods,
                              const bool isCallTargetEnabled, const bool isNetstandardEnabled,
-                             const std::vector<WSTRING> disabledIntegrationNames)
+                             const std::vector<WSTRING>& disabledIntegrationNames)
     {
         if (!src.is_object())
         {
@@ -126,7 +126,7 @@ namespace
         }
 
         // check if the integration is disabled
-        for (const WSTRING disabledName : disabledIntegrationNames)
+        for (const WSTRING& disabledName : disabledIntegrationNames)
         {
             if (name == disabledName)
             {
@@ -137,14 +137,14 @@ namespace
         auto arr = src.value("method_replacements", json::array());
         if (arr.is_array())
         {
-            for (auto& el : arr)
+            for (const auto& el : arr)
             {
                 MethodReplacementFromJson(el, name, integrationMethods, isCallTargetEnabled, isNetstandardEnabled);
             }
         }
     }
 
-    void MethodReplacementFromJson(const json::value_type& src, const WSTRING integrationName,
+    void MethodReplacementFromJson(const json::value_type& src, const WSTRING& integrationName,
                                    std::vector<IntegrationMethod>& integrationMethods,
                                    const bool isCallTargetEnabled, const bool isNetstandardEnabled)
     {

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.cpp
@@ -12,33 +12,30 @@ namespace trace
 
 using json = nlohmann::json;
 
-std::vector<Integration> LoadIntegrationsFromEnvironment()
+void LoadIntegrationsFromEnvironment(std::vector<IntegrationMethod>& integrationMethods, const bool isCallTargetEnabled,
+                                     const bool isNetstandardEnabled,
+                                     const std::vector<WSTRING> disabledIntegrationNames)
 {
-    std::vector<Integration> integrations;
-    for (const auto f : GetEnvironmentValues(environment::integrations_path))
+    for (const WSTRING filePath : GetEnvironmentValues(environment::integrations_path))
     {
-        Logger::Debug("Loading integrations from file: ", f);
-        auto is = LoadIntegrationsFromFile(f);
-        for (auto& i : is)
-        {
-            integrations.push_back(i);
-        }
+        Logger::Debug("Loading integrations from file: ", filePath);
+        LoadIntegrationsFromFile(filePath, integrationMethods, isCallTargetEnabled, isNetstandardEnabled,
+                                 disabledIntegrationNames);
     }
-    return integrations;
 }
 
-std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path)
+void LoadIntegrationsFromFile(const WSTRING& file_path, std::vector<IntegrationMethod>& integrationMethods,
+                              const bool isCallTargetEnabled, const bool isNetstandardEnabled,
+                              const std::vector<WSTRING> disabledIntegrationNames)
 {
-    std::vector<Integration> integrations;
-
     try
     {
-        std::ifstream stream;
-        stream.open(ToString(file_path));
+        std::ifstream stream(ToString(file_path));
 
         if (static_cast<bool>(stream))
         {
-            integrations = LoadIntegrationsFromStream(stream);
+            LoadIntegrationsFromStream(stream, integrationMethods, isCallTargetEnabled, isNetstandardEnabled,
+                                       disabledIntegrationNames);
         }
         else
         {
@@ -62,30 +59,26 @@ std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path)
             Logger::Warn("Failed to load integrations: ", ex.what());
         }
     }
-
-    return integrations;
 }
 
-std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream)
+void LoadIntegrationsFromStream(std::istream& stream, std::vector<IntegrationMethod>& integrationMethods,
+                                const bool isCallTargetEnabled, const bool isNetstandardEnabled,
+                                const std::vector<WSTRING> disabledIntegrationNames)
 {
-    std::vector<Integration> integrations;
-
     try
     {
         json j;
         // parse the stream
         stream >> j;
 
+        integrationMethods.reserve(j.size());
+
         for (auto& el : j)
         {
-            auto i = IntegrationFromJson(el);
-            if (std::get<1>(i))
-            {
-                integrations.push_back(std::get<0>(i));
-            }
+            IntegrationFromJson(el, integrationMethods, isCallTargetEnabled, isNetstandardEnabled,
+                                disabledIntegrationNames);
         }
 
-        // Logger::Debug("Loaded integrations: ", j.dump());
     }
     catch (const json::parse_error& e)
     {
@@ -110,55 +103,90 @@ std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream)
             Logger::Warn("Failed to load integrations: ", ex.what());
         }
     }
-
-    return integrations;
 }
 
 namespace
 {
 
-    std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src)
+    void IntegrationFromJson(const json::value_type& src, std::vector<IntegrationMethod>& integrationMethods,
+                             const bool isCallTargetEnabled, const bool isNetstandardEnabled,
+                             const std::vector<WSTRING> disabledIntegrationNames)
     {
         if (!src.is_object())
         {
-            return std::make_pair<Integration, bool>({}, false);
+            return;
         }
 
         // first get the name, which is required
-        const auto name = ToWSTRING(src.value("name", ""));
+        const WSTRING name = ToWSTRING(src.value("name", ""));
         if (name.empty())
         {
             Logger::Warn("Integration name is missing for integration: ", src.dump());
-            return std::make_pair<Integration, bool>({}, false);
+            return;
         }
 
-        std::vector<MethodReplacement> replacements;
+        // check if the integration is disabled
+        for (const WSTRING disabledName : disabledIntegrationNames)
+        {
+            if (name == disabledName)
+            {
+                return;
+            }
+        }
+
         auto arr = src.value("method_replacements", json::array());
         if (arr.is_array())
         {
             for (auto& el : arr)
             {
-                auto mr = MethodReplacementFromJson(el);
-                if (std::get<1>(mr))
-                {
-                    replacements.push_back(std::get<0>(mr));
-                }
+                MethodReplacementFromJson(el, name, integrationMethods, isCallTargetEnabled, isNetstandardEnabled);
             }
         }
-        return std::make_pair<Integration, bool>({name, replacements}, true);
     }
 
-    std::pair<MethodReplacement, bool> MethodReplacementFromJson(const json::value_type& src)
+    void MethodReplacementFromJson(const json::value_type& src, const WSTRING integrationName,
+                                   std::vector<IntegrationMethod>& integrationMethods,
+                                   const bool isCallTargetEnabled, const bool isNetstandardEnabled)
     {
-        if (!src.is_object())
+        if (src.is_object())
         {
-            return std::make_pair<MethodReplacement, bool>({}, false);
-        }
+            const MethodReference wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()), false, true);
 
-        const auto caller = MethodReferenceFromJson(src.value("caller", json::object()), false, false);
-        const auto target = MethodReferenceFromJson(src.value("target", json::object()), true, false);
-        const auto wrapper = MethodReferenceFromJson(src.value("wrapper", json::object()), false, true);
-        return std::make_pair<MethodReplacement, bool>({caller, target, wrapper}, true);
+            if (isCallTargetEnabled)
+            {
+                // Check if is a calltarget integration
+
+                if (wrapper.action != WStr("CallTargetModification"))
+                {
+                    return;
+                }
+
+                const MethodReference target =
+                    MethodReferenceFromJson(src.value("target", json::object()), true, false);
+
+                integrationMethods.push_back({integrationName, {{}, target, wrapper}});
+
+            }
+            else
+            {
+                const MethodReference target =
+                    MethodReferenceFromJson(src.value("target", json::object()), true, false);
+
+                // temporarily skip the calls into netstandard.dll that were added in
+                // https://github.com/DataDog/dd-trace-dotnet/pull/753.
+                // users can opt-in to the additional instrumentation by setting environment
+                // variable DD_TRACE_NETSTANDARD_ENABLED
+                if (!isNetstandardEnabled && target.assembly.name == WStr("netstandard"))
+                {
+                    return;
+                }
+
+                const MethodReference caller =
+                    MethodReferenceFromJson(src.value("caller", json::object()), false, false);
+
+                integrationMethods.push_back({integrationName, {caller, target, wrapper}});
+            }
+        }
     }
 
     MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method,

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
@@ -19,26 +19,26 @@ using json = nlohmann::json;
 // in the DD_INTEGRATIONS environment variable
 void LoadIntegrationsFromEnvironment(std::vector<IntegrationMethod>& integrationMethods, const bool isCallTargetEnabled,
                                      const bool isNetstandardEnabled,
-                                     const std::vector<WSTRING> disabledIntegrationNames);
+                                     const std::vector<WSTRING>& disabledIntegrationNames);
 
 // LoadIntegrationsFromFile loads the integrations from a file
 void LoadIntegrationsFromFile(const WSTRING& file_path, std::vector<IntegrationMethod>& integrationMethods,
                               const bool isCallTargetEnabled, const bool isNetstandardEnabled,
-                              const std::vector<WSTRING> disabledIntegrationNames);
+                              const std::vector<WSTRING>& disabledIntegrationNames);
 
 // LoadIntegrationsFromFile loads the integrations from a stream
 void LoadIntegrationsFromStream(std::istream& stream, std::vector<IntegrationMethod>& integrationMethods,
                                 const bool isCallTargetEnabled, const bool isNetstandardEnabled,
-                                const std::vector<WSTRING> disabledIntegrationNames);
+                                const std::vector<WSTRING>& disabledIntegrationNames);
 
 namespace
 {
 
     void IntegrationFromJson(const json::value_type& src, std::vector<IntegrationMethod>& integrationMethods,
                              const bool isCallTargetEnabled, const bool isNetstandardEnabled,
-                             const std::vector<WSTRING> disabledIntegrationNames);
+                             const std::vector<WSTRING>& disabledIntegrationNames);
 
-    void MethodReplacementFromJson(const json::value_type& src, const WSTRING integrationName,
+    void MethodReplacementFromJson(const json::value_type& src, const WSTRING& integrationName,
                                    std::vector<IntegrationMethod>& integrationMethods,
                                    const bool isCallTargetEnabled, const bool isNetstandardEnabled);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration_loader.h
@@ -17,17 +17,31 @@ using json = nlohmann::json;
 
 // LoadIntegrationsFromEnvironment loads integrations from any files specified
 // in the DD_INTEGRATIONS environment variable
-std::vector<Integration> LoadIntegrationsFromEnvironment();
+void LoadIntegrationsFromEnvironment(std::vector<IntegrationMethod>& integrationMethods, const bool isCallTargetEnabled,
+                                     const bool isNetstandardEnabled,
+                                     const std::vector<WSTRING> disabledIntegrationNames);
+
 // LoadIntegrationsFromFile loads the integrations from a file
-std::vector<Integration> LoadIntegrationsFromFile(const WSTRING& file_path);
+void LoadIntegrationsFromFile(const WSTRING& file_path, std::vector<IntegrationMethod>& integrationMethods,
+                              const bool isCallTargetEnabled, const bool isNetstandardEnabled,
+                              const std::vector<WSTRING> disabledIntegrationNames);
+
 // LoadIntegrationsFromFile loads the integrations from a stream
-std::vector<Integration> LoadIntegrationsFromStream(std::istream& stream);
+void LoadIntegrationsFromStream(std::istream& stream, std::vector<IntegrationMethod>& integrationMethods,
+                                const bool isCallTargetEnabled, const bool isNetstandardEnabled,
+                                const std::vector<WSTRING> disabledIntegrationNames);
 
 namespace
 {
 
-    std::pair<Integration, bool> IntegrationFromJson(const json::value_type& src);
-    std::pair<MethodReplacement, bool> MethodReplacementFromJson(const json::value_type& src);
+    void IntegrationFromJson(const json::value_type& src, std::vector<IntegrationMethod>& integrationMethods,
+                             const bool isCallTargetEnabled, const bool isNetstandardEnabled,
+                             const std::vector<WSTRING> disabledIntegrationNames);
+
+    void MethodReplacementFromJson(const json::value_type& src, const WSTRING integrationName,
+                                   std::vector<IntegrationMethod>& integrationMethods,
+                                   const bool isCallTargetEnabled, const bool isNetstandardEnabled);
+
     MethodReference MethodReferenceFromJson(const json::value_type& src, const bool is_target_method,
                                             const bool is_wrapper_method);
 

--- a/src/Datadog.Trace.ClrProfiler.Native/stats.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/stats.h
@@ -117,33 +117,58 @@ public:
     }
     std::string ToString()
     {
+        const auto ns_initialize = initialize.load();
+        const auto ns_moduleLoadFinished = moduleLoadFinished.load();
+        const auto ns_callTargetRequestRejit = callTargetRequestRejit.load();
+        const auto ns_callTargetRewriter = callTargetRewriter.load();
+        const auto ns_assemblyLoadFinished = assemblyLoadFinished.load();
+        const auto ns_moduleUnloadStarted = moduleUnloadStarted.load();
+        const auto ns_jitCompilationStarted = jitCompilationStarted.load();
+        const auto ns_jitInlining = jitInlining.load();
+        const auto ns_jitCachedFunctionSearchStarted = jitCachedFunctionSearchStarted.load();
+
+        const auto count_moduleLoadFinishedCount = moduleLoadFinishedCount.load();
+        const auto count_callTargetRequestRejitCount = callTargetRequestRejitCount.load();
+        const auto count_callTargetRewriterCount = callTargetRewriterCount.load();
+        const auto count_assemblyLoadFinishedCount = assemblyLoadFinishedCount.load();
+        const auto count_moduleUnloadStartedCount = moduleUnloadStartedCount.load();
+        const auto count_jitCompilationStartedCount = jitCompilationStartedCount.load();
+        const auto count_jitInliningCount = jitInliningCount.load();
+        const auto count_jitCachedFunctionSearchStartedCount = jitCachedFunctionSearchStartedCount.load();
+
+        const auto ns_total = ns_initialize + ns_moduleLoadFinished + ns_callTargetRequestRejit +
+                              ns_callTargetRewriter + ns_assemblyLoadFinished + ns_moduleUnloadStarted +
+                              ns_jitCompilationStarted + ns_jitInlining + ns_jitCachedFunctionSearchStarted;
+
         std::stringstream ss;
+        ss << "Total ";
+        ss << ns_total / 1000000 << "ms ";
         ss << "[Initialize=";
-        ss << initialize.load() / 1000000 << "ms";
+        ss << ns_initialize / 1000000 << "ms";
         ss << ", ModuleLoadFinished=";
-        ss << moduleLoadFinished.load() / 1000000 << "ms"
-           << "/" << moduleLoadFinishedCount.load();
+        ss << ns_moduleLoadFinished / 1000000 << "ms"
+           << "/" << count_moduleLoadFinishedCount;
         ss << ", CallTargetRequestRejit=";
-        ss << callTargetRequestRejit.load() / 1000000 << "ms"
-           << "/" << callTargetRequestRejitCount.load();
+        ss << ns_callTargetRequestRejit / 1000000 << "ms"
+           << "/" << count_callTargetRequestRejitCount;
         ss << ", CallTargetRewriter=";
-        ss << callTargetRewriter.load() / 1000000 << "ms"
-           << "/" << callTargetRewriterCount.load();
+        ss << ns_callTargetRewriter / 1000000 << "ms"
+           << "/" << count_callTargetRewriterCount;
         ss << ", AssemblyLoadFinished=";
-        ss << assemblyLoadFinished.load() / 1000000 << "ms"
-           << "/" << assemblyLoadFinishedCount.load();
+        ss << ns_assemblyLoadFinished / 1000000 << "ms"
+           << "/" << count_assemblyLoadFinishedCount;
         ss << ", ModuleUnloadStarted=";
-        ss << moduleUnloadStarted.load() / 1000000 << "ms"
-           << "/" << moduleUnloadStartedCount.load();
+        ss << ns_moduleUnloadStarted / 1000000 << "ms"
+           << "/" << count_moduleUnloadStartedCount;
         ss << ", JitCompilationStarted=";
-        ss << jitCompilationStarted.load() / 1000000 << "ms"
-           << "/" << jitCompilationStartedCount.load();
+        ss << ns_jitCompilationStarted / 1000000 << "ms"
+           << "/" << count_jitCompilationStartedCount;
         ss << ", JitInlining=";
-        ss << jitInlining.load() / 1000000 << "ms"
-           << "/" << jitInliningCount.load();
+        ss << ns_jitInlining / 1000000 << "ms"
+           << "/" << count_jitInliningCount;
         ss << ", JitCacheFunctionSearchStarted=";
-        ss << jitCachedFunctionSearchStarted.load() / 1000000 << "ms"
-           << "/" << jitCachedFunctionSearchStartedCount.load();
+        ss << ns_jitCachedFunctionSearchStarted / 1000000 << "ms"
+           << "/" << count_jitCachedFunctionSearchStartedCount;
         ss << "]";
         return ss.str();
     }


### PR DESCRIPTION
This PR optimize the `integrations.json` file parser, reducing allocations and cpu cycles.

#### Old Init vs New Init (time in milliseconds)

![image](https://user-images.githubusercontent.com/69803/128701976-2d636803-bd4a-4666-aabb-63c6d42a1e1f.png)





@DataDog/apm-dotnet