### PR TITLE
Fix percentages in coverage report

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -422,6 +422,9 @@ partial class Build
               var oldReportPath = oldReportdir / oldArtifact.Name / $"summary{oldBuildId}" / "Cobertura.xml";
               var newReportPath = newReportdir / newArtifact.Name / $"summary{newBuildId}" / "Cobertura.xml";
 
+              var reportOldLink = $"{AzureDevopsOrganisation}/dd-trace-dotnet/_build/results?buildId={oldBuildId}&view=codecoverage-tab";
+              var reportNewLink = $"{AzureDevopsOrganisation}/dd-trace-dotnet/_build/results?buildId={newBuildId}&view=codecoverage-tab";
+
               var downloadOldLink = oldArtifact.Resource.DownloadUrl;
               var downloadNewLink = newArtifact.Resource.DownloadUrl;
 
@@ -429,7 +432,15 @@ partial class Build
               var newReport = Covertura.CodeCoverage.ReadReport(newReportPath);
 
               var comparison = Covertura.CodeCoverage.Compare(oldReport, newReport);
-              var markdown = Covertura.CodeCoverage.RenderAsMarkdown(comparison, prNumber, downloadOldLink, downloadNewLink, oldBuild.SourceVersion, newBuild.SourceVersion);
+              var markdown = Covertura.CodeCoverage.RenderAsMarkdown(
+                  comparison,
+                  prNumber,
+                  downloadOldLink,
+                  downloadNewLink,
+                  reportOldLink,
+                  reportNewLink,
+                  oldBuild.SourceVersion,
+                  newBuild.SourceVersion);
 
               Console.WriteLine("Posting comment to GitHub");
 

--- a/tracer/build/_build/Covertura/CompareReports.cs
+++ b/tracer/build/_build/Covertura/CompareReports.cs
@@ -169,9 +169,9 @@ namespace Covertura
 |           | {oldBranchMarkdown} | {newBranchMarkdown}       | Change   | 
 |:----------|:-----------:|:-----------:|:--------:|
 | Lines     | `{oldReport.LinesCovered}` / `{oldReport.LinesValid}` | `{newReport.LinesCovered}` / `{newReport.LinesValid}` |          |
-| Lines %   | `{oldReport.LineRate:F2}%`      | `{newReport.LineRate:F2}%`      |  `{comparison.LineCoverageChange:F2}%` {GetIcon(comparison.LineCoverageChange)}  |
+| Lines %   | `{oldReport.LineRate:P0}`      | `{newReport.LineRate:P0}`      |  `{comparison.LineCoverageChange:P0}` {GetIcon(comparison.LineCoverageChange)}  |
 | Branches  | `{oldReport.BranchesCovered}` / `{oldReport.BranchesValid}` | `{newReport.BranchesCovered}` / `{newReport.BranchesValid}` |          |
-| Branches %| `{oldReport.BranchRate:F2}%`      | `{newReport.BranchRate:F2}%`      |  `{comparison.BranchCoverageChange:F2}%` {GetIcon(comparison.BranchCoverageChange)}  |
+| Branches %| `{oldReport.BranchRate:P0}`      | `{newReport.BranchRate:P0}`      |  `{comparison.BranchCoverageChange:P0}` {GetIcon(comparison.BranchCoverageChange)}  |
 | Complexity|   `{oldReport.Complexity}`      | `{newReport.Complexity}`        |  `{comparison.ComplexityChange}`  {GetIcon(-comparison.ComplexityChange)}    |
 
 View the full report for further details:
@@ -186,8 +186,8 @@ View the full report for further details:
 
 |        | {oldBranchMarkdown} | {newBranchMarkdown}       | Change   | 
 |:-------|:-----------:|:-----------:|:--------:|
-| Lines %| `{package.Old.LineRate:F2}%`      | `{package.New.LineRate:F2}%`       |  `{package.LineCoverageChange:F2}%` {GetIcon(package.LineCoverageChange)}  |
-| Branches %| `{package.Old.BranchRate:F2}%`      | `{package.New.BranchRate:F2}%`       |  `{package.BranchCoverageChange:F2}%` {GetIcon(package.BranchCoverageChange)}  |
+| Lines %| `{package.Old.LineRate:P0}`      | `{package.New.LineRate:P0}`       |  `{package.LineCoverageChange:P0}` {GetIcon(package.LineCoverageChange)}  |
+| Branches %| `{package.Old.BranchRate:P0}`      | `{package.New.BranchRate:P0}`       |  `{package.BranchCoverageChange:P0}` {GetIcon(package.BranchCoverageChange)}  |
 | Complexity| `{package.Old.Complexity}`      | `{package.New.Complexity}`       |  `{package.ComplexityChange}` {GetIcon(-package.ComplexityChange)}  |
 ");
                   if (package.ClassChanges.Any())
@@ -209,7 +209,7 @@ The following classes have significant coverage changes.
                       {
                           var change = classChange.Value;
                           sb.Append($@"
-| [{change.Name}]({FixFilename(change.Filename)}) | `{change.LineCoverageChange:F2}%` {GetIcon(change.LineCoverageChange)} | `{change.BranchCoverageChange:F2}%` {GetIcon(change.BranchCoverageChange)}   | `{change.ComplexityChange}` {GetIcon(-change.ComplexityChange)} |");
+| [{change.Name}]({FixFilename(change.Filename)}) | `{change.LineCoverageChange:P0}` {GetIcon(change.LineCoverageChange)} | `{change.BranchCoverageChange:P0}` {GetIcon(change.BranchCoverageChange)}   | `{change.ComplexityChange}` {GetIcon(-change.ComplexityChange)} |");
                       }
 
                       var extras = significantChanges.Count - maxFileDisplay;
@@ -234,7 +234,7 @@ The following classes were added in {newBranchMarkdown}:
                       foreach (var newClass in package.NewClasses.Take(maxFileDisplay))
                       {
                           sb.Append($@"
-| [{FixClassName(newClass.Name)}]({prFiles}) | `{newClass.LineRate:F2}%` | `{newClass.BranchRate:F2}%` | `{newClass.Complexity}` |");
+| [{FixClassName(newClass.Name)}]({prFiles}) | `{newClass.LineRate:P0}` | `{newClass.BranchRate:P0}` | `{newClass.Complexity}` |");
                       }
 
                       var extras = package.NewClasses.Count - maxFileDisplay;
@@ -269,7 +269,7 @@ The following classes were added in {newBranchMarkdown}:
                   foreach (var newProject in comparison.NewPackages.Take(maxDisplay))
                   {
                       sb.Append($@"
-| [{newProject.Name}]({prFiles}) | `{newProject.LineRate:F2}%` | `{newProject.BranchRate:F2}%` | `{newProject.Complexity}` |");
+| [{newProject.Name}]({prFiles}) | `{newProject.LineRate:P0}` | `{newProject.BranchRate:P0}` | `{newProject.Complexity}` |");
                   }
 
                   var extras = comparison.NewPackages.Count - maxDisplay;
@@ -294,7 +294,7 @@ The following classes were added in {newBranchMarkdown}:
                   foreach (var oldProject in comparison.RemovedPackages.Take(maxDisplay))
                   {
                       sb.Append($@"
-| [{oldProject.Name}]({prFiles}) | `{oldProject.LineRate:F2}%` | `{oldProject.BranchRate:F2}%` | `{oldProject.Complexity}` |");
+| [{oldProject.Name}]({prFiles}) | `{oldProject.LineRate:P0}` | `{oldProject.BranchRate:P0}` | `{oldProject.Complexity}` |");
                   }
 
                   var extras = comparison.RemovedPackages.Count - maxDisplay;
@@ -320,8 +320,8 @@ View the full reports for further details:
 
               static string GetDescription(decimal value, string metric) => value switch
               {
-                  < 0 => $"will **decrease** {metric} by `{-value:F2}%`",
-                  > 0 => $"will **increase** {metric} by `{value:F2}%`",
+                  < 0 => $"will **decrease** {metric} by `{-value:P0}`",
+                  > 0 => $"will **increase** {metric} by `{value:P0}`",
                   _ => $"**not change** {metric}",
               };
 

--- a/tracer/build/_build/Covertura/CompareReports.cs
+++ b/tracer/build/_build/Covertura/CompareReports.cs
@@ -150,7 +150,15 @@ namespace Covertura
             return comparison;
         }
 
-        public static string RenderAsMarkdown(CoverturaReportComparison comparison, int prNumber, string oldReportLink, string newReportlink, string oldCommit, string newCommit)
+        public static string RenderAsMarkdown(
+            CoverturaReportComparison comparison,
+            int prNumber,
+            string oldDownloadLink,
+            string newDownloadLink,
+            string oldReportLink,
+            string newReportLink,
+            string oldCommit,
+            string newCommit)
         {
             var oldBranchMarkdown = $"[master](https://github.com/DataDog/dd-trace-dotnet/tree/{oldCommit})";
             var newBranchMarkdown = $"#{prNumber}";
@@ -176,8 +184,8 @@ namespace Covertura
 
 View the full report for further details:
 
-* [For master]({oldReportLink})
-* [For this PR #{prNumber}]({newReportlink})
+* [HTML report for master]({oldReportLink}) | [Source file]({oldDownloadLink})  
+* [HTML report for this PR #{prNumber}]({newReportLink}) | [Source file]({newDownloadLink})
 
 ");
               foreach (var package in comparison.MatchedPackages)
@@ -308,8 +316,8 @@ The following classes were added in {newBranchMarkdown}:
               sb.AppendLine($@"
 View the full reports for further details:
 
-* [For master]({oldReportLink})
-* [For this PR #{prNumber}]({newReportlink})");
+* [HTML report for master]({oldReportLink}) | [Source file]({oldDownloadLink})  
+* [HTML report for this PR #{prNumber}]({newReportLink}) | [Source file]({newDownloadLink})");
 
               static string GetIcon(decimal value) => value switch
               {


### PR DESCRIPTION
Percentage values were x100 too low, as was printing with `F2`. There was a reason I chose to do that originally instead of using `P0`, but I can't for the life of me think what it was, so gone with that for simplicity. Also include a direct link to the HTML report, as well as the source coverage files

@DataDog/apm-dotnet