### PR TITLE
Add a custom test framework to monitor execution of unit tests in ducktyping library

### DIFF
--- a/test/Datadog.Trace.DuckTyping.Tests/CustomTestFramework.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/CustomTestFramework.cs
@@ -1,0 +1,133 @@
+// <copyright file="CustomTestFramework.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("Datadog.Trace.DuckTyping.Tests.CustomTestFramework", "Datadog.Trace.DuckTyping.Tests")]
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class CustomTestFramework : XunitTestFramework
+    {
+        public CustomTestFramework(IMessageSink messageSink)
+            : base(messageSink)
+        {
+        }
+
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            return new CustomExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
+        }
+
+        private class CustomExecutor : XunitTestFrameworkExecutor
+        {
+            public CustomExecutor(AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider, IMessageSink diagnosticMessageSink)
+                : base(assemblyName, sourceInformationProvider, diagnosticMessageSink)
+            {
+            }
+
+            protected override async void RunTestCases(IEnumerable<IXunitTestCase> testCases, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+            {
+                using (var assemblyRunner = new CustomAssemblyRunner(TestAssembly, testCases, DiagnosticMessageSink, executionMessageSink, executionOptions))
+                {
+                    await assemblyRunner.RunAsync();
+                }
+            }
+        }
+
+        private class CustomAssemblyRunner : XunitTestAssemblyRunner
+        {
+            public CustomAssemblyRunner(ITestAssembly testAssembly, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageSink executionMessageSink, ITestFrameworkExecutionOptions executionOptions)
+                : base(testAssembly, testCases, diagnosticMessageSink, executionMessageSink, executionOptions)
+            {
+            }
+
+            protected override Task<RunSummary> RunTestCollectionAsync(IMessageBus messageBus, ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, CancellationTokenSource cancellationTokenSource)
+            {
+                return new CustomTestCollectionRunner(testCollection, testCases, DiagnosticMessageSink, messageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), cancellationTokenSource).RunAsync();
+            }
+        }
+
+        private class CustomTestCollectionRunner : XunitTestCollectionRunner
+        {
+            private readonly IMessageSink _diagnosticMessageSink;
+
+            public CustomTestCollectionRunner(ITestCollection testCollection, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+                : base(testCollection, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource)
+            {
+                _diagnosticMessageSink = diagnosticMessageSink;
+            }
+
+            protected override Task<RunSummary> RunTestClassAsync(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases)
+            {
+                return new CustomTestClassRunner(testClass, @class, testCases, _diagnosticMessageSink, MessageBus, TestCaseOrderer, new ExceptionAggregator(Aggregator), CancellationTokenSource, CollectionFixtureMappings)
+                   .RunAsync();
+            }
+        }
+
+        private class CustomTestClassRunner : XunitTestClassRunner
+        {
+            public CustomTestClassRunner(ITestClass testClass, IReflectionTypeInfo @class, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ITestCaseOrderer testCaseOrderer, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, IDictionary<Type, object> collectionFixtureMappings)
+                : base(testClass, @class, testCases, diagnosticMessageSink, messageBus, testCaseOrderer, aggregator, cancellationTokenSource, collectionFixtureMappings)
+            {
+            }
+
+            protected override Task<RunSummary> RunTestMethodAsync(ITestMethod testMethod, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, object[] constructorArguments)
+            {
+                return new CustomTestMethodRunner(testMethod, this.Class, method, testCases, this.DiagnosticMessageSink, this.MessageBus, new ExceptionAggregator(this.Aggregator), this.CancellationTokenSource, constructorArguments)
+                   .RunAsync();
+            }
+        }
+
+        private class CustomTestMethodRunner : XunitTestMethodRunner
+        {
+            private readonly IMessageSink _diagnosticMessageSink;
+
+            public CustomTestMethodRunner(ITestMethod testMethod, IReflectionTypeInfo @class, IReflectionMethodInfo method, IEnumerable<IXunitTestCase> testCases, IMessageSink diagnosticMessageSink, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource, object[] constructorArguments)
+                : base(testMethod, @class, method, testCases, diagnosticMessageSink, messageBus, aggregator, cancellationTokenSource, constructorArguments)
+            {
+                _diagnosticMessageSink = diagnosticMessageSink;
+            }
+
+            protected override async Task<RunSummary> RunTestCaseAsync(IXunitTestCase testCase)
+            {
+                var parameters = string.Empty;
+
+                if (testCase.TestMethodArguments != null)
+                {
+                    parameters = string.Join(", ", testCase.TestMethodArguments.Select(a => a?.ToString() ?? "null"));
+                }
+
+                var test = $"{TestMethod.TestClass.Class.Name}.{TestMethod.Method.Name}({parameters})";
+
+                _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"STARTED: {test}"));
+
+                try
+                {
+                    var result = await base.RunTestCaseAsync(testCase);
+
+                    var status = result.Failed > 0 ? "FAILURE" : "SUCCESS";
+
+                    _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"{status}: {test} ({result.Time}s)"));
+
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"ERROR: {test} ({ex.Message})"));
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
+++ b/test/Datadog.Trace.DuckTyping.Tests/Datadog.Trace.DuckTyping.Tests.csproj
@@ -23,4 +23,9 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Remove="xunit.runner.json" />
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
 </Project>

--- a/test/Datadog.Trace.DuckTyping.Tests/xunit.runner.json
+++ b/test/Datadog.Trace.DuckTyping.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+﻿{
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
+}


### PR DESCRIPTION
We are seeing occasional abort messages for the test host. This allows us to monitor the executing test to help track down the issue

@DataDog/apm-dotnet