### PR TITLE
Dont test all integration package versions on every PR

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -521,7 +521,7 @@ stages:
           baseImage: alpine
 
     variables:
-      TestAllPackageVersions: true
+      TestAllPackageVersions: $(isMainBranch)
 
     pool:
       vmImage: ubuntu-18.04
@@ -593,7 +593,7 @@ stages:
   jobs:
     - job: Test
       variables:
-        TestAllPackageVersions: true
+        TestAllPackageVersions: $(isMainBranch)
         publishTargetFramework: net5.0
         baseImage: debian
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1009,21 +1009,22 @@ partial class Build
 
             // These sample projects are built using RestoreAndBuildSamplesForPackageVersions
             // so no point building them now
-            List<string> multiPackageProjects;
-            var samplesFile = BuildDirectory / "PackageVersionsGeneratorDefinitions.json";
-            using (var fs = File.OpenRead(samplesFile))
+            var multiPackageProjects = new List<string>();
+            if (TestAllPackageVersions)
             {
+                var samplesFile = BuildDirectory / "PackageVersionsGeneratorDefinitions.json";
+                using var fs = File.OpenRead(samplesFile);
                 var json = JsonDocument.Parse(fs);
                 multiPackageProjects = json.RootElement
-                                       .EnumerateArray()
-                                       .Select(e => e.GetProperty("SampleProjectName").GetString())
-                                       .Distinct()
-                                       .Where(name => name switch
-                                        {
-                                            "Samples.MySql" => false, // the "non package version" is _ALSO_ tested separately
-                                            _ => true
-                                        })
-                                       .ToList();
+                                           .EnumerateArray()
+                                           .Select(e => e.GetProperty("SampleProjectName").GetString())
+                                           .Distinct()
+                                           .Where(name => name switch
+                                            {
+                                                "Samples.MySql" => false, // the "non package version" is _ALSO_ tested separately
+                                                _ => true
+                                            })
+                                           .ToList();
             }
 
             var projectsToBuild = sampleProjects
@@ -1102,7 +1103,6 @@ partial class Build
                 .SetProperty("TargetFramework", Framework.ToString())
                 .SetProperty("BuildInParallel", "true")
                 .SetProcessArgumentConfigurator(arg => arg.Add("/nowarn:NU1701"))
-                .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
                 .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                 .CombineWith(targets, (c, target) => c.SetTargets(target))
             );
@@ -1129,9 +1129,7 @@ partial class Build
                     .SetFramework(Framework)
                     // .SetTargetPlatform(Platform)
                     .SetNoWarnDotNetCore3()
-                    .When(TestAllPackageVersions, o => o
-                        .SetProperty("TestAllPackageVersions", "true"))
-                    .AddProcessEnvironmentVariable("TestAllPackageVersions", "true")
+                    .When(TestAllPackageVersions, o => o.SetProperty("TestAllPackageVersions", "true"))
                     .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
                         o.SetPackageDirectory(NugetPackageDirectory))
                     .CombineWith(integrationTestProjects, (c, project) => c
@@ -1172,8 +1170,7 @@ partial class Build
                         .EnableMemoryDumps()
                         .SetFilter(filter)
                         .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
-                        .When(TestAllPackageVersions, o => o
-                            .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                        .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                         .When(CodeCoverage, ConfigureCodeCoverage)
                         .CombineWith(ParallelIntegrationTests, (s, project) => s
                             .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -1190,8 +1187,7 @@ partial class Build
                     .EnableMemoryDumps()
                     .SetFilter(filter)
                     .SetProcessEnvironmentVariable("TracerHomeDirectory", TracerHomeDirectory)
-                    .When(TestAllPackageVersions, o => o
-                        .SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
+                    .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .When(CodeCoverage, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         {
             foreach (object[] item in PackageVersions.MySqlData)
             {
-                if (!((string)item[0]).StartsWith("8"))
+                if (!((string)item[0]).StartsWith("8") && !string.IsNullOrEmpty((string)item[0]))
                 {
                     continue;
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -30,8 +30,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [Trait("Category", "TestIntegrations")]
         public void SubmitTraces(string packageVersion)
         {
+            var version = string.IsNullOrEmpty(packageVersion) ? new Version("2.0.0") : new Version(packageVersion);
             List<MockTracerAgent.Span> spans = null;
-            var expectedSpanCount = new Version(packageVersion).CompareTo(new Version("2.2.5")) < 0 ? 13 : 15;
+            var expectedSpanCount = version.CompareTo(new Version("2.2.5")) < 0 ? 13 : 15;
 
             try
             {


### PR DESCRIPTION
This PR updates the Linux integration tests to only test all the minor package versions on builds of master.  This can significantly reduce CI execution time, as we don't need to build all the samples either. Initial tests suggest execution times:

* Linux, reduce from 45-60 mins -> 20-30mins
* Arm64, reduce from ~25mins -> 15mins

Obviously we will have to be more aware of build failures on master if we take this approach.

@DataDog/apm-dotnet