### PR TITLE
Parallelize throughput tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1018,13 +1018,34 @@ stages:
 - stage: throughput
   condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [build_linux, build_arm64, build_windows]
+  pool: Throughput
   jobs:
 
   #### Throughput Linux 64, windows 64, linux arm 64 
 
-  - job: Throughput
-    pool: Throughput
-    timeoutInMinutes: 190
+  - job: Linux64
+    timeoutInMinutes: 60
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux native binary
+      inputs:
+        artifact: linux-tracer-home-debian
+        path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
+
+    - script: |
+        test ! -s "tracer/tracer-home-linux/integrations.json" && echo "tracer/tracer-home-linux/integrations.json does not exist" && exit 1
+        test ! -s "tracer/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
+        test ! -s "tracer/tracer-home-linux/libddwaf.so" && echo "tracer/tracer-home-linux/libddwaf.so does not exist" && exit 1
+        cd $(System.DefaultWorkingDirectory)/tracer/build/crank
+        chmod +x ./run.sh
+        ./run.sh "linux"
+      displayName: Crank
+      env:
+        DD_SERVICE: dd-trace-dotnet
+
+  - job: Windows64
+    timeoutInMinutes: 60
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -1033,12 +1054,21 @@ stages:
         artifact: windows-tracer-home
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-win
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux native binary
-      inputs:
-        artifact: linux-tracer-home-debian
-        path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
+    - script: |
+        test ! -s "tracer/tracer-home-win/integrations.json" && echo "tracer/tracer-home-win/integrations.json does not exist" && exit 1
+        test ! -s "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll does not exist" && exit 1
+        test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
+        cd $(System.DefaultWorkingDirectory)/tracer/build/crank
+        chmod +x ./run.sh
+        ./run.sh "windows"
+      displayName: Crank
+      env:
+        DD_SERVICE: dd-trace-dotnet
 
+  - job: LinuxArm64
+    timeoutInMinutes: 60
+
+    steps:
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 native binary
       inputs:
@@ -1046,17 +1076,11 @@ stages:
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux-arm64
 
     - script: |
-        test ! -s "tracer/tracer-home-win/integrations.json" && echo "tracer/tracer-home-win/integrations.json does not exist" && exit 1
-        test ! -s "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll does not exist" && exit 1
-        test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/integrations.json" && echo "tracer/tracer-home-linux/integrations.json does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/libddwaf.so" && echo "tracer/tracer-home-linux/libddwaf.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux-arm64/integrations.json" && echo "tracer/tracer-home-linux-arm64/integrations.json does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux-arm64/Datadog.Trace.ClrProfiler.Native.so does not exist" && exit 1
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
-        ./run.sh
+        ./run.sh "linux_arm64"
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -24,41 +24,48 @@ echo "Using repo=$repo commit=$commit_sha"
 repository="--application.source.repository $repo"
 commit="--application.source.branchOrCommit #$commit_sha"
 
-#windows
+if [ "$1" = "windows" ]; then
+    echo "Running windows throughput tests"
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="baseline_windows.json"
-rm baseline_windows.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile windows --json baseline_windows.json $repository $commit --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="baseline_windows.json"
+    rm baseline_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile windows --json calltarget_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="calltarget_windows.json"
-rm calltarget_windows.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile windows --json calltarget_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_windows.json"
+    rm calltarget_windows.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --json calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="calltarget_ngen_windows.json"
-rm calltarget_ngen_windows.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile windows --json calltarget_ngen_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_ngen_windows.json"
+    rm calltarget_ngen_windows.json
 
-#linux
+elif [ "$1" = "linux" ]; then
+    echo "Running Linux  x64 throughput tests"
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="baseline_linux.json"
-rm baseline_linux.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux --json baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="baseline_linux.json"
+    rm baseline_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux --json calltarget_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="calltarget_linux.json"
-rm calltarget_linux.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux --json calltarget_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_linux.json"
+    rm calltarget_linux.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="calltarget_ngen_linux.json"
-rm calltarget_ngen_linux.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget_ngen --profile linux --json calltarget_ngen_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget_ngen --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_ngen_linux.json"
+    rm calltarget_ngen_linux.json
 
-#linux arm64
+elif [ "$1" = "linux_arm64" ]; then
+    echo "Running Linux arm64 throughput tests"
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="baseline_linux_arm64.json"
-rm baseline_linux_arm64.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario baseline --profile linux_arm64 --json baseline_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=baseline --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="baseline_linux_arm64.json"
+    rm baseline_linux_arm64.json
 
-crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --json calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
-dd-trace --crank-import="calltarget_linux_arm64.json"
-rm calltarget_linux_arm64.json
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario calltarget --profile linux_arm64 --json calltarget_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=calltarget --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="calltarget_linux_arm64.json"
+    rm calltarget_linux_arm64.json
 
+else
+    echo "Unknown argument $1"
+    exit 1
+fi


### PR DESCRIPTION
Runs the throughput tests as three separate jobs. To see speed ups, this will require three separate crank controllers. We still only have 1 agent for each OS, so it shouldn't adversely affect throughput tests stability (on the assumption that the controllers + network are not the limiting factors)

@DataDog/apm-dotnet