### PR TITLE
Fix flaky aspnet security test

### DIFF
--- a/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             Func<Task<(HttpStatusCode StatusCode, string ResponseText)>> attack = () => SubmitRequest("/Health/?arg=[$slice]");
             var resultRequests = await Task.WhenAll(attack(), attack(), attack(), attack(), attack());
             agent.SpanFilters.Add(s => s.Tags["http.url"].IndexOf("Health", StringComparison.InvariantCultureIgnoreCase) > 0);
-            var spans = agent.WaitForSpans(5);
+            var spans = agent.WaitForSpans(expectedSpans);
             Assert.Equal(expectedSpans, spans.Count());
             foreach (var span in spans)
             {


### PR DESCRIPTION
The test expects 10 spans in some cases but only wait for 5.