### PR TITLE
Prepare `/shared` folder for consumption by the Profiler.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -3,6 +3,6 @@ Datadog
 
 (dd-trace-dotnet)
 
-Copyright 2017-2021 Datadog, Inc.
+Copyright 2017 Datadog, Inc.
 
 This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/profiler/README.MD
+++ b/profiler/README.MD
@@ -11,7 +11,7 @@ Copyright (c) 2017-2021 Datadog
 
 ### License
 
-See [license information](./LICENSE).
+See [license information](../LICENSE).
 
 ## Note
 

--- a/shared/README.md
+++ b/shared/README.md
@@ -11,4 +11,4 @@ Copyright (c) 2017-2021 Datadog
 
 ### License
 
-See [license information](./LICENSE).
+See [license information](../LICENSE).

--- a/shared/src/Shared-Src/README.MD
+++ b/shared/src/Shared-Src/README.MD
@@ -3,6 +3,6 @@
 One of the reasons for doing it is to share the implementation across projects for APIs that should
 not be public and therefore cannot be grouped into a separate shared assembly.
 
-Formanaged code, the subdirectories here carry the name of the respective namespaces.
+For managed code, the subdirectories here carry the name of the respective namespaces.
 E.g. all classes in a namespace `Datadog.AutoInstrumentation.Util` must be
 placed in a subdirectory with the same name.

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -11,7 +11,7 @@ Copyright (c) 2017-2021 Datadog
 
 ### License
 
-See [license information](./LICENSE).
+See [license information](../LICENSE).
 
 ## Note
 


### PR DESCRIPTION
(Work in progress)

This change moves some directories around so that they can be consumed by the profiler.