### PR TITLE
CallSite instrumentation - Add exceptions to active span during ASP.NET Web API 2 message handler exception

### DIFF
--- a/tracer/integrations.json
+++ b/tracer/integrations.json
@@ -193,7 +193,7 @@
           "maximum_patch": 65535
         },
         "wrapper": {
-          "assembly": "Datadog.Trace, Version=1.28.6.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "assembly": "Datadog.Trace, Version=1.28.8.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
           "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
           "method": "HandleAsync",
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",

--- a/tracer/integrations.json
+++ b/tracer/integrations.json
@@ -172,6 +172,33 @@
           "signature": "00 06 1C 1C 1C 1C 08 08 0A",
           "action": "ReplaceTargetMethod"
         }
+      },
+      {
+        "caller": {},
+        "target": {
+          "assembly": "System.Web.Http",
+          "type": "System.Web.Http.ExceptionHandling.ExceptionHandlerExtensions",
+          "method": "HandleAsync",
+          "signature_types": [
+            "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>",
+            "System.Web.Http.ExceptionHandling.IExceptionHandler",
+            "System.Web.Http.ExceptionHandling.ExceptionContext",
+            "System.Threading.CancellationToken"
+          ],
+          "minimum_major": 5,
+          "minimum_minor": 1,
+          "minimum_patch": 0,
+          "maximum_major": 5,
+          "maximum_minor": 65535,
+          "maximum_patch": 65535
+        },
+        "wrapper": {
+          "assembly": "Datadog.Trace, Version=1.28.6.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb",
+          "type": "Datadog.Trace.ClrProfiler.Integrations.AspNetWebApi2Integration",
+          "method": "HandleAsync",
+          "signature": "00 06 1C 1C 1C 1C 08 08 0A",
+          "action": "ReplaceTargetMethod"
+        }
       }
     ]
   },

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/IntegrationSignatureTests.cs
@@ -15,7 +15,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         // This is a list of instrumented methods that are static, i.e., the target method is static.
         private static readonly List<MethodInfo> StaticInstrumentations = new List<MethodInfo>()
         {
-            // This list is currently empty
+#if NETFRAMEWORK
+            typeof(Integrations.AspNetWebApi2Integration).GetRuntimeMethod(nameof(Integrations.AspNetWebApi2Integration.HandleAsync), new[] { typeof(object), typeof(object), typeof(object), typeof(int), typeof(int), typeof(long) }),
+#endif
         };
 
         public static IEnumerable<object[]> GetCallSiteMethodsWithInterceptionAttribute()

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Classic.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.NoFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_statuscode_201-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api2_transientfailure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ConventionsController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_api_transient-failure_false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Passed in value was not 'true': false,
+      error.stack: 
+System.ArgumentException: Passed in value was not 'true': false
+at Samples.AspNetMvc5.Controllers.ApiController.TransientFailure(String value),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=false&ts=true_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: PassThroughQuerySuccessMessageHandler. Error: Query param ps was set to a non-true value
+at Samples.AspNetMvc5.Handlers.PassThroughQuerySuccessMessageHandler.<SendAsync>d__1.MoveNext(),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,

--- a/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetWebApi2Tests.CallTarget.Integrated.WithFF.__path=_handler-api_api-ps=true&ts=false_statusCode=500.verified.txt
@@ -22,7 +22,11 @@
     Error: 1,
     Tags: {
       env: integration_tests,
-      error.msg: The HTTP response has status code 500.,
+      error.msg: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value,
+      error.stack: 
+System.ArgumentException: Source: TerminatingQuerySuccessMessageHandler. Error: Query param ts was set to a non-true value
+at Samples.AspNetMvc5.Handlers.TerminatingQuerySuccessMessageHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken),
+      error.type: System.ArgumentException,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 500,


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/dd-trace-dotnet/pull/1734

See the original PR for the full motivation. The original PR only added a fix for CallTarget instrumentation, so this PR adds the fix when the instrumented application is using CallSite instrumentation.

@DataDog/apm-dotnet