### PR TITLE
Don't cache the process instance for runtime metrics

### DIFF
--- a/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -6,14 +6,11 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Datadog.Trace.Util
 {
     internal static class ProcessHelpers
     {
-        private static Process _currentProcess;
-
         /// <summary>
         /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.ProcessName"/>
         ///
@@ -72,33 +69,12 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long privateMemorySize)
         {
-            var process = Volatile.Read(ref _currentProcess);
+            using var process = Process.GetCurrentProcess();
 
-            if (process == null)
-            {
-                process = Process.GetCurrentProcess();
-
-                var oldProcess = Interlocked.CompareExchange(ref _currentProcess, process, null);
-
-                if (oldProcess != null)
-                {
-                    // This thread lost the race
-                    process.Dispose();
-                    process = oldProcess;
-                }
-            }
-
-            lock (process)
-            {
-                // Bad things will happen if a thread read process information while another refreshes it
-                // so we make sure to refresh from inside of the lock
-                process.Refresh();
-
-                userProcessorTime = process.UserProcessorTime;
-                systemCpuTime = process.PrivilegedProcessorTime;
-                threadCount = process.Threads.Count;
-                privateMemorySize = process.PrivateMemorySize64;
-            }
+            userProcessorTime = process.UserProcessorTime;
+            systemCpuTime = process.PrivilegedProcessorTime;
+            threadCount = process.Threads.Count;
+            privateMemorySize = process.PrivateMemorySize64;
         }
     }
 }


### PR DESCRIPTION
A textbook case of premature optimization. Keeping the process instance doesn't save much (almost everything is recomputed when calling `Refresh`), yet adds significant memory pressure on applications with a large number of appdomains and threads.