### PR TITLE
Fix Benchmarks build break from removing Datadog.Trace.Abstractions namespace

### DIFF
--- a/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
-using Datadog.Trace.Abstractions;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.AppSec;


### PR DESCRIPTION
@DataDog/apm-dotnet