### PR TITLE
Don't fail the build if uploading core dumps fails

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -235,6 +235,7 @@ stages:
       - publish: build_data
         artifact: profiler-logs_unit_tests_windows_$(System.JobAttempt)
         condition: succeededOrFailed()
+        continueOnError: true
 
       - task: PublishTestResults@2
         displayName: publish test results
@@ -276,6 +277,7 @@ stages:
       - publish: build_data
         artifact: profiler-logs_unit_tests_macos_$(System.JobAttempt)
         condition: succeededOrFailed()
+        continueOnError: true
 
       - task: PublishTestResults@2
         displayName: publish test results
@@ -314,6 +316,7 @@ stages:
     - publish: build_data
       artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
       condition: succeededOrFailed()
+      continueOnError: true
 
     - task: PublishTestResults@2
       displayName: publish test results
@@ -321,11 +324,6 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
-
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'build_data/results/'
-      continueOnError: true
 
 - stage: unit_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
@@ -349,6 +347,7 @@ stages:
         - publish: build_data
           artifact: profiler-logs_unit_tests_linux_$(Agent.JobName)_$(System.JobAttempt)
           condition: succeededOrFailed()
+          continueOnError: true
 
         - task: PublishTestResults@2
           displayName: publish test results
@@ -409,12 +408,7 @@ stages:
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
 
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'build_data/results/'
-      continueOnError: true
-
-    - publish: build_data\logs\
+    - publish: build_data
       displayName: Uploading integration_tests_windows tracer logs
       artifact: integration_tests_windows_tracer_logs_$(platform)_$(target)
       condition: succeededOrFailed()
@@ -478,11 +472,6 @@ stages:
         testResultsFiles: build_data/results/**/*.trx
       condition: succeededOrFailed()
 
-    - task: PublishPipelineArtifact@1
-      inputs:
-        targetPath: 'build_data/results/'
-      continueOnError: true
-
     - task: DockerCompose@0
       displayName: docker-compose stop services
       inputs:
@@ -490,7 +479,7 @@ stages:
         dockerComposeCommand: down
       condition: succeededOrFailed()
 
-    - publish: build_data\logs\
+    - publish: build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
       artifact: integration_tests_windows_iis_tracer_logs_$(platform)
       condition: succeededOrFailed()
@@ -586,6 +575,7 @@ stages:
     - publish: build_data
       artifact: profiler-logs_integration_tests_linux_$(baseImage)_$(publishTargetFramework)_$(System.JobAttempt)
       condition: succeededOrFailed()
+      continueOnError: true
 
     - task: PublishTestResults@2
       displayName: publish test results
@@ -663,6 +653,7 @@ stages:
         - publish: build_data
           artifact: profiler-logs_integration_tests_linux_arm64_$(publishTargetFramework)_$(System.JobAttempt)
           condition: succeededOrFailed()
+          continueOnError: true
 
         - task: PublishTestResults@2
           displayName: publish test results


### PR DESCRIPTION
By adding `continueOnError: true` to the log upload stage
Also removed some "duplicate" uploads for consistency

@DataDog/apm-dotnet 