### PR TITLE
Rename ADO.NET providers integration name

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetClientInstrumentMethodAttribute.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetClientInstrumentMethodAttribute.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
             TypeName = AdoNetClientData.SqlCommandType;
             MinimumVersion = AdoNetClientData.MinimumVersion;
             MaximumVersion = AdoNetClientData.MaximumVersion;
-            IntegrationName = AdoNetClientData.IntegrationName;
+            IntegrationName = AdoNetConstants.IntegrationName;
         }
 
         protected IAdoNetClientData AdoNetClientData { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetConstants.cs
@@ -15,8 +15,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
         internal struct SystemDataClientData : IAdoNetClientData
         {
-            public string IntegrationName => AdoNet.AdoNetConstants.IntegrationName;
-
             public string AssemblyName => "System.Data";
 
             public string SqlCommandType => "System.Data.Common.DbCommand";
@@ -32,8 +30,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
         internal struct SystemDataCommonClientData : IAdoNetClientData
         {
-            public string IntegrationName => AdoNet.AdoNetConstants.IntegrationName;
-
             public string AssemblyName => "System.Data.Common";
 
             public string SqlCommandType => "System.Data.Common.DbCommand";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/IAdoNetClientData.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/IAdoNetClientData.cs
@@ -7,8 +7,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 {
     internal interface IAdoNetClientData
     {
-        string IntegrationName { get; }
-
         string AssemblyName { get; }
 
         string SqlCommandType { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/MySql/MySqlConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/MySql/MySqlConstants.cs
@@ -9,12 +9,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
 {
     internal static class MySqlConstants
     {
-        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
-
         internal struct MySqlDataClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "MySql.Data";
 
             public string SqlCommandType => "MySql.Data.MySqlClient.MySqlCommand";
@@ -30,8 +26,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
 
         internal struct MySqlData8ClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "MySql.Data";
 
             public string SqlCommandType => "MySql.Data.MySqlClient.MySqlCommand";
@@ -47,8 +41,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
 
         internal struct MySqlConnectorClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "MySqlConnector";
 
             public string SqlCommandType => "MySqlConnector.MySqlCommand";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/MySql/MySqlConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/MySql/MySqlConstants.cs
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Configuration;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.MySql
 {
     internal static class MySqlConstants
     {
-        public const string SqlCommandIntegrationName = "MySqlCommand";
+        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
 
         internal struct MySqlDataClientData : IAdoNetClientData
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Npgsql/NpgsqlConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Npgsql/NpgsqlConstants.cs
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Configuration;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Npgsql
 {
     internal static class NpgsqlConstants
     {
-        public const string SqlCommandIntegrationName = "NpgsqlCommand";
+        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
 
         internal struct NpgsqlClientData : IAdoNetClientData
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Npgsql/NpgsqlConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Npgsql/NpgsqlConstants.cs
@@ -9,12 +9,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Npgsql
 {
     internal static class NpgsqlConstants
     {
-        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
-
         internal struct NpgsqlClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "Npgsql";
 
             public string SqlCommandType => "Npgsql.NpgsqlCommand";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Oracle/OracleConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Oracle/OracleConstants.cs
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Configuration;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Oracle
 {
     internal static class OracleConstants
     {
-        public const string SqlCommandIntegrationName = "OracleCommand";
+        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
 
         internal struct OracleClientData : IAdoNetClientData
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Oracle/OracleConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Oracle/OracleConstants.cs
@@ -9,12 +9,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Oracle
 {
     internal static class OracleConstants
     {
-        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
-
         internal struct OracleClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "Oracle.ManagedDataAccess";
 
             public string SqlCommandType => "Oracle.ManagedDataAccess.Client.OracleCommand";
@@ -30,8 +26,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Oracle
 
         internal struct OracleCoreClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "Oracle.ManagedDataAccess";
 
             public string SqlCommandType => "Oracle.ManagedDataAccess.Client.OracleCommand";
@@ -47,8 +41,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Oracle
 
         internal struct OracleDataAccessClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "Oracle.DataAccess";
 
             public string SqlCommandType => "Oracle.DataAccess.Client.OracleCommand";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/SqlClient/SqlClientConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/SqlClient/SqlClientConstants.cs
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Configuration;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.SqlClient
 {
     internal static class SqlClientConstants
     {
-        public const string SqlCommandIntegrationName = "SqlCommand";
+        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
 
         internal struct SystemDataAdoNetClientData : IAdoNetClientData
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/SqlClient/SqlClientConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/SqlClient/SqlClientConstants.cs
@@ -9,12 +9,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.SqlClient
 {
     internal static class SqlClientConstants
     {
-        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
-
         internal struct SystemDataAdoNetClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "System.Data";
 
             public string SqlCommandType => "System.Data.SqlClient.SqlCommand";
@@ -30,8 +26,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.SqlClient
 
         internal struct SystemDataSqlClientAdoNetClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "System.Data.SqlClient";
 
             public string SqlCommandType => "System.Data.SqlClient.SqlCommand";
@@ -47,8 +41,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.SqlClient
 
         internal struct MicrosoftDataAdoNetClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "Microsoft.Data.SqlClient";
 
             public string SqlCommandType => "Microsoft.Data.SqlClient.SqlCommand";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Sqlite/SqliteConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Sqlite/SqliteConstants.cs
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Configuration;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Sqlite
 {
     internal static class SqliteConstants
     {
-        public const string SqlCommandIntegrationName = "SqliteCommand";
+        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
 
         internal struct MicrosoftDataSqliteClientData : IAdoNetClientData
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Sqlite/SqliteConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/Sqlite/SqliteConstants.cs
@@ -9,12 +9,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Sqlite
 {
     internal static class SqliteConstants
     {
-        public const string SqlCommandIntegrationName = nameof(IntegrationIds.AdoNet);
-
         internal struct MicrosoftDataSqliteClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "Microsoft.Data.Sqlite";
 
             public string SqlCommandType => "Microsoft.Data.Sqlite.SqliteCommand";
@@ -30,8 +26,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.Sqlite
 
         internal struct SystemDataSqliteClientData : IAdoNetClientData
         {
-            public string IntegrationName => SqlCommandIntegrationName;
-
             public string AssemblyName => "System.Data.SQLite";
 
             public string SqlCommandType => "System.Data.SQLite.SQLiteCommand";


### PR DESCRIPTION
This PR renames the current integration name for each individual CallTarget provider integration to use the same `AdoNet` name, as we do in CallSite. 

On CallSite all ADO.NET instrumentation is handled by the unique AdoNet integration name.

Currently in CallTarget we have multiple integration names per provider and the AdoNet one for the DBCommand base class instrumentation.

There's no good reason to this behavior change, so this PR fixes that.

@DataDog/apm-dotnet