### PR TITLE
[Appsec] Fixing empty appsec payload sent to backend

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Agent/AppSecAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Agent/AppSecAgentWriter.cs
@@ -66,8 +66,8 @@ namespace Datadog.Trace.AppSec.Agent
 
                 if (_events.Count == 0)
                 {
-                    _senderMutex.Wait();
                     _senderMutex.Reset();
+                    _senderMutex.Wait();
                 }
 
                 try


### PR DESCRIPTION
Sometimes backend would receive empty payloads. 

Fixes #

Changes proposed in this pull request:
Waiting after reseting, otherwise the thread is not blocked yet but only next time.



@DataDog/apm-dotnet