### PR TITLE
[DuckType] - Improve generic methods support.

### DIFF
--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -706,7 +706,7 @@ namespace Datadog.Trace.DuckTyping
                                     }
 
                                     // If the proxy parameter type is a value type (no ducktyping neither a base class) both types must match
-                                    if (!proxyParamTypeGenericType.IsEnum && proxyParamTypeGenericType != candidateParamTypeGenericType)
+                                    if (proxyParamTypeGenericType.IsValueType && !proxyParamTypeGenericType.IsEnum && proxyParamTypeGenericType != candidateParamTypeGenericType)
                                     {
                                         skip = true;
                                         break;

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -666,8 +666,68 @@ namespace Datadog.Trace.DuckTyping
                     {
                         if (!candidateParamType.IsAssignableFrom(proxyParamType))
                         {
-                            skip = true;
-                            break;
+                            // Check if the parameter type contains generic types before skipping
+                            if (!candidateParamType.IsGenericType || candidateParamType.IsGenericType != proxyParamType.IsGenericType)
+                            {
+                                skip = true;
+                                break;
+                            }
+
+                            // if the string representation of the generic parameter types is not the same we need to analyze the
+                            // GenericTypeArguments array before skipping it
+                            if (candidateParamType.ToString() != proxyParamType.ToString())
+                            {
+                                if (candidateParamType.GenericTypeArguments.Length != proxyParamType.GenericTypeArguments.Length)
+                                {
+                                    skip = true;
+                                    break;
+                                }
+
+                                for (int paramIndex = 0; paramIndex < candidateParamType.GenericTypeArguments.Length; paramIndex++)
+                                {
+                                    Type candidateParamTypeGenericType = candidateParamType.GenericTypeArguments[paramIndex];
+                                    Type proxyParamTypeGenericType = proxyParamType.GenericTypeArguments[paramIndex];
+
+                                    // Both need to have the same element type or byref type signature.
+                                    if (proxyParamTypeGenericType.IsByRef != candidateParamTypeGenericType.IsByRef)
+                                    {
+                                        skip = true;
+                                        break;
+                                    }
+
+                                    // If the parameters are by ref we unwrap them to have the actual type
+                                    proxyParamTypeGenericType = proxyParamTypeGenericType.IsByRef ? proxyParamTypeGenericType.GetElementType() : proxyParamTypeGenericType;
+                                    candidateParamTypeGenericType = candidateParamTypeGenericType.IsByRef ? candidateParamTypeGenericType.GetElementType() : candidateParamTypeGenericType;
+
+                                    // We can't compare generic parameters
+                                    if (candidateParamTypeGenericType.IsGenericParameter)
+                                    {
+                                        continue;
+                                    }
+
+                                    // If the proxy parameter type is a value type (no ducktyping neither a base class) both types must match
+                                    if (!proxyParamTypeGenericType.IsEnum && proxyParamTypeGenericType != candidateParamTypeGenericType)
+                                    {
+                                        skip = true;
+                                        break;
+                                    }
+
+                                    // If the proxy parameter is a class and not is an abstract class (only interface and abstract class can be used as ducktype base type)
+                                    if (proxyParamTypeGenericType.IsClass && !proxyParamTypeGenericType.IsAbstract && proxyParamTypeGenericType != typeof(object))
+                                    {
+                                        if (!candidateParamTypeGenericType.IsAssignableFrom(proxyParamTypeGenericType))
+                                        {
+                                            skip = true;
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                if (skip)
+                                {
+                                    break;
+                                }
+                            }
                         }
                     }
                 }

--- a/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
+++ b/src/Datadog.Trace/DuckTyping/DuckType.Methods.cs
@@ -667,7 +667,7 @@ namespace Datadog.Trace.DuckTyping
                         if (!candidateParamType.IsAssignableFrom(proxyParamType))
                         {
                             // Check if the parameter type contains generic types before skipping
-                            if (!candidateParamType.IsGenericType || candidateParamType.IsGenericType != proxyParamType.IsGenericType)
+                            if (!candidateParamType.IsGenericType || !proxyParamType.IsGenericType)
                             {
                                 skip = true;
                                 break;

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -341,6 +341,27 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Tuple<object, string> wrapper3 = duckAbstract.Wrap<object, string>(null, "World");
             Assert.Null(wrapper3.Item1);
             Assert.Equal("World", wrapper3.Item2);
+
+            duckInterface.ForEachScope<int>(
+                (obj, x) =>
+                {
+                    Assert.Equal(42, x);
+                },
+                42);
+
+            duckAbstract.ForEachScope<int>(
+                (obj, x) =>
+                {
+                    Assert.Equal(42, x);
+                },
+                42);
+
+            duckVirtual.ForEachScope<int>(
+                (obj, x) =>
+                {
+                    Assert.Equal(42, x);
+                },
+                42);
         }
 
         [Theory]

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -342,26 +342,40 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Assert.Null(wrapper3.Item1);
             Assert.Equal("World", wrapper3.Item2);
 
-            duckInterface.ForEachScope<int>(
-                (obj, x) =>
-                {
-                    Assert.Equal(42, x);
-                },
-                42);
+            // Generic methods with generic types in parameters
+            RunForEachScopeTest(42);
+            RunForEachScopeTest(new object());
+            RunForEachScopeTest("Hello World");
+            RunForEachScopeTest(new { AnonymousType = true });
 
-            duckAbstract.ForEachScope<int>(
-                (obj, x) =>
-                {
-                    Assert.Equal(42, x);
-                },
-                42);
+            void RunForEachScopeTest<T>(T value)
+            {
+                // Generic methods with generic types in parameters
 
-            duckVirtual.ForEachScope<int>(
+                duckInterface.ForEachScope<T>(
                 (obj, x) =>
                 {
-                    Assert.Equal(42, x);
+                    Assert.Same(obscureObject, obj);
+                    Assert.Equal(value, x);
                 },
-                42);
+                value);
+
+                duckAbstract.ForEachScope<T>(
+                    (obj, x) =>
+                    {
+                        Assert.Same(obscureObject, obj);
+                        Assert.Equal(value, x);
+                    },
+                    value);
+
+                duckVirtual.ForEachScope<T>(
+                    (obj, x) =>
+                    {
+                        Assert.Same(obscureObject, obj);
+                        Assert.Equal(value, x);
+                    },
+                    value);
+            }
         }
 
         [Theory]

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/DefaultGenericMethodDuckTypeAbstractClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/DefaultGenericMethodDuckTypeAbstractClass.cs
@@ -12,5 +12,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
         public abstract T GetDefault<T>();
 
         public abstract Tuple<T1, T2> Wrap<T1, T2>(T1 a, T2 b);
+
+        public abstract void ForEachScope<TState2>(Action<object, TState2> callback, TState2 state);
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/DefaultGenericMethodDuckTypeVirtualClass.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/DefaultGenericMethodDuckTypeVirtualClass.cs
@@ -12,5 +12,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
         public virtual T GetDefault<T>() => default;
 
         public virtual Tuple<T1, T2> Wrap<T1, T2>(T1 a, T2 b) => null;
+
+        public virtual void ForEachScope<TState2>(Action<object, TState2> callback, TState2 state)
+        {
+        }
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/IDefaultGenericMethodDuckType.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/IDefaultGenericMethodDuckType.cs
@@ -12,5 +12,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
         T GetDefault<T>();
 
         Tuple<T1, T2> Wrap<T1, T2>(T1 a, T2 b);
+
+        void ForEachScope<TState2>(Action<object, TState2> callback, TState2 state);
     }
 }

--- a/test/Datadog.Trace.DuckTyping.Tests/ObscureObject.cs
+++ b/test/Datadog.Trace.DuckTyping.Tests/ObscureObject.cs
@@ -534,6 +534,14 @@ namespace Datadog.Trace.DuckTyping.Tests
             {
                 return obj;
             }
+
+            private void ForEachScope<TState>(Action<object, TState> callback, TState state)
+            {
+                for (var i = 0; i < 50; i++)
+                {
+                    callback(this, state);
+                }
+            }
         }
 
         internal class PropertyInternalObject
@@ -769,6 +777,14 @@ namespace Datadog.Trace.DuckTyping.Tests
             {
                 return obj;
             }
+
+            private void ForEachScope<TState>(Action<object, TState> callback, TState state)
+            {
+                for (var i = 0; i < 50; i++)
+                {
+                    callback(this, state);
+                }
+            }
         }
 
         private class PropertyPrivateObject
@@ -1002,6 +1018,14 @@ namespace Datadog.Trace.DuckTyping.Tests
             private DummyFieldObject Bypass(DummyFieldObject obj)
             {
                 return obj;
+            }
+
+            private void ForEachScope<TState>(Action<object, TState> callback, TState state)
+            {
+                for (var i = 0; i < 50; i++)
+                {
+                    callback(this, state);
+                }
             }
         }
 


### PR DESCRIPTION
This PR adds support for Types with generics types inside a generic parameters method in DuckType.

#### Example: 
`void ForEachScope<TState2>(Action<object, TState2> callback, TState2 state);`



@DataDog/apm-dotnet