### PR TITLE
Minor tweaks to shared files

### DIFF
--- a/shared/NuGet.config
+++ b/shared/NuGet.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <fallbackPackageFolders>
+    <!-- Do not depend on global state -->
+    <clear />
+  </fallbackPackageFolders>
+  
+  <packageRestore>
+    <!-- Allow NuGet to download missing packages -->
+    <add key="enabled" value="True" />
+
+    <!-- Automatically check for missing packages during build in Visual Studio -->
+    <add key="automatic" value="True" />
+  </packageRestore>
+  
+  <packageSources>    
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  
+  <config>
+    <add key="RepositoryPath" value="../../_build/ImportedPackages" />
+  </config>
+</configuration>

--- a/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LateLoadDS.NetFx/Directory.Build.props
+++ b/shared/samples/Datadog.DynamicDiagnosticSourceBindings.Demo/LateLoadDS.NetFx/Directory.Build.props
@@ -9,6 +9,6 @@
         <SkipCodeAnalysis>true</SkipCodeAnalysis>
     </PropertyGroup>
     
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     
 </Project>

--- a/shared/src/managed-lib/DynamicDiagnosticSourceBindings/Directory.Build.props
+++ b/shared/src/managed-lib/DynamicDiagnosticSourceBindings/Directory.Build.props
@@ -2,7 +2,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     
     <Import Project="ProductVersion.props" />
 

--- a/shared/src/managed-lib/ManagedLoader/Directory.Build.props
+++ b/shared/src/managed-lib/ManagedLoader/Directory.Build.props
@@ -2,7 +2,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     
-    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../../'))" />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
     
     <Import Project="ProductVersion.props" />
 

--- a/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Composition.props
+++ b/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Composition.props
@@ -5,7 +5,11 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
+    <!-- In .csproj files we define 'SharedSrcBaseDir' similar to this:                                 -->
+    <!--   <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>                -->
+    <!-- However, in this .props file we need to use a relative path, becasue it may be pulled into a   -->
+    <!-- project located in a different repo which has a different value for 'EnlistmentRoot'.          -->
+    <SharedSrcBaseDir>$([System.IO.Path]::GetFullPath( $(MSBuildThisFileDirectory)\..\ ))</SharedSrcBaseDir>     
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   

--- a/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Emission.props
+++ b/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Emission.props
@@ -5,7 +5,11 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
+    <!-- In .csproj files we define 'SharedSrcBaseDir' similar to this:                                 -->
+    <!--   <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>                -->
+    <!-- However, in this .props file we need to use a relative path, becasue it may be pulled into a   -->
+    <!-- project located in a different repo which has a different value for 'EnlistmentRoot'.          -->
+    <SharedSrcBaseDir>$([System.IO.Path]::GetFullPath( $(MSBuildThisFileDirectory)\..\ ))</SharedSrcBaseDir>  
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 

--- a/shared/test/Vendored.System.Diagnostics.DiagnosticSource.Tests/NuGet.config
+++ b/shared/test/Vendored.System.Diagnostics.DiagnosticSource.Tests/NuGet.config
@@ -15,6 +15,6 @@
     <clear />
   </disabledPackageSources>
   <config>
-    <add key="RepositoryPath" value="../../packages" />
+    <add key="RepositoryPath" value="../../../../_build/ImportedPackages" />
   </config>
 </configuration>


### PR DESCRIPTION
As we are cleaning up the Profiler build to reference `dd-trace-dotnet` instead of `dd-shared-components-dotnet`, we discover the need to minor tweaks. This PR is the collection of such tweaks which I collected into a single PR to minimize churn.

The Profiler work is now done (https://github.com/DataDog/dd-continuous-profiler-dotnet/pull/135).
Note that while this PR is being reviewed and merged, the Profiler builds cleanly while referencing `dd-trace-dotnet / macrogreg/SharedItemsCatchup`. Once this PR is merged, we must point the profiler to `dd-trace-dotnet / master`.

Changes here:

* Make packages path the same for all shared items.
* Props files must use relative paths to construct shared file references.
* Fix upward walking chains in `Directory.Build.props` files.