### PR TITLE
Add a beta suffix to the Datadog.Monitoring.Distribution NuGet package

### DIFF
--- a/src/Datadog.Monitoring.Distribution/Datadog.Monitoring.Distribution.csproj
+++ b/src/Datadog.Monitoring.Distribution/Datadog.Monitoring.Distribution.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <Version>1.28.5-prerelease</Version>
+    <Version>$(Version)-beta.1</Version> <!-- Unconditionally add a beta suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
     <Title>Datadog APM Auto-instrumentation Assets</Title>
     <Description>Auto-instrumentation assets for Datadog APM</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/Datadog.Monitoring.Distribution/Datadog.Monitoring.Distribution.csproj
+++ b/src/Datadog.Monitoring.Distribution/Datadog.Monitoring.Distribution.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.28.5-prerelease</Version>
-    <Version>$(Version)-beta.1</Version> <!-- Unconditionally add a beta suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
+    <Version>$(Version)-beta01</Version> <!-- Unconditionally add a beta suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
     <Title>Datadog APM Auto-instrumentation Assets</Title>
     <Description>Auto-instrumentation assets for Datadog APM</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
By adding an additional `<Version>$(Version)-beta01</Version>` property to the NuGet package, we can get a `-beta01` suffix regardless of the version of the release. This achieves the following results:
1. Running the version update with the existing version does not change the version number
```powershell
$env:Version = "1.28.5"
build.ps1 UpdateVersions
```

2. Running the version update with a newer version changes the version number
```powershell
$env:Version = "1.28.6"
$env:IsPrerelease = "false"
build.ps1 UpdateVersions
```

3. Building the NuGet package results in Datadog.Monitoring.Distribution.1.28.6-beta01
```powershell
.\build.ps1 BuildTracerHome CreateDistributionHome BuildDistributionNuget
```

@DataDog/apm-dotnet