### PR TITLE
Enable shared logger for managed log file

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -79,7 +79,8 @@ namespace Datadog.Trace.Logging
                             outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}{Properties}{NewLine}",
                             rollingInterval: RollingInterval.Day,
                             rollOnFileSizeLimit: true,
-                            fileSizeLimitBytes: MaxLogFileSize);
+                            fileSizeLimitBytes: MaxLogFileSize,
+                            shared: true);
 
                 try
                 {


### PR DESCRIPTION
`shared: true` should be set when multiple process may write to the managed log file, [as per the docs](https://github.com/serilog/serilog-sinks-file/#shared-log-files). 

I suspect [we should also enable buffering](https://github.com/serilog/serilog-sinks-file/#performance) or use the async package. Worth considering.

@DataDog/apm-dotnet