### PR TITLE
Ensure the PInvoke map rewrite on some CallSite scenarios

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -695,8 +695,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ModuleLoadFinished(ModuleID module_id, HR
         // subscribe to DiagnosticSource events.
         // don't skip Dapper: it makes ADO.NET calls even though it doesn't reference
         // System.Data or System.Data.Common
+        // don't skip Datadog.Trace: we need to ensure we do the PInvokesMap rewrites.
         if (module_info.assembly.name != microsoft_aspnetcore_hosting_assemblyName &&
-            module_info.assembly.name != dapper_assemblyName)
+            module_info.assembly.name != dapper_assemblyName &&
+            module_info.assembly.name != managed_profiler_name)
         {
             filtered_integrations = FilterIntegrationsByTarget(filtered_integrations, assembly_import);
 


### PR DESCRIPTION
This PR fixes some callsite scenarios where the pinvoke maps rewriter doesn't get called because the `Datadog.Trace` module is skipped.

#### Normal and expected log:
```
09/14/21 05:29:10.284 PM [19155|90489] [info] JITCompilationStarted: Startup hook registered in function_id=4835942816 token=100667476 name=System.Xml.XmlReaderSettings..ctor(), assembly_name=System.Private.Xml app_domain_id=140419979588608 domain_neutral=0
09/14/21 05:29:10.291 PM [19155|90489] [info] ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain 140419979588608 clrhost
09/14/21 05:29:10.344 PM [19155|90489] [info] ModuleLoadFinished: Datadog.Trace - Fix PInvoke maps
09/14/21 05:29:10.345 PM [19155|90489] [info] Rewriting pinvoke for: IsProfilerAttached
09/14/21 05:29:10.345 PM [19155|90489] [info] Rewriting pinvoke for: InitializeProfiler
09/14/21 05:29:10.345 PM [19155|90489] [info] Rewriting pinvoke for: dddlopen
09/14/21 05:29:10.345 PM [19155|90489] [info] Rewriting pinvoke for: dddlerror
09/14/21 05:29:10.345 PM [19155|90489] [info] Rewriting pinvoke for: dddlsym
09/14/21 05:29:10.346 PM [19155|90489] [info] AssemblyLoadFinished: Datadog.Trace.dll v1.28.6.0 matched profiler version v1.28.6.0
```

#### Log with the issue:
```
09/14/21 07:20:58.160 AM [5520|5520] [info] COR library: System.Private.CoreLib 4.0.0
09/14/21 07:20:58.395 AM [5520|5520] [info] JITCompilationStarted: Startup hook registered in function_id=140548188819296 token=100663314 name=Samples.Microsoft.Data.SqlClient.Program.<Main>(), assembly_name=Samples.Microsoft.Data.SqlClient app_domain_id=94308137663552 domain_neutral=0
09/14/21 07:20:58.413 AM [5520|5520] [info] ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain 94308137663552 clrhost
09/14/21 07:20:58.482 AM [5520|5520] [info] AssemblyLoadFinished: Datadog.Trace.dll v1.28.6.0 matched profiler version v1.28.6.0
```

By digging in the issue I found:
```
09/14/21 09:19:38.965 PM [24953|24964] [debug] ModuleLoadFinished skipping module (filtered by target): 139982402903512 Datadog.Trace
```

@DataDog/apm-dotnet