### PR TITLE
Package windows native symbols in a separate archive

### DIFF
--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -35,9 +35,11 @@ partial class Build
 
     AbsolutePath OutputDirectory => RootDirectory / "bin";
     AbsolutePath TracerHomeDirectory => TracerHome ?? (OutputDirectory / "tracer-home");
+    AbsolutePath SymbolsDirectory => TracerHome ?? (OutputDirectory / "symbols");
     AbsolutePath DDTracerHomeDirectory => DDTracerHome ?? (OutputDirectory / "dd-tracer-home");
     AbsolutePath ArtifactsDirectory => Artifacts ?? (OutputDirectory / "artifacts");
     AbsolutePath WindowsTracerHomeZip => ArtifactsDirectory / "windows-tracer-home.zip";
+    AbsolutePath WindowsSymbolsZip => ArtifactsDirectory / "windows-native-symbols.zip";
     AbsolutePath BuildDataDirectory => RootDirectory / "build_data";
 
     const string LibDdwafVersion = "1.0.6";
@@ -327,6 +329,22 @@ partial class Build
                     .SetOutput(TracerHomeDirectory / framework)));
         });
 
+    Target PublishNativeSymbolsWindows => _ => _
+      .Unlisted()
+      .OnlyWhenStatic(() => IsWin)
+      .After(CompileNativeSrc, PublishManagedProfiler)
+      .Executes(() =>
+       {
+           foreach (var architecture in ArchitecturesForPlatform)
+           {
+               var source = NativeProfilerProject.Directory / "bin" / BuildConfiguration / architecture.ToString() /
+                            $"{NativeProfilerProject.Name}.pdb";
+               var dest = SymbolsDirectory / $"win-{architecture}";
+               Logger.Info($"Copying '{source}' to '{dest}'");
+               CopyFileToDirectory(source, dest, FileExistsPolicy.Overwrite);
+           }
+       });
+
     Target PublishNativeProfilerWindows => _ => _
         .Unlisted()
         .OnlyWhenStatic(() => IsWin)
@@ -384,6 +402,7 @@ partial class Build
     Target PublishNativeProfiler => _ => _
         .Unlisted()
         .DependsOn(PublishNativeProfilerWindows)
+        .DependsOn(PublishNativeSymbolsWindows)                                
         .DependsOn(PublishNativeProfilerLinux)
         .DependsOn(PublishNativeProfilerMacOs);
 
@@ -492,6 +511,15 @@ partial class Build
                     Cmd.Value(arguments: $"cmd /c mklink /J \"{newDir}\" \"{existingDir}\"");
                 }
             });
+        });
+
+    Target ZipSymbols => _ => _
+        .Unlisted()
+        .After(BuildTracerHome)
+        .OnlyWhenStatic(() => IsWin)
+        .Executes(() =>
+        {
+            CompressZip(SymbolsDirectory, WindowsSymbolsZip, fileMode: FileMode.Create);
         });
 
     Target ZipTracerHome => _ => _

--- a/build/_build/Build.Steps.cs
+++ b/build/_build/Build.Steps.cs
@@ -402,7 +402,6 @@ partial class Build
     Target PublishNativeProfiler => _ => _
         .Unlisted()
         .DependsOn(PublishNativeProfilerWindows)
-        .DependsOn(PublishNativeSymbolsWindows)                                
         .DependsOn(PublishNativeProfilerLinux)
         .DependsOn(PublishNativeProfilerMacOs);
 
@@ -516,6 +515,7 @@ partial class Build
     Target ZipSymbols => _ => _
         .Unlisted()
         .After(BuildTracerHome)
+        .DependsOn(PublishNativeSymbolsWindows)
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -141,7 +141,6 @@ partial class Build : NukeBuild
         .After(Clean, BuildTracerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(ZipTracerHome)
-        .DependsOn(ZipSymbols)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);
 

--- a/build/_build/Build.cs
+++ b/build/_build/Build.cs
@@ -141,6 +141,7 @@ partial class Build : NukeBuild
         .After(Clean, BuildTracerHome)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(ZipTracerHome)
+        .DependsOn(ZipSymbols)
         .DependsOn(BuildMsi)
         .DependsOn(PackNuGet);
 

--- a/build/_build/gitlab.bat
+++ b/build/_build/gitlab.bat
@@ -5,7 +5,7 @@ call "%VSTUDIO_ROOT%\vc\auxiliary\build\vcvars64.bat"
 SET VSToolsPath=%VSTUDIO_ROOT%\MSBuild\Microsoft\Visual Studio\v16.0
 
 cd c:\mnt\
-dotnet run --project build/_build/_build.csproj -- Info Clean BuildTracerHome PackageTracerHome SignDlls SignMsiAndNupkg --Artifacts "build-out\%CI_JOB_ID%"
+dotnet run --project build/_build/_build.csproj -- Info Clean BuildTracerHome PackageTracerHome ZipSymbols SignDlls SignMsiAndNupkg --Artifacts "build-out\%CI_JOB_ID%"
 goto :EOF
 
 :nomntdir


### PR DESCRIPTION
Native symbols are needed to analyze some memory dumps, but are too big to be shipped to the customers. Instead, we can store them as artifacts for each release and pull them when needed.