### PR TITLE
update code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,8 @@
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
 *                                 @DataDog/apm-dotnet
+/shared                           @DataDog/apm-dotnet @DataDog/profiling-dotnet
 /tracer                           @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Ci      @DataDog/apm-dotnet @DataDog/ci-app-tracers
-/tracer/src/Datadog.Trace/AppSec  @DataDog/apm-dotnet @DataDog/appsec-dotnet
+# /tracer/src/Datadog.Trace/AppSec  @DataDog/apm-dotnet @DataDog/appsec-dotnet
 /profiler                         @DataDog/profiling-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 
 *                          @DataDog/apm-dotnet
 /tracer                    @DataDog/apm-dotnet
-/src/Datadog.Trace/Ci      @DataDog/apm-dotnet @DataDog/ci-app-tracers
-/src/Datadog.Trace/AppSec  @DataDog/apm-dotnet @DataDog/appsec-dotnet
+/tracer/src/Datadog.Trace/Ci      @DataDog/apm-dotnet @DataDog/ci-app-tracers
+/tracer/src/Datadog.Trace/AppSec  @DataDog/apm-dotnet @DataDog/appsec-dotnet
 /profiler                  @DataDog/profiling-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
-* @DataDog/apm-dotnet
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
+
+*                          @DataDog/apm-dotnet
+/tracer                    @DataDog/apm-dotnet
+/src/Datadog.Trace/Ci      @DataDog/apm-dotnet @DataDog/ci-app-tracers
+/src/Datadog.Trace/AppSec  @DataDog/apm-dotnet @DataDog/appsec-dotnet
+/profiler                  @DataDog/profiling-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
-*                          @DataDog/apm-dotnet
-/tracer                    @DataDog/apm-dotnet
+*                                 @DataDog/apm-dotnet
+/tracer                           @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Ci      @DataDog/apm-dotnet @DataDog/ci-app-tracers
 /tracer/src/Datadog.Trace/AppSec  @DataDog/apm-dotnet @DataDog/appsec-dotnet
-/profiler                  @DataDog/profiling-dotnet
+/profiler                         @DataDog/profiling-dotnet

--- a/shared/CODEOWNERS
+++ b/shared/CODEOWNERS
@@ -1,1 +1,0 @@
-﻿* @macrogreg @DataDog/apm-dotnet

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -6,7 +6,7 @@ This directory (`/tracer`) contains the source for the __Tracer for .NET__ produ
 
 ### Copyright
 
-Copyright (c) 2017-2021 Datadog
+Copyright (c) 2017 Datadog
 [https://www.datadoghq.com](https://www.datadoghq.com/)
 
 ### License
@@ -18,4 +18,3 @@ See [license information](../LICENSE).
 Currently, this directory is empty.
 It is a placeholder for the Tracer sources, which will be available here in the future.
 In the meantime, the Tracer is available directly in the root of this repo.
- 


### PR DESCRIPTION
Update `CODEOWNERS` file to assign github teams as code owners to specific repository sub-folders.

NOTE: Updated with changes from #1748
TODO: add GitHub team `profiling-dotnet` to the default (`*`) owner when the profiler code moves into this repository.
