### PR TITLE
Fix flakiness in Datadog.Trace.ClrProfiler.IntegrationTests.WebRequestTests.SubmitsTraces

### DIFF
--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode}");
 
-                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
+                var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName).OrderBy(s => s.Start);
                 spans.Should().HaveCount(expectedSpanCount);
 
                 foreach (var span in spans)


### PR DESCRIPTION
As part of the test, the trace ID and span ID of `spans.First()` is compared against the first distributed tracing headers seen by the in-memory HttpListener. In the most recent test failure, the trace ID comparison failed, and I suspect it's because the in-memory list of spans was not ordered by start time. Ordering the spans should solve this.

@DataDog/apm-dotnet