### PR TITLE
Ensure that ILogger sample version is bumped each release

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -101,6 +101,7 @@ partial class Build
                 "docs/CHANGELOG.md",
                 "build/_build/Build.cs",
                 "integrations.json",
+                "samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj",
                 "samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj",
                 "samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj",
                 "samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj",

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -44,6 +44,9 @@ namespace PrepareRelease
 
             // Sample application package updates
             SynchronizeVersion(
+                "samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj",
+                DatadogTraceNugetDependencyVersionReplace);
+            SynchronizeVersion(
                 "samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj",
                 DatadogTraceNugetDependencyVersionReplace);
             SynchronizeVersion(


### PR DESCRIPTION
#1740 added a sample for ILogger logs injection. The sample version should be bumped when we do a new release

@DataDog/apm-dotnet