### PR TITLE
Exclude the profiler from the regression sample apps

### DIFF
--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -23,6 +23,9 @@
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+
+    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
+    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(ExcludeManagedProfiler)' != 'true' and

--- a/tracer/test/test-applications/regression/AspNetMvcCorePerformance/Directory.Build.props
+++ b/tracer/test/test-applications/regression/AspNetMvcCorePerformance/Directory.Build.props
@@ -3,4 +3,8 @@
   This file intentionally left blank...
   to stop msbuild from looking up the folder hierarchy
   -->
+  <PropertyGroup>
+    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
+    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/AutomapperTest/Program.cs
+++ b/tracer/test/test-applications/regression/AutomapperTest/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using AutoMapper;
-using Datadog.Trace.ClrProfiler;
 
 namespace AutomapperTest
 {
@@ -9,7 +9,7 @@ namespace AutomapperTest
     {
         public static void Main()
         {
-            Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
+            Console.WriteLine($"Profiler attached: {IsProfilerAttached()}");
 
             Mapper.Initialize(
                 configuration =>
@@ -18,6 +18,22 @@ namespace AutomapperTest
                 });
 
             Console.WriteLine("Done");
+        }
+
+        private static bool IsProfilerAttached()
+        {
+            Type nativeMethodsType = Type.GetType("Datadog.Trace.ClrProfiler.NativeMethods, Datadog.Trace");
+            MethodInfo profilerAttachedMethodInfo = nativeMethodsType.GetMethod("IsProfilerAttached");
+            try
+            {
+                return (bool)profilerAttachedMethodInfo.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return false;
         }
     }
 

--- a/tracer/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/Directory.Build.props
+++ b/tracer/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/Directory.Build.props
@@ -3,4 +3,9 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
+    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/MismatchedTracerVersions/Directory.Build.props
+++ b/tracer/test/test-applications/regression/MismatchedTracerVersions/Directory.Build.props
@@ -1,2 +1,6 @@
 <Project>
+  <PropertyGroup>
+    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
+    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/Directory.Build.props
+++ b/tracer/test/test-applications/regression/Reproduction.Wpf.ExpenseIt/ExpenseIt/Directory.Build.props
@@ -3,4 +3,9 @@
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
+
+  <PropertyGroup>
+    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
+    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
+  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/Directory.Build.props
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.LegacyProject/Directory.Build.props
@@ -3,4 +3,9 @@
   This file intentionally left blank...
   to stop msbuild from looking up the folder hierarchy
   -->
+
+  <PropertyGroup>
+    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
+    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
It's just a temporary fix, but it saves ~1GB of drive space which is sufficient to get the regression samples running again

@DataDog/apm-dotnet