### PR TITLE
Use AppDomain.CurrentDomain.BaseDirectory to get current directory for configuration

### DIFF
--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -155,39 +155,7 @@ namespace Datadog.Trace.Configuration
 
         private static string GetCurrentDirectory()
         {
-            try
-            {
-                // Entering TryLoadHostingEnvironmentPath and accessing System.Web.dll
-                // will immediately throw an exception in partial trust scenarios,
-                // so surround this call by a try/catch block
-                if (TryLoadHostingEnvironmentPath(out var hostingPath))
-                {
-                    return hostingPath;
-                }
-            }
-            catch (Exception)
-            {
-                // The configuration manager should not depend on a logger being bootstrapped yet
-                // so do not do anything
-            }
-
-            return System.Environment.CurrentDirectory;
-        }
-
-        private static bool TryLoadHostingEnvironmentPath(out string hostingPath)
-        {
-#if NETFRAMEWORK
-            // on .NET Framework only, use application's root folder
-            // as default path when looking for datadog.json
-            if (System.Web.Hosting.HostingEnvironment.IsHosted)
-            {
-                hostingPath = System.Web.Hosting.HostingEnvironment.MapPath("~");
-                return true;
-            }
-
-#endif
-            hostingPath = default;
-            return false;
+            return System.AppDomain.CurrentDomain.BaseDirectory;
         }
     }
 }


### PR DESCRIPTION
`Environment.CurrentDirectory()` does not necessarily point to the directory containing the application. being run The most obvious example is Windows Services, where Environment.CurrentDirectory points to `C:\Windows\System32`

Using `AppDomain.CurrentDomain.BaseDirectory` seems to be a better (and safer) alternative, as it points to the original assembly probing directory.

Tested the following scenarios, and they behave as expected
* asp.net sites,  (iis express + iis)
* asp.net in a virtual directory ((iis express + iis)
* Owin self hosted
* Owin hosted in a windows service
* ASP.NET Core app hosted in iis
* `dotnet run` on an asp.net core app (returns the bin directory, whereas Environment.CurrentDirectory returns the app directory/content root)
* `dotnet dll`/running .exe directly. Returns app directory instead of the console's current directory (e.g. if entering full path to exe)

As a minor benefit, we no longer need to call `System.Web.Hosting.HostingEnvironment.IsHosted`, which avoids forcing System.Web.dll to be loaded