### PR TITLE
Correct memory management for interactions with libddwaf

### DIFF
--- a/src/Datadog.Trace/AppSec/Waf/Obj.cs
+++ b/src/Datadog.Trace/AppSec/Waf/Obj.cs
@@ -24,7 +24,10 @@ namespace Datadog.Trace.AppSec.Waf
             this.ptr = ptr;
         }
 
-        // NOTE: do not add a finalizer here. Mostly DdwafObject will be owned and freed by the native code
+        ~Obj()
+        {
+            Dispose(false);
+        }
 
         public ObjType ArgsType
         {
@@ -43,6 +46,7 @@ namespace Datadog.Trace.AppSec.Waf
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         public void Dispose(bool disposing)
@@ -54,7 +58,7 @@ namespace Datadog.Trace.AppSec.Waf
 
             disposed = true;
 
-            WafNative.ObjectFree(ptr);
+            Marshal.FreeHGlobal(ptr);
         }
 
         private void Initailize()


### PR DESCRIPTION
I had assumed that libddwaf took ownership of objects assoicated with it and therefore
free them when context objects where freed. However this isn't the case, all objects
allocated by the C# code for the ddlibwaf need to be explicitly freed. This PR does that
in a simple way.

Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet