### PR TITLE
Fix broken paths after repository move

### DIFF
--- a/.azure-pipelines/third-party-test-suites.yml
+++ b/.azure-pipelines/third-party-test-suites.yml
@@ -13,11 +13,6 @@ schedules:
 variables:
   buildConfiguration: Release
   dotnetCoreSdk5Version: 5.0.103
-  relativeTracerHome: /src/bin/windows-tracer-home
-  relativeArtifacts: /src/bin/artifacts
-  ddTracerHome: $(System.DefaultWorkingDirectory)/src/bin/dd-tracer-home
-  tracerHome: $(System.DefaultWorkingDirectory)/src/bin/windows-tracer-home
-  artifacts: $(System.DefaultWorkingDirectory)/src/bin/artifacts
   ddApiKey: $(DD_API_KEY)
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
   # Src libraries
   - package-ecosystem: "nuget"
-    directory: "/src/Datadog.Trace"
+    directory: "/tracer/src/Datadog.Trace"
     schedule:
       interval: "daily"
     labels:
@@ -37,7 +37,7 @@ updates:
       - dependency-name: "Microsoft.Build.Framework"
 
   - package-ecosystem: "nuget"
-    directory: "/src/Datadog.Trace.OpenTracing"
+    directory: "/tracer/src/Datadog.Trace.OpenTracing"
     schedule:
       interval: "daily"
     labels:
@@ -58,7 +58,7 @@ updates:
       - dependency-name: "System.Reflection.Emit.Lightweight"
       ### End Datadog.Trace.csproj ignored dependencies
   - package-ecosystem: "nuget"
-    directory: "/src/Datadog.Trace.BenchmarkDotNet"
+    directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
     schedule:
       interval: "daily"
     labels:

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -20,7 +20,7 @@ jobs:
           dotnet-version: '5.0.x'
 
       - name: "Assign to vNext Milestone"
-        run: ./build.sh AssignPullRequestToMilestone
+        run: ./tracer/build.sh AssignPullRequestToMilestone
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/auto_tag_version_bump_commit.yml
+++ b/.github/workflows/auto_tag_version_bump_commit.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: "Output current version"
         id: versions
-        run: ./build.sh OutputCurrentVersionToGitHub
+        run: ./tracer/build.sh OutputCurrentVersionToGitHub
 
       - name: "Configure Git Credentials"
         run: |

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -20,15 +20,15 @@ jobs:
 
       - name: "Get current version"
         id: version
-        run: ./build.sh OutputCurrentVersionToGitHub
+        run: ./tracer/build.sh OutputCurrentVersionToGitHub
 
       - name: "Download assets from Azure Pipelines"
         id: assets
-        run: ./build.sh DownloadAzurePipelineArtifacts
+        run: ./tracer/build.sh DownloadAzurePipelineArtifacts
 
       - name: "Extract release notes from changelog"
         id: release_notes
-        run: ./build.sh ExtractReleaseNotes
+        run: ./tracer/build.sh ExtractReleaseNotes
         env:
           PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
 

--- a/.github/workflows/create_version_bump_pr.yml
+++ b/.github/workflows/create_version_bump_pr.yml
@@ -31,22 +31,22 @@ jobs:
           dotnet-version: '5.0.x'
 
       - name: "Update Changelog"
-        run: .\build.ps1 UpdateChangeLog
+        run: .\tracer\build.ps1 UpdateChangeLog
 
       - name: "Bump Version"
-        run: .\build.ps1 UpdateIntegrationsJson UpdateVersion UpdateMsiContents
+        run: .\tracer\build.ps1 UpdateIntegrationsJson UpdateVersion UpdateMsiContents
 
       - name: "Verify Changes"
         id: changes
-        run: .\build.ps1 VerifyChangedFilesFromVersionBump
+        run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump
 
       - name: "Output version"
         id: versions
-        run: .\build.ps1 OutputCurrentVersionToGitHub
+        run: .\tracer\build.ps1 OutputCurrentVersionToGitHub
 
       - name: "Rename vNext milestone"
         id: rename
-        run: .\build.ps1 RenameVNextMilestone
+        run: .\tracer\build.ps1 RenameVNextMilestone
 
       - name: Create Pull Request
         id: pr

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ driver_build:
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_x64:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\build\_build\gitlab.bat
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_x64:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tracer\build\_build\gitlab.bat
     - mkdir artifacts
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
     - remove-item -recurse -force build-out\${CI_JOB_ID}


### PR DESCRIPTION
- Fix paths in GitHub workflows
- Fix paths in honeypot.yml
- Remove unused (incorrect) paths from third-party-test-suites pipeline
- Fix path for GitLab build

@DataDog/apm-dotnet 