### PR TITLE
Add tests for ASP.NET Core on .NET 5.0 and .NET Framework 4.6.1

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1098,7 +1098,7 @@ partial class Build
                     {
                         "Samples.AspNetCoreMvc21" => Framework == TargetFramework.NETCOREAPP2_1,
                         "Samples.AspNetCoreMvc30" => Framework == TargetFramework.NETCOREAPP3_0,
-                        "Samples.AspNetCoreMvc31" => Framework == TargetFramework.NETCOREAPP3_1,
+                        "Samples.AspNetCoreMvc31" => Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NET5_0,
                         "Samples.AspNetCore2" => Framework == TargetFramework.NETCOREAPP2_1,
                         "Samples.AspNetCore5" => Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NETCOREAPP3_0,
                         "Samples.GraphQL4" => Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NET5_0,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc50Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc50Tests.cs
@@ -1,0 +1,72 @@
+// <copyright file="AspNetCoreIisMvc50Tests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET5_0
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc50TestsInProcessWithFeatureFlag : AspNetCoreIisMvc50Tests
+    {
+        public AspNetCoreIisMvc50TestsInProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMvc50TestsOutOfProcessWithFeatureFlag : AspNetCoreIisMvc50Tests
+    {
+        public AspNetCoreIisMvc50TestsOutOfProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreIisMvc50Tests : AspNetCoreIisMvcTestBase
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        protected AspNetCoreIisMvc50Tests(IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc31", fixture, output, inProcess, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName("AspNetCoreIisMvc31Tests");
+            _iisFixture = fixture;
+            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "LinuxUnsupported")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            // We actually sometimes expect 2, but waiting for 1 is good enough
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            settings.DisableRequireUniquePrefix(); // Disable default Verifier behavior so AspNetCore31 and AspNetCore50 can share snapshots
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21NetFxTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc21NetFxTests.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="AspNetCoreMvc21NetFxTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET461
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    public class AspNetCoreMvc21NetFxTests : AspNetCoreMvcTestBase
+    {
+        public AspNetCoreMvc21NetFxTests(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base("AspNetCoreMvc21", fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+
+        [Fact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public async Task MeetsAllAspNetCoreMvcExpectations()
+        {
+            await Fixture.TryStartApp(this);
+
+            var path = "/";
+            var spans = await Fixture.WaitForSpans(path);
+
+            // We don't expect any spans for netfx
+            spans.Should().BeEmpty();
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc50Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvc50Tests.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="AspNetCoreMvc50Tests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET5_0
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    public class AspNetCoreMvc50TestsCallTarget : AspNetCoreMvc50Tests
+    {
+        public AspNetCoreMvc50TestsCallTarget(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMvc50TestsCallTargetWithFeatureFlag : AspNetCoreMvc50Tests
+    {
+        public AspNetCoreMvc50TestsCallTargetWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableCallTarget: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreMvc50Tests : AspNetCoreMvcTestBase
+    {
+        private readonly string _testName;
+
+        protected AspNetCoreMvc50Tests(AspNetCoreTestFixture fixture, ITestOutputHelper output, bool enableCallTarget, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMvc31", fixture, output, enableCallTarget, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName("AspNetCoreMvc31Tests");
+        }
+
+        [Theory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            await Fixture.TryStartApp(this);
+
+            var spans = await Fixture.WaitForSpans(path);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+            settings.DisableRequireUniquePrefix(); // Disable default Verifier behavior so AspNetCore31 and AspNetCore50 can share snapshots
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMvcTestBase.cs
@@ -2,7 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
-#if NETCOREAPP
+#if NETCOREAPP || NET461
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net452'">
-    <PackageReference Include="Verify.Xunit" Version="11.12.1" />
+    <PackageReference Include="Verify.Xunit" Version="13.2.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <RootNamespace>Samples.AspNetCoreMvc</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
This ports the additional ASP.NET Core tests that were originally part of #1549 (which was closed without merging).

* Adds explicit ASP.NET Core 5.0 tests (identical to the 3.1 tests in practice, so just reused that app)
* Adds tests for .NET Framework on ASP.NET Core (currently confirms we _don't_ see any traces)

I trimmed down the test cases considerably given how similar netcoreapp31 and net5 are (calltarget only, feature flag enabled only), so as to not increase testing time to much.

Don't know if we actually want to include these or not, not passionate about it either way, as doesn't add a huge amount, just closes a small gap

@DataDog/apm-dotnet