### PR TITLE
Native logger error fix

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Native/logger_impl.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logger_impl.h
@@ -135,7 +135,10 @@ LoggerImpl<TLoggerPolicy>::LoggerImpl()
     }
     catch (...)
     {
-        std::cerr << "LoggerImpl Handler: Error creating native log file." << std::endl;
+        // By writing into the stderr was changing the behavior in a CI scenario.
+        // There's not a good way to report errors when trying to create the log file.
+        // But we never should be changing the normal behavior of an app.
+        // std::cerr << "LoggerImpl Handler: Error creating native log file." << std::endl;
         m_fileout = spdlog::null_logger_mt("LoggerImpl");
     }
 


### PR DESCRIPTION
Fixes #1676 

With #1625 we started writing to `stderr` when the native logger can't create the log file. This can break and change the behavior of systems depending on the console output/error (like CI). This PR fixes the issue, like was handled before in https://github.com/DataDog/dd-trace-dotnet/blob/master/src/Datadog.Trace.ClrProfiler.Native/logger_impl.h#L117-L120

@DataDog/apm-dotnet