### PR TITLE
Used the parsed version of the query string

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -86,8 +86,10 @@ namespace Datadog.Trace.AppSec.Waf
                     ulong i => new Obj(WafNative.ObjectUnsigned(i)),
                     IEnumerable<KeyValuePair<string, JToken>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
                     IEnumerable<KeyValuePair<string, string>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
+                    IEnumerable<KeyValuePair<string, List<string>>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
                     IEnumerable<KeyValuePair<string, object>> objDict => EncodeDictionary(objDict, argCache, remainingDepth),
                     IList<JToken> objs => EncodeList(objs.Select(x => (object)x), argCache, remainingDepth),
+                    IList<string> objs => EncodeList(objs.Select(x => (object)x), argCache, remainingDepth),
                     IList<object> objs => EncodeList(objs, argCache, remainingDepth),
                     _ => throw new Exception($"Couldn't encode: {o}, type: {o.GetType()}")
                 };

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Util.Http
                 cookiesDic.Add(k, request.Cookies[k]);
             }
 
-            var queryStringDic = new Dictionary<string, List<string>>();
+            var queryStringDic = new Dictionary<string, List<string>>(request.Query.Count);
             foreach (var kvp in request.Query)
             {
                 queryStringDic.Add(kvp.Key, kvp.Value.ToList());

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -35,11 +35,17 @@ namespace Datadog.Trace.Util.Http
                 cookiesDic.Add(k, request.Cookies[k]);
             }
 
+            var queryStringDic = new Dictionary<string, List<string>>();
+            foreach (var kvp in request.Query)
+            {
+                queryStringDic.Add(kvp.Key, kvp.Value.ToList());
+            }
+
             var dict = new Dictionary<string, object>()
             {
                 { AddressesConstants.RequestMethod, request.Method },
                 { AddressesConstants.RequestUriRaw, url },
-                { AddressesConstants.RequestQuery, request.QueryString.ToString() },
+                { AddressesConstants.RequestQuery, queryStringDic },
                 { AddressesConstants.RequestHeaderNoCookies, headersDic },
                 { AddressesConstants.RequestCookies, cookiesDic },
             };

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Util.Http
         internal static Dictionary<string, object> PrepareArgsForWaf(this HttpRequest request, RouteData routeDatas = null)
         {
             var url = GetUrl(request);
-            var headersDic = new Dictionary<string, string>();
+            var headersDic = new Dictionary<string, string>(request.Headers.Keys.Count);
             foreach (var k in request.Headers.Keys)
             {
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Util.Http
                 }
             }
 
-            var cookiesDic = new Dictionary<string, string>();
+            var cookiesDic = new Dictionary<string, string>(request.Cookies.Keys.Count);
             foreach (var k in request.Cookies.Keys)
             {
                 cookiesDic.Add(k, request.Cookies[k]);
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Util.Http
                 queryStringDic.Add(kvp.Key, kvp.Value.ToList());
             }
 
-            var dict = new Dictionary<string, object>()
+            var dict = new Dictionary<string, object>
             {
                 { AddressesConstants.RequestMethod, request.Method },
                 { AddressesConstants.RequestUriRaw, url },

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -33,11 +33,18 @@ namespace Datadog.Trace.Util.Http
                 cookiesDic.Add(k, request.Cookies[k].Value);
             }
 
+            var queryDic = new Dictionary<string, string>();
+            foreach (var k in request.QueryString.AllKeys)
+            {
+                var values = request.QueryString[k];
+                queryDic.Add(k, values);
+            }
+
             var dict = new Dictionary<string, object>()
             {
                 { AddressesConstants.RequestMethod, request.HttpMethod },
                 { AddressesConstants.RequestUriRaw, request.Url.AbsoluteUri },
-                { AddressesConstants.RequestQuery, request.Url.Query },
+                { AddressesConstants.RequestQuery, queryDic },
                 { AddressesConstants.RequestHeaderNoCookies, headersDic },
                 { AddressesConstants.RequestCookies, cookiesDic },
             };

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Util.Http
                 cookiesDic.Add(k, request.Cookies[k].Value);
             }
 
-            var queryDic = new Dictionary<string, string>();
+            var queryDic = new Dictionary<string, string>(request.QueryString.AllKeys.Length);
             foreach (var k in request.QueryString.AllKeys)
             {
                 var values = request.QueryString[k];

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Util.Http
     {
         internal static Dictionary<string, object> PrepareArgsForWaf(this HttpRequest request, RouteData routeDatas = null)
         {
-            var headersDic = new Dictionary<string, string>();
+            var headersDic = new Dictionary<string, string>(request.Headers.Keys.Count);
             var headerKeys = request.Headers.Keys;
             foreach (string k in headerKeys)
             {
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Util.Http
                 }
             }
 
-            var cookiesDic = new Dictionary<string, string>();
+            var cookiesDic = new Dictionary<string, string>(request.Cookies.AllKeys.Length);
             foreach (var k in request.Cookies.AllKeys)
             {
                 cookiesDic.Add(k, request.Cookies[k].Value);
@@ -40,7 +40,7 @@ namespace Datadog.Trace.Util.Http
                 queryDic.Add(k, values);
             }
 
-            var dict = new Dictionary<string, object>()
+            var dict = new Dictionary<string, object>
             {
                 { AddressesConstants.RequestMethod, request.HttpMethod },
                 { AddressesConstants.RequestUriRaw, request.Url.AbsoluteUri },


### PR DESCRIPTION
Fixes bug APPSEC-1404 as this means a URL decode is automatically applied so the <script> tag will be seen by the WAF.