### PR TITLE
Add a native API to parse boolean environment variable values

### DIFF
--- a/shared/src/native-src/util.cpp
+++ b/shared/src/native-src/util.cpp
@@ -54,6 +54,48 @@ namespace shared
         return trimmed;
     }
 
+    bool TryParseBooleanEnvironmentValue(const WSTRING& valueToParse, bool& parsedValue)
+    {
+        WSTRING trimmedValueToParse = Trim(valueToParse);
+        
+        // In the future we should convert trimmedValueToParse to lower case in a portable manner and simplify the IFs below.
+        // Being pragmatic for now.
+
+        if (trimmedValueToParse == WStr("false")
+                || trimmedValueToParse == WStr("False")
+                || trimmedValueToParse == WStr("FALSE")
+                || trimmedValueToParse == WStr("no")
+                || trimmedValueToParse == WStr("No")
+                || trimmedValueToParse == WStr("NO")
+                || trimmedValueToParse == WStr("f")
+                || trimmedValueToParse == WStr("F")
+                || trimmedValueToParse == WStr("N")
+                || trimmedValueToParse == WStr("n")
+                || trimmedValueToParse == WStr("0"))
+        {
+            parsedValue = false;
+            return true;
+        }
+
+        if (trimmedValueToParse == WStr("true")
+                || trimmedValueToParse == WStr("True")
+                || trimmedValueToParse == WStr("TRUE")
+                || trimmedValueToParse == WStr("yes")
+                || trimmedValueToParse == WStr("Yes")
+                || trimmedValueToParse == WStr("YES")
+                || trimmedValueToParse == WStr("t")
+                || trimmedValueToParse == WStr("T")
+                || trimmedValueToParse == WStr("Y")
+                || trimmedValueToParse == WStr("y")
+                || trimmedValueToParse == WStr("1"))
+        {
+            parsedValue = true;
+            return true;
+        }
+
+        return false;
+    }
+
     WSTRING GetEnvironmentValue(const WSTRING& name)
     {
 #ifdef _WIN32

--- a/shared/src/native-src/util.h
+++ b/shared/src/native-src/util.h
@@ -23,6 +23,9 @@ namespace shared
     template <typename Out>
     void Split(const WSTRING& s, wchar_t delim, Out result);
 
+    // Permissively parse a boolean envirinment variable value in a way similar to how we parse settings in managed code.
+    bool TryParseBooleanEnvironmentValue(const WSTRING& valueToParse, bool& parsedValue);
+
     // Split splits a string by the given delimiter.
     std::vector<WSTRING> Split(const WSTRING& s, wchar_t delim);
 


### PR DESCRIPTION
While parsing boolean environment variable in managed code we go out of our way to interpret the value. [Here is the profiler code](https://github.com/DataDog/dd-continuous-profiler-dotnet/blob/7a326481d97aa0ccf7f451482feef3c4edfcfa24/src/ProfilerEngine/Datadog.AutoInstrumentation.Profiler.Managed/Datadog.AutoInstrumentation.Configuration/internal/ConfigurationProviderUtils.cs#L110-L139), and the tracer does the same - that logic was originally copied from there.

In native we currently do not have the same capability.
This change adds this.
Once merged, we can use the new API in [this manner](https://github.com/DataDog/dd-continuous-profiler-dotnet/pull/160).
