### PR TITLE
Scan integration test logs for errors

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -34,7 +34,7 @@ trigger:
 #     - Fmt lib:
       - shared/src/native-lib/fmt_x64-windows-static/*
       - shared/src/native-lib/fmt_x86-windows-static/*
-#     - Spdlob lib:      
+#     - Spdlob lib:
       - shared/src/native-lib/spdlog/*
 #     - Mics common native sources:
       - shared/src/native-src/*
@@ -280,6 +280,7 @@ stages:
           testResultsFiles: tracer/build_data/results/**/*.trx
         condition: succeededOrFailed()
 
+
     - job: native
       steps:
       - template: steps/install-dotnet.yml
@@ -323,7 +324,6 @@ stages:
         condition: succeededOrFailed()
 
 
-
 - stage: unit_tests_linux
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_linux]
@@ -360,6 +360,7 @@ stages:
         testResultsFormat: VSTest
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
+
 
 - stage: unit_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
@@ -453,6 +454,9 @@ stages:
       condition: succeededOrFailed()
       continueOnError: true
 
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: Check logs for errors
+
 - stage: integration_tests_windows_iis
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_windows, package_windows]
@@ -539,6 +543,9 @@ stages:
       artifact: integration_tests_windows_iis_tracer_logs_$(targetPlatform)_$(framework)
       condition: succeededOrFailed()
       continueOnError: true
+
+    - script: tracer\build.cmd CheckBuildLogsForErrors
+      displayName: Check logs for errors
 
 - stage: integration_tests_linux
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
@@ -639,6 +646,11 @@ stages:
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
 
+    - template: steps/run-in-docker.yml
+      parameters:
+        baseImage: $(baseImage)
+        command: "CheckBuildLogsForErrors"
+
 - stage: integration_tests_arm64
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_arm64]
@@ -716,6 +728,11 @@ stages:
             testResultsFormat: VSTest
             testResultsFiles: tracer/build_data/results/**/*.trx
           condition: succeededOrFailed()
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            baseImage: $(baseImage)
+            command: "CheckBuildLogsForErrors"
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))


### PR DESCRIPTION
A recent check of the logs identified the issue in #1771. To make sure we don't miss similar issues, this adds a check of the logs to all the integration test runs.

There are some errors we _expect_ to see, either because we're testing error scenarios (or because it's a situation we expect to see in CallSite), so we exclude those errors. If we see any unexpected errors in the logs, we fail the build

@DataDog/apm-dotnet