### PR TITLE
Prepare hotfixes for 1.28.4, based on 1.28.2

### DIFF
--- a/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -78,6 +78,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         /// <param name="exception">Exception instance in case the original code threw an exception.</param>
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
+        [PreserveContext]
         public static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse responseMessage, Exception exception, CallTargetState state)
         {
             var scope = state.Scope;

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/NoThrowAwaiter.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/NoThrowAwaiter.cs
@@ -13,10 +13,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
     internal struct NoThrowAwaiter : ICriticalNotifyCompletion
     {
         private readonly Task _task;
+        private readonly bool _preserveContext;
 
-        public NoThrowAwaiter(Task task)
+        public NoThrowAwaiter(Task task, bool preserveContext)
         {
             _task = task;
+            _preserveContext = preserveContext;
         }
 
         public bool IsCompleted => _task.IsCompleted;
@@ -27,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
         {
         }
 
-        public void OnCompleted(Action continuation) => _task.GetAwaiter().OnCompleted(continuation);
+        public void OnCompleted(Action continuation) => _task.ConfigureAwait(_preserveContext).GetAwaiter().OnCompleted(continuation);
 
         public void UnsafeOnCompleted(Action continuation) => OnCompleted(continuation);
     }

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/Continuations/ValueTaskContinuationGenerator`1.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Reflection.Emit;
 using System.Threading.Tasks;
 #pragma warning disable SA1649 // File name must match first type name
 
@@ -14,13 +13,15 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
     internal class ValueTaskContinuationGenerator<TIntegration, TTarget, TReturn, TResult> : ContinuationGenerator<TTarget, TReturn>
     {
         private static readonly Func<TTarget, TResult, Exception, CallTargetState, TResult> _continuation;
+        private static readonly bool _preserveContext;
 
         static ValueTaskContinuationGenerator()
         {
-            DynamicMethod continuationMethod = IntegrationMapper.CreateAsyncEndMethodDelegate(typeof(TIntegration), typeof(TTarget), typeof(TResult));
-            if (continuationMethod != null)
+            var result = IntegrationMapper.CreateAsyncEndMethodDelegate(typeof(TIntegration), typeof(TTarget), typeof(TResult));
+            if (result.Method != null)
             {
-                _continuation = (Func<TTarget, TResult, Exception, CallTargetState, TResult>)continuationMethod.CreateDelegate(typeof(Func<TTarget, TResult, Exception, CallTargetState, TResult>));
+                _continuation = (Func<TTarget, TResult, Exception, CallTargetState, TResult>)result.Method.CreateDelegate(typeof(Func<TTarget, TResult, Exception, CallTargetState, TResult>));
+                _preserveContext = result.PreserveContext;
             }
         }
 
@@ -45,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 TResult result = default;
                 try
                 {
-                    result = await previousValueTask;
+                    result = await previousValueTask.ConfigureAwait(_preserveContext);
                 }
                 catch (Exception ex)
                 {

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/CreateAsyncEndMethodResult.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/CreateAsyncEndMethodResult.cs
@@ -1,0 +1,21 @@
+// <copyright file="CreateAsyncEndMethodResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Reflection.Emit;
+
+namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
+{
+    internal readonly struct CreateAsyncEndMethodResult
+    {
+        public readonly DynamicMethod Method;
+        public readonly bool PreserveContext;
+
+        public CreateAsyncEndMethodResult(DynamicMethod method, bool preserveContext)
+        {
+            Method = method;
+            PreserveContext = preserveContext;
+        }
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationMapper.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/Handlers/IntegrationMapper.cs
@@ -509,7 +509,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             return callMethod;
         }
 
-        internal static DynamicMethod CreateAsyncEndMethodDelegate(Type integrationType, Type targetType, Type returnType)
+        internal static CreateAsyncEndMethodResult CreateAsyncEndMethodDelegate(Type integrationType, Type targetType, Type returnType)
         {
             /*
              * OnAsyncMethodEnd signatures with 3 or 4 parameters with 1 or 2 generics:
@@ -527,7 +527,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             if (onAsyncMethodEndMethodInfo is null)
             {
                 Log.Warning($"Couldn't find the method: {EndAsyncMethodName} in type: {integrationType.FullName}");
-                return null;
+                return default;
             }
 
             if (!onAsyncMethodEndMethodInfo.ReturnType.IsGenericParameter && onAsyncMethodEndMethodInfo.ReturnType != returnType)
@@ -560,6 +560,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 throw new ArgumentException($"The CallTargetState type parameter of the method: {EndAsyncMethodName} in type: {integrationType.FullName} is missing.");
             }
+
+            bool preserveContext = onAsyncMethodEndMethodInfo.GetCustomAttribute<PreserveContextAttribute>() != null;
 
             List<Type> callGenericTypes = new List<Type>();
 
@@ -650,7 +652,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             ilWriter.Emit(OpCodes.Ret);
 
             Log.Debug($"Created AsyncEndMethod Dynamic Method for '{integrationType.FullName}' integration. [Target={targetType.FullName}, ReturnType={returnType.FullName}]");
-            return callMethod;
+            return new CreateAsyncEndMethodResult(callMethod, preserveContext);
         }
 
         private static void WriteCreateNewProxyInstance(ILGenerator ilWriter, Type proxyType, Type targetType)

--- a/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/PreserveContextAttribute.cs
+++ b/src/Datadog.Trace.ClrProfiler.Managed/CallTarget/PreserveContextAttribute.cs
@@ -1,0 +1,18 @@
+// <copyright file="PreserveContextAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.ClrProfiler.CallTarget
+{
+    /// <summary>
+    /// Apply on a calltarget async callback to indicate that the method
+    /// should execute under the current synchronization context/task scheduler.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    internal class PreserveContextAttribute : Attribute
+    {
+    }
+}

--- a/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
+++ b/src/Datadog.Trace.ClrProfiler.Native/integration.cpp
@@ -51,6 +51,11 @@ namespace
         unsigned short build = 0;
         unsigned short revision = 0;
 
+        if (str.empty())
+        {
+            return {major, minor, build, revision};
+        }
+
 #ifdef _WIN32
 
         static auto re = std::wregex(WStr("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)"));
@@ -67,7 +72,7 @@ namespace
 #else
 
         static re2::RE2 re("Version=([0-9]+)\\.([0-9]+)\\.([0-9]+)\\.([0-9]+)", RE2::Quiet);
-        re2::RE2::FullMatch(ToString(str), re, &major, &minor, &build, &revision);
+        re2::RE2::PartialMatch(ToString(str), re, &major, &minor, &build, &revision);
 
 #endif
 
@@ -77,6 +82,11 @@ namespace
     WSTRING GetLocaleFromAssemblyReferenceString(const WSTRING& str)
     {
         WSTRING locale = WStr("neutral");
+
+        if (str.empty())
+        {
+            return locale;
+        }
 
 #ifdef _WIN32
 
@@ -92,7 +102,7 @@ namespace
         static re2::RE2 re("Culture=([a-zA-Z0-9]+)", RE2::Quiet);
 
         std::string match;
-        if (re2::RE2::FullMatch(ToString(str), re, &match))
+        if (re2::RE2::PartialMatch(ToString(str), re, &match))
         {
             locale = ToWSTRING(match);
         }
@@ -105,6 +115,11 @@ namespace
     PublicKey GetPublicKeyFromAssemblyReferenceString(const WSTRING& str)
     {
         BYTE data[8] = {0};
+
+        if (str.empty())
+        {
+            return PublicKey(data);
+        }
 
 #ifdef _WIN32
 
@@ -125,7 +140,7 @@ namespace
 
         static re2::RE2 re("PublicKeyToken=([a-fA-F0-9]{16})");
         std::string match;
-        if (re2::RE2::FullMatch(ToString(str), re, &match))
+        if (re2::RE2::PartialMatch(ToString(str), re, &match))
         {
             for (int i = 0; i < 8; i++)
             {

--- a/src/Datadog.Trace.ClrProfiler.Native/logger_impl.h
+++ b/src/Datadog.Trace.ClrProfiler.Native/logger_impl.h
@@ -135,7 +135,10 @@ LoggerImpl<TLoggerPolicy>::LoggerImpl()
     }
     catch (...)
     {
-        std::cerr << "LoggerImpl Handler: Error creating native log file." << std::endl;
+        // By writing into the stderr was changing the behavior in a CI scenario.
+        // There's not a good way to report errors when trying to create the log file.
+        // But we never should be changing the normal behavior of an app.
+        // std::cerr << "LoggerImpl Handler: Error creating native log file." << std::endl;
         m_fileout = spdlog::null_logger_mt("LoggerImpl");
     }
 

--- a/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -155,39 +155,7 @@ namespace Datadog.Trace.Configuration
 
         private static string GetCurrentDirectory()
         {
-            try
-            {
-                // Entering TryLoadHostingEnvironmentPath and accessing System.Web.dll
-                // will immediately throw an exception in partial trust scenarios,
-                // so surround this call by a try/catch block
-                if (TryLoadHostingEnvironmentPath(out var hostingPath))
-                {
-                    return hostingPath;
-                }
-            }
-            catch (Exception)
-            {
-                // The configuration manager should not depend on a logger being bootstrapped yet
-                // so do not do anything
-            }
-
-            return System.Environment.CurrentDirectory;
-        }
-
-        private static bool TryLoadHostingEnvironmentPath(out string hostingPath)
-        {
-#if NETFRAMEWORK
-            // on .NET Framework only, use application's root folder
-            // as default path when looking for datadog.json
-            if (System.Web.Hosting.HostingEnvironment.IsHosted)
-            {
-                hostingPath = System.Web.Hosting.HostingEnvironment.MapPath("~");
-                return true;
-            }
-
-#endif
-            hostingPath = default;
-            return false;
+            return System.AppDomain.CurrentDomain.BaseDirectory;
         }
     }
 }

--- a/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/AzureAppServicePerformanceCounters.cs
@@ -1,0 +1,85 @@
+// <copyright file="AzureAppServicePerformanceCounters.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.StatsdClient;
+
+namespace Datadog.Trace.RuntimeMetrics
+{
+    internal class AzureAppServicePerformanceCounters : IRuntimeMetricsListener
+    {
+        internal const string EnvironmentVariableName = "WEBSITE_COUNTERS_CLR";
+
+        private readonly IDogStatsd _statsd;
+
+        private int? _previousGen0Count;
+        private int? _previousGen1Count;
+        private int? _previousGen2Count;
+
+        public AzureAppServicePerformanceCounters(IDogStatsd statsd)
+        {
+            _statsd = statsd;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void Refresh()
+        {
+            var rawValue = EnvironmentHelpers.GetEnvironmentVariable(EnvironmentVariableName);
+            var value = JsonConvert.DeserializeObject<PerformanceCountersValue>(rawValue);
+
+            _statsd.Gauge(MetricsNames.Gen0HeapSize, value.Gen0Size);
+            _statsd.Gauge(MetricsNames.Gen1HeapSize, value.Gen1Size);
+            _statsd.Gauge(MetricsNames.Gen2HeapSize, value.Gen2Size);
+            _statsd.Gauge(MetricsNames.LohSize, value.LohSize);
+
+            var gen0 = GC.CollectionCount(0);
+            var gen1 = GC.CollectionCount(1);
+            var gen2 = GC.CollectionCount(2);
+
+            if (_previousGen0Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen0CollectionsCount, gen0 - _previousGen0Count.Value);
+            }
+
+            if (_previousGen1Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen1CollectionsCount, gen1 - _previousGen1Count.Value);
+            }
+
+            if (_previousGen2Count != null)
+            {
+                _statsd.Increment(MetricsNames.Gen2CollectionsCount, gen2 - _previousGen2Count.Value);
+            }
+
+            _previousGen0Count = gen0;
+            _previousGen1Count = gen1;
+            _previousGen2Count = gen2;
+        }
+
+        private class PerformanceCountersValue
+        {
+            [JsonProperty("gen0HeapSize")]
+            public int Gen0Size { get; set; }
+
+            [JsonProperty("gen1HeapSize")]
+            public int Gen1Size { get; set; }
+
+            [JsonProperty("gen2HeapSize")]
+            public int Gen2Size { get; set; }
+
+            [JsonProperty("largeObjectHeapSize")]
+            public int LohSize { get; set; }
+        }
+    }
+}
+
+#endif

--- a/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -130,7 +130,7 @@ namespace Datadog.Trace.RuntimeMetrics
                 // Catching error UnauthorizedAccessException: Access to the registry key 'Global' is denied.
                 // The 'Global' part seems consistent across localizations
 
-                Log.Error(ex, "The process does not have sufficient permissions to read performance counters. Please refer to https://docs.datadoghq.com/tracing/runtime_metrics/dotnet/#additional-permissions-for-iis to learn how to grant those permissions.");
+                Log.Error(ex, "The process does not have sufficient permissions to read performance counters. Please refer to https://dtdg.co/net-runtime-metrics to learn how to grant those permissions.");
                 throw;
             }
             catch (Exception ex)

--- a/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -54,14 +53,6 @@ namespace Datadog.Trace.RuntimeMetrics
             // That's because performance counters may rely on wmiApSrv being started,
             // and the windows service manager only allows one service at a time to be starting: https://docs.microsoft.com/en-us/windows/win32/services/service-startup
             _initializationTask = Task.Run(InitializePerformanceCounters);
-            _initializationTask.ContinueWith(
-                t =>
-                {
-                    Log.Error(t.Exception, "An error occured while initializing the performance counters");
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
         }
 
         public Task WaitForInitialization() => _initializationTask;
@@ -77,7 +68,7 @@ namespace Datadog.Trace.RuntimeMetrics
 
         public void Refresh()
         {
-            if (!_initializationTask.IsCompleted)
+            if (_initializationTask.Status != TaskStatus.RanToCompletion)
             {
                 return;
             }
@@ -120,17 +111,33 @@ namespace Datadog.Trace.RuntimeMetrics
 
         protected virtual void InitializePerformanceCounters()
         {
-            _memoryCategory = new PerformanceCounterCategory(MemoryCategoryName);
+            try
+            {
+                _memoryCategory = new PerformanceCounterCategory(MemoryCategoryName);
 
-            var instanceName = GetInstanceName();
-            _fullInstanceName = instanceName.Item2;
-            _instanceName = instanceName.Item1;
+                var instanceName = GetInstanceName();
+                _fullInstanceName = instanceName.Item2;
+                _instanceName = instanceName.Item1;
 
-            _gen0Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 0 heap size", _instanceName);
-            _gen1Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 1 heap size", _instanceName);
-            _gen2Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 2 heap size", _instanceName);
-            _lohSize = new PerformanceCounterWrapper(MemoryCategoryName, "Large Object Heap size", _instanceName);
-            _contentionCount = new PerformanceCounterWrapper(ThreadingCategoryName, "Total # of Contentions", _instanceName);
+                _gen0Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 0 heap size", _instanceName);
+                _gen1Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 1 heap size", _instanceName);
+                _gen2Size = new PerformanceCounterWrapper(MemoryCategoryName, "Gen 2 heap size", _instanceName);
+                _lohSize = new PerformanceCounterWrapper(MemoryCategoryName, "Large Object Heap size", _instanceName);
+                _contentionCount = new PerformanceCounterWrapper(ThreadingCategoryName, "Total # of Contentions", _instanceName);
+            }
+            catch (UnauthorizedAccessException ex) when (ex.Message.Contains("'Global'"))
+            {
+                // Catching error UnauthorizedAccessException: Access to the registry key 'Global' is denied.
+                // The 'Global' part seems consistent across localizations
+
+                Log.Error(ex, "The process does not have sufficient permissions to read performance counters. Please refer to https://docs.datadoghq.com/tracing/runtime_metrics/dotnet/#additional-permissions-for-iis to learn how to grant those permissions.");
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occured while initializing the performance counters");
+                throw;
+            }
         }
 
         private void TryUpdateGauge(string path, PerformanceCounterWrapper counter)

--- a/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using Datadog.Trace.Logging;
+using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.StatsdClient;
 
@@ -144,7 +145,7 @@ namespace Datadog.Trace.RuntimeMetrics
 #if NETCOREAPP
             return new RuntimeEventListener(statsd, delay);
 #elif NETFRAMEWORK
-            return new PerformanceCountersListener(statsd);
+            return AzureAppServices.Metadata.IsRelevant ? new AzureAppServicePerformanceCounters(statsd) : new PerformanceCountersListener(statsd);
 #else
             return null;
 #endif

--- a/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -6,14 +6,11 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Threading;
 
 namespace Datadog.Trace.Util
 {
     internal static class ProcessHelpers
     {
-        private static Process _currentProcess;
-
         /// <summary>
         /// Wrapper around <see cref="Process.GetCurrentProcess"/> and <see cref="Process.ProcessName"/>
         ///
@@ -72,33 +69,12 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long privateMemorySize)
         {
-            var process = Volatile.Read(ref _currentProcess);
+            using var process = Process.GetCurrentProcess();
 
-            if (process == null)
-            {
-                process = Process.GetCurrentProcess();
-
-                var oldProcess = Interlocked.CompareExchange(ref _currentProcess, process, null);
-
-                if (oldProcess != null)
-                {
-                    // This thread lost the race
-                    process.Dispose();
-                    process = oldProcess;
-                }
-            }
-
-            lock (process)
-            {
-                // Bad things will happen if a thread read process information while another refreshes it
-                // so we make sure to refresh from inside of the lock
-                process.Refresh();
-
-                userProcessorTime = process.UserProcessorTime;
-                systemCpuTime = process.PrivilegedProcessorTime;
-                threadCount = process.Threads.Count;
-                privateMemorySize = process.PrivateMemorySize64;
-            }
+            userProcessorTime = process.UserProcessorTime;
+            systemCpuTime = process.PrivilegedProcessorTime;
+            threadCount = process.Threads.Count;
+            privateMemorySize = process.PrivateMemorySize64;
         }
     }
 }

--- a/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
+++ b/test/Datadog.Trace.Tests/RuntimeMetrics/AzurePerformanceCountersListenerTests.cs
@@ -1,0 +1,61 @@
+// <copyright file="AzurePerformanceCountersListenerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+
+using System;
+using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.Vendors.StatsdClient;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.RuntimeMetrics
+{
+    public class AzurePerformanceCountersListenerTests
+    {
+        [Fact]
+        public void PushEvents()
+        {
+            Environment.SetEnvironmentVariable(
+                AzureAppServicePerformanceCounters.EnvironmentVariableName,
+                "{\"bytesInAllHeaps\": 8069304,\"gcHandles\": 6796,\"gen0Collections\": 108,\"gen1Collections\": 76,\"gen2Collections\": 16,\"inducedGC\": 0,\"pinnedObjects\": 20,\"committedBytes\": 17788928,\"reservedBytes\": 50319360,\"timeInGC\": 99342447,\"timeInGCBase\": 385095681,\"allocatedBytes\": 761378928,\"gen0HeapSize\": 8388608,\"gen1HeapSize\": 1448968,\"gen2HeapSize\": 3857504,\"largeObjectHeapSize\": 2762832,\"currentAssemblies\": 104,\"currentClassesLoaded\": 177389,\"exceptionsThrown\": 913,\"appDomains\": 10,\"appDomainsUnloaded\": 8}");
+
+            const double expectedGen0HeapSize = 8388608;
+            const double expectedGen1HeapSize = 1448968;
+            const double expectedGen2HeapSize = 3857504;
+            const double expectedLohHeapSize = 2762832;
+
+            var statsd = new Mock<IDogStatsd>();
+
+            using var listener = new AzureAppServicePerformanceCounters(statsd.Object);
+
+            listener.Refresh();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, expectedGen0HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, expectedGen1HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, expectedGen2HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, expectedLohHeapSize, 1, null), Times.Once);
+
+            statsd.VerifyNoOtherCalls();
+            statsd.Invocations.Clear();
+
+            listener.Refresh();
+
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen0HeapSize, expectedGen0HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen1HeapSize, expectedGen1HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.Gen2HeapSize, expectedGen2HeapSize, 1, null), Times.Once);
+            statsd.Verify(s => s.Gauge(MetricsNames.LohSize, expectedLohHeapSize, 1, null), Times.Once);
+
+            // Those metrics aren't pushed the first time (differential count)
+            statsd.Verify(s => s.Increment(MetricsNames.Gen0CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Increment(MetricsNames.Gen1CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+            statsd.Verify(s => s.Increment(MetricsNames.Gen2CollectionsCount, It.IsAny<int>(), 1, null), Times.Once);
+
+            statsd.VerifyNoOtherCalls();
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Changes proposed in this pull request:
This PR is set to merge into the `release/1.28.4` branch, which is based on the 1.28.2 release (set at the `v1.28.2` tag). To minimize risk while deploying fixes for customers, this PR is only porting the following changes to be released:
- #1662
- #1651 
- #1652
- #1666 
- #1677
- #1698
- #1700
- #1702

Please let me know if I'm missing any fixes that should go in, or if you think some fixes should not go into this hotfix release.

@DataDog/apm-dotnet