### PR TITLE
Fix profiler build issue

### DIFF
--- a/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Composition.props
+++ b/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Composition.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\..\dd-trace-dotnet\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
   

--- a/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Emission.props
+++ b/shared/src/managed-src/Datadog.Logging/Datadog.Logging.Emission.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <SharedSrcBaseDir>$(EnlistmentRoot)\shared\src\managed-src</SharedSrcBaseDir>
+    <SharedSrcBaseDir>$(EnlistmentRoot)\..\dd-trace-dotnet\shared\src\managed-src</SharedSrcBaseDir>
     <SharedSrcBaseLabel>Shared-Src</SharedSrcBaseLabel>
   </PropertyGroup>
 


### PR DESCRIPTION
When compiling the profiler, props files that uses EnlistmentRoot variable will point to the profiler repository.
But in the shared logging `props` files, EntlistmentRoot variable is considered as being the tracer repository.
This prevents the profiler to build correctly its managed libraries.

Fixes #

For now, in the shared logging `props` files, we will consider EntlistmentRoot variable as the path to the profiler repository and computer the other path relative to it.



@DataDog/apm-dotnet