### PR TITLE
Header keys should be lower case

### DIFF
--- a/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
+++ b/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
@@ -448,7 +448,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
 
             return files
                 .Select(File.ReadAllText)
-                .Any(fileContents => muslDistros.Any(distroId => fileContents.ToLower(CultureInfo.InvariantCulture).Contains(distroId)));
+                .Any(fileContents => muslDistros.Any(distroId => fileContents.ToLowerInvariant().Contains(distroId)));
         }
 
         private static void GetLibNameAndRuntimeId(FrameworkDescription frameworkDescription, out string libName, out string runtimeId)

--- a/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -5,6 +5,7 @@
 
 #if !NETFRAMEWORK
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Datadog.Trace.AppSec;
 using Microsoft.AspNetCore.Http;
@@ -24,7 +25,7 @@ namespace Datadog.Trace.Util.Http
             {
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    headersDic.Add(k, request.Headers[k]);
+                    headersDic.Add(k.ToLower(CultureInfo.InvariantCulture), request.Headers[k]);
                 }
             }
 

--- a/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Util.Http
             {
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    headersDic.Add(k.ToLower(CultureInfo.InvariantCulture), request.Headers[k]);
+                    headersDic.Add(k.ToLowerInvariant(), request.Headers[k]);
                 }
             }
 

--- a/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -5,6 +5,7 @@
 #if NETFRAMEWORK
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Web;
 using System.Web.Routing;
@@ -22,7 +23,7 @@ namespace Datadog.Trace.Util.Http
             {
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    headersDic.Add(k, request.Headers[k]);
+                    headersDic.Add(k.ToLower(CultureInfo.InvariantCulture), request.Headers[k]);
                 }
             }
 

--- a/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Util.Http
             {
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    headersDic.Add(k.ToLower(CultureInfo.InvariantCulture), request.Headers[k]);
+                    headersDic.Add(k.ToLowerInvariant(), request.Headers[k]);
                 }
             }
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet