### PR TITLE
Appsec/anna/v0 integration/crankscenarios

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -979,10 +979,11 @@ stages:
   dependsOn: [build_linux, build_arm64, build_windows]
   jobs:
 
-  #### Linux
+  #### Throughput Linux 64, windows 64, linux arm 64 
 
-  - job: Linux
+  - job: Throughput
     pool: Throughput
+    timeoutInMinutes: 190
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -1006,8 +1007,10 @@ stages:
     - script: |
         test ! -s "tracer-home-win/integrations.json" && echo "tracer-home-win/integrations.json does not exist" && exit 1
         test ! -s "tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll does not exist" && exit 1
+        test ! -s "tracer-home-win/win-x64/Sqreen.dll" && echo "tracer-home-win/win-x64/Sqreen.dll does not exist" && exit 1
         test ! -s "tracer-home-linux/integrations.json" && echo "tracer-home-linux/integrations.json does not exist" && exit 1
         test ! -s "tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
+         test ! -s "tracer-home-linux/libSqreen.so" && echo "tracer-home-linux/libSqreen.so does not exist" && exit 1
         test ! -s "tracer-home-linux-arm64/integrations.json" && echo "tracer-home-linux-arm64/integrations.json does not exist" && exit 1
         test ! -s "tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/build/crank

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -343,6 +343,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "crank", "crank", "{E3FB283A
 	ProjectSection(SolutionItems) = preProject
 		build\crank\run.sh = build\crank\run.sh
 		build\crank\Samples.AspNetCoreSimpleController.yml = build\crank\Samples.AspNetCoreSimpleController.yml
+		build\crank\Security.Samples.AspNetCoreSimpleController.yml = build\crank\Security.Samples.AspNetCoreSimpleController.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}"
@@ -1582,17 +1583,6 @@ Global
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x64.Build.0 = Release|Any CPU
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x86.ActiveCfg = Release|Any CPU
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x86.Build.0 = Release|Any CPU
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|Any CPU.Build.0 = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x64.ActiveCfg = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x64.Build.0 = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x86.ActiveCfg = Debug|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x86.Build.0 = Debug|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|Any CPU.ActiveCfg = Release|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x64.ActiveCfg = Release|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x64.Build.0 = Release|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x86.ActiveCfg = Release|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x86.Build.0 = Release|x86
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.Build.0 = Debug|x64
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|x64.ActiveCfg = Debug|x64

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -343,7 +343,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "crank", "crank", "{E3FB283A
 	ProjectSection(SolutionItems) = preProject
 		build\crank\run.sh = build\crank\run.sh
 		build\crank\Samples.AspNetCoreSimpleController.yml = build\crank\Samples.AspNetCoreSimpleController.yml
-		build\crank\Security.Samples.AspNetCoreSimpleController.yml = build\crank\Security.Samples.AspNetCoreSimpleController.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}"
@@ -1583,6 +1582,17 @@ Global
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x64.Build.0 = Release|Any CPU
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x86.ActiveCfg = Release|Any CPU
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x86.Build.0 = Release|Any CPU
+		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|Any CPU.Build.0 = Debug|x64
+		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x64.ActiveCfg = Debug|x64
+		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x64.Build.0 = Debug|x64
+		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x86.ActiveCfg = Debug|x86
+		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x86.Build.0 = Debug|x86
+		{3F146731-A66B-464F-9257-98A828883FC5}.Release|Any CPU.ActiveCfg = Release|x86
+		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x64.ActiveCfg = Release|x64
+		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x64.Build.0 = Release|x64
+		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x86.ActiveCfg = Release|x86
+		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x86.Build.0 = Release|x86
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.Build.0 = Debug|x64
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|x64.ActiveCfg = Debug|x64

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -341,8 +341,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreSimpleCon
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "crank", "crank", "{E3FB283A-B766-4887-95E1-329667671921}"
 	ProjectSection(SolutionItems) = preProject
+		build\crank\os.profiles.yml = build\crank\os.profiles.yml
 		build\crank\run.sh = build\crank\run.sh
 		build\crank\Samples.AspNetCoreSimpleController.yml = build\crank\Samples.AspNetCoreSimpleController.yml
+		build\crank\Security.Samples.AspNetCoreSimpleController.yml = build\crank\Security.Samples.AspNetCoreSimpleController.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}"
@@ -1582,17 +1584,6 @@ Global
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x64.Build.0 = Release|Any CPU
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x86.ActiveCfg = Release|Any CPU
 		{04B3C44A-D21B-40A8-A167-CB6C035D613B}.Release|x86.Build.0 = Release|Any CPU
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|Any CPU.ActiveCfg = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|Any CPU.Build.0 = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x64.ActiveCfg = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x64.Build.0 = Debug|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x86.ActiveCfg = Debug|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Debug|x86.Build.0 = Debug|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|Any CPU.ActiveCfg = Release|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x64.ActiveCfg = Release|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x64.Build.0 = Release|x64
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x86.ActiveCfg = Release|x86
-		{3F146731-A66B-464F-9257-98A828883FC5}.Release|x86.Build.0 = Release|x86
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|Any CPU.Build.0 = Debug|x64
 		{AF000E79-8F94-4F52-A7EE-52781C958DCB}.Debug|x64.ActiveCfg = Debug|x64

--- a/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -1,6 +1,6 @@
 imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - /var/opt/crank/variables.yml
+  - ./os.profiles.yml
 
 variables:
   commit_hash: 0
@@ -65,80 +65,3 @@ scenarios:
         duration: 240
         serverPort: 5000
         path: /hello
-
-profiles:
-
-  windows:
-    variables:
-      serverAddress: "{{ windowsIp }}"
-    jobs:
-      application:
-        endpoints:
-          - "{{ windowsEndpoint }}"
-        environmentVariables:
-          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
-          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
-          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
-          DD_INTEGRATIONS: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\integrations.json"
-          DD_AGENT_HOST: "{{ controllerIp }}"
-          DD_TRACE_DEBUG: 0
-        options:
-          requiredOperatingSystem: windows
-          requiredArchitecture: x64
-          buildFiles:
-          - "../../tracer-home-win/**;{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
-      load:
-        endpoints:
-          - http://localhost:5010
-
-  linux:
-    variables:
-      serverAddress: "{{ linuxIp }}"
-    jobs:
-      application:
-        endpoints:
-          - "{{ linuxEndpoint }}"
-        environmentVariables:
-          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
-          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
-          DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
-          DD_INTEGRATIONS: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/integrations.json"
-          DD_AGENT_HOST: "{{ controllerIp }}"
-          DD_TRACE_DEBUG: 0
-        options:
-          requiredOperatingSystem: linux
-          requiredArchitecture: x64
-          buildFiles:
-          - "../../tracer-home-linux/**;{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
-      load:
-        endpoints:
-          - http://localhost:5010
-
-  linux_arm64:
-    variables:
-      serverAddress: "{{ linuxArm64Ip }}"
-    jobs:
-      application:
-        endpoints:
-          - "{{ linuxArm64Endpoint }}"
-        environmentVariables:
-          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
-          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
-          DD_DOTNET_TRACER_HOME: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64"
-          DD_INTEGRATIONS: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64/integrations.json"
-          DD_AGENT_HOST: "{{ controllerIp }}"
-          DD_TRACE_DEBUG: 0
-        options:
-          requiredOperatingSystem: linux
-          requiredArchitecture: arm64
-          buildFiles:
-          - "../../tracer-home-linux-arm64/**;{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64"
-      load:
-        endpoints:
-          - http://localhost:5010

--- a/build/crank/Security.Samples.AspNetCoreSimpleController.yml
+++ b/build/crank/Security.Samples.AspNetCoreSimpleController.yml
@@ -1,0 +1,123 @@
+﻿imports:
+  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+  - /var/opt/crank/variables.yml
+
+variables:
+  commit_hash: 0
+
+jobs:
+  server:
+    source:
+      project: test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+    readyStateText: Application started.
+    options:
+      displayOutput: true
+      displayBuild: true
+      counterProviders:
+      - System.Runtime
+      - Microsoft.AspNetCore.Hosting
+      - Microsoft.AspNetCore.Http.Connections
+
+scenarios:
+  appsec_baseline:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_TRACE_CALLTARGET_ENABLED: 1
+        DD_APPSEC_ENABLED: false
+        DD_APPSEC_BLOCKING_ENABLED: false
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello?arg=[$slice]
+
+  appsec_noblocking:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_TRACE_CALLTARGET_ENABLED: 1
+        DD_APPSEC_ENABLED: true
+        DD_APPSEC_BLOCKING_ENABLED: false
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello?arg=[$slice]
+
+  appsec_withblocking:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_TRACE_CALLTARGET_ENABLED: 1
+        DD_APPSEC_ENABLED: true
+        DD_APPSEC_BLOCKING_ENABLED: true
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello?arg=[$slice]
+
+profiles:
+
+  windows:
+    variables:
+      serverAddress: "{{ windowsIp }}"
+    jobs:
+      application:
+        endpoints:
+          - "{{ windowsEndpoint }}"
+        environmentVariables:
+          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
+          DD_INTEGRATIONS: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\integrations.json"
+          DD_AGENT_HOST: "{{ controllerIp }}"
+          DD_TRACE_DEBUG: 0
+        options:
+          requiredOperatingSystem: windows
+          requiredArchitecture: x64
+          buildFiles:
+          - "../../tracer-home-win/**;{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
+      load:
+        endpoints:
+          - http://localhost:5010
+
+  linux:
+    variables:
+      serverAddress: "{{ linuxIp }}"
+    jobs:
+      application:
+        endpoints:
+          - "{{ linuxEndpoint }}"
+        environmentVariables:
+          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          COR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
+          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
+          DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
+          DD_INTEGRATIONS: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/integrations.json"
+          DD_AGENT_HOST: "{{ controllerIp }}"
+          DD_TRACE_DEBUG: 0
+        options:
+          requiredOperatingSystem: linux
+          requiredArchitecture: x64
+          buildFiles:
+          - "../../tracer-home-linux/**;{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
+      load:
+        endpoints:
+          - http://localhost:5010

--- a/build/crank/Security.Samples.AspNetCoreSimpleController.yml
+++ b/build/crank/Security.Samples.AspNetCoreSimpleController.yml
@@ -1,6 +1,6 @@
 ﻿imports:
   - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
-  - /var/opt/crank/variables.yml
+  - ./os.profiles.yml
 
 variables:
   commit_hash: 0
@@ -19,41 +19,7 @@ jobs:
       - Microsoft.AspNetCore.Http.Connections
 
 scenarios:
-  appsec_baseline:
-    application:
-      job: server
-      environmentVariables:
-        COR_ENABLE_PROFILING: 1
-        CORECLR_ENABLE_PROFILING: 1
-        DD_TRACE_CALLTARGET_ENABLED: 1
-        DD_APPSEC_ENABLED: false
-        DD_APPSEC_BLOCKING_ENABLED: false
-    load:
-      job: bombardier
-      variables:
-        warmup: 30
-        duration: 240
-        serverPort: 5000
-        path: /hello?arg=[$slice]
-
-  appsec_noblocking:
-    application:
-      job: server
-      environmentVariables:
-        COR_ENABLE_PROFILING: 1
-        CORECLR_ENABLE_PROFILING: 1
-        DD_TRACE_CALLTARGET_ENABLED: 1
-        DD_APPSEC_ENABLED: true
-        DD_APPSEC_BLOCKING_ENABLED: false
-    load:
-      job: bombardier
-      variables:
-        warmup: 30
-        duration: 240
-        serverPort: 5000
-        path: /hello?arg=[$slice]
-
-  appsec_withblocking:
+  appsec_noattack:
     application:
       job: server
       environmentVariables:
@@ -68,56 +34,39 @@ scenarios:
         warmup: 30
         duration: 240
         serverPort: 5000
+        path: /hello
+
+  appsec_attack_noblocking:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_TRACE_CALLTARGET_ENABLED: 1
+        DD_APPSEC_ENABLED: true
+        DD_APPSEC_BLOCKING_ENABLED: false
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
         path: /hello?arg=[$slice]
 
-profiles:
+  appsec_attack_blocking:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_APPSEC_ENABLED: true
+        DD_TRACE_CALLTARGET_ENABLED: 1
+        DD_APPSEC_BLOCKING_ENABLED: true
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello?arg=[$slice]
 
-  windows:
-    variables:
-      serverAddress: "{{ windowsIp }}"
-    jobs:
-      application:
-        endpoints:
-          - "{{ windowsEndpoint }}"
-        environmentVariables:
-          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
-          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
-          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
-          DD_INTEGRATIONS: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\integrations.json"
-          DD_AGENT_HOST: "{{ controllerIp }}"
-          DD_TRACE_DEBUG: 0
-        options:
-          requiredOperatingSystem: windows
-          requiredArchitecture: x64
-          buildFiles:
-          - "../../tracer-home-win/**;{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
-      load:
-        endpoints:
-          - http://localhost:5010
-
-  linux:
-    variables:
-      serverAddress: "{{ linuxIp }}"
-    jobs:
-      application:
-        endpoints:
-          - "{{ linuxEndpoint }}"
-        environmentVariables:
-          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          COR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
-          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
-          CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
-          DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
-          DD_INTEGRATIONS: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/integrations.json"
-          DD_AGENT_HOST: "{{ controllerIp }}"
-          DD_TRACE_DEBUG: 0
-        options:
-          requiredOperatingSystem: linux
-          requiredArchitecture: x64
-          buildFiles:
-          - "../../tracer-home-linux/**;{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
-      load:
-        endpoints:
-          - http://localhost:5010

--- a/build/crank/os.profiles.yml
+++ b/build/crank/os.profiles.yml
@@ -1,0 +1,82 @@
+﻿imports:
+    - /var/opt/crank/variables.yml
+
+profiles:
+
+  windows:
+    variables:
+      serverAddress: "{{ windowsIp }}"
+    jobs:
+      application:
+        endpoints:
+          - "{{ windowsEndpoint }}"
+        environmentVariables:
+          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          COR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          CORECLR_PROFILER_PATH: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+          DD_DOTNET_TRACER_HOME: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
+          DD_INTEGRATIONS: "{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win\\integrations.json"
+          DD_AGENT_HOST: "{{ controllerIp }}"
+          DD_TRACE_LOGGING_RATE: 6
+          DD_TRACE_DEBUG: 0
+        options:
+          requiredOperatingSystem: windows
+          requiredArchitecture: x64
+          buildFiles:
+          - "../../tracer-home-win/**;{{ windowsProfilerPath }}\\{{ commit_hash }}\\tracer-home-win"
+      load:
+        endpoints:
+          - http://localhost:5010
+
+  linux:
+    variables:
+      serverAddress: "{{ linuxIp }}"
+    jobs:
+      application:
+        endpoints:
+          - "{{ linuxEndpoint }}"
+        environmentVariables:
+          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          COR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
+          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          CORECLR_PROFILER_PATH: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so"
+          DD_DOTNET_TRACER_HOME: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
+          DD_INTEGRATIONS: "{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux/integrations.json"
+          DD_AGENT_HOST: "{{ controllerIp }}"
+          DD_TRACE_LOGGING_RATE: 6
+          DD_TRACE_DEBUG: 0
+        options:
+          requiredOperatingSystem: linux
+          requiredArchitecture: x64
+          buildFiles:
+          - "../../tracer-home-linux/**;{{ linuxProfilerPath }}/{{ commit_hash }}/tracer-home-linux"
+      load:
+        endpoints:
+          - http://localhost:5010
+
+  linux_arm64:
+    variables:
+      serverAddress: "{{ linuxArm64Ip }}"
+    jobs:
+      application:
+        endpoints:
+          - "{{ linuxArm64Endpoint }}"
+        environmentVariables:
+          COR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          COR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+          CORECLR_PROFILER: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+          CORECLR_PROFILER_PATH: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so"
+          DD_DOTNET_TRACER_HOME: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64"
+          DD_INTEGRATIONS: "{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64/integrations.json"
+          DD_AGENT_HOST: "{{ controllerIp }}"
+          DD_TRACE_LOGGING_RATE: 6
+          DD_TRACE_DEBUG: 0
+        options:
+          requiredOperatingSystem: linux
+          requiredArchitecture: arm64
+          buildFiles:
+          - "../../tracer-home-linux-arm64/**;{{ linuxArm64ProfilerPath }}/{{ commit_hash }}/tracer-home-linux-arm64"
+      load:
+        endpoints:
+          - http://localhost:5010

--- a/build/crank/run.sh
+++ b/build/crank/run.sh
@@ -62,3 +62,35 @@ rm baseline_linux_arm64.json
 crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --output calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_linux_arm64.json"
 rm calltarget_linux_arm64.json
+
+
+#appsec
+
+
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_baseline --profile windows --json appsec_baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=appsec_baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_baseline_windows.json"
+rm appsec_baseline_windows.json
+
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noblocking --profile windows --json appsec_baseline_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_noblocking --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_noblocking_windows.json"
+rm appsec_noblocking_windows.json
+
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_withblocking --profile windows --json appsec_withblocking_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_withblocking --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_withblocking_windows.json"
+rm appsec_withblocking_windows.json
+
+
+
+
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_baseline --profile linux --json appsec_baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_baseline_linux.json"
+rm appsec_baseline_linux.json
+
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noblocking --profile linux --json appsec_baseline_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_noblocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_noblocking_linux.json"
+rm appsec_noblocking_linux.json
+
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_withblocking --profile linux --json appsec_withblocking_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_withblocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_withblocking_linux.json"
+rm appsec_withblocking_linux.json
+

--- a/build/crank/run.sh
+++ b/build/crank/run.sh
@@ -24,73 +24,67 @@ echo "Using repo=$repo commit=$commit_sha"
 repository="--application.source.repository $repo"
 commit="--application.source.branchOrCommit #$commit_sha"
 
+#windows 
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --output baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="baseline_windows.json"
 rm baseline_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile windows --output calltarget_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile windows --json calltarget_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_windows.json"
 rm calltarget_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --output calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --json calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_ngen_windows.json"
 rm calltarget_ngen_windows.json
 
 
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noattack --profile windows --json appsec_noattack_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=appsec_noattack --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_noattack_windows.json"
+rm appsec_noattack_windows.json
 
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_attack_noblocking --profile windows --json appsec_attack_noblocking_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_attack_noblocking --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_attack_noblocking_windows.json"
+rm appsec_attack_noblocking_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --output baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_attack_blocking --profile windows --json appsec_attack_blocking_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_attack_blocking --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_attack_blocking_windows.json"
+rm appsec_attack_blocking_windows.json
+
+#linux 
+
+crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="baseline_linux.json"
 rm baseline_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux --output calltarget_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux --json calltarget_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_linux.json"
 rm calltarget_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --output calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_ngen_linux.json"
 rm calltarget_ngen_linux.json
 
 
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noattack --profile linux --json appsec_noattack_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_noattack --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_noattack_linux.json"
+rm appsec_noattack_linux.json
 
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_attack_noblocking --profile linux --json appsec_attack_noblocking_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_attack_noblocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_attack_noblocking_linux.json"
+rm appsec_attack_noblocking_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --output baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_attack_blocking --profile linux --json appsec_attack_blocking_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_attack_blocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+dd-trace --crank-import="appsec_attack_blocking_linux.json"
+rm appsec_attack_blocking_linux.json
+
+#linux arm64
+
+crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="baseline_linux_arm64.json"
 rm baseline_linux_arm64.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --output calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --json calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
 dd-trace --crank-import="calltarget_linux_arm64.json"
 rm calltarget_linux_arm64.json
-
-
-#appsec
-
-
-crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_baseline --profile windows --json appsec_baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=appsec_baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="appsec_baseline_windows.json"
-rm appsec_baseline_windows.json
-
-crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noblocking --profile windows --json appsec_baseline_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_noblocking --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="appsec_noblocking_windows.json"
-rm appsec_noblocking_windows.json
-
-crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_withblocking --profile windows --json appsec_withblocking_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_withblocking --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="appsec_withblocking_windows.json"
-rm appsec_withblocking_windows.json
-
-
-
-
-crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_baseline --profile linux --json appsec_baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="appsec_baseline_linux.json"
-rm appsec_baseline_linux.json
-
-crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_noblocking --profile linux --json appsec_baseline_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_noblocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="appsec_noblocking_linux.json"
-rm appsec_noblocking_linux.json
-
-crank --config Security.Samples.AspNetCoreSimpleController.yml --scenario appsec_withblocking --profile linux --json appsec_withblocking_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=appsec_withblocking --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="appsec_withblocking_linux.json"
-rm appsec_withblocking_linux.json
 


### PR DESCRIPTION
Changes proposed in this pull request:
3 Crank scenarios under windows and linux:
- with security without attack
- with attack with security without blocking
- with attack with security with blocking 

Update from -output to -json cli argument
Change name from Linux to generic Throughput since it does all environments 
Imports os platforms to share environments between scenarios

Related to https://datadoghq.atlassian.net/browse/APPSEC-930

@DataDog/apm-dotnet