### PR TITLE
Parallelise Windows integration tests by framework

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -376,7 +376,7 @@ stages:
             if [ $target == "BuildAndRunWindowsIntegrationTests" ]; then cosmos=true; else cosmos=false; fi
             matrix="${matrix} '${name}':"
             matrix="${matrix} { 'framework': '${framework}', "
-            matrix="${matrix} 'platform': '${platform}' },"
+            matrix="${matrix} 'targetPlatform': '${platform}' },"
           done
         done
         matrix="${matrix::-1} }"
@@ -416,7 +416,7 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows tracer logs
-      artifact: integration_tests_windows_tracer_logs_$(platform)_$(framework)_$(System.JobAttempt)
+      artifact: integration_tests_windows_tracer_logs_$(targetPlatform)_$(framework)_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
@@ -437,7 +437,7 @@ stages:
               if [ $platform == "x86" ]; then enable32bit=true; else enable32bit=false; fi
               matrix="${matrix} '${name}':"
               matrix="${matrix} { 'framework': '${framework}', "
-              matrix="${matrix} 'platform': '${platform}', "
+              matrix="${matrix} 'targetPlatform': '${platform}', "
               matrix="${matrix} 'enable32bit': ${enable32bit} },"
             done
           done
@@ -453,7 +453,7 @@ stages:
     pool:
       vmImage: windows-2019
     variables:
-      relativeMsiOutputDirectory: $(relativeArtifacts)/$(platform)/en-us
+      relativeMsiOutputDirectory: $(relativeArtifacts)/$(targetPlatform)/en-us
 
     steps:
 
@@ -465,7 +465,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download MSI
       inputs:
-        artifact: windows-msi-$(platform)
+        artifact: windows-msi-$(targetPlatform)
         patterns: '**/*.msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 
@@ -503,7 +503,7 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
-      artifact: integration_tests_windows_iis_tracer_logs_$(platform)_$(framework)
+      artifact: integration_tests_windows_iis_tracer_logs_$(targetPlatform)_$(framework)
       condition: succeededOrFailed()
       continueOnError: true
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -362,30 +362,34 @@ stages:
 - stage: integration_tests_windows
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_windows
-  pool:
-    vmImage: windows-2019
-  jobs:
 
-  - job: Windows
+  jobs:
+  - job: generator
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+    - bash: |
+        matrix="{"
+        for framework in "net452" "net461" "netcoreapp2.1" "netcoreapp3.0" "netcoreapp3.1" "net5.0"; do
+          for platform in "x64" "x86"; do
+            name="${platform}_${framework//./_}"
+            if [ $target == "BuildAndRunWindowsIntegrationTests" ]; then cosmos=true; else cosmos=false; fi
+            matrix="${matrix} '${name}':"
+            matrix="${matrix} { 'framework': '${framework}', "
+            matrix="${matrix} 'platform': '${platform}' },"
+          done
+        done
+        matrix="${matrix::-1} }"
+        echo "##vso[task.setVariable variable=values;isOutput=true]${matrix}"
+      name: mtrx
+
+  - job: Win
+    dependsOn: generator
+    pool:
+      vmImage: windows-2019
     timeoutInMinutes: 100
     strategy:
-      matrix:
-        x64_integration:
-          platform: x64
-          target: BuildAndRunWindowsIntegrationTests
-          requiresCosmos: true
-        x86_interation:
-          platform: x86
-          target: BuildAndRunWindowsIntegrationTests
-          requiresCosmos: true
-        x64_regression:
-          platform: x64
-          target: BuildAndRunWindowsRegressionTests
-          requiresCosmos: false
-        x86_regression:
-          platform: x86
-          target: BuildAndRunWindowsRegressionTests
-          requiresCosmos: false
+      matrix: $[ dependencies.generator.outputs['mtrx.values'] ]
 
     steps:
     - template: steps/install-dotnet-sdks.yml
@@ -398,10 +402,9 @@ stages:
         Import-Module "C:/Program Files/Azure Cosmos DB Emulator/PSModules/Microsoft.Azure.CosmosDB.Emulator"
         Start-CosmosDbEmulator -Timeout 300
       displayName: 'Start CosmosDB Emulator'
-      condition: eq(variables.requiresCosmos, true)
       workingDirectory: $(Pipeline.Workspace)
 
-    - script: tracer\build.cmd $(target) --PrintDriveSpace --code-coverage
+    - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests
 
     - task: PublishTestResults@2
@@ -413,24 +416,40 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows tracer logs
-      artifact: integration_tests_windows_tracer_logs_$(platform)_$(target)_$(System.JobAttempt)
+      artifact: integration_tests_windows_tracer_logs_$(platform)_$(framework)_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
 
 - stage: integration_tests_windows_iis
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_windows, package_windows]
+
   jobs:
-  - job: Windows_IIS
+  - job: generator
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+      - bash: |
+          matrix="{"
+          for framework in "net452" "net461" "netcoreapp2.1" "netcoreapp3.0" "netcoreapp3.1" "net5.0"; do
+            for platform in "x64" "x86"; do
+              name="${framework//./_}_${platform}"
+              if [ $platform == "x86" ]; then enable32bit=true; else enable32bit=false; fi
+              matrix="${matrix} '${name}':"
+              matrix="${matrix} { 'framework': '${framework}', "
+              matrix="${matrix} 'platform': '${platform}', "
+              matrix="${matrix} 'enable32bit': ${enable32bit} },"
+            done
+          done
+          matrix="${matrix::-1} }"
+          echo "##vso[task.setVariable variable=values;isOutput=true]${matrix}"
+        name: mtrx
+
+  - job: IIS
     timeoutInMinutes: 100
+    dependsOn: generator
     strategy:
-      matrix:
-        x64:
-          platform: x64
-          enable32bit: false
-        x86:
-          platform: x86
-          enable32bit: true
+      matrix: $[ dependencies.generator.outputs['mtrx.values'] ]
     pool:
       vmImage: windows-2019
     variables:
@@ -450,7 +469,7 @@ stages:
         patterns: '**/*.msi'
         path: $(System.DefaultWorkingDirectory)/$(relativeMsiOutputDirectory)
 
-    - script: tracer\build.cmd BuildWindowsIntegrationTests
+    - script: tracer\build.cmd BuildWindowsIntegrationTests -Framework $(framework)
       displayName: BuildWindowsIntegrationTests
 
     - task: DockerCompose@0
@@ -465,7 +484,7 @@ stages:
         containerregistrytype: Container Registry
         dockerComposeCommand: up -d IntegrationTests.IIS
 
-    - script: tracer\build.cmd RunWindowsIisIntegrationTests --code-coverage
+    - script: tracer\build.cmd RunWindowsIisIntegrationTests -Framework $(framework) --code-coverage
       displayName: RunWindowsIisIntegrationTests
 
     - task: PublishTestResults@2
@@ -484,7 +503,7 @@ stages:
 
     - publish: tracer/build_data
       displayName: Uploading integration_tests_windows_iis tracer logs
-      artifact: integration_tests_windows_iis_tracer_logs_$(platform)
+      artifact: integration_tests_windows_iis_tracer_logs_$(platform)_$(framework)
       condition: succeededOrFailed()
       continueOnError: true
 

--- a/tracer/Datadog.Trace.proj
+++ b/tracer/Datadog.Trace.proj
@@ -50,7 +50,14 @@
 
   <!-- Used by CompileIntegrationTests-->
   <Target Name="BuildCsharpIntegrationTests">
-    <MSBuild Targets="Build" Projects="@(RazorPagesProject);@(CsharpIntegrationTestProject);@(CsharpIntegrationTestRegressionProject);@(ExcludeExpenseItDemoProject);@(ExcludeEF6DemoProject);@(ExcludeLegacyRedisProject)">
+
+    <!-- Filter the sample projects by TargetFramework -->
+    <ItemGroup>
+      <IntegrationTestProjects Include="@(RazorPagesProject)" Condition="!$(TargetFramework.StartsWith('net4'))" />
+      <IntegrationTestProjects Include="@(CsharpIntegrationTestProject);@(CsharpIntegrationTestRegressionProject);@(ExcludeExpenseItDemoProject);@(ExcludeEF6DemoProject);@(ExcludeLegacyRedisProject)" />
+    </ItemGroup>
+
+    <MSBuild Targets="Build" Projects="@(IntegrationTestProjects)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput"/>
     </MSBuild>
   </Target>

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -79,7 +79,7 @@ partial class Build
         {
             MSBuild(s => s
                 .SetConfiguration(BuildConfiguration)
-                .SetTargetPlatform(Platform)
+                .SetTargetPlatform(TargetPlatform)
                 .SetProjectFile(Solution.GetProject(SampleName)));
         });
 
@@ -173,16 +173,16 @@ partial class Build
                 .SetProjectFile(project)
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()
-                .SetProperty("platform", Platform));
+                .SetProperty("platform", TargetPlatform));
 
             DotNetRun(s => s
-                .SetDotnetPath(Platform)
+                .SetDotnetPath(TargetPlatform)
                 .SetFramework(Framework)
                 .EnableNoLaunchProfile()
                 .SetProjectFile(project)
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()
-                .SetProperty("platform", Platform)
+                .SetProperty("platform", TargetPlatform)
                 .SetProcessEnvironmentVariables(envVars));
 
         });

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -169,7 +169,7 @@ partial class Build : NukeBuild
         .DependsOn(PublishIisSamples)
         .DependsOn(CompileIntegrationTests);
 
-    Target BuildWindowsRegressionIntegrationTests => _ => _
+    Target BuildWindowsRegressionTests => _ => _
         .Unlisted()
         .Requires(() => IsWin)
         .Description("Builds the integration tests for Windows")
@@ -189,7 +189,7 @@ partial class Build : NukeBuild
     Target BuildAndRunWindowsRegressionTests => _ => _
         .Requires(() => IsWin)
         .Description("Builds and runs the Windows regression tests")
-        .DependsOn(BuildWindowsRegressionIntegrationTests)
+        .DependsOn(BuildWindowsRegressionTests)
         .DependsOn(RunWindowsRegressionTests);
 
     Target BuildAndRunWindowsIisIntegrationTests => _ => _

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -29,7 +29,7 @@ partial class Build : NukeBuild
     readonly Configuration BuildConfiguration = Configuration.Release;
 
     [Parameter("Platform to build - x86 or x64. Default is x64")]
-    readonly MSBuildTargetPlatform Platform = MSBuildTargetPlatform.x64;
+    readonly MSBuildTargetPlatform TargetPlatform = MSBuildTargetPlatform.x64;
 
     [Parameter("The TargetFramework to execute when running or building a sample app, or linux integration tests")]
     readonly TargetFramework Framework;
@@ -71,7 +71,7 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             Logger.Info($"Configuration: {BuildConfiguration}");
-            Logger.Info($"Platform: {Platform}");
+            Logger.Info($"Platform: {TargetPlatform}");
             Logger.Info($"Framework: {Framework}");
             Logger.Info($"TestAllPackageVersions: {TestAllPackageVersions}");
             Logger.Info($"TracerHomeDirectory: {TracerHomeDirectory}");

--- a/tracer/build/_build/NukeExtensions/ProjectExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/ProjectExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Nuke.Common;
+using Nuke.Common.ProjectModel;
+
+public static class ProjectExtensions
+{
+    public static IReadOnlyCollection<string> TryGetTargetFrameworks(this Project project)
+    {
+        try
+        {
+            return project?.GetTargetFrameworks();
+        }
+        catch (Exception ex)
+        {
+            Logger.Info($"Error fetching target frameworks for {project?.Name}: {ex}");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
In this PR I split the Windows integration tests so they run in parallel for each framework, the same as the linux tests do. The obvious benefit is that the tests take less time overall, though there's a lot of duplicated work between the branches, so the speedup isn't quite as big as we'd hope. An additional advantage is that we gain some drive space too. 

The big downside to this approach is that increases the number of hosted agents in use. If we don't have many agents available, then this PR may actually _reduce_ throughput. To reduce that impact somewhat (half the number of agents used) I re-combined the regression and integration tests into a single run. As many of the targets are _relatively_ quick (~20mins) the overall impact even in congested times might not be that bad

> I also had to rename the `platform` parameter to `TargetPlatform`. Using `platform` was causing the Nuke process _itself_ to run as 32 bit, which was then causing some `BadImageFormatException`s. It's a bit weird, and undocumented as far as I can see, but this resolves it

Before this change:
* Integration tests ~50-70mins
* Regression tests ~15-20mins
* IIS tests ~40-60mins

[After this change](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=75930&view=logs&j=d7a40246-cb79-5c52-f181-90faa131e710):
* Integration + Regression tests ~15-45mins 
* IIS tests ~15-40mins

Most of the runs are on the lower end of those estimates. The notable exception is `net461` which takes roughly twice the time to run as the others

![image](https://user-images.githubusercontent.com/18755388/134668237-79c09bdc-0028-437b-ae7e-20b6629577c8.png)




@DataDog/apm-dotnet