### PR TITLE
Define 'SharedSrcBaseDir' consistently across projects.

### DIFF
--- a/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LateLoadDS.NetFx/Datadog.DynamicDiagnosticSourceBindings.Demo.LateLoadDS.NetFx.csproj
+++ b/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LateLoadDS.NetFx/Datadog.DynamicDiagnosticSourceBindings.Demo.LateLoadDS.NetFx.csproj
@@ -54,7 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   <PropertyGroup>

--- a/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LoadUnloadPlugin.NetCore31/Datadog.DynamicDiagnosticSourceBindings.Demo.LoadUnloadPlugin.NetCore31.csproj
+++ b/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LoadUnloadPlugin.NetCore31/Datadog.DynamicDiagnosticSourceBindings.Demo.LoadUnloadPlugin.NetCore31.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   <PropertyGroup>

--- a/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/Simple.NetCore31/Datadog.DynamicDiagnosticSourceBindings.Demo.Simple.NetCore31.csproj
+++ b/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/Simple.NetCore31/Datadog.DynamicDiagnosticSourceBindings.Demo.Simple.NetCore31.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   <PropertyGroup>

--- a/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/Simple.NetFx45/Datadog.DynamicDiagnosticSourceBindings.Demo.Simple.NetFx45.csproj
+++ b/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/Simple.NetFx45/Datadog.DynamicDiagnosticSourceBindings.Demo.Simple.NetFx45.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   <PropertyGroup>

--- a/shared/samples/Datadog.Logging.Demo/EmitterAndComposerApp/Datadog.Logging.Demo.EmitterAndComposerApp.csproj
+++ b/shared/samples/Datadog.Logging.Demo/EmitterAndComposerApp/Datadog.Logging.Demo.EmitterAndComposerApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 

--- a/shared/samples/Datadog.Logging.Demo/EmitterLib/Datadog.Logging.Demo.EmitterLib.csproj
+++ b/shared/samples/Datadog.Logging.Demo/EmitterLib/Datadog.Logging.Demo.EmitterLib.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 

--- a/shared/src/managed-lib/DynamicDiagnosticSourceBindings/Datadog.DynamicDiagnosticSourceBindings.csproj
+++ b/shared/src/managed-lib/DynamicDiagnosticSourceBindings/Datadog.DynamicDiagnosticSourceBindings.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 	
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\managed-src</SharedSrcBaseDir>
-	  <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 	
   <!-- Datadog.Logging.Emission.props is required for emitting logs: -->

--- a/shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader.csproj
+++ b/shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 	
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..\..\..\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 

--- a/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Composition.props
+++ b/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Composition.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   

--- a/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Emission.props
+++ b/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Emission.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(MSBuildThisFileDirectory)..</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
Several projects in `/shared` and in `dd-continuous-profiler-dotnet` define the `SharedSrcBaseDir` MSBuild property to refer to the folder that has recently been moved to `dd-trace-dotnet\shared\src\managed-src\`. Previously, projects were using different ways to refer to that same folder, which was fragile. This change switches to a consistent reference based on the existing `EnlistmentRoot` MSBuild variable.