### PR TITLE
Implement shutdown to help fix app sec test flakiness

### DIFF
--- a/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -21,13 +21,15 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetBase : TestHelper
     {
         private readonly HttpClient httpClient;
+        private readonly string shutdownPath;
         private int httpPort;
         private Process process;
 
-        public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string samplesDir = null)
+        public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null)
             : base(sampleName, samplesDir ?? "test/test-applications/security", outputHelper)
         {
             httpClient = new HttpClient();
+            this.shutdownPath = shutdownPath;
         }
 
         public async Task<MockTracerAgent> RunOnSelfHosted(bool enableSecurity, bool enableBlocking)
@@ -42,6 +44,9 @@ namespace Datadog.Trace.Security.IntegrationTests
 
         public void Dispose()
         {
+            var request = WebRequest.CreateHttp($"http://localhost:{httpPort}{shutdownPath}");
+            request.GetResponse().Close();
+
             if (process != null && !process.HasExited)
             {
                 process.Kill();

--- a/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore2 : AspNetBase, IDisposable
     {
         public AspNetCore2(ITestOutputHelper outputHelper)
-            : base("AspNetCore2", outputHelper)
+            : base("AspNetCore2", outputHelper, "/shutdown")
         {
         }
 

--- a/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetCore5 : AspNetBase, IDisposable
     {
         public AspNetCore5(ITestOutputHelper outputHelper)
-            : base("AspNetCore5", outputHelper)
+            : base("AspNetCore5", outputHelper, "/shutdown")
         {
         }
 

--- a/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private readonly string _testName;
 
         public AspNetMvc5(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity, bool blockingEnabled)
-            : base(nameof(AspNetMvc5), output, @"test\test-applications\security\aspnet")
+            : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetCallTargetSettings(true);
             SetSecurity(enableSecurity);

--- a/test/test-applications/security/Samples.AspNetCore2/Startup.cs
+++ b/test/test-applications/security/Samples.AspNetCore2/Startup.cs
@@ -43,6 +43,15 @@ namespace Samples.AspNetCore2
                 app.UseDeveloperExceptionPage();
             }
 
+            app.Map("/shutdown", builder =>
+            {
+                builder.Run(async context =>
+                {
+                    await context.Response.WriteAsync("Shutting down");
+                    _ = Task.Run(() => builder.ApplicationServices.GetService<IApplicationLifetime>().StopApplication());
+                });
+            });
+
             app.UseMvc(routes =>
             {
                 routes.MapRoute(

--- a/test/test-applications/security/Samples.AspNetCore5/Startup.cs
+++ b/test/test-applications/security/Samples.AspNetCore5/Startup.cs
@@ -1,5 +1,7 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -46,7 +48,14 @@ namespace Samples.AspNetCore5
 
             app.UseAuthorization();
 
-          
+            app.Map("/shutdown", builder =>
+            {
+                builder.Run(async context =>
+                {
+                    await context.Response.WriteAsync("Shutting down");
+                    _ = Task.Run(() => builder.ApplicationServices.GetService<IHostApplicationLifetime>().StopApplication());
+                });
+            });
 
             app.UseEndpoints(endpoints =>
             {

--- a/test/test-applications/security/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs
+++ b/test/test-applications/security/aspnet/Samples.AspNetMvc5/Controllers/HomeController.cs
@@ -38,5 +38,24 @@ namespace Samples.AspNetMvc5.Controllers
 
             return View();
         }
+
+        public ActionResult Shutdown()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+
+            foreach (var assembly in assemblies)
+            {
+                foreach (var type in assembly.DefinedTypes)
+                {
+                    if (type.Namespace == "Coverlet.Core.Instrumentation.Tracker")
+                    {
+                        var unloadModuleMethod = type.GetMethod("UnloadModule", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                        unloadModuleMethod.Invoke(null, new object[] { this, EventArgs.Empty });
+                    }
+                }
+            }
+
+            return RedirectToAction("Index");
+        }
     }
 }


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet