### PR TITLE
Add fast lookup for `SpanId` and `LocalRootSpanId`.

### DIFF
--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -36,6 +36,10 @@ namespace Datadog.Trace
             Tags = tags ?? new CommonTags();
             Context = context;
             StartTime = start ?? Context.TraceContext.UtcNow;
+            SpanId = Context.SpanId;
+
+            Span localRootSpan = Context.TraceContext?.RootSpan;
+            LocalRootSpanId = (localRootSpan == null || localRootSpan == this) ? SpanId : localRootSpan.SpanId;
 
             Log.Debug(
                 "Span started: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
@@ -83,7 +87,13 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the span's unique identifier.
         /// </summary>
-        public ulong SpanId => Context.SpanId;
+        public ulong SpanId { get; }
+
+        /// <summary>
+        /// Gets the id of the span that is the root of the local, non-reentrant
+        /// part of the distributed trace that contains this span.
+        /// </summary>
+        internal ulong LocalRootSpanId { get; }
 
         internal ITags Tags { get; set; }
 


### PR DESCRIPTION
In https://github.com/DataDog/dd-trace-dotnet/pull/1839 we are adding the `LocalRootSpanId` property to `Span` for use by Code Hotspots. Notably, Code Hotspots accesses `SpanId` and `LocalRootSpanId` very frequently. This PR stores those values in local fields to avoid repeated dereferencing. 

Putting it in draft mode for now as it is not clear at this point whether this change would really improve performance.