### PR TITLE
Env var to override default AppSec rules

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.AppSec
                 _settings.Enabled = _settings.Enabled && AreArchitectureAndOsSupported();
                 if (_settings.Enabled)
                 {
-                    _powerWaf = powerWaf ?? Waf.Waf.Initialize();
+                    _powerWaf = powerWaf ?? Waf.Waf.Initialize(_settings.Rules);
                     if (_powerWaf != null)
                     {
                         _agentWriter = agentWriter ?? new AppSecAgentWriter();

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -19,11 +19,14 @@ namespace Datadog.Trace.AppSec
             // both should default to false
             Enabled = source?.GetBool(ConfigurationKeys.AppSecEnabled) ?? false;
             BlockingEnabled = source?.GetBool(ConfigurationKeys.AppSecBlockingEnabled) ?? false;
+            Rules = source?.GetString(ConfigurationKeys.AppSecRules);
         }
 
         public bool Enabled { get; set; }
 
         public bool BlockingEnabled { get; }
+
+        public string Rules { get; }
 
         public static SecuritySettings FromDefaultSources()
         {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/NativeLibrary.cs
@@ -71,7 +71,8 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             if (errorPtr != IntPtr.Zero)
             {
                 var error = Marshal.PtrToStringAnsi(errorPtr);
-                Log.Error($"Error during '{op}': {error}");
+                // warning, since in some cases dddlerror returns a message when an error didn't occur or was recoverable
+                Log.Warning("'{Op}' dddlerror returned: {Error}", op, error);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -178,7 +178,7 @@ namespace Datadog.Trace.AppSec.Waf
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error occured logging rules");
+                Log.Error(ex, "Error occured logging the ddwaf rules");
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -151,7 +151,7 @@ namespace Datadog.Trace.AppSec.Waf
                         var idProp = ev.Value<JValue>("id");
                         var nameProp = ev.Value<JValue>("name");
                         var addresses = ev.Value<JArray>("conditions").SelectMany(x => x.Value<JObject>("parameters").Value<JArray>("inputs"));
-                        Log.Debug($"Loaded rule: {idProp.Value} - {nameProp.Value} on addresses: {string.Join(", ", addresses)}");
+                        Log.Debug("Loaded rule: {id} - {name} on addresses: {addresses}", idProp.Value, nameProp.Value, string.Join(", ", addresses));
                     }
                 }
                 catch (Exception ex)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -87,6 +87,11 @@ namespace Datadog.Trace.AppSec.Waf
             using var jsonReader = new JsonTextReader(reader);
             var root = JToken.ReadFrom(jsonReader);
 
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                LogRuleDetails(root);
+            }
+
             return Encoder.Encode(root, argCache);
         }
 
@@ -121,11 +126,6 @@ namespace Datadog.Trace.AppSec.Waf
                     return null;
                 }
 
-                if (Log.IsEnabled(LogEventLevel.Debug))
-                {
-                    LogRuleDetails(rulesFile);
-                }
-
                 configObj = CreatObjFromRulesStream(argCache, stream);
             }
             catch (Exception ex)
@@ -155,18 +155,10 @@ namespace Datadog.Trace.AppSec.Waf
             }
         }
 
-        private static void LogRuleDetails(string rulesFile)
+        private static void LogRuleDetails(JToken root)
         {
             try
             {
-                // because of the generic way rules are encoded for the WAF there's no good
-                // way to log them without double parsing, but as this only happens at debug
-                // log level, I think this is okay
-                using var stream = GetRulesStream(rulesFile);
-                using var reader = new StreamReader(stream);
-                using var jsonReader = new JsonTextReader(reader);
-                var root = JToken.ReadFrom(jsonReader);
-
                 var eventsProp = root.Value<JArray>("events");
                 foreach (var ev in eventsProp)
                 {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -6,10 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.Waf
 {
@@ -17,12 +19,12 @@ namespace Datadog.Trace.AppSec.Waf
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Waf));
 
-        private readonly WafHandle rule;
+        private readonly WafHandle wafHandle;
         private bool disposed = false;
 
-        private Waf(WafHandle rule)
+        private Waf(WafHandle wafHandle)
         {
-            this.rule = rule;
+            this.wafHandle = wafHandle;
         }
 
         ~Waf()
@@ -39,15 +41,25 @@ namespace Datadog.Trace.AppSec.Waf
             }
         }
 
-        public static Waf Initialize()
+        public static Waf Initialize(string rulesFile)
         {
-            var rule = NewRule();
-            return rule == null ? null : new Waf(rule);
+            var wafHandle = CreateWafHandle(rulesFile);
+
+            if (wafHandle == null)
+            {
+                Log.Error("Failed to create rules.");
+            }
+            else
+            {
+                Log.Information("Rules successfully created.");
+            }
+
+            return wafHandle == null ? null : new Waf(wafHandle);
         }
 
         public IContext CreateContext()
         {
-            var handle = WafNative.InitContext(rule.Handle, WafNative.ObjectFreeFuncPtr);
+            var handle = WafNative.InitContext(wafHandle.Handle, WafNative.ObjectFreeFuncPtr);
             return new Context(handle);
         }
 
@@ -66,53 +78,111 @@ namespace Datadog.Trace.AppSec.Waf
 
             disposed = true;
 
-            rule?.Dispose();
+            wafHandle?.Dispose();
         }
 
-        private static Obj RuleSetFromManifest(List<Obj> argCache)
+        private static Obj CreatObjFromRulesStream(List<Obj> argCache, Stream stream)
         {
-            var assembly = typeof(Waf).Assembly;
-            var resource = assembly.GetManifestResourceStream("Datadog.Trace.AppSec.Waf.rule-set.json");
-            using var reader = new JsonTextReader(new StreamReader(resource));
-            var root = JToken.ReadFrom(reader);
+            var root = GetJsonReaderFromStream(stream);
 
             return Encoder.Encode(root, argCache);
         }
 
-        private static WafHandle NewRule()
+        private static JToken GetJsonReaderFromStream(Stream stream)
         {
+            var reader = new JsonTextReader(new StreamReader(stream));
+            return JToken.ReadFrom(reader);
+        }
+
+        private static Stream GetRulesManifestStream()
+        {
+            var assembly = typeof(Waf).Assembly;
+            return assembly.GetManifestResourceStream("Datadog.Trace.AppSec.Waf.rule-set.json");
+        }
+
+        private static Stream GetRulesFileStream(string rulesFile)
+        {
+            if (!File.Exists(rulesFile))
+            {
+                Log.Error($"AppSec could not find the rules file in path \"{rulesFile}\". AppSec will not run any protections in this application.");
+                return null;
+            }
+
+            return File.OpenRead(rulesFile);
+        }
+
+        private static WafHandle CreateWafHandle(string rulesFile)
+        {
+            var argCache = new List<Obj>();
+            Obj configObj;
+            try
+            {
+                var stream = GetRulesStream(rulesFile);
+
+                if (stream == null)
+                {
+                    return null;
+                }
+
+                if (Log.IsEnabled(LogEventLevel.Debug))
+                {
+                    LogRuleDetails(rulesFile);
+                }
+
+                configObj = CreatObjFromRulesStream(argCache, stream);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"AppSec could not read the rule file \"{rulesFile}\" as it was invalid. AppSec will not run any protections in this application.");
+                return null;
+            }
+
             try
             {
                 DdwafConfigStruct args = default;
-
-                var argCache = new List<Obj>();
-                var rules = RuleSetFromManifest(argCache);
-
-                var ruleHandle = WafNative.Init(rules.RawPtr, ref args);
-
-                rules.Dispose();
+                var ruleHandle = WafNative.Init(configObj.RawPtr, ref args);
+                return new WafHandle(ruleHandle);
+            }
+            finally
+            {
+                configObj?.Dispose();
                 foreach (var arg in argCache)
                 {
                     arg.Dispose();
                 }
+            }
+        }
 
-                if (ruleHandle == IntPtr.Zero)
-                {
-                    Log.Error("Failed to create rules.");
-                    return null;
-                }
-                else
-                {
-                    Log.Information("Rules successfully created.");
-                }
+        private static void LogRuleDetails(string rulesFile)
+        {
+            try
+            {
+                // because of the generic way rules are encoded for the WAF there's no good
+                // way to log them without double parsing, but as this only happens at debug
+                // log level, I think this is okay
+                var stream = GetRulesStream(rulesFile);
+                var root = GetJsonReaderFromStream(stream);
 
-                return new WafHandle(ruleHandle);
+                var eventsProp = root.Value<JArray>("events");
+                foreach (var ev in eventsProp)
+                {
+                    var idProp = ev.Value<JValue>("id");
+                    var nameProp = ev.Value<JValue>("name");
+                    var addresses = ev.Value<JArray>("conditions").SelectMany(x => x.Value<JObject>("parameters").Value<JArray>("inputs"));
+                    Log.Debug($"Loaded rule: {idProp.Value} - {nameProp.Value} on addresses: {string.Join(", ", addresses)}");
+                }
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Error loading the power WAF rules");
-                return null;
+                Log.Error(ex, "Error occured logging rules");
             }
+        }
+
+        private static Stream GetRulesStream(string rulesFile)
+        {
+            return string.IsNullOrWhiteSpace(rulesFile) ?
+                    GetRulesManifestStream() :
+                    GetRulesFileStream(rulesFile);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -57,8 +57,8 @@ namespace Datadog.Trace.Configuration
         public const string AppSecBlockingEnabled = "DD_APPSEC_BLOCKING_ENABLED";
 
         /// <summary>
-        /// Configuration key for enabling or disabling blocking in AppSec.
-        /// Default is value is false (disabled).
+        /// Override the default rule file provide. Must be a path to a valid JSON rule file.
+        /// Default is value is null (no not override).
         /// </summary>
         public const string AppSecRules = "DD_APPSEC_RULES";
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -57,8 +57,8 @@ namespace Datadog.Trace.Configuration
         public const string AppSecBlockingEnabled = "DD_APPSEC_BLOCKING_ENABLED";
 
         /// <summary>
-        /// Override the default rule file provide. Must be a path to a valid JSON rule file.
-        /// Default is value is null (no not override).
+        /// Override the default rules file provided. Must be a path to a valid JSON rules file.
+        /// Default is value is null (do not override).
         /// </summary>
         public const string AppSecRules = "DD_APPSEC_RULES";
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -57,6 +57,12 @@ namespace Datadog.Trace.Configuration
         public const string AppSecBlockingEnabled = "DD_APPSEC_BLOCKING_ENABLED";
 
         /// <summary>
+        /// Configuration key for enabling or disabling blocking in AppSec.
+        /// Default is value is false (disabled).
+        /// </summary>
+        public const string AppSecRules = "DD_APPSEC_RULES";
+
+        /// <summary>
         /// Configuration key for enabling or disabling the Tracer's debug mode.
         /// Default is value is false (disabled).
         /// </summary>

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
@@ -23,6 +23,7 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
         public const string AppSecBlockingEnabled = "DD_APPSEC_BLOCKING_ENABLED";
         public const string AppSecEnabled = "DD_APPSEC_ENABLED";
+        public const string AppSecRules = "DD_APPSEC_RULES";
         public const string BufferSize = "DD_TRACE_BUFFER_SIZE";
         public const string ConfigurationFileName = "DD_TRACE_CONFIG_FILE";
         public const string CustomSamplingRules = "DD_TRACE_SAMPLING_RULES";

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
@@ -23,6 +23,7 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
         public const string AppSecBlockingEnabled = "DD_APPSEC_BLOCKING_ENABLED";
         public const string AppSecEnabled = "DD_APPSEC_ENABLED";
+        public const string AppSecRules = "DD_APPSEC_RULES";
         public const string BufferSize = "DD_TRACE_BUFFER_SIZE";
         public const string ConfigurationFileName = "DD_TRACE_CONFIG_FILE";
         public const string CustomSamplingRules = "DD_TRACE_SAMPLING_RULES";


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet