### PR TITLE
Restore the original env-var value before asserting.

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -181,18 +181,16 @@ namespace Datadog.Trace.Tests.Configuration
                 // after load settings we can restore the original DD_SERVICE
                 Environment.SetEnvironmentVariable(ConfigurationKeys.ServiceName, originalServiceName, EnvironmentVariableTarget.Process);
 
-                // restore original value
-                Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
             }
             else
             {
                 Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
                 IConfigurationSource source = new EnvironmentConfigurationSource();
                 settings = new TracerSettings(source);
-
-                // restore original value
-                Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
             }
+
+            // restore original value
+            Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
 
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
@@ -251,7 +249,6 @@ namespace Datadog.Trace.Tests.Configuration
 
             // save original value so we can restore later
             var originalValue = Environment.GetEnvironmentVariable(key);
-            Environment.SetEnvironmentVariable(key, string.Empty, EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
             var settings = new GlobalSettings(source);
             Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -187,7 +187,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 settings = GetTracerSettings(key, value);
 
-                // after load settings we can restore the original DD_SERVICE
+                // after load settings we can restore the original DD_TRACE_AGENT_URL
                 Environment.SetEnvironmentVariable(ConfigurationKeys.AgentUri, originalAgentUri, EnvironmentVariableTarget.Process);
             }
             else

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -163,36 +163,20 @@ namespace Datadog.Trace.Tests.Configuration
             Func<TracerSettings, object> settingGetter,
             object expectedValue)
         {
+            IConfigurationSource source = new EnvironmentConfigurationSource();
+
             // save original value so we can restore later
             var originalValue = Environment.GetEnvironmentVariable(key);
 
-            TracerSettings settings;
-
-            if (key == "DD_SERVICE_NAME")
-            {
-                // We need to ensure DD_SERVICE is empty.
-                string originalServiceName = Environment.GetEnvironmentVariable(ConfigurationKeys.ServiceName);
-                Environment.SetEnvironmentVariable(ConfigurationKeys.ServiceName, null, EnvironmentVariableTarget.Process);
-
-                Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
-                IConfigurationSource source = new EnvironmentConfigurationSource();
-                settings = new TracerSettings(source);
-
-                // after load settings we can restore the original DD_SERVICE
-                Environment.SetEnvironmentVariable(ConfigurationKeys.ServiceName, originalServiceName, EnvironmentVariableTarget.Process);
-            }
-            else
-            {
-                Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
-                IConfigurationSource source = new EnvironmentConfigurationSource();
-                settings = new TracerSettings(source);
-            }
-
-            object actualValue = settingGetter(settings);
-            Assert.Equal(expectedValue, actualValue);
+            // Set new value
+            Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
+            var settings = new TracerSettings(source);
 
             // restore original value
             Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
+
+            object actualValue = settingGetter(settings);
+            Assert.Equal(expectedValue, actualValue);
         }
 
         [Theory]
@@ -244,14 +228,16 @@ namespace Datadog.Trace.Tests.Configuration
             Func<GlobalSettings, object> settingGetter,
             object expectedValue)
         {
+            IConfigurationSource source = new EnvironmentConfigurationSource();
+
             // save original value so we can restore later
             var originalValue = Environment.GetEnvironmentVariable(key);
             Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
-            IConfigurationSource source = new EnvironmentConfigurationSource();
             var settings = new GlobalSettings(source);
+            Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
+
             object actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
-            Environment.SetEnvironmentVariable(key, originalValue, EnvironmentVariableTarget.Process);
         }
 
         // Special case for dictionary-typed settings in JSON


### PR DESCRIPTION
Restore the original env-var value before asserting. To avoid any collision to CI App dogfooding


@DataDog/apm-dotnet