### PR TITLE
Change more timeouts in MassTransit

### DIFF
--- a/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
+++ b/tracer/test/test-applications/regression/ServiceBus.Minimal.MassTransit/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace ServiceBus.Minimal.MassTransit
+namespace ServiceBus.Minimal.MassTransit
 {
     using System;
     using System.Collections.Generic;
@@ -96,8 +96,8 @@
         static async Task SendMessagesAsync(IServiceProvider provider, int jobCount = 10, int activeThreshold = 10, int? delayInSeconds = null)
         {
             var clientFactory = provider.GetRequiredService<IClientFactory>();
-            var submitBatchClient = clientFactory.CreateRequestClient<SubmitBatch>();
-            var batchStatusClient = clientFactory.CreateRequestClient<BatchStatusRequested>();
+            var submitBatchClient = clientFactory.CreateRequestClient<SubmitBatch>(TimeSpan.FromSeconds(60));
+            var batchStatusClient = clientFactory.CreateRequestClient<BatchStatusRequested>(TimeSpan.FromSeconds(60));
 
             List<Task> batchCompletedTasks = new();
 


### PR DESCRIPTION
I believe https://github.com/DataDog/dd-trace-dotnet/pull/1779 missed a few. A run in the CI did timeout after 54 seconds, so the 60 seconds timeout is definitely not working as expected.