### PR TITLE
Add tags for App Sec

### DIFF
--- a/src/Datadog.Trace/Tagging/WebTags.cs
+++ b/src/Datadog.Trace/Tagging/WebTags.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Tagging

--- a/src/Datadog.Trace/Tags.cs
+++ b/src/Datadog.Trace/Tags.cs
@@ -405,5 +405,11 @@ namespace Datadog.Trace
         internal const string ElasticsearchUrl = "elasticsearch.url";
 
         internal const string RuntimeId = "runtime-id";
+
+        internal const string AppSecEvent = "appsec.event";
+
+        internal const string AppSecEnabled = "_dd.appsec.enabled";
+
+        internal const string AppSecLanguage = "_dd.appsec.language";
     }
 }


### PR DESCRIPTION
- appsec.event allows us to know that span is part of an appsec event
- manual.keep ensures tags are not dropped
- _dd.appsec.enabled specifies if app sec is enabled
- _dd.appsec.language specifies the langauge of the tracer generating
  the span

The tags prefixed with _dd are for app sec telemetry and are a temporary measure till full telemetry is available

APPSEC-962



Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet