### PR TITLE
Update .NET SDK to 5.0.401

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -31,6 +31,8 @@ steps:
         --env tracerHome=/project/$(relativeTracerHome) \
         --env artifacts=/project/$(relativeArtifacts) \
         --env DD_CLR_ENABLE_NGEN=$(DD_CLR_ENABLE_NGEN) \
+        --env Verify_DisableClipboard=true \
+        --env DiffEngine_Disabled=true \
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }} \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}
   displayName: Run '${{ parameters.command }}' in Docker

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -54,7 +54,7 @@ schedules:
 # Global variables
 variables:
   buildConfiguration: Release
-  dotnetCoreSdk5Version: 5.0.103
+  dotnetCoreSdk5Version: 5.0.401
   relativeTracerHome: /tracer/src/bin/windows-tracer-home
   relativeArtifacts: /tracer/src/bin/artifacts
   ddTracerHome: $(System.DefaultWorkingDirectory)/tracer/src/bin/dd-tracer-home

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -70,6 +70,8 @@ variables:
   isScheduledBuild: ${{ eq(variables['Build.Reason'], 'Schedule') }} # only works if you have a main branch
   # Allow forcing a benchmark/throughput run using run_benchmarks_only=true
   dotnetToolTag: build-dotnet-tool
+  Verify_DisableClipboard: true
+  DiffEngine_Disabled: true
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,7 +273,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdk5Version:-5.0.103}
+        - DOTNETSDK_VERSION=${dotnetCoreSdk5Version:-5.0.401}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage
     volumes:
@@ -342,7 +342,7 @@ services:
       context: ./tracer/build/_build/
       dockerfile: docker/${baseImage:-debian}.dockerfile
       args:
-        - DOTNETSDK_VERSION=${dotnetCoreSdk5Version:-5.0.103}
+        - DOTNETSDK_VERSION=${dotnetCoreSdk5Version:-5.0.401}
     image: dd-trace-dotnet/${baseImage:-debian}-tester
     command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1}
     volumes:

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,6 +1,6 @@
 ﻿ARG DOTNETSDK_VERSION
 # debian 10 image
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.14 as base
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.13 as base
 # ubuntu image
 # FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-focal
 

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,6 +1,6 @@
 ﻿ARG DOTNETSDK_VERSION
 # debian 10 image
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.12 as base
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-alpine3.14 as base
 # ubuntu image
 # FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-focal
 

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -5,7 +5,7 @@ set -euox pipefail
 cd "$(dirname "$0")"
 
 ROOT_DIR="$(pwd)"
-BUILD_DIR="$ROOT_DIR/build/_build"
+BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/debian-base"
 
 docker build \
@@ -17,8 +17,8 @@ docker build \
 docker run -it --rm \
     --mount type=bind,source="$ROOT_DIR",target=/project \
     --env NugetPackageDirectory=/project/packages \
-    --env tracerHome=/project/bin/tracer-home \
-    --env artifacts=/project/bin/artifacts \
+    --env tracerHome=/project/tracer/bin/tracer-home \
+    --env artifacts=/project/tracer/bin/artifacts \
     -p 5003:5003 \
     -v /ddlogs:/var/log/datadog/dotnet \
     $IMAGE_NAME \

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/build/_build"
 IMAGE_NAME="dd-trace-dotnet/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=5.0.103 \
+   --build-arg DOTNETSDK_VERSION=5.0.401 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/debian.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
We're getting some cert issues on macOS, this upgrade should hopefully address it.

Also took the opportunity to fix a path issue in the `build_in_docker.sh` script
Will also need to update the GitLab SDK version
Required upgrading alpine to 3.13, as 3.12 is no longer supported. I tried upgrading to 3.14 but that caused all sorts of strange issues. It will do for now as this a blocker, but we'll need to look into that again before upgrading to .NET 6

@DataDog/apm-dotnet