### PR TITLE
Disable NGEN images on the shared loader when using .NET Framework 4.5

### DIFF
--- a/shared/src/native-src/loader.h
+++ b/shared/src/native-src/loader.h
@@ -255,7 +255,7 @@ namespace shared
         DWORD GetLoaderProfilerEventMask()
         {
             DWORD eventMask = COR_PRF_MONITOR_MODULE_LOADS | COR_PRF_DISABLE_TRANSPARENCY_CHECKS_UNDER_FULL_TRUST;
-            if (_loaderOptions.DisableNGENImagesSupport)
+            if (_loaderOptions.DisableNGENImagesSupport || !_loaderOptions.IsNet46OrGreater)
             {
                 eventMask |= COR_PRF_DISABLE_ALL_NGEN_IMAGES;
             }


### PR DESCRIPTION
Because we can't rewrite `mscorlib` in .NET Framework 4.5 there's some scenarios (IIS + .NET 4.5 app)  where we cannot inject the loader properly (Only on the default app domain and not in the app-pool domains). This PR fixes the issue by disabling NGEN images when using .NET Framework 4.5, by doing that we ensure module initializers will run on children app domains.

@DataDog/apm-dotnet