### PR TITLE
Synchronously wait for tasks in HttpClient sample

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -182,8 +182,6 @@ namespace Samples.HttpMessageHandler
                 {
                     var context = listener.GetContext();
 
-                    Thread.Sleep(100);
-
                     Console.WriteLine("[HttpListener] received request");
 
                     // read request content and headers

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -38,7 +38,7 @@ namespace Samples.HttpMessageHandler
                 Console.WriteLine("Sending async request with default HttpClient.");
                 using (var client = new HttpClient())
                 {
-                    await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
                 }
 
                 // send async http requests using HttpClient with CustomHandler
@@ -46,7 +46,7 @@ namespace Samples.HttpMessageHandler
                 Console.WriteLine("Sending async request with HttpClient(CustomHandler).");
                 using (var client = new HttpClient(new CustomHandler()))
                 {
-                    await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
                 }
 
 #if !NET452
@@ -57,7 +57,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Sending async request with HttpClient(WinHttpHandler).");
                     using (var client = new HttpClient(new WinHttpHandler()))
                     {
-                        await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                        RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
                     }
                 }
 #endif
@@ -68,7 +68,7 @@ namespace Samples.HttpMessageHandler
                 Console.WriteLine("Sending async request with HttpClient(SocketsHttpHandler).");
                 using (var client = new HttpClient(new SocketsHttpHandler()))
                 {
-                    await RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
                 }
 #endif
 

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -40,7 +40,7 @@ namespace Samples.HttpMessageHandler
                 Console.WriteLine("Sending async request with default HttpClient.");
                 using (var client = new HttpClient())
                 {
-                    RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    RequestHelpers.SendAsyncHttpClientRequests(client, tracingDisabled, Url, RequestContent);
                 }
 
                 // send async http requests using HttpClient with CustomHandler
@@ -48,7 +48,7 @@ namespace Samples.HttpMessageHandler
                 Console.WriteLine("Sending async request with HttpClient(CustomHandler).");
                 using (var client = new HttpClient(new CustomHandler()))
                 {
-                    RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    RequestHelpers.SendAsyncHttpClientRequests(client, tracingDisabled, Url, RequestContent);
                 }
 
 #if !NET452
@@ -59,7 +59,7 @@ namespace Samples.HttpMessageHandler
                     Console.WriteLine("Sending async request with HttpClient(WinHttpHandler).");
                     using (var client = new HttpClient(new WinHttpHandler()))
                     {
-                        RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                        RequestHelpers.SendAsyncHttpClientRequests(client, tracingDisabled, Url, RequestContent);
                     }
                 }
 #endif
@@ -70,7 +70,7 @@ namespace Samples.HttpMessageHandler
                 Console.WriteLine("Sending async request with HttpClient(SocketsHttpHandler).");
                 using (var client = new HttpClient(new SocketsHttpHandler()))
                 {
-                    RequestHelpers.SendHttpClientRequestsAsync(client, tracingDisabled, Url, RequestContent);
+                    RequestHelpers.SendAsyncHttpClientRequests(client, tracingDisabled, Url, RequestContent);
                 }
 #endif
 

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Program.cs
@@ -20,7 +20,9 @@ namespace Samples.HttpMessageHandler
 
         private static string Url;
 
+#pragma warning disable 1998
         public static async Task Main(string[] args)
+#pragma warning restore 1998
         {
             bool tracingDisabled = args.Any(arg => arg.Equals("TracingDisabled", StringComparison.OrdinalIgnoreCase));
             Console.WriteLine($"TracingDisabled {tracingDisabled}");
@@ -179,6 +181,8 @@ namespace Samples.HttpMessageHandler
                 try
                 {
                     var context = listener.GetContext();
+
+                    Thread.Sleep(100);
 
                     Console.WriteLine("[HttpListener] received request");
 

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Diagnostics;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Net.Http;
 using System.Text;
@@ -13,155 +13,162 @@ namespace Samples.HttpMessageHandler
     {
         private static readonly Encoding Utf8 = Encoding.UTF8;
 
-        public static async Task SendHttpClientRequestsAsync(HttpClient client, bool tracingDisabled, string url, string requestContent)
+        public static void SendHttpClientRequestsAsync(HttpClient client, bool tracingDisabled, string url, string requestContent)
         {
-            // Insert a call to the Tracer.Instance to include an AssemblyRef to Datadog.Trace assembly in the final executable
-            Console.WriteLine($"[HttpClient] sending requests to {url}");
-
-            if (tracingDisabled)
+            void Invoke()
             {
-                client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
-            }
+                // Insert a call to the Tracer.Instance to include an AssemblyRef to Datadog.Trace assembly in the final executable
+                Console.WriteLine($"[HttpClient] sending requests to {url}");
 
-            using (Tracer.Instance.StartActive("HttpClientRequestAsync"))
-            {
-                using (Tracer.Instance.StartActive("DeleteAsync"))
+                if (tracingDisabled)
                 {
-                    await client.DeleteAsync(url);
-                    Console.WriteLine("Received response for client.DeleteAsync(String)");
-
-                    await client.DeleteAsync(new Uri(url));
-                    Console.WriteLine("Received response for client.DeleteAsync(Uri)");
-
-                    await client.DeleteAsync(url, CancellationToken.None);
-                    Console.WriteLine("Received response for client.DeleteAsync(String, CancellationToken)");
-
-                    await client.DeleteAsync(new Uri(url), CancellationToken.None);
-                    Console.WriteLine("Received response for client.DeleteAsync(Uri, CancellationToken)");
+                    client.DefaultRequestHeaders.Add(HttpHeaderNames.TracingEnabled, "false");
                 }
 
-                using (Tracer.Instance.StartActive("GetAsync"))
+                using (Tracer.Instance.StartActive("HttpClientRequestAsync"))
                 {
-                    await client.GetAsync(url);
-                    Console.WriteLine("Received response for client.GetAsync(String)");
+                    using (Tracer.Instance.StartActive("DeleteAsync"))
+                    {
+                        client.DeleteAsync(url).Wait();
+                        Console.WriteLine("Received response for client.DeleteAsync(String)");
 
-                    await client.GetAsync(new Uri(url));
-                    Console.WriteLine("Received response for client.GetAsync(Uri)");
+                        client.DeleteAsync(new Uri(url)).Wait();
+                        Console.WriteLine("Received response for client.DeleteAsync(Uri)");
 
-                    await client.GetAsync(url, CancellationToken.None);
-                    Console.WriteLine("Received response for client.GetAsync(String, CancellationToken)");
+                        client.DeleteAsync(url, CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.DeleteAsync(String, CancellationToken)");
 
-                    await client.GetAsync(new Uri(url), CancellationToken.None);
-                    Console.WriteLine("Received response for client.GetAsync(Uri, CancellationToken)");
+                        client.DeleteAsync(new Uri(url), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.DeleteAsync(Uri, CancellationToken)");
+                    }
 
-                    await client.GetAsync(url, HttpCompletionOption.ResponseContentRead);
-                    Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption)");
+                    using (Tracer.Instance.StartActive("GetAsync"))
+                    {
+                        client.GetAsync(url).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(String)");
 
-                    await client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead);
-                    Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption)");
+                        client.GetAsync(new Uri(url)).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(Uri)");
 
-                    await client.GetAsync(url, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                    Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption, CancellationToken)");
+                        client.GetAsync(url, CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(String, CancellationToken)");
 
-                    await client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                    Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption, CancellationToken)");
-                }
+                        client.GetAsync(new Uri(url), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(Uri, CancellationToken)");
 
-                using (Tracer.Instance.StartActive("GetByteArrayAsync"))
-                {
-                    await client.GetByteArrayAsync(url);
-                    Console.WriteLine("Received response for client.GetByteArrayAsync(String)");
+                        client.GetAsync(url, HttpCompletionOption.ResponseContentRead).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption)");
 
-                    await client.GetByteArrayAsync(new Uri(url));
-                    Console.WriteLine("Received response for client.GetByteArrayAsync(Uri)");
-                }
+                        client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption)");
 
-                using (Tracer.Instance.StartActive("GetStreamAsync"))
-                {
-                    using Stream stream1 = await client.GetStreamAsync(url);
-                    Console.WriteLine("Received response for client.GetStreamAsync(String)");
+                        client.GetAsync(url, HttpCompletionOption.ResponseContentRead, CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(String, HttpCompletionOption, CancellationToken)");
 
-                    using Stream stream2 = await client.GetStreamAsync(new Uri(url));
-                    Console.WriteLine("Received response for client.GetStreamAsync(Uri)");
-                }
+                        client.GetAsync(new Uri(url), HttpCompletionOption.ResponseContentRead, CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.GetAsync(Uri, HttpCompletionOption, CancellationToken)");
+                    }
 
-                using (Tracer.Instance.StartActive("GetStringAsync"))
-                {
-                    await client.GetStringAsync(url);
-                    Console.WriteLine("Received response for client.GetStringAsync(String)");
+                    using (Tracer.Instance.StartActive("GetByteArrayAsync"))
+                    {
+                        client.GetByteArrayAsync(url).Wait();
+                        Console.WriteLine("Received response for client.GetByteArrayAsync(String)");
 
-                    await client.GetStringAsync(new Uri(url));
-                    Console.WriteLine("Received response for client.GetStringAsync(Uri)");
-                }
+                        client.GetByteArrayAsync(new Uri(url)).Wait();
+                        Console.WriteLine("Received response for client.GetByteArrayAsync(Uri)");
+                    }
+
+                    using (Tracer.Instance.StartActive("GetStreamAsync"))
+                    {
+                        using Stream stream1 = client.GetStreamAsync(url).Result;
+                        Console.WriteLine("Received response for client.GetStreamAsync(String)");
+
+                        using Stream stream2 = client.GetStreamAsync(new Uri(url)).Result;
+                        Console.WriteLine("Received response for client.GetStreamAsync(Uri)");
+                    }
+
+                    using (Tracer.Instance.StartActive("GetStringAsync"))
+                    {
+                        client.GetStringAsync(url).Wait();
+                        Console.WriteLine("Received response for client.GetStringAsync(String)");
+
+                        client.GetStringAsync(new Uri(url)).Wait();
+                        Console.WriteLine("Received response for client.GetStringAsync(Uri)");
+                    }
 
 #if NETCOREAPP
-                using (Tracer.Instance.StartActive("PatchAsync"))
-                {
-                    await client.PatchAsync(url, new StringContent(requestContent, Utf8));
-                    Console.WriteLine("Received response for client.PatchAsync(String, HttpContent)");
+                    using (Tracer.Instance.StartActive("PatchAsync"))
+                    {
+                        client.PatchAsync(url, new StringContent(requestContent, Utf8)).Wait();
+                        Console.WriteLine("Received response for client.PatchAsync(String, HttpContent)");
 
-                    await client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8));
-                    Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent)");
+                        client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8)).Wait();
+                        Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent)");
 
-                    await client.PatchAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
-                    Console.WriteLine("Received response for client.PatchAsync(String, HttpContent, CancellationToken)");
+                        client.PatchAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.PatchAsync(String, HttpContent, CancellationToken)");
 
-                    await client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
-                    Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent, CancellationToken)");
-                }
+                        client.PatchAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.PatchAsync(Uri, HttpContent, CancellationToken)");
+                    }
 
 #endif
-                using (Tracer.Instance.StartActive("PostAsync"))
-                {
-                    await client.PostAsync(url, new StringContent(requestContent, Utf8));
-                    Console.WriteLine("Received response for client.PostAsync(String, HttpContent)");
+                    using (Tracer.Instance.StartActive("PostAsync"))
+                    {
+                        client.PostAsync(url, new StringContent(requestContent, Utf8)).Wait();
+                        Console.WriteLine("Received response for client.PostAsync(String, HttpContent)");
 
-                    await client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8));
-                    Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent)");
+                        client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8)).Wait();
+                        Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent)");
 
-                    await client.PostAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
-                    Console.WriteLine("Received response for client.PostAsync(String, HttpContent, CancellationToken)");
+                        client.PostAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.PostAsync(String, HttpContent, CancellationToken)");
 
-                    await client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
-                    Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent, CancellationToken)");
-                }
+                        client.PostAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.PostAsync(Uri, HttpContent, CancellationToken)");
+                    }
 
-                using (Tracer.Instance.StartActive("PutAsync"))
-                {
-                    await client.PutAsync(url, new StringContent(requestContent, Utf8));
-                    Console.WriteLine("Received response for client.PutAsync(String, HttpContent)");
+                    using (Tracer.Instance.StartActive("PutAsync"))
+                    {
+                        client.PutAsync(url, new StringContent(requestContent, Utf8)).Wait();
+                        Console.WriteLine("Received response for client.PutAsync(String, HttpContent)");
 
-                    await client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8));
-                    Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent)");
+                        client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8)).Wait();
+                        Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent)");
 
-                    await client.PutAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None);
-                    Console.WriteLine("Received response for client.PutAsync(String, HttpContent, CancellationToken)");
+                        client.PutAsync(url, new StringContent(requestContent, Utf8), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.PutAsync(String, HttpContent, CancellationToken)");
 
-                    await client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None);
-                    Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent, CancellationToken)");
-                }
+                        client.PutAsync(new Uri(url), new StringContent(requestContent, Utf8), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.PutAsync(Uri, HttpContent, CancellationToken)");
+                    }
 
-                using (Tracer.Instance.StartActive("SendAsync"))
-                {
-                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url));
-                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage)");
+                    using (Tracer.Instance.StartActive("SendAsync"))
+                    {
+                        client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url)).Wait();
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage)");
 
-                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None);
-                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, CancellationToken)");
+                        client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, CancellationToken)");
 
-                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead);
-                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption)");
+                        client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead).Wait();
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption)");
 
-                    await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None);
-                    Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
-                }
+                        client.SendAsync(new HttpRequestMessage(HttpMethod.Get, url), HttpCompletionOption.ResponseContentRead, CancellationToken.None).Wait();
+                        Console.WriteLine("Received response for client.SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken)");
+                    }
 
-                using (Tracer.Instance.StartActive("ErrorSpanBelow"))
-                {
-                    await client.GetAsync($"{url}HttpErrorCode");
-                    Console.WriteLine("Received response for client.GetAsync Error Span");
+                    using (Tracer.Instance.StartActive("ErrorSpanBelow"))
+                    {
+                        client.GetAsync($"{url}HttpErrorCode").Wait();
+                        Console.WriteLine("Received response for client.GetAsync Error Span");
+                    }
                 }
             }
+
+            // Wait for the tasks in a single threaded synchronization context, to detect potential deadlocks
+            var synchronizationContext = new SingleThreadedSynchronizationContext();
+            synchronizationContext.Send(_ => Invoke(), null);
         }
 
 #if NET5_0
@@ -277,6 +284,43 @@ namespace Samples.HttpMessageHandler
 
             Console.WriteLine("Received response for HttpMessageInvoker.SendAsync");
             await invoker.SendAsync(httpRequest, CancellationToken.None);
+        }
+
+        private class SingleThreadedSynchronizationContext : SynchronizationContext
+        {
+            private readonly BlockingCollection<Action> _callbacks;
+
+            public SingleThreadedSynchronizationContext()
+            {
+                _callbacks = new BlockingCollection<Action>();
+
+                Task.Run(
+                    () =>
+                    {
+                        foreach (var item in _callbacks.GetConsumingEnumerable())
+                        {
+                            item();
+                        }
+                    });
+            }
+
+            public override void Post(SendOrPostCallback d, object state)
+            {
+                _callbacks.Add(() => d(state));
+            }
+
+            public override void Send(SendOrPostCallback d, object state)
+            {
+                using var mutex = new ManualResetEventSlim();
+
+                _callbacks.Add(() =>
+                {
+                    d(state);
+                    mutex.Set();
+                });
+
+                mutex.Wait();
+            }
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/RequestHelpers.cs
@@ -13,7 +13,7 @@ namespace Samples.HttpMessageHandler
     {
         private static readonly Encoding Utf8 = Encoding.UTF8;
 
-        public static void SendHttpClientRequestsAsync(HttpClient client, bool tracingDisabled, string url, string requestContent)
+        public static void SendAsyncHttpClientRequests(HttpClient client, bool tracingDisabled, string url, string requestContent)
         {
             void Invoke()
             {
@@ -168,7 +168,9 @@ namespace Samples.HttpMessageHandler
 
             // Wait for the tasks in a single threaded synchronization context, to detect potential deadlocks
             var synchronizationContext = new SingleThreadedSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
             synchronizationContext.Send(_ => Invoke(), null);
+            SynchronizationContext.SetSynchronizationContext(null);
         }
 
 #if NET5_0


### PR DESCRIPTION
This is done to detect future regression of https://github.com/DataDog/dd-trace-dotnet/pull/1702

I'm first making sure that the test indeed deadlocks, then I'll rebase on top of the fix.