### PR TITLE
Apply Private attribute on Datadog.Trace references in samples

### DIFF
--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/Samples.AWS.SQS.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/Samples.AWS.SQS.csproj
@@ -4,12 +4,13 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="AWSSDK.SQS" Version="$(ApiVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/Samples.AWS.SQS.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/Samples.AWS.SQS.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -18,7 +18,9 @@ namespace Samples.MongoDB
             return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public static async Task Main(string[] args)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             bool IsProfilerAttached()
             {

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -18,7 +18,7 @@ namespace Samples.MongoDB
             return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
         }
 
-        public static void Main(string[] args)
+        public static async Task Main(string[] args)
         {
             bool IsProfilerAttached()
             {

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -18,9 +18,7 @@ namespace Samples.MongoDB
             return Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
         }
 
-#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public static async Task Main(string[] args)
-#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             bool IsProfilerAttached()
             {
@@ -65,7 +63,7 @@ namespace Samples.MongoDB
                 var collection = database.GetCollection<BsonDocument>("employees");
 
                 Run(collection, newDocument);
-                RunAsync(collection, newDocument).Wait();
+                await RunAsync(collection, newDocument);
 
 #if MONGODB_2_2
                 WireProtocolExecuteIntegrationTest(client);

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Samples.MongoDB.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.RateLimiter/Samples.RateLimiter.csproj
+++ b/tracer/test/test-applications/integrations/Samples.RateLimiter/Samples.RateLimiter.csproj
@@ -3,6 +3,6 @@
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Samples.TracingWithoutLimits.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Samples.TracingWithoutLimits.csproj
@@ -3,6 +3,6 @@
     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Program.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace;
 using Datadog.Trace.TestHelpers;
 
@@ -18,7 +19,9 @@ namespace Samples.WebRequest.NetFramework20
 
         private static string Url;
 
-        public static void Main(string[] args)
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public static async Task Main(string[] args)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             bool tracingDisabled = args.Any(arg => arg.Equals("TracingDisabled", StringComparison.OrdinalIgnoreCase));
             Console.WriteLine($"TracingDisabled {tracingDisabled}");

--- a/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Samples.WebRequest.NetFramework20.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Samples.WebRequest.NetFramework20.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
     <ProjectReference Include="..\dependency-libs\Samples.WebRequestHelper.NetFramework20\Samples.WebRequestHelper.NetFramework20.csproj" />
   </ItemGroup>
 

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/DataDogThreadTest/DataDogThreadTest.csproj
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/DataDogThreadTest.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/regression/DogStatsD.RaceCondition/DogStatsD.RaceCondition.csproj
+++ b/tracer/test/test-applications/regression/DogStatsD.RaceCondition/DogStatsD.RaceCondition.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
+++ b/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
@@ -1,4 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
+  </PropertyGroup>
+
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
+++ b/tracer/test/test-applications/regression/HttpMessageHandler.StackOverflowException/HttpMessageHandler.StackOverflowException.csproj
@@ -8,6 +8,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/regression/LargePayload/LargePayload.csproj
+++ b/tracer/test/test-applications/regression/LargePayload/LargePayload.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/regression/Sandbox.ManualTracing/Sandbox.ManualTracing.csproj
+++ b/tracer/test/test-applications/regression/Sandbox.ManualTracing/Sandbox.ManualTracing.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/regression/TraceContext.InvalidOperationException/TraceContext.InvalidOperationException.csproj
+++ b/tracer/test/test-applications/regression/TraceContext.InvalidOperationException/TraceContext.InvalidOperationException.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" Private="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The Datadog.Trace.dll in the profiler directory is patched to enable code coverage. If a Datadog.Trace.dll is found in the bin folder, this one will be used instead and coverage won't work. This PR adds the `Private="false"` attribute on references to Datadog.Trace to prevent it from being copied to the bin folder.