### PR TITLE
[CIVisibility] Add Test Framework version to test spans

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/TestTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestTags.cs
@@ -45,6 +45,12 @@ namespace Datadog.Trace.Ci
         public const string Framework = "test.framework";
 
         /// <summary>
+        /// Test framework version
+        /// </summary>
+        [FeatureTracking]
+        public const string FrameworkVersion = "test.framework_version";
+
+        /// <summary>
         /// Test parameters
         /// </summary>
         [FeatureTracking]

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -42,6 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);
+            span.SetTag(TestTags.FrameworkVersion, type.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
             CIEnvironmentValues.DecorateSpan(span);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -58,6 +58,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);
+            span.SetTag(TestTags.FrameworkVersion, targetType.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
             CIEnvironmentValues.DecorateSpan(span);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -24,8 +24,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             string testSuite = runnerInstance.TestClass.ToString();
             string testName = runnerInstance.TestMethod.Name;
 
-            AssemblyName testInvokerAssemblyName = targetType.Assembly.GetName();
-
             string testFramework = "xUnit";
 
             Scope scope = Common.TestTracer.StartActive("xunit.test", serviceName: Common.TestTracer.DefaultServiceName);
@@ -38,6 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             span.SetTag(TestTags.Suite, testSuite);
             span.SetTag(TestTags.Name, testName);
             span.SetTag(TestTags.Framework, testFramework);
+            span.SetTag(TestTags.FrameworkVersion, targetType.Assembly?.GetName().Version.ToString());
             span.SetTag(TestTags.Type, TestTags.TypeTest);
             CIEnvironmentValues.DecorateSpan(span);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/Testing/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/Testing/XUnitIntegration.cs
@@ -404,7 +404,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                     }
                 }
 
-                string testFramework = "xUnit " + testInvokerAssemblyName.Version.ToString();
+                string testFramework = "xUnit";
 
                 scope = Common.TestTracer.StartActive("xunit.test", serviceName: Common.TestTracer.DefaultServiceName);
                 Span span = scope.Span;
@@ -416,6 +416,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 span.SetTag(TestTags.Suite, testSuite);
                 span.SetTag(TestTags.Name, testName);
                 span.SetTag(TestTags.Framework, testFramework);
+                span.SetTag(TestTags.FrameworkVersion, testInvokerAssemblyName.Version.ToString());
                 span.SetTag(TestTags.Type, TestTags.TypeTest);
                 CIEnvironmentValues.DecorateSpan(span);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -70,6 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         // check the test framework
                         AssertTargetSpanContains(targetSpan, TestTags.Framework, "MSTestV2");
+                        Assert.True(targetSpan.Tags.Remove(TestTags.FrameworkVersion));
 
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -95,6 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         // check the test framework
                         AssertTargetSpanContains(targetSpan, TestTags.Framework, "NUnit");
+                        Assert.True(targetSpan.Tags.Remove(TestTags.FrameworkVersion));
 
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -81,6 +81,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         // check the test framework
                         AssertTargetSpanContains(targetSpan, TestTags.Framework, "xUnit");
+                        Assert.True(targetSpan.Tags.Remove(TestTags.FrameworkVersion));
 
                         // check the version
                         AssertTargetSpanEqual(targetSpan, "version", "1.0.0");


### PR DESCRIPTION
This PR adds the `test.framework_version` to test spans with the framework version number.

@DataDog/apm-dotnet