### PR TITLE
Stop copying profiler/tracer home to test directories

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -401,7 +401,7 @@ stages:
       condition: eq(variables.requiresCosmos, true)
       workingDirectory: $(Pipeline.Workspace)
 
-    - script: tracer\build.cmd $(target) --PrintDriveSpace --code-coverage
+    - script: tracer\build.cmd $(target) CleanPackages --PrintDriveSpace --code-coverage
       displayName: Run integration tests
 
     - task: PublishTestResults@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -401,7 +401,7 @@ stages:
       condition: eq(variables.requiresCosmos, true)
       workingDirectory: $(Pipeline.Workspace)
 
-    - script: tracer\build.cmd $(target) CleanPackages --PrintDriveSpace --code-coverage
+    - script: tracer\build.cmd $(target) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
 
     - task: PublishTestResults@2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,8 +292,8 @@ services:
       - ./:/project
     environment:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
-      - tracerHome=/project/${relativeTracerHome:-src/bin/windows-tracer-home}
-      - artifacts=/project/${relativeArtifacts:-src/bin/artifacts}
+      - tracerHome=/project/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
+      - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-default}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-0}
@@ -364,8 +364,8 @@ services:
       - ./:/project
     environment:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
-      - tracerHome=/project/${relativeTracerHome:-src/bin/windows-tracer-home}
-      - artifacts=/project/${relativeArtifacts:-src/bin/artifacts}
+      - tracerHome=/project/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
+      - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-debian}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-0}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -782,7 +782,6 @@ partial class Build
                 .EnableNoDependencies()
                 .SetConfiguration(BuildConfiguration)
                 .SetTargetPlatform(Platform)
-                .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                 .SetTargets("BuildCsharpIntegrationTests")
                 .SetMaxCpuCount(null));
         });
@@ -820,10 +819,6 @@ partial class Build
                 .SetTargetPlatform(Platform)
                 .EnableNoDependencies()
                 .SetProperty("BuildInParallel", "false")
-                .SetProperty("ExcludeManagedProfiler", true)
-                .SetProperty("ExcludeNativeProfiler", true)
-                .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
-                .SetProperty("LoadManagedProfilerFromProfilerDirectory", false)
                 .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
                 .CombineWith(projects, (s, project) => s
                     .SetProjectFile(project)));
@@ -1063,9 +1058,6 @@ partial class Build
                     .SetFramework(Framework)
                     // .SetTargetPlatform(Platform)
                     .SetNoWarnDotNetCore3()
-                    .SetProperty("ExcludeManagedProfiler", "true")
-                    .SetProperty("ExcludeNativeProfiler", "true")
-                    .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                     .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
                     .CombineWith(projectsToBuild, (c, project) => c
@@ -1080,7 +1072,6 @@ partial class Build
                     .SetFramework(Framework)
                     // .SetTargetPlatform(Platform)
                     .SetNoWarnDotNetCore3()
-                    .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                     .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o => o.SetPackageDirectory(NugetPackageDirectory))
                     .CombineWith(projectsToBuild, (c, project) => c
@@ -1109,10 +1100,7 @@ partial class Build
                 .SetConfiguration(BuildConfiguration)
                 .EnableNoDependencies()
                 .SetProperty("TargetFramework", Framework.ToString())
-                .SetProperty("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                 .SetProperty("BuildInParallel", "true")
-                .SetProperty("ExcludeManagedProfiler", "true")
-                .SetProperty("ExcludeNativeProfiler", "true")
                 .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
                 .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
                 .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
@@ -1144,7 +1132,6 @@ partial class Build
                     .When(TestAllPackageVersions, o => o
                         .SetProperty("TestAllPackageVersions", "true"))
                     .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
-                    .AddProcessEnvironmentVariable("ManagedProfilerOutputDirectory", TracerHomeDirectory)
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
                         o.SetPackageDirectory(NugetPackageDirectory))
                     .CombineWith(integrationTestProjects, (c, project) => c

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -879,6 +879,7 @@ partial class Build
                     .SetTargetPlatform(Platform)
                     .EnableNoRestore()
                     .EnableNoBuild()
+                    .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .When(!string.IsNullOrEmpty(Filter), c => c.SetFilter(Filter))
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ParallelIntegrationTests, (s, project) => s
@@ -895,6 +896,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "RunOnWindows=True&LoadFromGAC!=True&IIS!=True")
+                    .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -926,6 +928,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "Category=Smoke&LoadFromGAC!=True")
+                    .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -958,6 +961,7 @@ partial class Build
                     .EnableNoRestore()
                     .EnableNoBuild()
                     .SetFilter(Filter ?? "(RunOnWindows=True)&LoadFromGAC=True")
+                    .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -1180,6 +1184,7 @@ partial class Build
                         .SetFramework(Framework)
                         .EnableMemoryDumps()
                         .SetFilter(filter)
+                        .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                         .When(TestAllPackageVersions, o => o
                             .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                         .When(CodeCoverage, ConfigureCodeCoverage)
@@ -1197,6 +1202,7 @@ partial class Build
                     .SetFramework(Framework)
                     .EnableMemoryDumps()
                     .SetFilter(filter)
+                    .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
                     .When(TestAllPackageVersions, o => o
                         .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .When(CodeCoverage, ConfigureCodeCoverage)

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -299,7 +299,7 @@ partial class Build
             }
             else
             {
-                var (architecture, ext) = GetUnixArchitectureAndExtention();
+                var (architecture, ext) = GetUnixArchitectureAndExtension(includeMuslSuffixOnAlpine: true);
                 var ddwafFileName = $"libddwaf.{ext}";
 
                 var source = LibDdwafDirectory / "runtimes" / architecture / "native" / ddwafFileName;
@@ -422,7 +422,7 @@ partial class Build
            }
 
            // Move the native file to the architecture-specific folder
-           var (architecture, ext) = GetUnixArchitectureAndExtention();
+           var (architecture, ext) = GetUnixArchitectureAndExtension(includeMuslSuffixOnAlpine: false);
 
            var profilerFileName = $"{NativeProfilerProject.Name}.{ext}";
            var ddwafFileName = $"libddwaf.{ext}";
@@ -1208,13 +1208,14 @@ partial class Build
 
     private void EnsureResultsDirectory(Project proj) => EnsureCleanDirectory(GetResultsDirectory(proj));
 
-    private (string, string) GetUnixArchitectureAndExtention()
+    private (string, string) GetUnixArchitectureAndExtension(bool includeMuslSuffixOnAlpine)
     {
-        var archExt = IsOsx
-            ? ("osx-x64", "dylib")
-            : ($"linux-{LinuxArchitectureIdentifier}", "so");
-
-        return archExt;
+        return (IsOsx, IsAlpine, includeMuslSuffixOnAlpine) switch
+        {
+            (true, _, _) => ("osx-x64", "dylib"),
+            (_, true, true) => ($"linux-musl-{LinuxArchitectureIdentifier}", "so"),
+            _ => ($"linux-{LinuxArchitectureIdentifier}", "so"),
+        };
     }
 
     // the integration tests need their own copy of the profiler, this achived through build.props on Windows, but doesn't seem to work under Linux

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -113,28 +113,6 @@ partial class Build : NukeBuild
             }
         });
 
-    Target CleanPackages => _ => _
-        .Unlisted()
-        .Description("Cleans the packages folder output")
-        .Requires(() => NugetPackageDirectory)
-        .Before(RunWindowsIntegrationTests, RunWindowsRegressionTests, RunWindowsIisIntegrationTests)
-        .After(BuildWindowsIntegrationTests, BuildWindowsRegressionIntegrationTests)
-        .Executes(()=>
-        {
-            // clean each individual directory, instead of the top level, as some packages will often be locked
-            foreach (var directory in Directory.EnumerateDirectories(NugetPackageDirectory))
-            {
-                try
-                {
-                    EnsureCleanDirectory(directory);
-                }
-                catch (Exception ex)
-                {
-                    Logger.Info($"Error cleaning packages directory {directory}: {ex}");
-                }
-            }
-        });
-
     Target CleanObjFiles => _ => _
          .Unlisted()
          .Description("Deletes all build output files, but preserves folders to work around AzDo issues")

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -113,6 +113,28 @@ partial class Build : NukeBuild
             }
         });
 
+    Target CleanPackages => _ => _
+        .Unlisted()
+        .Description("Cleans the packages folder output")
+        .Requires(() => NugetPackageDirectory)
+        .Before(RunWindowsIntegrationTests, RunWindowsRegressionTests, RunWindowsIisIntegrationTests)
+        .After(BuildWindowsIntegrationTests, BuildWindowsRegressionIntegrationTests)
+        .Executes(()=>
+        {
+            // clean each individual directory, instead of the top level, as some packages will often be locked
+            foreach (var directory in Directory.EnumerateDirectories(NugetPackageDirectory))
+            {
+                try
+                {
+                    EnsureCleanDirectory(directory);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Info($"Error cleaning packages directory {directory}: {ex}");
+                }
+            }
+        });
+
     Target CleanObjFiles => _ => _
          .Unlisted()
          .Description("Deletes all build output files, but preserves folders to work around AzDo issues")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Datadog.Trace.ClrProfiler.IntegrationTests.csproj
@@ -6,15 +6,11 @@
     <!--These should be consolidated in a file that can be shared for the tests and samples directories -->
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)'=='true' or '$(TestAllPackageVersions)'!='true'">$(DefineConstants);DEFAULT_SAMPLES</DefineConstants>
     <DefineConstants Condition="'$(PerformComprehensiveTesting)'=='true'">$(DefineConstants);COMPREHENSIVE_TESTS</DefineConstants>
-
-    <ManagedProfilerOutputDirectory Condition="'$(ManagedProfilerOutputDirectory)' == ''">$(MSBuildThisFileDirectory)\..\src\Datadog.Trace\bin\$(Configuration)</ManagedProfilerOutputDirectory>
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
     <None Remove="applicationHost.config" />
     <None Remove="xunit.runner.json" />
-    <Content Include="..\..\integrations.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Link="profiler-lib\integrations.json" />
     <Content Include="applicationHost.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -46,16 +42,6 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-
-  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild">
-    <ItemGroup>
-      <!-- Subfolders of the output directory should each be a target framework -->
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.pdb" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.pdb" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ManagedProfilerFiles)" DestinationFolder="$(OutputPath)profiler-lib\%(RecursiveDir)" />
-  </Target>
 
   <ItemGroup>
     <None Update="CI\Data\*.*">

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -128,9 +128,6 @@ namespace Datadog.Trace.Security.IntegrationTests
                 throw new Exception($"application not found: {sampleAppPath}");
             }
 
-            // get full paths to integration definitions
-            var integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
-
             // EnvironmentHelper.DebugModeEnabled = true;
 
             Output.WriteLine($"Starting Application: {sampleAppPath}");

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Datadog.Trace.Security.IntegrationTests.csproj
@@ -7,16 +7,11 @@
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)'=='true' or '$(TestAllPackageVersions)'!='true'">$(DefineConstants);DEFAULT_SAMPLES</DefineConstants>
     <DefineConstants Condition="'$(PerformComprehensiveTesting)'=='true'">$(DefineConstants);COMPREHENSIVE_TESTS</DefineConstants>
 
-    <ManagedProfilerOutputDirectory Condition="'$(ManagedProfilerOutputDirectory)' == ''">$(MSBuildThisFileDirectory)\..\src\Datadog.Trace.ClrProfiler.Managed\bin\$(Configuration)</ManagedProfilerOutputDirectory>
-    <NativeProfilerOutputDirectory Condition="'$(NativeProfilerOutputDirectory)' == ''">$(MSBuildThisFileDirectory)\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$()</NativeProfilerOutputDirectory>
-
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)\**" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
     <None Remove="applicationHost.config" />
     <None Remove="xunit.runner.json" />
-    <Content Include="..\..\integrations.json" CopyToOutputDirectory="Always" CopyToPublishDirectory="Always" Link="profiler-lib\integrations.json" />
     <Content Include="applicationHost.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -43,18 +38,6 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
-
-  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild">
-    <ItemGroup>
-      <!-- Subfolders of the output directory should each be a target framework -->
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.pdb" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.pdb" />
-      <SecurityLibraryFiles Include="$(Pkglibddwaf)\runtimes\**\*.*" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ManagedProfilerFiles)" DestinationFolder="$(OutputPath)profiler-lib\%(RecursiveDir)" />
-    <Copy SourceFiles="@(SecurityLibraryFiles)" DestinationFolder="$(OutputPath)profiler-lib\%(RecursiveDir)" />
-  </Target>
 
   <ItemGroup>
     <None Update="CI\Data\*.*">

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -42,19 +42,14 @@ namespace Datadog.Trace.TestHelpers
 
         internal static string GetProfilerTargetFolder()
         {
-            var targetFrameworkDirectory = GetTargetFrameworkDirectory();
+            var tracerHome = EnvironmentHelper.GetTracerHomePath();
+            var targetFrameworkDirectory = EnvironmentTools.GetTracerTargetFrameworkDirectory();
 
-            var paths = EnvironmentHelper.GetProfilerPathCandidates(null).ToArray();
+            var finalDirectory = Path.Combine(tracerHome, targetFrameworkDirectory);
 
-            foreach (var path in paths)
+            if (Directory.Exists(finalDirectory))
             {
-                var baseDirectory = Path.GetDirectoryName(path);
-                var finalDirectory = Path.Combine(baseDirectory, targetFrameworkDirectory);
-
-                if (Directory.Exists(finalDirectory))
-                {
-                    return finalDirectory;
-                }
+                return finalDirectory;
             }
 
             return null;
@@ -63,23 +58,6 @@ namespace Datadog.Trace.TestHelpers
         protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
         {
             return new CustomExecutor(assemblyName, SourceInformationProvider, DiagnosticMessageSink);
-        }
-
-        private static string GetTargetFrameworkDirectory()
-        {
-            // The conditions looks weird, but it seems like _OR_GREATER is not supported yet in all environments
-            // We can trim all the additional conditions when this is fixed
-#if NETCOREAPP3_1_OR_GREATER || NETCOREAPP3_1 || NET5_0
-            return "netcoreapp3.1";
-#elif NETCOREAPP || NETSTANDARD
-            return "netstandard2.0";
-#elif NET461_OR_GREATER || NET461 || NET47 || NET471 || NET472 || NET48
-            return "net461";
-#elif NET45_OR_GREATER || NET45 || NET451 || NET452 || NET46
-            return "net45";
-#else
-#error Unexpected TFM
-#endif
         }
 
         private class CustomExecutor : XunitTestFrameworkExecutor

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -86,18 +86,6 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeFrameworkDescription.Contains("core") || IsNet5();
         }
 
-        public static string GetRuntimeIdentifier()
-        {
-            return IsCoreClr()
-                       ? string.Empty
-                       : $"{EnvironmentTools.GetOS()}-{EnvironmentTools.GetPlatform()}";
-        }
-
-        public static string GetSolutionDirectory()
-        {
-            return EnvironmentTools.GetSolutionDirectory();
-        }
-
         public static IEnumerable<string> GetProfilerPathCandidates(string sampleApplicationOutputDirectory)
         {
             string extension = EnvironmentTools.GetOS() switch

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -131,7 +131,7 @@ namespace Datadog.Trace.TestHelpers
                 ("win", "X64") => ("dll", "win-x64"),
                 ("win", "X86") => ("dll", "win-x86"),
                 ("linux", "X64") => ("so", null),
-                ("linux", "ARM64") => ("so", null),
+                ("linux", "Arm64") => ("so", null),
                 ("osx", _) => ("dylib", null),
                 _ => throw new PlatformNotSupportedException()
             };

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -33,8 +32,6 @@ namespace Datadog.Trace.TestHelpers
         private readonly TargetFrameworkAttribute _targetFramework;
 
         private bool _requiresProfiling;
-        private string _integrationsFileLocation;
-        private string _profilerFileLocation;
 
         public EnvironmentHelper(
             string sampleName,
@@ -49,6 +46,9 @@ namespace Datadog.Trace.TestHelpers
             _targetFramework = Assembly.GetAssembly(anchorType).GetCustomAttribute<TargetFrameworkAttribute>();
             _output = output;
             _requiresProfiling = requiresProfiling;
+            TracerHome = GetTracerHomePath();
+            ProfilerPath = GetProfilerPath();
+            IntegrationsJsonPath = GetIntegrationsJsonFilePath();
 
             var parts = _targetFramework.FrameworkName.Split(',');
             _runtime = parts[0];
@@ -74,6 +74,12 @@ namespace Datadog.Trace.TestHelpers
 
         public string SampleName { get; }
 
+        public string ProfilerPath { get; }
+
+        public string TracerHome { get; }
+
+        public string IntegrationsJsonPath { get; }
+
         public string FullSampleName => $"{_appNamePrepend}{SampleName}";
 
         public static bool IsNet5()
@@ -86,27 +92,74 @@ namespace Datadog.Trace.TestHelpers
             return RuntimeFrameworkDescription.Contains("core") || IsNet5();
         }
 
-        public static IEnumerable<string> GetProfilerPathCandidates(string sampleApplicationOutputDirectory)
+        public static string GetTracerHomePath()
         {
-            string extension = EnvironmentTools.GetOS() switch
+            var tracerHomeDirectoryEnvVar = "TracerHomeDirectory";
+            var tracerHome = Environment.GetEnvironmentVariable(tracerHomeDirectoryEnvVar);
+            if (string.IsNullOrEmpty(tracerHome))
             {
-                "win" => "dll",
-                "linux" => "so",
-                "osx" => "dylib",
+                // default
+                return Path.Combine(
+                    EnvironmentTools.GetSolutionDirectory(),
+                    "tracer",
+                    "bin",
+                    "tracer-home");
+            }
+
+            if (!Directory.Exists(tracerHome))
+            {
+                throw new InvalidOperationException($"{tracerHomeDirectoryEnvVar} was set to '{tracerHome}', but directory does not exist");
+            }
+
+            // basic verification
+            var tfmDirectory = EnvironmentTools.GetTracerTargetFrameworkDirectory();
+            var dllLocation = Path.Combine(tracerHome, tfmDirectory);
+            if (!Directory.Exists(dllLocation))
+            {
+                throw new InvalidOperationException($"{tracerHomeDirectoryEnvVar} was set to '{tracerHome}', but location does not contain expected folder '{tfmDirectory}'");
+            }
+
+            return tracerHome;
+        }
+
+        public static string GetProfilerPath()
+        {
+            var tracerHome = GetTracerHomePath();
+
+            var (extension, dir) = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform()) switch
+            {
+                ("win", "X64") => ("dll", "win-x64"),
+                ("win", "X86") => ("dll", "win-x86"),
+                ("linux", "X64") => ("so", null),
+                ("linux", "ARM64") => ("so", null),
+                ("osx", _) => ("dylib", null),
                 _ => throw new PlatformNotSupportedException()
             };
 
-            string fileName = $"Datadog.Trace.ClrProfiler.Native.{extension}";
+            var fileName = $"Datadog.Trace.ClrProfiler.Native.{extension}";
 
-            var relativePath = Path.Combine("profiler-lib", fileName);
+            var path = dir is null
+                           ? Path.Combine(tracerHome, fileName)
+                           : Path.Combine(tracerHome, dir, fileName);
 
-            if (sampleApplicationOutputDirectory != null)
+            if (!File.Exists(path))
             {
-                yield return Path.Combine(sampleApplicationOutputDirectory, relativePath);
+                throw new Exception($"Unable to find profiler at {path}");
             }
 
-            yield return Path.Combine(GetExecutingProjectBin(), relativePath);
-            yield return Path.Combine(GetProfilerProjectBin(), fileName);
+            return path;
+        }
+
+        public static string GetIntegrationsJsonFilePath()
+        {
+            string fileName = "integrations.json";
+            var path = Path.Combine(GetTracerHomePath(), fileName);
+            if (!File.Exists(path))
+            {
+                throw new Exception($"Attempt 3: Unable to find integrations at {path}");
+            }
+
+            return path;
         }
 
         public static void ClearProfilerEnvironmentVariables()
@@ -154,25 +207,19 @@ namespace Datadog.Trace.TestHelpers
             bool callTargetEnabled = false)
         {
             string profilerEnabled = _requiresProfiling ? "1" : "0";
-            string profilerPath;
+            environmentVariables["DD_DOTNET_TRACER_HOME"] = TracerHome;
 
             if (IsCoreClr())
             {
                 environmentVariables["CORECLR_ENABLE_PROFILING"] = profilerEnabled;
                 environmentVariables["CORECLR_PROFILER"] = EnvironmentTools.ProfilerClsId;
-
-                profilerPath = GetProfilerPath();
-                environmentVariables["CORECLR_PROFILER_PATH"] = profilerPath;
-                environmentVariables["DD_DOTNET_TRACER_HOME"] = Path.GetDirectoryName(profilerPath);
+                environmentVariables["CORECLR_PROFILER_PATH"] = ProfilerPath;
             }
             else
             {
                 environmentVariables["COR_ENABLE_PROFILING"] = profilerEnabled;
                 environmentVariables["COR_PROFILER"] = EnvironmentTools.ProfilerClsId;
-
-                profilerPath = GetProfilerPath();
-                environmentVariables["COR_PROFILER_PATH"] = profilerPath;
-                environmentVariables["DD_DOTNET_TRACER_HOME"] = Path.GetDirectoryName(profilerPath);
+                environmentVariables["COR_PROFILER_PATH"] = ProfilerPath;
             }
 
             if (DebugModeEnabled)
@@ -190,8 +237,7 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables["DD_PROFILER_PROCESSES"] = Path.GetFileName(processToProfile);
             }
 
-            string integrations = string.Join(";", GetIntegrationsFilePaths());
-            environmentVariables["DD_INTEGRATIONS"] = integrations;
+            environmentVariables["DD_INTEGRATIONS"] = IntegrationsJsonPath;
             environmentVariables["DD_TRACE_AGENT_HOSTNAME"] = "127.0.0.1";
             environmentVariables["DD_TRACE_AGENT_PORT"] = agentPort.ToString();
 
@@ -236,79 +282,6 @@ namespace Datadog.Trace.TestHelpers
             {
                 environmentVariables[key] = CustomEnvironmentVariables[key];
             }
-        }
-
-        public string[] GetIntegrationsFilePaths()
-        {
-            if (_integrationsFileLocation == null)
-            {
-                string fileName = "integrations.json";
-
-                var directory = GetSampleApplicationOutputDirectory();
-
-                var relativePath = Path.Combine(
-                    "profiler-lib",
-                    fileName);
-
-                _integrationsFileLocation = Path.Combine(
-                    directory,
-                    relativePath);
-
-                // TODO: get rid of the fallback options when we have a consistent convention
-
-                if (!File.Exists(_integrationsFileLocation))
-                {
-                    _output?.WriteLine($"Attempt 1: Unable to find integrations at {_integrationsFileLocation}.");
-                    // Let's try the executing directory, as dotnet publish ignores the Copy attributes we currently use
-                    _integrationsFileLocation = Path.Combine(
-                        GetExecutingProjectBin(),
-                        relativePath);
-                }
-
-                if (!File.Exists(_integrationsFileLocation))
-                {
-                    _output?.WriteLine($"Attempt 2: Unable to find integrations at {_integrationsFileLocation}.");
-                    // One last attempt at the solution root
-                    _integrationsFileLocation = Path.Combine(
-                        EnvironmentTools.GetSolutionDirectory(),
-                        "tracer",
-                        fileName);
-                }
-
-                if (!File.Exists(_integrationsFileLocation))
-                {
-                    throw new Exception($"Attempt 3: Unable to find integrations at {_integrationsFileLocation}");
-                }
-
-                _output?.WriteLine($"Found integrations at {_integrationsFileLocation}.");
-            }
-
-            return new[]
-            {
-                _integrationsFileLocation
-            };
-        }
-
-        public string GetProfilerPath()
-        {
-            if (_profilerFileLocation == null)
-            {
-                var paths = GetProfilerPathCandidates(GetSampleApplicationOutputDirectory()).ToArray();
-
-                foreach (var candidate in paths)
-                {
-                    if (File.Exists(candidate))
-                    {
-                        _profilerFileLocation = candidate;
-                        _output?.WriteLine($"Found profiler at {_profilerFileLocation}.");
-                        return candidate;
-                    }
-                }
-
-                throw new Exception($"Unable to find profiler in any of the paths: {string.Join("; ", paths)}");
-            }
-
-            return _profilerFileLocation;
         }
 
         public string GetSampleApplicationPath(string packageVersion = "", string framework = "")
@@ -476,23 +449,6 @@ namespace Datadog.Trace.TestHelpers
             }
 
             return $"net{_major}{_minor}{_patch ?? string.Empty}";
-        }
-
-        private static string GetProfilerProjectBin()
-        {
-            return Path.Combine(
-                EnvironmentTools.GetSolutionDirectory(),
-                "tracer",
-                "src",
-                "Datadog.Trace.ClrProfiler.Native",
-                "bin",
-                EnvironmentTools.GetBuildConfiguration(),
-                EnvironmentTools.GetPlatform().ToLower());
-        }
-
-        private static string GetExecutingProjectBin()
-        {
-            return Path.GetDirectoryName(ExecutingAssembly.Location);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -482,6 +482,7 @@ namespace Datadog.Trace.TestHelpers
         {
             return Path.Combine(
                 EnvironmentTools.GetSolutionDirectory(),
+                "tracer",
                 "src",
                 "Datadog.Trace.ClrProfiler.Native",
                 "bin",

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentTools.cs
@@ -82,5 +82,22 @@ namespace Datadog.Trace.TestHelpers
             return "Release";
 #endif
         }
+
+        public static string GetTracerTargetFrameworkDirectory()
+        {
+            // The conditions looks weird, but it seems like _OR_GREATER is not supported yet in all environments
+            // We can trim all the additional conditions when this is fixed
+#if NETCOREAPP3_1_OR_GREATER || NETCOREAPP3_1 || NET5_0
+            return "netcoreapp3.1";
+#elif NETCOREAPP || NETSTANDARD
+            return "netstandard2.0";
+#elif NET461_OR_GREATER || NET461 || NET47 || NET471 || NET472 || NET48
+            return "net461";
+#elif NET45_OR_GREATER || NET45 || NET451 || NET452 || NET46
+            return "net45";
+#else
+#error Unexpected TFM
+#endif
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -62,9 +62,6 @@ namespace Datadog.Trace.TestHelpers
                 throw new Exception($"application not found: {sampleAppPath}");
             }
 
-            // get full paths to integration definitions
-            IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
-
             Output.WriteLine($"Starting Application: {sampleAppPath}");
             string testCli = EnvironmentHelper.GetDotNetTest();
             string exec = testCli;

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -117,9 +117,6 @@ namespace Datadog.Trace.TestHelpers
                 throw new Exception($"application not found: {sampleAppPath}");
             }
 
-            // get full paths to integration definitions
-            IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
-
             Output.WriteLine($"Starting Application: {sampleAppPath}");
             var executable = EnvironmentHelper.IsCoreClr() ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
             var args = EnvironmentHelper.IsCoreClr() ? $"{sampleAppPath} {arguments ?? string.Empty}" : arguments;
@@ -166,9 +163,6 @@ namespace Datadog.Trace.TestHelpers
 
         public (Process Process, string ConfigFile) StartIISExpress(int traceAgentPort, int iisPort, IisAppType appType)
         {
-            // get full paths to integration definitions
-            IEnumerable<string> integrationPaths = Directory.EnumerateFiles(".", "*integrations.json").Select(Path.GetFullPath);
-
             var iisExpress = EnvironmentHelper.GetIisExpressPath();
 
             var appPool = appType switch

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -14,8 +14,6 @@
 
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <ProfilerOutputDirectory>$(MSBuildThisFileDirectory)\..\..\src\Datadog.Trace.ClrProfiler.Native\bin\$(Configuration)\$(Platform)</ProfilerOutputDirectory>
-    <ManagedProfilerOutputDirectory Condition="'$(ManagedProfilerOutputDirectory)' == ''">$(MSBuildThisFileDirectory)\..\..\src\Datadog.Trace\bin\$(Configuration)</ManagedProfilerOutputDirectory>
 
     <!--These should be consolidated in a file that can be shared for the tests and samples directories -->
     <DefineConstants Condition="'$(BuildingInsideVisualStudio)'=='true' or '$(TestAllPackageVersions)'!='true'">$(DefineConstants);DEFAULT_SAMPLES</DefineConstants>
@@ -24,32 +22,4 @@
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(ExcludeManagedProfiler)' != 'true' and
-                        '$(LoadManagedProfilerFromProfilerDirectory)' != 'true' ">
-    <ProjectReference Include="$(MSBuildThisFileDirectory)\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(ExcludeNativeProfiler)' != 'true'">
-    <None Include="$(ProfilerOutputDirectory)\*.dll;$(ProfilerOutputDirectory)\*.so;$(ProfilerOutputDirectory)\*.pdb"
-          CopyToOutputDirectory="Always"
-          CopyToPublishDirectory="Always"
-          Link="profiler-lib\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Content Include="$(MSBuildThisFileDirectory)\..\..\integrations.json"
-             CopyToOutputDirectory="Always"
-             CopyToPublishDirectory="Always"
-             Link="profiler-lib\integrations.json" />
-  </ItemGroup>
-
-  <Target Name="AfterBuildCopyManagedProfiler" AfterTargets="AfterBuild"
-          Condition=" '$(ExcludeManagedProfiler)' != 'true' AND '$(LoadManagedProfilerFromProfilerDirectory)' == 'true'">
-    <ItemGroup>
-      <!-- Subfolders of the output directory should each be a target framework -->
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.dll" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.dll" />
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.lib" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.lib" />
-      <ManagedProfilerFiles Include="$(ManagedProfilerOutputDirectory)\**\*.pdb" Exclude="$(ManagedProfilerOutputDirectory)\*\runtimes\**\*.pdb" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(ManagedProfilerFiles)" DestinationFolder="$(OutputPath)profiler-lib\%(RecursiveDir)" />
-  </Target>
 </Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger/LogsInjection.ILogger.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
@@ -8,8 +8,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
-    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
@@ -7,9 +7,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-
-    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
-    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
@@ -10,8 +10,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
-    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Aerospike/Samples.Aerospike.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Aerospike/Samples.Aerospike.csproj
@@ -6,7 +6,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -8,7 +8,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
     <!--  Ignore package version outside of dependency constraint: NEST 5.3.0 requires Newtonsoft.Json (>= 9.0.0 && < 10.0.0)  -->
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/Samples.Elasticsearch.V7/Samples.Elasticsearch.V7.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Elasticsearch.V7/Samples.Elasticsearch.V7.csproj
@@ -9,7 +9,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Elasticsearch/Samples.Elasticsearch.csproj
@@ -10,7 +10,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform, which is needed for the CI library/version matrix -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.FakeDbCommand/Samples.FakeDbCommand.csproj
+++ b/tracer/test/test-applications/integrations/Samples.FakeDbCommand/Samples.FakeDbCommand.csproj
@@ -5,7 +5,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
+++ b/tracer/test/test-applications/integrations/Samples.HttpMessageHandler/Samples.HttpMessageHandler.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />

--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Samples.Microsoft.Data.SqlClient.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient/Samples.Microsoft.Data.SqlClient.csproj
@@ -10,7 +10,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-     <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Samples.Microsoft.Data.Sqlite.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite/Samples.Microsoft.Data.Sqlite.csproj
@@ -10,7 +10,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.MultiDomainHost.Runner/Samples.MultiDomainHost.Runner.csproj
+++ b/tracer/test/test-applications/integrations/Samples.MultiDomainHost.Runner/Samples.MultiDomainHost.Runner.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <IsPackable>false</IsPackable>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,7 +24,7 @@
     <ConvertToAbsolutePath Paths="$(OutputPath)">
       <Output TaskParameter="AbsolutePaths" PropertyName="AbsoluteOutputPath" />
     </ConvertToAbsolutePath>
-    <MSBuild BuildInParallel="false" RunEachTargetSeparately="true" Projects="@(SubApplications)" Targets="Restore;Build" Properties="OutputPath=$(AbsoluteOutputPath)\%(Name)\;TargetFramework=$(TargetFramework);ExcludeNativeProfiler=true;ExcludeManagedProfiler=true;LoadManagedProfilerFromProfilerDirectory=false" />
+    <MSBuild BuildInParallel="false" RunEachTargetSeparately="true" Projects="@(SubApplications)" Targets="Restore;Build" Properties="OutputPath=$(AbsoluteOutputPath)\%(Name)\;TargetFramework=$(TargetFramework);" />
   </Target>
 
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.MySql/Samples.MySql.csproj
+++ b/tracer/test/test-applications/integrations/Samples.MySql/Samples.MySql.csproj
@@ -6,7 +6,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.NoMultiLoader/Samples.NoMultiLoader.csproj
+++ b/tracer/test/test-applications/integrations/Samples.NoMultiLoader/Samples.NoMultiLoader.csproj
@@ -5,7 +5,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Npgsql/Samples.Npgsql.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Npgsql/Samples.Npgsql.csproj
@@ -10,7 +10,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.OracleMDA.Core/Samples.OracleMDA.Core.csproj
+++ b/tracer/test/test-applications/integrations/Samples.OracleMDA.Core/Samples.OracleMDA.Core.csproj
@@ -10,7 +10,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.OracleMDA/Samples.OracleMDA.csproj
+++ b/tracer/test/test-applications/integrations/Samples.OracleMDA/Samples.OracleMDA.csproj
@@ -8,7 +8,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;net461</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.RateLimiter/Samples.RateLimiter.csproj
+++ b/tracer/test/test-applications/integrations/Samples.RateLimiter/Samples.RateLimiter.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Samples.RuntimeMetrics.csproj
+++ b/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Samples.RuntimeMetrics.csproj
@@ -1,5 +1,2 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.SQLite.Core/Samples.SQLite.Core.csproj
+++ b/tracer/test/test-applications/integrations/Samples.SQLite.Core/Samples.SQLite.Core.csproj
@@ -5,7 +5,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Samples.SqlServer.NetFramework20.csproj
+++ b/tracer/test/test-applications/integrations/Samples.SqlServer.NetFramework20/Samples.SqlServer.NetFramework20.csproj
@@ -7,7 +7,6 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.SqlServer/Samples.SqlServer.csproj
+++ b/tracer/test/test-applications/integrations/Samples.SqlServer/Samples.SqlServer.csproj
@@ -7,7 +7,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">

--- a/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Samples.TracingWithoutLimits.csproj
+++ b/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Samples.TracingWithoutLimits.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Samples.WebRequest.NetFramework20.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20/Samples.WebRequest.NetFramework20.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- override to only build/run net452 -->
     <TargetFrameworks>net452</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Samples.WebRequest.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects/Samples.MultiDomainHost.App.FrameworkHttpNoRedirects.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpNoRedirects/Samples.MultiDomainHost.App.NuGetHttpNoRedirects.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpNoRedirects/Samples.MultiDomainHost.App.NuGetHttpNoRedirects.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpWithRedirects/Samples.MultiDomainHost.App.NuGetHttpWithRedirects.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetHttpWithRedirects/Samples.MultiDomainHost.App.NuGetHttpWithRedirects.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetJsonWithRedirects/Samples.MultiDomainHost.App.NuGetJsonWithRedirects.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.MultiDomainHost.App.NuGetJsonWithRedirects/Samples.MultiDomainHost.App.NuGetJsonWithRedirects.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net45;net451;net452;net46;net461;net462;net47;net471;net472;net48</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/AssemblyLoad.FileNotFoundException/AssemblyLoad.FileNotFoundException.csproj
+++ b/tracer/test/test-applications/regression/AssemblyLoad.FileNotFoundException/AssemblyLoad.FileNotFoundException.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ExcludeManagedProfiler>true</ExcludeManagedProfiler>
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">   

--- a/tracer/test/test-applications/regression/AutomapperTest/Program.cs
+++ b/tracer/test/test-applications/regression/AutomapperTest/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using AutoMapper;
-using Datadog.Trace.ClrProfiler;
 
 namespace AutomapperTest
 {
@@ -9,7 +9,7 @@ namespace AutomapperTest
     {
         public static void Main()
         {
-            Console.WriteLine($"Profiler attached: {Instrumentation.ProfilerAttached}");
+            Console.WriteLine($"Profiler attached: {IsProfilerAttached()}");
 
             Mapper.Initialize(
                 configuration =>
@@ -18,6 +18,22 @@ namespace AutomapperTest
                 });
 
             Console.WriteLine("Done");
+        }
+
+        private static bool IsProfilerAttached()
+        {
+            Type nativeMethodsType = Type.GetType("Datadog.Trace.ClrProfiler.NativeMethods, Datadog.Trace");
+            MethodInfo profilerAttachedMethodInfo = nativeMethodsType.GetMethod("IsProfilerAttached");
+            try
+            {
+                return (bool)profilerAttachedMethodInfo.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return false;
         }
     }
 

--- a/tracer/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
+++ b/tracer/test/test-applications/regression/DuplicateTypeProxy/DuplicateTypeProxy.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-      <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-    </PropertyGroup>
-
     <ItemGroup>
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>

--- a/tracer/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/EntityFramework6x.MdTokenLookupFailure.csproj
+++ b/tracer/test/test-applications/regression/EntityFramework6x.MdTokenLookupFailure/EntityFramework6x.MdTokenLookupFailure.csproj
@@ -12,7 +12,6 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/tracer/test/test-applications/regression/EnumerateAssemblyReferences/EnumerateAssemblyReferences.csproj
+++ b/tracer/test/test-applications/regression/EnumerateAssemblyReferences/EnumerateAssemblyReferences.csproj
@@ -1,7 +1,3 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
-
 </Project>

--- a/tracer/test/test-applications/regression/LargePayload/LargePayload.csproj
+++ b/tracer/test/test-applications/regression/LargePayload/LargePayload.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
+++ b/tracer/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/Sandbox.ManualTracing/Sandbox.ManualTracing.csproj
+++ b/tracer/test/test-applications/regression/Sandbox.ManualTracing/Sandbox.ManualTracing.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/ServiceBus.Minimal.MassTransit.csproj
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/ServiceBus.Minimal.MassTransit.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <!-- Override TargetFrameworks to remove net452 -->
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.NServiceBus/ServiceBus.Minimal.NServiceBus.csproj
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.NServiceBus/ServiceBus.Minimal.NServiceBus.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
-  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="7.5.0" />

--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.Rebus/ServiceBus.Minimal.Rebus.csproj
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.Rebus/ServiceBus.Minimal.Rebus.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <!-- Override TargetFrameworks to remove net452 -->
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0</TargetFrameworks>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/dependency-libs/AppDomain.Instance/AppDomain.Instance.csproj
+++ b/tracer/test/test-applications/regression/dependency-libs/AppDomain.Instance/AppDomain.Instance.csproj
@@ -6,7 +6,6 @@
     <Platforms>x64;x86</Platforms>
     <PlatformTarget>$(Platform)</PlatformTarget>
     <IsPackable>false</IsPackable>
-    <LoadManagedProfilerFromProfilerDirectory>true</LoadManagedProfilerFromProfilerDirectory>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/regression/dependency-libs/Directory.Build.props
+++ b/tracer/test/test-applications/regression/dependency-libs/Directory.Build.props
@@ -3,6 +3,5 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;net461;netcoreapp2.1</TargetFrameworks>
-    <ExcludeNativeProfiler>true</ExcludeNativeProfiler>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This is a more aggressive version alternative to #1807. That PR stops copying the profiler to the regression samples only. This PR stops copying it around full stop.

Pros:
* The profiler is always in the same place - in the tracer home directory
* Significantly simplifies the logic in the test helper for finding the profiler
* Reduces a large amount of MSBuild-foo
* We save a lot of space (even though we only copy it in the integration tests currently, that still uses ~1.5GB)

Cons
* If you want to run integration tests from VS/Rider  you _must_ build the tracer home directory first (using `./tracer/build.ps1 BuildTracerHome)
* ? I'm sure I must be missing something!

> Note that in this PR I rely on the build setting the environment variable `TracerHomeDirectory`. I'm not passionate about this naming; I thought it _might_ be preferable to use something _other_ than `DD_DOTNET_TRACER_HOME` but definitely open to changing it

@DataDog/apm-dotnet