### PR TITLE
Refactor ILogger integration

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1473,7 +1473,7 @@
         },
         "wrapper": {
           "assembly": "Datadog.Trace, Version=1.28.6.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.ILogger.LoggerExternalScopeProviderForEachScopeIntegration",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration",
           "action": "CallTargetModification"
         }
       },
@@ -1497,7 +1497,7 @@
         },
         "wrapper": {
           "assembly": "Datadog.Trace, Version=1.28.6.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
-          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration",
+          "type": "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration",
           "action": "CallTargetModification"
         }
       }

--- a/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
+++ b/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Datadog.Monitoring.Distribution" Version="1.28.6-beta01" />
+    <PackageReference Include="Datadog.Trace" Version="1.28.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.18" />
+    <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.5.0-beta01" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Logs" />
+  </ItemGroup>
+</Project>

--- a/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Program.cs
+++ b/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Program.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Serilog;
+using Serilog.Formatting.Json;
+
+namespace MicrosoftExtensionsExample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureServices(services => services.AddHostedService<Worker>())
+                .ConfigureLogging(logging => 
+                {
+                    // The JsonFormatter used by NetEscapades.Extensions.Logging.RollingFile includes all properties
+                    // if scopes are enabled
+                    //
+                    // Additions to configuration:
+                    // - used json format
+                    // - enabled scopes
+                    logging.AddFile(opts =>
+                    {
+                        opts.IncludeScopes = true; // must include scopes so that correlation identifiers are added
+                        opts.FileName = "log-MicrosoftExtensions-jsonFile";
+                        opts.Extension = "log";
+                        opts.FormatterName = "json";
+                    });
+
+                    // Using Serilog with Microsoft.Extensions.Logging is supported, but uses the Serilog log injection
+                    // not Microsoft.Extensions.Logging logs injection.
+                    // See the SerilogExample project for examples of valid Serilog configurations and output formats
+                    logging.AddSerilog(new LoggerConfiguration()
+                        .Enrich.FromLogContext()
+                        .WriteTo.File(new JsonFormatter(), "Logs/log-Serilog-jsonFile.log")
+                        .CreateLogger());
+                });
+    }
+}

--- a/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Properties/launchSettings.json
+++ b/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+﻿{
+  "profiles": {
+    "MicrosoftExtensionsExample": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development",
+        "DD_LOGS_INJECTION": "true",
+        "DD_ENV": "dev",
+        "DD_SERVICE": "MicrosoftExtensionsExample",
+        "DD_VERSION": "1.0.0",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(ProjectDir)$(OutputPath)datadog\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+        "DD_INTEGRATIONS": "$(ProjectDir)$(OutputPath)datadog\\integrations.json",
+        "DD_DOTNET_TRACER_HOME": "$(ProjectDir)$(OutputPath)datadog"
+      }
+    }
+  }
+}

--- a/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Worker.cs
+++ b/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Worker.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while(!stoppingToken.IsCancellationRequested)
+        {
+            using (_logger.BeginScope(new Dictionary<string, object>{{"order-number", 1024}}))
+            {
+                _logger.LogInformation("Message before a trace.");
+
+                using (Tracer.Instance.StartActive("Microsoft.Extensions.Example - Worker.ExecuteAsync()"))
+                {
+                    _logger.LogInformation("Message during a trace.");
+
+                    using (Tracer.Instance.StartActive("Microsoft.Extensions.Example - Nested span"))
+                    {
+                        _logger.LogInformation("Message during a child span.");
+                    }
+                }
+                _logger.LogInformation("Message after a trace.");
+            }
+
+            await Task.Delay(1_000, stoppingToken);
+        }
+    }
+}

--- a/samples/AutomaticTraceIdInjection/README.md
+++ b/samples/AutomaticTraceIdInjection/README.md
@@ -19,3 +19,9 @@ Layouts configured in the sample:
 - JSON format: `JsonFormatter`
 - JSON format: `CompactJsonFormatter` (from the `Serilog.Formatting.Compact` NuGet package)
 - Raw format: output template (requires a custom Datadog Log Pipeline for processing)
+
+### Microsoft.Extensions.Logging
+Log injection for Microsoft.Extensions.Logging uses auto-instrumentation to inject logs. In this sample the [Datadog.Monitoring.Distribution](https://www.nuget.org/packages/Datadog.Monitoring.Distribution/) NuGet package is used to enable automatic instrumentation, but you can use any of the installation methods described in [the documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/).  
+
+Layouts configured in the sample:
+- JSON format (from the `NetEscapades.Extensions.Logging.RollingFile` NuGet package)

--- a/samples/samples.sln
+++ b/samples/samples.sln
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog46Example", "AutomaticT
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog40Example", "AutomaticTraceIdInjection\NLog40Example\NLog40Example.csproj", "{13CA2EF4-EF35-4473-BA59-F0F6C35ED147}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MicrosoftExtensionsExample", "AutomaticTraceIdInjection\MicrosoftExtensionsExample\MicrosoftExtensionsExample.csproj", "{1CD71746-301E-42D6-B6E7-EE5FB0E2EC09}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{13CA2EF4-EF35-4473-BA59-F0F6C35ED147}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13CA2EF4-EF35-4473-BA59-F0F6C35ED147}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13CA2EF4-EF35-4473-BA59-F0F6C35ED147}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CD71746-301E-42D6-B6E7-EE5FB0E2EC09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CD71746-301E-42D6-B6E7-EE5FB0E2EC09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CD71746-301E-42D6-B6E7-EE5FB0E2EC09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CD71746-301E-42D6-B6E7-EE5FB0E2EC09}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +65,7 @@ Global
 		{B987A36C-111D-41B7-9DA0-35DF790DD450} = {8AD58831-2198-4661-AC87-EFA754EDC4E9}
 		{82DD704F-20C9-4F77-B3ED-7E555E8077C8} = {8AD58831-2198-4661-AC87-EFA754EDC4E9}
 		{13CA2EF4-EF35-4473-BA59-F0F6C35ED147} = {8AD58831-2198-4661-AC87-EFA754EDC4E9}
+		{1CD71746-301E-42D6-B6E7-EE5FB0E2EC09} = {8AD58831-2198-4661-AC87-EFA754EDC4E9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1C64C3C7-7F87-46D4-88F8-1DB81303FBAC}

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
@@ -8,7 +8,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 
-namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ILogger
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 {
     internal class DatadogLoggingScope : IReadOnlyList<KeyValuePair<string, object>>
     {

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
@@ -41,8 +41,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
                     0 => new KeyValuePair<string, object>("dd_service", _tracer.ActiveScope?.Span.ServiceName ?? _service),
                     1 => new KeyValuePair<string, object>("dd_env", _env),
                     2 => new KeyValuePair<string, object>("dd_version", _version),
-                    3 => new KeyValuePair<string, object>("dd_trace_id", _tracer.ActiveScope?.Span.TraceId),
-                    4 => new KeyValuePair<string, object>("dd_span_id", _tracer.ActiveScope?.Span.SpanId),
+                    3 => new KeyValuePair<string, object>("dd_trace_id", (_tracer.ActiveScope?.Span.TraceId ?? 0).ToString()),
+                    4 => new KeyValuePair<string, object>("dd_span_id", (_tracer.ActiveScope?.Span.SpanId ?? 0).ToString()),
                     _ => throw new ArgumentOutOfRangeException(nameof(index))
                 };
             }
@@ -58,8 +58,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
                 span?.ServiceName ?? _service,
                 _env,
                 _version,
-                _tracer.ActiveScope?.Span.TraceId,
-                _tracer.ActiveScope?.Span.SpanId);
+                _tracer.ActiveScope?.Span.TraceId ?? 0,
+                _tracer.ActiveScope?.Span.SpanId ?? 0);
         }
 
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
@@ -71,8 +71,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 
             if (span is not null)
             {
-                yield return new KeyValuePair<string, object>("dd_trace_id", span.TraceId);
-                yield return new KeyValuePair<string, object>("dd_span_id", span.SpanId);
+                yield return new KeyValuePair<string, object>("dd_trace_id", span.TraceId.ToString());
+                yield return new KeyValuePair<string, object>("dd_span_id", span.SpanId.ToString());
             }
         }
 

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
             _version = tracer.Settings.ServiceVersion ?? string.Empty;
             _cachedFormat = string.Format(
                 CultureInfo.InvariantCulture,
-                "{{\"dd_service\":\"{0}\", \"dd_env\":\"{1}\", \"dd_version\":\"{2}\"}}",
+                "dd_service:\"{0}\", dd_env:\"{1}\", dd_version:\"{2}\"",
                 _service,
                 _env,
                 _version);
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 
             return string.Format(
                 CultureInfo.InvariantCulture,
-                "{{\"dd_service\":\"{0}\", \"dd_env\":\"{1}\", \"dd_version\":\"{2}\", \"dd_trace_id\":\"{3}\", \"dd_span_id\":\"{4}\"}}",
+                "dd_service:\"{0}\", dd_env:\"{1}\", dd_version:\"{2}\", dd_trace_id:\"{3}\", dd_span_id:\"{4}\"",
                 span?.ServiceName ?? _service,
                 _env,
                 _version,

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LoggerExternalScopeProviderForEachScopeIntegration.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LoggerExternalScopeProviderForEachScopeIntegration.cs
@@ -7,7 +7,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 
-namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ILogger
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 {
     /// <summary>
     /// LoggerExternalScopeProvider.ForEach&lt;TState&gt; calltarget instrumentation

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LoggerFactoryScopeProviderForEachScopeIntegration.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LoggerFactoryScopeProviderForEachScopeIntegration.cs
@@ -7,7 +7,7 @@ using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 
-namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ILogger
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 {
     /// <summary>
     /// LoggerFactoryScopeProvider.ForEach&lt;TState&gt; calltarget instrumentation

--- a/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LoggerIntegrationCommon.cs
+++ b/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LoggerIntegrationCommon.cs
@@ -6,7 +6,7 @@
 using System;
 using Datadog.Trace.Configuration;
 
-namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ILogger
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 {
     internal static class LoggerIntegrationCommon
     {

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/DatadogLoggingScopeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/DatadogLoggingScopeTests.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="DatadogLoggingScopeTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Agent;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DogStatsd;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging
+{
+    public class DatadogLoggingScopeTests
+    {
+        [Fact]
+        public void OutputsJsonFormattedStringWhenNoActiveTrace()
+        {
+            var settings = new TracerSettings
+            {
+                ServiceName = "TestService",
+                ServiceVersion = "1.2.3",
+                Environment = "test"
+            };
+
+            var tracer = new Tracer(settings, new Mock<IAgentWriter>().Object, null, null, new NoOpStatsd());
+
+            var scope = new DatadogLoggingScope(tracer);
+
+            var actual = scope.ToString();
+
+            actual.Should().Be(@"{""dd_service"":""TestService"", ""dd_env"":""test"", ""dd_version"":""1.2.3""}");
+
+            // Shouldn't throw
+            JObject.Parse(actual).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void OutputsJsonFormattedStringWhenActiveTrace()
+        {
+            var settings = new TracerSettings
+            {
+                ServiceName = "TestService",
+                ServiceVersion = "1.2.3",
+                Environment = "test"
+            };
+
+            var tracer = new Tracer(settings, new Mock<IAgentWriter>().Object, null, null, new NoOpStatsd());
+            using var spanScope = tracer.StartActive("test");
+            var scope = new DatadogLoggingScope(tracer);
+
+            var actual = scope.ToString();
+
+            var expcted = @"{""dd_service"":""TestService"", ""dd_env"":""test"", ""dd_version"":""1.2.3"", "
+                        + $@"""dd_trace_id"":""{spanScope.Span.TraceId}"", ""dd_span_id"":""{spanScope.Span.SpanId}""}}";
+            actual.Should()
+                  .Be(
+                       expcted);
+
+            // Shouldn't throw
+            JObject.Parse(actual).Should().NotBeNull();
+        }
+    }
+}

--- a/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DatadogLoggingScopeTests.cs
+++ b/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DatadogLoggingScopeTests.cs
@@ -7,12 +7,11 @@ using Datadog.Trace.Agent;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.ILogger
 {
     public class DatadogLoggingScopeTests
     {
@@ -32,10 +31,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging
 
             var actual = scope.ToString();
 
-            actual.Should().Be(@"{""dd_service"":""TestService"", ""dd_env"":""test"", ""dd_version"":""1.2.3""}");
-
-            // Shouldn't throw
-            JObject.Parse(actual).Should().NotBeNull();
+            actual.Should().Be(@"dd_service:""TestService"", dd_env:""test"", dd_version:""1.2.3""");
         }
 
         [Fact]
@@ -54,14 +50,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging
 
             var actual = scope.ToString();
 
-            var expcted = @"{""dd_service"":""TestService"", ""dd_env"":""test"", ""dd_version"":""1.2.3"", "
-                        + $@"""dd_trace_id"":""{spanScope.Span.TraceId}"", ""dd_span_id"":""{spanScope.Span.SpanId}""}}";
-            actual.Should()
-                  .Be(
-                       expcted);
-
-            // Shouldn't throw
-            JObject.Parse(actual).Should().NotBeNull();
+            var expected = @$"dd_service:""TestService"", dd_env:""test"", dd_version:""1.2.3"", dd_trace_id:""{spanScope.Span.TraceId}"", dd_span_id:""{spanScope.Span.SpanId}""";
+            actual.Should().Be(expected);
         }
     }
 }

--- a/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Datadog.Trace;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger;
+using Datadog.Trace.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Benchmarks.Trace
+{
+    [MemoryDiagnoser]
+    public class ILoggerBenchmark
+    {
+        private static readonly Tracer LogInjectionTracer;
+        private static readonly ILogger Logger;
+
+        static ILoggerBenchmark()
+        {
+            var logInjectionSettings = new TracerSettings
+            {
+                StartupDiagnosticLogEnabled = false,
+                LogsInjectionEnabled = true,
+                Environment = "env",
+                ServiceVersion = "version"
+            };
+
+            LogInjectionTracer = new Tracer(logInjectionSettings, new DummyAgentWriter(), null, null, null);
+            Tracer.Instance = LogInjectionTracer;
+
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddSingleton<ILoggerProvider, TestProvider>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Logger = serviceProvider.GetRequiredService<ILogger<ILoggerBenchmark>>();
+        }
+
+        [Benchmark]
+        public void EnrichedLog()
+        {
+            using (LogInjectionTracer.StartActive("Test"))
+            {
+                using (LogInjectionTracer.StartActive("Child"))
+                {
+                    Logger.LogInformation("Hello");
+                }
+            }
+        }
+
+        internal class TestProvider : ILoggerProvider, ISupportExternalScope
+        {
+            private IExternalScopeProvider _scopeProvider;
+            public static TestProvider Instance { get; } = new();
+
+            public ILogger CreateLogger(string categoryName)
+            {
+                return new TestLogger(_scopeProvider, categoryName);
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+            }
+
+            public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+            {
+                _scopeProvider = scopeProvider;
+            }
+        }
+
+        internal class TestLogger : ILogger
+        {
+            private readonly IExternalScopeProvider _scopeProvider;
+            private readonly string _category;
+            private const string LoglevelPadding = ": ";
+
+            public TestLogger(IExternalScopeProvider scopeProvider, string category)
+            {
+                _scopeProvider = scopeProvider;
+                _category = category;
+            }
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+#if DEBUG
+                var textWriter = System.Console.Out;
+#else
+                var textWriter = TextWriter.Null;
+#endif
+                if (!IsEnabled(logLevel))
+                {
+                    return;
+                }
+
+                textWriter.Write(LoglevelPadding);
+                textWriter.Write(_category);
+                textWriter.Write('[');
+
+                textWriter.Write(eventId.ToString());
+
+                textWriter.Write(']');
+
+                // scope information
+                WriteScopeInformation(textWriter, _scopeProvider);
+                var message = formatter(state, exception);
+                WriteMessage(textWriter, message);
+
+                if (exception != null)
+                {
+                    // exception message
+                    WriteMessage(textWriter, exception.ToString());
+                }
+
+                textWriter.Write(Environment.NewLine);
+            }
+
+            private static void WriteMessage(TextWriter writer, string text)
+            {
+                if (!string.IsNullOrEmpty(text))
+                {
+                    writer.Write(' ');
+                    writer.Write(text.Replace(Environment.NewLine, " "));
+                }
+            }
+
+            private static void WriteScopeInformation(TextWriter textWriter, IExternalScopeProvider scopeProvider)
+            {
+                if (scopeProvider != null)
+                {
+                    Action<object,TextWriter> callback = (scope, state) =>
+                    {
+                        state.Write(" => ");
+                        state.Write(scope);
+                    };
+
+                    // Logs injection emulation
+                    LoggerIntegrationCommon.AddScope(Tracer.Instance, callback, textWriter);
+                    scopeProvider.ForEachScope(callback, textWriter);
+                }
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public IDisposable BeginScope<TState>(TState state)
+                => _scopeProvider?.Push(state) ?? NullScope.Instance;
+        }
+
+        internal sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+
+            private NullScope()
+            {
+            }
+
+            /// <inheritdoc />
+            public void Dispose()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Changes in this PR:

* Moves the  `ILogger` instrumentation into Logging sub-folder. We're going to have a lot of common code for the different ILogger integrations for direct log shipping, so makes sense to do this I think
* Call `ToString()` on `SpanId` and `TraceId`. Ensures they're written as strings by log providers to hopefully circumvent parsing issues when using custom log parsing.
* Addd a benchmark for logs injection (uninjected vs injected results shown below, but only the injected benchmark included, in line with other log injection)
* Added a sample app demonstrating the ILogger logs injection
* Output a better format string from DatadogScope. Some simplistic logger providers just call `ToString()` on an injected scope, instead of enumerating the values. This change ensures there's a valid json blob in the output for the logs agent to parse.

@DataDog/apm-dotnet 
