### PR TITLE
Make vuln app database samples path work cross OS

### DIFF
--- a/tracer/test/test-applications/security/Samples.AspNetCore5/Data/DatabaseHelper.cs
+++ b/tracer/test/test-applications/security/Samples.AspNetCore5/Data/DatabaseHelper.cs
@@ -25,7 +25,7 @@ namespace Samples.AspNetCore5.Data
             sqlConnection.Close();
             if (!dbExists)
             {
-                string script = File.ReadAllText(@"Data\\createdb.sql");
+                string script = File.ReadAllText(Path.Combine(@"Data", "createdb.sql"));
                 {
                     using var connection = new SqlConnection(connectionString);
                     var myCommand = new SqlCommand(script, connection);
@@ -33,7 +33,7 @@ namespace Samples.AspNetCore5.Data
                     myCommand.ExecuteNonQuery();
                     connection.Close();
                 }
-                script = File.ReadAllText(@"Data\\database.sql");
+                script = File.ReadAllText(Path.Combine(@"Data", "database.sql"));
                 {
                     using var connection = new SqlConnection(connectionString);
                     var myCommand = new SqlCommand(script, connection);


### PR DESCRIPTION
Fixes the path to the database samples so they work on Linux as well.

@DataDog/apm-dotnet