### PR TITLE
Appsec/v0 integration small fixes

### DIFF
--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -762,7 +762,8 @@ partial class Build
         {
             // This does some "unnecessary" rebuilding and restoring
             var includeIntegration = RootDirectory.GlobFiles("test/test-applications/integrations/**/*.csproj");
-            var includeSecurity = RootDirectory.GlobFiles("test/test-applications/security/**/*.csproj");
+            // Don't build aspnet full framework sample in this step
+            var includeSecurity = RootDirectory.GlobFiles("test/test-applications/security/*/*.csproj");
 
             var exclude = RootDirectory.GlobFiles("test/test-applications/integrations/dependency-libs/**/*.csproj");
 

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -762,7 +762,7 @@ partial class Build
         {
             // This does some "unnecessary" rebuilding and restoring
             var includeIntegration = RootDirectory.GlobFiles("test/test-applications/integrations/**/*.csproj");
-            var includeSecurity = RootDirectory.GlobFiles("test/test-applications/security/*/*.csproj");
+            var includeSecurity = RootDirectory.GlobFiles("test/test-applications/security/**/*.csproj");
 
             var exclude = RootDirectory.GlobFiles("test/test-applications/integrations/dependency-libs/**/*.csproj");
 

--- a/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -36,15 +36,15 @@ namespace Datadog.Trace.Tools.Runner
 
             RunnerFolder = Path.GetDirectoryName(location);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {
                 Platform = Platform.Windows;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
             {
                 Platform = Platform.Linux;
             }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
             {
                 Platform = Platform.MacOS;
             }

--- a/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -34,20 +34,18 @@ namespace Datadog.Trace.Agent.Transports
         public async Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
         {
             var ms = new MemoryStream();
+            var sw = new StreamWriter(ms, leaveOpen: true);
+            using (var content = new StreamContent(ms))
             {
-                var sw = new StreamWriter(ms, leaveOpen: true);
-                using (var content = new StreamContent(ms))
+                using (JsonWriter writer = new JsonTextWriter(sw) { CloseOutput = true })
                 {
-                    using (JsonWriter writer = new JsonTextWriter(sw) { CloseOutput = true })
-                    {
-                        serializer.Serialize(writer, events);
-                        content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-                        _request.Content = content;
-                        await writer.FlushAsync();
-                        ms.Seek(0, SeekOrigin.Begin);
-                        var response = await _client.SendAsync(_request).ConfigureAwait(false);
-                        return new HttpClientResponse(response);
-                    }
+                    serializer.Serialize(writer, events);
+                    content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                    _request.Content = content;
+                    await writer.FlushAsync();
+                    ms.Seek(0, SeekOrigin.Begin);
+                    var response = await _client.SendAsync(_request).ConfigureAwait(false);
+                    return new HttpClientResponse(response);
                 }
             }
         }

--- a/src/Datadog.Trace/AppSec/Agent/AppSecAgentWriter.cs
+++ b/src/Datadog.Trace/AppSec/Agent/AppSecAgentWriter.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.AppSec.Agent
                 try
                 {
                     var appsecEvents = new List<IEvent>();
-                    while (_events.TryDequeue(out var result) && appsecEvents.Count <= MaxItemsPerBatch)
+                    while (appsecEvents.Count <= MaxItemsPerBatch && _events.TryDequeue(out var result))
                     {
                         appsecEvents.Add(result);
                     }

--- a/src/Datadog.Trace/AppSec/Security.cs
+++ b/src/Datadog.Trace/AppSec/Security.cs
@@ -198,6 +198,7 @@ namespace Datadog.Trace.AppSec
         {
             _agentWriter.Shutdown();
             _instrumentationGateway.InstrumentationGatewayEvent -= InstrumentationGatewayInstrumentationGatewayEvent;
+            Dispose();
         }
 
         private void RegisterShutdownTasks()

--- a/src/Datadog.Trace/AppSec/Security.cs
+++ b/src/Datadog.Trace/AppSec/Security.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.AppSec
     /// <summary>
     /// The Secure is responsible cooridating app sec
     /// </summary>
-    public class Security : IDatadogSecurity
+    public class Security : IDatadogSecurity, IDisposable
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Security>();
 
@@ -173,7 +173,7 @@ namespace Datadog.Trace.AppSec
         {
             var frameworkDescription = FrameworkDescription.Instance;
             var osSupported = false;
-            var supportedOs = new[] { OSPlatforms.Linux, OSPlatforms.MacOS, OSPlatforms.Windows };
+            var supportedOs = new[] { OSPlatform.Linux, OSPlatform.MacOS, OSPlatform.Windows };
             if (supportedOs.Contains(frameworkDescription.OSPlatform))
             {
                 osSupported = true;

--- a/src/Datadog.Trace/AppSec/Waf/NativeBindings/Native.cs
+++ b/src/Datadog.Trace/AppSec/Waf/NativeBindings/Native.cs
@@ -287,7 +287,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                     AppDomain.CurrentDomain.BaseDirectory : AppDomain.CurrentDomain.RelativeSearchPath;
             integrationsPaths.Add(currentDir);
 
-            Log.Warning($"current dir is {currentDir}'");
+            Log.Debug($"current dir is {currentDir}'");
 
             // the home folder could contain the native dll directly, but it could also
             // be under a runtime specific folder
@@ -361,12 +361,12 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
 
             switch (frameworkDescription.OSPlatform)
             {
-                case OSPlatforms.MacOS:
+                case OSPlatform.MacOS:
                     runtimeIdPart1 = "osx";
                     libPrefix = "lib";
                     libExt = "dylib";
                     break;
-                case OSPlatforms.Linux:
+                case OSPlatform.Linux:
                     runtimeIdPart1 =
                         IsMuslBasedLinux() ?
                             "linux-musl" :
@@ -374,7 +374,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                     libPrefix = "lib";
                     libExt = "so";
                     break;
-                case OSPlatforms.Windows:
+                case OSPlatform.Windows:
                     runtimeIdPart1 = "win";
                     libPrefix = string.Empty;
                     libExt = "dll";

--- a/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
+++ b/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
 #if NETFRAMEWORK
             false;
 #else
-            !RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            !RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
 #endif
 
         internal static bool TryLoad(string libraryPath, out IntPtr handle)

--- a/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -45,15 +45,15 @@ namespace Datadog.Trace
 
                 if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                 {
-                    osPlatform = OSPlatforms.Windows;
+                    osPlatform = Trace.OSPlatform.Windows;
                 }
                 else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux))
                 {
-                    osPlatform = OSPlatforms.Linux;
+                    osPlatform = Trace.OSPlatform.Linux;
                 }
                 else if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX))
                 {
-                    osPlatform = OSPlatforms.MacOS;
+                    osPlatform = Trace.OSPlatform.MacOS;
                 }
 
                 osArchitecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();

--- a/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -188,7 +188,7 @@ namespace Datadog.Trace.Logging
 #if NETFRAMEWORK
                 logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
 #else
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
                 {
                     logDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), @"Datadog .NET Tracer", "logs");
                 }

--- a/src/Datadog.Trace/OSPlatform.cs
+++ b/src/Datadog.Trace/OSPlatform.cs
@@ -1,11 +1,11 @@
-// <copyright file="OSPlatforms.cs" company="Datadog">
+// <copyright file="OSPlatform.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 namespace Datadog.Trace
 {
-    internal static class OSPlatforms
+    internal static class OSPlatform
     {
         public const string Windows = "Windows";
         public const string Linux = "Linux";

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private static int CalculateExpectedAsyncSpans(InstrumentationOptions instrumentation, bool enableCallTarget)
         {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            var isWindows = RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
 
             // net4x doesn't have patch
             var spansPerHttpClient = EnvironmentHelper.IsCoreClr() ? 35 : 31;

--- a/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -13,10 +13,10 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+    <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
-    <Reference Include="System.EnterpriseServices" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -16,10 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Reference Include="System.EnterpriseServices" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
+++ b/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
@@ -59,14 +59,14 @@ namespace Datadog.Trace.TestHelpers
         public static string GetOS()
         {
             return IsWindows()                                       ? "win" :
-                   RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "linux" :
-                   RuntimeInformation.IsOSPlatform(OSPlatform.OSX)   ? "osx" :
+                   RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Linux) ? "linux" :
+                   RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.OSX)   ? "osx" :
                                                                        string.Empty;
         }
 
         public static bool IsWindows()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
         }
 
         public static string GetPlatform()


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:
- remove useless scope in HttpClientRequest
- IDisposable for Security 
- Build.Steps > 2 wildcards to take into account asp.net core samples
- Don't lose app sec events in case of list of events full
- renaming of osplatform
- debug instead of warning log

@DataDog/apm-dotnet