### PR TITLE
Automatically retry some flaky integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.Retry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        [Theory]
+        [RetryTheory]
         [MemberData(nameof(GetElasticsearch))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.Retry;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        [Theory]
+        [RetryTheory]
         [MemberData(nameof(GetElasticsearch))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.Retry;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
@@ -40,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetCallTargetSettings(enableCallTarget: true);
         }
 
-        [Theory]
+        [RetryTheory]
         [MemberData(nameof(PackageVersions.Kafka), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/BlockingMessageBus.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/BlockingMessageBus.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="BlockingMessageBus.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System.Collections.Concurrent;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    /// <summary>
+    /// An XUnit message bus that can block messages from being passed until we want them to be.
+    /// </summary>
+    public class BlockingMessageBus : IMessageBus
+    {
+        private readonly IMessageBus underlyingMessageBus;
+        private ConcurrentQueue<IMessageSinkMessage> messageQueue = new ConcurrentQueue<IMessageSinkMessage>();
+
+        public BlockingMessageBus(IMessageBus underlyingMessageBus)
+        {
+            this.underlyingMessageBus = underlyingMessageBus;
+        }
+
+        public bool QueueMessage(IMessageSinkMessage message)
+        {
+            messageQueue.Enqueue(message);
+
+            // Returns if execution should continue. Since we are intercepting the message, we
+            //  have no way of checking this so always continue...
+            return true;
+        }
+
+        public void Clear()
+        {
+            messageQueue = new ConcurrentQueue<IMessageSinkMessage>();
+        }
+
+        /// <summary>
+        /// Write the cached messages to the underlying message bus
+        /// </summary>
+        public void Flush()
+        {
+            while (messageQueue.TryDequeue(out IMessageSinkMessage message))
+            {
+                underlyingMessageBus.QueueMessage(message);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not dispose of the underlying message bus - it is an externally owned resource
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/IRetryableTestCase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/IRetryableTestCase.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="IRetryableTestCase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    public interface IRetryableTestCase : IXunitTestCase
+    {
+        int MaxRetries { get; }
+
+        int DelayBetweenRetriesMs { get; }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryFactAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryFactAttribute.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="RetryFactAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    /// <summary>
+    /// Attribute that is applied to a method to indicate that it is a fact that should be run
+    /// by the test runner up to MaxRetries times, until it succeeds.
+    /// </summary>
+    [XunitTestCaseDiscoverer("Datadog.Trace.TestHelpers.Retry.RetryFactDiscoverer", "Datadog.Trace.TestHelpers")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public class RetryFactAttribute : FactAttribute
+    {
+        /// <summary>
+        /// Ctor
+        /// </summary>
+        /// <param name="maxRetries">The number of times to run a test for until it succeeds</param>
+        /// <param name="delayBetweenRetriesMs">The amount of time (in ms) to wait between each test run attempt</param>
+        public RetryFactAttribute(int maxRetries = 3, int delayBetweenRetriesMs = 0)
+        {
+            if (maxRetries < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxRetries) + " must be >= 1");
+            }
+
+            if (delayBetweenRetriesMs < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delayBetweenRetriesMs) + " must be >= 0");
+            }
+
+            MaxRetries = maxRetries;
+            DelayBetweenRetriesMs = delayBetweenRetriesMs;
+        }
+
+        public int MaxRetries { get; }
+
+        public int DelayBetweenRetriesMs { get; }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryFactDiscoverer.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryFactDiscoverer.cs
@@ -1,0 +1,65 @@
+﻿// <copyright file="RetryFactDiscoverer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    public class RetryFactDiscoverer : IXunitTestCaseDiscoverer
+    {
+        private readonly IMessageSink messageSink;
+
+        public RetryFactDiscoverer(IMessageSink messageSink)
+        {
+            this.messageSink = messageSink;
+        }
+
+        public IEnumerable<IXunitTestCase> Discover(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo factAttribute)
+        {
+            IXunitTestCase testCase;
+
+            if (testMethod.Method.GetParameters().Any())
+            {
+                testCase = new ExecutionErrorTestCase(
+                    messageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    "[RetryFact] methods are not allowed to have parameters. Did you mean to use [RetryTheory]?");
+            }
+            else if (testMethod.Method.IsGenericMethodDefinition)
+            {
+                testCase = new ExecutionErrorTestCase(
+                    messageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    "[RetryFact] methods are not allowed to be generic.");
+            }
+            else
+            {
+                int maxRetries = factAttribute.GetNamedArgument<int>(nameof(RetryFactAttribute.MaxRetries));
+                int delayBetweenRetriesMs =
+                    factAttribute.GetNamedArgument<int>(nameof(RetryFactAttribute.DelayBetweenRetriesMs));
+                testCase = new RetryTestCase(
+                    messageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    maxRetries,
+                    delayBetweenRetriesMs);
+            }
+
+            return new[] { testCase };
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTestCase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTestCase.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="RetryTestCase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    [Serializable]
+    public class RetryTestCase : XunitTestCase, IRetryableTestCase
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes", true)]
+        public RetryTestCase()
+        {
+        }
+
+        public RetryTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            int maxRetries,
+            int delayBetweenRetriesMs,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+            MaxRetries = maxRetries;
+            DelayBetweenRetriesMs = delayBetweenRetriesMs;
+        }
+
+        public int MaxRetries { get; private set; }
+
+        public int DelayBetweenRetriesMs { get; private set; }
+
+        public override Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource) =>
+            RetryTestCaseRunner.RunAsync(
+                this,
+                diagnosticMessageSink,
+                messageBus,
+                cancellationTokenSource,
+                blockingMessageBus => new XunitTestCaseRunner(
+                        this,
+                        DisplayName,
+                        SkipReason,
+                        constructorArguments,
+                        TestMethodArguments,
+                        blockingMessageBus,
+                        aggregator,
+                        cancellationTokenSource)
+                   .RunAsync());
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+
+            data.AddValue("MaxRetries", MaxRetries);
+            data.AddValue("DelayBetweenRetriesMs", DelayBetweenRetriesMs);
+        }
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+
+            MaxRetries = data.GetValue<int>("MaxRetries");
+            DelayBetweenRetriesMs = data.GetValue<int>("DelayBetweenRetriesMs");
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTestCaseRunner.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTestCaseRunner.cs
@@ -1,0 +1,96 @@
+﻿// <copyright file="RetryTestCaseRunner.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    internal static class RetryTestCaseRunner
+    {
+        /// <summary>
+        /// Runs a retryable test case, handling any wait and retry logic between test runs, reporting statuses out to xunit etc...
+        /// </summary>
+        /// <param name="testCase">The test case to be retried</param>
+        /// <param name="diagnosticMessageSink">The diagnostic message sink to write messages to about retries, waits etc...</param>
+        /// <param name="messageBus">The message bus xunit is listening for statuses to report on</param>
+        /// <param name="cancellationTokenSource">The cancellation token source from xunit</param>
+        /// <param name="fnRunSingle">(async) Lambda to run this test case once (without retries) - takes the blocking message bus and returns the test run result</param>
+        /// <returns>Resulting run summary</returns>
+        public static async Task<RunSummary> RunAsync(
+            IRetryableTestCase testCase,
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            CancellationTokenSource cancellationTokenSource,
+            Func<IMessageBus, Task<RunSummary>> fnRunSingle)
+        {
+            for (int i = 1; ; i++)
+            {
+                // Prevent messages from the test run from being passed through, as we don't want
+                //  a message to mark the test as failed when we're going to retry it
+                using (BlockingMessageBus blockingMessageBus = new BlockingMessageBus(messageBus))
+                {
+                    diagnosticMessageSink.OnMessage(
+                        new DiagnosticMessage(
+                            "Running test \"{0}\" attempt ({1}/{2})",
+                            testCase.DisplayName,
+                            i,
+                            testCase.MaxRetries));
+
+                    RunSummary summary = await fnRunSingle(blockingMessageBus);
+
+                    // If we succeeded, or we've reached the max retries return the result
+                    if (summary.Failed == 0 || i == testCase.MaxRetries)
+                    {
+                        // If we have failed (after all retries, log that)
+                        if (summary.Failed != 0)
+                        {
+                            diagnosticMessageSink.OnMessage(
+                                new DiagnosticMessage(
+                                    "Test \"{0}\" has failed and been retried the maximum number of times ({1})",
+                                    testCase.DisplayName,
+                                    testCase.MaxRetries));
+                        }
+
+                        blockingMessageBus.Flush();
+                        return summary;
+                    }
+
+                    // Otherwise log that we've had a failed run and will retry
+                    diagnosticMessageSink.OnMessage(
+                        new DiagnosticMessage(
+                            "Test \"{0}\" failed but is set to retry ({1}/{2}) . . .",
+                            testCase.DisplayName,
+                            i,
+                            testCase.MaxRetries));
+
+                    // If there is a delay between test attempts, apply it now
+                    if (testCase.DelayBetweenRetriesMs > 0)
+                    {
+                        diagnosticMessageSink.OnMessage(
+                            new DiagnosticMessage(
+                                "Test \"{0}\" attempt ({1}/{2}) delayed by {3}ms. Waiting . . .",
+                                testCase.DisplayName,
+                                i,
+                                testCase.MaxRetries,
+                                testCase.DelayBetweenRetriesMs));
+
+                        // Don't await to prevent thread hopping.
+                        //  If all of a users test cases in a collection/class are synchronous and expecting to not thread-hop
+                        //  (because they're making use of thread static/thread local/managed thread ID to share data between tests rather than
+                        //  a more modern async-friendly mechanism) then if a thread-hop were to happen here we'd get flickering tests.
+                        //  SpecFlow relies on this as they use the managed thread ID to separate instances of some of their internal classes, which caused
+                        //  a this problem for xRetry.SpecFlow: https://github.com/JoshKeegan/xRetry/issues/18
+                        Task.Delay(testCase.DelayBetweenRetriesMs, cancellationTokenSource.Token).Wait();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTheoryAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTheoryAttribute.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="RetryTheoryAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    /// <summary>
+    /// Attribute that is applied to a method to indicate that it is a theory that should be run
+    /// by the test runner up to MaxRetries times, until it succeeds.
+    /// </summary>
+    [XunitTestCaseDiscoverer("Datadog.Trace.TestHelpers.Retry.RetryTheoryDiscoverer", "Datadog.Trace.TestHelpers")]
+    [AttributeUsage(AttributeTargets.Method)]
+    public class RetryTheoryAttribute : RetryFactAttribute
+    {
+        /// <inheritdoc/>
+        public RetryTheoryAttribute(int maxRetries = 3, int delayBetweenRetriesMs = 0)
+            : base(maxRetries, delayBetweenRetriesMs)
+        {
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTheoryDiscoverer.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTheoryDiscoverer.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="RetryTheoryDiscoverer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System.Collections.Generic;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    public class RetryTheoryDiscoverer : TheoryDiscoverer
+    {
+        public RetryTheoryDiscoverer(IMessageSink diagnosticMessageSink)
+            : base(diagnosticMessageSink)
+        {
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+            ITestFrameworkDiscoveryOptions discoveryOptions,
+            ITestMethod testMethod,
+            IAttributeInfo theoryAttribute,
+            object[] dataRow)
+        {
+            int maxRetries = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.MaxRetries));
+            int delayBetweenRetriesMs =
+                theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.DelayBetweenRetriesMs));
+            return new[]
+            {
+                new RetryTestCase(
+                    DiagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    maxRetries,
+                    delayBetweenRetriesMs,
+                    dataRow)
+            };
+        }
+
+        protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+            ITestFrameworkDiscoveryOptions discoveryOptions, ITestMethod testMethod, IAttributeInfo theoryAttribute)
+        {
+            int maxRetries = theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.MaxRetries));
+            int delayBetweenRetriesMs =
+                theoryAttribute.GetNamedArgument<int>(nameof(RetryTheoryAttribute.DelayBetweenRetriesMs));
+
+            return new[]
+            {
+                new RetryTheoryDiscoveryAtRuntimeCase(
+                    DiagnosticMessageSink,
+                    discoveryOptions.MethodDisplayOrDefault(),
+                    discoveryOptions.MethodDisplayOptionsOrDefault(),
+                    testMethod,
+                    maxRetries,
+                    delayBetweenRetriesMs)
+            };
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTheoryDiscoveryAtRuntimeCase.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Retry/RetryTheoryDiscoveryAtRuntimeCase.cs
@@ -1,0 +1,87 @@
+﻿// <copyright file="RetryTheoryDiscoveryAtRuntimeCase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.dev/JoshKeegan/xRetry
+
+using System;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers.Retry
+{
+    /// <summary>
+    /// Represents a test case to be retried which runs multiple tests for theory data, either because the
+    /// data was not enumerable or because the data was not serializable.
+    /// Equivalent to xunit's XunitTheoryTestCase
+    /// </summary>
+    [Serializable]
+    public class RetryTheoryDiscoveryAtRuntimeCase : XunitTestCase, IRetryableTestCase
+    {
+        /// <summary/>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+        public RetryTheoryDiscoveryAtRuntimeCase()
+        {
+        }
+
+        public RetryTheoryDiscoveryAtRuntimeCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            int maxRetries,
+            int delayBetweenRetriesMs)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
+        {
+            MaxRetries = maxRetries;
+            DelayBetweenRetriesMs = delayBetweenRetriesMs;
+        }
+
+        public int MaxRetries { get; private set; }
+
+        public int DelayBetweenRetriesMs { get; private set; }
+
+        /// <inheritdoc />
+        public override Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource) =>
+            RetryTestCaseRunner.RunAsync(
+                this,
+                diagnosticMessageSink,
+                messageBus,
+                cancellationTokenSource,
+                blockingMessageBus => new XunitTheoryTestCaseRunner(
+                        this,
+                        DisplayName,
+                        SkipReason,
+                        constructorArguments,
+                        diagnosticMessageSink,
+                        blockingMessageBus,
+                        aggregator,
+                        cancellationTokenSource)
+                   .RunAsync());
+
+        public override void Serialize(IXunitSerializationInfo data)
+        {
+            base.Serialize(data);
+
+            data.AddValue("MaxRetries", MaxRetries);
+            data.AddValue("DelayBetweenRetriesMs", DelayBetweenRetriesMs);
+        }
+
+        public override void Deserialize(IXunitSerializationInfo data)
+        {
+            base.Deserialize(data);
+
+            MaxRetries = data.GetValue<int>("MaxRetries");
+            DelayBetweenRetriesMs = data.GetValue<int>("DelayBetweenRetriesMs");
+        }
+    }
+}


### PR DESCRIPTION
Some tests are naturally flaky, as they rely on external dependencies.

This PR vendors in the https://github.com/JoshKeegan/xRetry library, which automatically retries a Fact/Theory up to 3 times, before declaring it failed. 

> I had to vendor the library in as it's not strong named, so couldn't use it from NuGet

We should definitely use this sparingly, but it might help improve our test reliability overall. Applied the `[RetryTheory]` to the Kafka and elasticsearch tests for now

@DataDog/apm-dotnet 
