### PR TITLE
Disable ILogger integration by default

### DIFF
--- a/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -396,6 +396,11 @@ namespace Datadog.Trace.Configuration
             /// Feature Flag: enables instrumenting calls to netstandard.dll (only applies to CallSite instrumentation)
             /// </summary>
             public const string NetStandardEnabled = "DD_TRACE_NETSTANDARD_ENABLED";
+
+            /// <summary>
+            /// Feature Flag: enables the ILogger logs injection integration. Defaults to false.
+            /// </summary>
+            public const string ILoggerIntegrationEnabled = "DD_TRACE_ILOGGER_LOGS_INJECTION_ENABLED";
         }
     }
 }

--- a/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -201,6 +201,11 @@ namespace Datadog.Trace.Configuration
             RouteTemplateResourceNamesEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled)
                                                    ?? false;
 
+            if (!(source?.GetBool(ConfigurationKeys.FeatureFlags.ILoggerIntegrationEnabled) ?? false))
+            {
+                DisabledIntegrationNames.Add(nameof(IntegrationIds.ILogger));
+            }
+
             PartialFlushEnabled = source?.GetBool(ConfigurationKeys.PartialFlushEnabled)
                 // default value
                 ?? false;

--- a/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -31,6 +31,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion("1.0.0");
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            SetEnvironmentVariable("DD_TRACE_ILOGGER_LOGS_INJECTION_ENABLED", "true");
             SetCallTargetSettings(true);
         }
 

--- a/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.AgentUri), new Uri("http://127.0.0.1:8126/") };
             yield return new object[] { CreateFunc(s => s.Environment), null };
             yield return new object[] { CreateFunc(s => s.ServiceName), null };
-            yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
+            yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 1 }; // ILogger is disabled by default
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
             yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.ServiceName, "web-service", CreateFunc(s => s.ServiceName), "web-service" };
             yield return new object[] { "DD_SERVICE_NAME", "web-service", CreateFunc(s => s.ServiceName), "web-service" };
 
-            yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2;;INTEGRATION2", CreateFunc(s => s.DisabledIntegrationNames.Count), 2 };
+            yield return new object[] { ConfigurationKeys.DisabledIntegrations, "integration1;integration2;;INTEGRATION2", CreateFunc(s => s.DisabledIntegrationNames.Count), 3 }; // ILogger is disabled by default
 
             yield return new object[] { ConfigurationKeys.AdoNetExcludedTypes, "System.Data.SqlClient.SqlCommand;SYSTEM.DATA.SQLCLIENT.SQLCOMMAND;;System.Data.SqlClient.SqlConnection", CreateFunc(s => s.AdoNetExcludedTypes.Count), 2 };
 


### PR DESCRIPTION
In order to better verify the performance impact of the `ILogger` logs injection integration, disable the integration by default, by adding an additional feature flag.