### PR TITLE
JITInline callback refactor to fix race condition.

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
@@ -82,7 +82,6 @@ public:
     void SetModuleMetadata(ModuleMetadata* metadata);
 
     RejitHandlerModuleMethod* GetOrAddMethod(mdMethodDef methodDef);
-    bool TryGetMethod(mdMethodDef methodDef, RejitHandlerModuleMethod** methodHandler);
     bool ContainsMethod(mdMethodDef methodDef);
 
     void RequestRejitForInlinersInModule(ModuleID moduleId);
@@ -123,8 +122,8 @@ public:
 
     RejitHandlerModule* GetOrAddModule(ModuleID moduleId);
 
-    bool TryGetModule(ModuleID moduleId, RejitHandlerModule** moduleHandler);
     void RemoveModule(ModuleID moduleId);
+    bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef);
 
     void AddNGenModule(ModuleID moduleId);
 


### PR DESCRIPTION
This PR is a refactor the JITInline callback to fix the race condition where the RejitHandlerModule is released before calling ContainsMethod due to lock release.


@DataDog/apm-dotnet