### PR TITLE
Proxy calls to dl

### DIFF
--- a/build/_build/Build.Utilities.cs
+++ b/build/_build/Build.Utilities.cs
@@ -118,23 +118,30 @@ partial class Build
         .Description("Builds and runs a sample app using dotnet run, enabling profiling.")
         .Requires(() => SampleName)
         .Requires(() => Framework)
-        .Requires(() => IsWin)
         .Executes(() =>
         {
             var envVars = new Dictionary<string,string>()
             {
                 {"COR_ENABLE_PROFILING", "1"},
                 {"COR_PROFILER", "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"},
-                {"COR_PROFILER_PATH_32", TracerHomeDirectory / "win-x86" / "Datadog.Trace.ClrProfiler.Native.dll" },
-                {"COR_PROFILER_PATH_64", TracerHomeDirectory / "win-x64" / "Datadog.Trace.ClrProfiler.Native.dll" },
+                {"COR_PROFILER_PATH_32", TracerHomeDirectory / "win-x86" / "Datadog.Trace.ClrProfiler.Native.dll"},
+                {"COR_PROFILER_PATH_64", TracerHomeDirectory / "win-x64" / "Datadog.Trace.ClrProfiler.Native.dll"},
                 {"CORECLR_ENABLE_PROFILING", "1"},
                 {"CORECLR_PROFILER", "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"},
-                {"CORECLR_PROFILER_PATH_32", TracerHomeDirectory / "win-x86" / "Datadog.Trace.ClrProfiler.Native.dll" },
-                {"CORECLR_PROFILER_PATH_64", TracerHomeDirectory / "win-x64" / "Datadog.Trace.ClrProfiler.Native.dll" },
                 {"DD_INTEGRATIONS", TracerHomeDirectory / "integrations.json" },
                 {"DD_DOTNET_TRACER_HOME", TracerHomeDirectory },
                 {"ASPNETCORE_URLS", "https://*:5003" },
             };
+
+            if (IsWin)
+            {
+                envVars.Add("CORECLR_PROFILER_PATH_32", TracerHomeDirectory / "win-x86" / "Datadog.Trace.ClrProfiler.Native.dll");
+                envVars.Add("CORECLR_PROFILER_PATH_64", TracerHomeDirectory / "win-x64" / "Datadog.Trace.ClrProfiler.Native.dll");
+            }
+            else
+            {
+                envVars.Add("CORECLR_PROFILER_PATH", TracerHomeDirectory / "Datadog.Trace.ClrProfiler.Native.so");
+            }
 
             if (ExtraEnvVars?.Length > 0)
             {

--- a/build_in_docker.sh
+++ b/build_in_docker.sh
@@ -19,5 +19,7 @@ docker run -it --rm \
     --env NugetPackageDirectory=/project/packages \
     --env tracerHome=/project/bin/tracer-home \
     --env artifacts=/project/bin/artifacts \
+    -p 5003:5003 \
+    -v /ddlogs:/var/log/datadog/dotnet \
     $IMAGE_NAME \
     dotnet /build/bin/Debug/_build.dll "$@"

--- a/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -253,11 +253,13 @@ if (ISMACOS)
     target_link_libraries("Datadog.Trace.ClrProfiler.Native.static"
         ${OUTPUT_DEPS_DIR}/re2/obj/libre2.a
         ${OUTPUT_DEPS_DIR}/fmt/libfmt.a
+        ${CMAKE_DL_LIBS}
     )
 elseif(ISLINUX)
     target_link_libraries("Datadog.Trace.ClrProfiler.Native.static"
         ${OUTPUT_DEPS_DIR}/re2/obj/libre2.a
         ${OUTPUT_DEPS_DIR}/fmt/libfmt.a
+        ${CMAKE_DL_LIBS}
         -static-libgcc
         -static-libstdc++
     )

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -422,7 +422,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
     return S_OK;
 }
 
-void STDMETHODCALLTYPE CorProfiler::RewritingPInvokeMaps(ComPtr<IUnknown> metadata_interfaces, ModuleMetadata* module_metadata, WSTRING nativemethods_type_name)
+void CorProfiler::RewritingPInvokeMaps(ComPtr<IUnknown> metadata_interfaces, ModuleMetadata* module_metadata, WSTRING nativemethods_type_name)
 {
     HRESULT hr;
     const auto metadata_import = metadata_interfaces.As<IMetaDataImport2>(IID_IMetaDataImport);

--- a/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -63,6 +63,7 @@ private:
     //
     // Helper methods
     //
+    void RewritingPInvokeMaps(ComPtr<IUnknown> metadata_interfaces, ModuleMetadata* module_metadata, WSTRING nativemethods_type_name);
     WSTRING GetCoreCLRProfilerPath();
     bool GetWrapperMethodRef(ModuleMetadata* module_metadata, ModuleID module_id,
                              const MethodReplacement& method_replacement, mdMemberRef& wrapper_method_ref,

--- a/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -70,6 +70,7 @@ const WSTRING managed_profiler_full_assembly_version =
 const WSTRING managed_profiler_name = WStr("Datadog.Trace");
 
 const WSTRING nonwindows_nativemethods_type = WStr("Datadog.Trace.ClrProfiler.NativeMethods+NonWindows");
+const WSTRING appsec_nonwindows_nativemethods_type = WStr("Datadog.Trace.AppSec.Waf.NativeBindings.NativeLibrary+NonWindows");
 
 const WSTRING calltarget_modification_action = WStr("CallTargetModification");
 

--- a/src/Datadog.Trace.ClrProfiler.Native/interop.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/interop.cpp
@@ -25,14 +25,12 @@ EXTERN_C VOID STDAPICALLTYPE GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, i
 }
 
 #ifndef _WIN32
-EXTERN_C void *dlopen (const char *__file, int __mode)
+EXTERN_C void *dddlopen (const char *__file, int __mode)
 {
-    trace::Logger::Debug("dlopen: __file: ", __file, " __mode:", __mode);
-
     return dlopen(__file, __mode);
 }
 
-EXTERN_C char *dlerror (void)
+EXTERN_C char *dddlerror (void)
 {
     auto errorPtr = dlerror();
 
@@ -44,10 +42,8 @@ EXTERN_C char *dlerror (void)
     return errorPtr;
 }
 
-EXTERN_C void *dlsym (void *__restrict __handle, const char *__restrict __name)
+EXTERN_C void *dddlsym (void *__restrict __handle, const char *__restrict __name)
 {
-    trace::Logger::Debug("dlsym: __handle: ", __handle, " __name: ", __name);
-
     return dlsym(__handle, __name);
 }
 #endif

--- a/src/Datadog.Trace.ClrProfiler.Native/interop.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/interop.cpp
@@ -8,6 +8,11 @@
 
 #include "cor_profiler.h"
 
+#ifndef _WIN32
+#include <dlfcn.h>
+#include "logger.h"
+#endif
+
 EXTERN_C BOOL STDAPICALLTYPE IsProfilerAttached()
 {
     return trace::profiler->IsAttached();
@@ -18,3 +23,31 @@ EXTERN_C VOID STDAPICALLTYPE GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, i
 {
     return trace::profiler->GetAssemblyAndSymbolsBytes(pAssemblyArray, assemblySize, pSymbolsArray, symbolsSize);
 }
+
+#ifndef _WIN32
+EXTERN_C void *dlopen (const char *__file, int __mode)
+{
+    trace::Logger::Debug("dlopen: __file: ", __file, " __mode:", __mode);
+
+    return dlopen(__file, __mode);
+}
+
+EXTERN_C char *dlerror (void)
+{
+    auto errorPtr = dlerror();
+
+    if (errorPtr)
+    {
+        trace::Logger::Error("dlerror: ", errorPtr);
+    }
+    
+    return errorPtr;
+}
+
+EXTERN_C void *dlsym (void *__restrict __handle, const char *__restrict __name)
+{
+    trace::Logger::Debug("dlsym: __handle: ", __handle, " __name: ", __name);
+
+    return dlsym(__handle, __name);
+}
+#endif

--- a/src/Datadog.Trace/AppSec/Security.cs
+++ b/src/Datadog.Trace/AppSec/Security.cs
@@ -196,8 +196,12 @@ namespace Datadog.Trace.AppSec
 
         private void RunShutdown()
         {
-            _agentWriter.Shutdown();
-            _instrumentationGateway.InstrumentationGatewayEvent -= InstrumentationGatewayInstrumentationGatewayEvent;
+            _agentWriter?.Shutdown();
+            if (_instrumentationGateway != null)
+            {
+                _instrumentationGateway.InstrumentationGatewayEvent -= InstrumentationGatewayInstrumentationGatewayEvent;
+            }
+
             Dispose();
         }
 

--- a/src/Datadog.Trace/AppSec/Waf/NativeBindings/Native.cs
+++ b/src/Datadog.Trace/AppSec/Waf/NativeBindings/Native.cs
@@ -213,8 +213,9 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         private static T GetDelegateForNativeFunction<T>(IntPtr handle, string functionName)
             where T : Delegate
         {
-            var initHPtr = NativeLibrary.GetExport(handle, functionName);
-            return (T)Marshal.GetDelegateForFunctionPointer(initHPtr, typeof(T));
+            var funcPtr = NativeLibrary.GetExport(handle, functionName);
+            Log.Debug("GetDelegateForNativeFunction -  funcPtr: " + funcPtr);
+            return (T)Marshal.GetDelegateForFunctionPointer(funcPtr, typeof(T));
         }
 
         private static List<string> GetDatadogNativeFolders(FrameworkDescription frameworkDescription, string runtimeId)
@@ -319,7 +320,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                 if (loaded)
                 {
                     success = true;
-                    Log.Information($"Loaded library '{libName}' from '{path}'");
+                    Log.Information($"Loaded library '{libName}' from '{path}' with handle '{handle}'");
                     break;
                 }
                 else

--- a/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
+++ b/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         {
             if (isPosixLike)
             {
-                var exportPtr = dddlsym(handle, name);
+                var exportPtr = NonWindows.dddlsym(handle, name);
                 ReadDlerror("dddlsym");
                 return exportPtr;
             }
@@ -59,7 +59,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         private static IntPtr LoadPosixLibrary(string path)
         {
             const int RTLD_NOW = 2;
-            var addr = dddlopen(path, RTLD_NOW);
+            var addr = NonWindows.dddlopen(path, RTLD_NOW);
             ReadDlerror("dddlopen");
 
             return addr;
@@ -67,7 +67,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
 
         private static void ReadDlerror(string op)
         {
-            var errorPtr = dddlerror();
+            var errorPtr = NonWindows.dddlerror();
             if (errorPtr != IntPtr.Zero)
             {
                 var error = Marshal.PtrToStringAnsi(errorPtr);
@@ -76,20 +76,22 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         }
 
 #pragma warning disable SA1300 // Element should begin with upper-case letter
-
-        [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        private static extern IntPtr dddlopen(string fileName, int flags);
-
-        [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        private static extern IntPtr dddlerror();
-
-        [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        private static extern IntPtr dddlsym(IntPtr hModule, string lpProcName);
-
         [DllImport("kernel32.dll")]
         private static extern IntPtr LoadLibrary(string dllToLoad);
 
         [DllImport("Kernel32.dll")]
         private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+
+        private static class NonWindows
+        {
+            [DllImport("Datadog.Trace.ClrProfiler.Native")]
+            internal static extern IntPtr dddlopen(string fileName, int flags);
+
+            [DllImport("Datadog.Trace.ClrProfiler.Native")]
+            internal static extern IntPtr dddlerror();
+
+            [DllImport("Datadog.Trace.ClrProfiler.Native")]
+            internal static extern IntPtr dddlsym(IntPtr hModule, string lpProcName);
+        }
     }
 }

--- a/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
+++ b/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
@@ -46,8 +46,8 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         {
             if (isPosixLike)
             {
-                var exportPtr = dlsym(handle, name);
-                ReadDlerror("dlsym");
+                var exportPtr = dddlsym(handle, name);
+                ReadDlerror("dddlsym");
                 return exportPtr;
             }
             else
@@ -59,15 +59,15 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
         private static IntPtr LoadPosixLibrary(string path)
         {
             const int RTLD_NOW = 2;
-            var addr = dlopen(path, RTLD_NOW);
-            ReadDlerror("dlopen");
+            var addr = dddlopen(path, RTLD_NOW);
+            ReadDlerror("dddlopen");
 
             return addr;
         }
 
         private static void ReadDlerror(string op)
         {
-            var errorPtr = dlerror();
+            var errorPtr = dddlerror();
             if (errorPtr != IntPtr.Zero)
             {
                 var error = Marshal.PtrToStringAnsi(errorPtr);
@@ -78,13 +78,13 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
 #pragma warning disable SA1300 // Element should begin with upper-case letter
 
         [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        private static extern IntPtr dlopen(string fileName, int flags);
+        private static extern IntPtr dddlopen(string fileName, int flags);
 
         [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        private static extern IntPtr dlerror();
+        private static extern IntPtr dddlerror();
 
         [DllImport("Datadog.Trace.ClrProfiler.Native")]
-        private static extern IntPtr dlsym(IntPtr hModule, string lpProcName);
+        private static extern IntPtr dddlsym(IntPtr hModule, string lpProcName);
 
         [DllImport("kernel32.dll")]
         private static extern IntPtr LoadLibrary(string dllToLoad);


### PR DESCRIPTION
Some Linux distros don't have a version of libdl.so without a version prefix. Call from manage code will fail to
find the library on these distros. Proxying via a C++ library should cure this, because the C libraries will
handle loading in this case.

Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet