### PR TITLE
Increase timeout in MassTransit smoke tests

### DIFF
--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
@@ -92,8 +92,6 @@
 
         static async Task SendMessagesAsync(IServiceProvider provider, int jobCount = 10, int activeThreshold = 10, int? delayInSeconds = null)
         {
-            IBus bus = provider.GetRequiredService<IBus>();
-
             var clientFactory = provider.GetRequiredService<IClientFactory>();
             var submitBatchClient = clientFactory.CreateRequestClient<SubmitBatch>();
             var batchStatusClient = clientFactory.CreateRequestClient<BatchStatusRequested>();

--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
@@ -32,11 +32,7 @@
                     .EntityFrameworkRepository(r =>
                     {
                         r.ConcurrencyMode = ConcurrencyMode.Pessimistic;
-
-                        r.AddDbContext<DbContext, SampleBatchDbContext>((provider, optionsBuilder) =>
-                        {
-                            optionsBuilder.UseSqlServer(connectionString);
-                        });
+                        r.ExistingDbContext<SampleBatchDbContext>();
 
                         // I specified the MsSqlLockStatements because in my State Entities EFCore EntityConfigurations, I changed the column name from CorrelationId, to "BatchId" and "BatchJobId"
                         // Otherwise, I could just use r.UseSqlServer(), which uses the default, which are "... WHERE CorrelationId = @p0"
@@ -48,11 +44,7 @@
                     .EntityFrameworkRepository(r =>
                     {
                         r.ConcurrencyMode = ConcurrencyMode.Pessimistic;
-
-                        r.AddDbContext<DbContext, SampleBatchDbContext>((provider, optionsBuilder) =>
-                        {
-                            optionsBuilder.UseSqlServer(connectionString);
-                        });
+                        r.ExistingDbContext<SampleBatchDbContext>();
 
                         // I specified the MsSqlLockStatements because in my State Entities EFCore EntityConfigurations, I changed the column name from CorrelationId, to "BatchId" and "BatchJobId"
                         // Otherwise, I could just use r.UseSqlServer(), which uses the default, which are "... WHERE CorrelationId = @p0"
@@ -174,7 +166,7 @@
         {
             using (var scope = provider.CreateScope())
             {
-                var db = scope.ServiceProvider.GetRequiredService<DbContext>();
+                var db = scope.ServiceProvider.GetRequiredService<SampleBatchDbContext>();
 
                 db.Database.EnsureCreated();
             }

--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
@@ -70,7 +70,10 @@
                 logging.AddConsole();
             });
 
-            services.AddDbContext<SampleBatchDbContext>(x => x.UseSqlServer(connectionString));
+            services.AddDbContext<SampleBatchDbContext>(
+                x => x.UseSqlServer(
+                    connectionString,
+                    opts => opts.CommandTimeout(60)));
 
             await using var provider = services.BuildServiceProvider(true);
 


### PR DESCRIPTION
A [recent test run](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=75001&view=logs&j=6ae8a54a-1208-53b6-02f5-457b7eaa6e6d&t=1a9deb0f-0447-59a2-217b-a0e5237fe234) failed because of a timeout reading from the context. This tries a brute force fix of increasing the timeout. Also tidies up some of the config - I'm not sure what the impact was of registering the same context multiple times.


@DataDog/apm-dotnet