### PR TITLE
Enable static analysis for ConfigureAwait

### DIFF
--- a/tracer/src/.editorconfig
+++ b/tracer/src/.editorconfig
@@ -1,0 +1,4 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+[*.{cs,vb}]
+dotnet_diagnostic.CA2007.severity=error # Consider calling ConfigureAwait on the awaited task

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -27,14 +27,11 @@ namespace Datadog.Trace.Tools.Runner
         private static void Main(string[] args)
         {
             // Initializing
-            string executablePath = (Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly()).Location;
-            string location = executablePath;
-            if (string.IsNullOrEmpty(location))
+            RunnerFolder = AppContext.BaseDirectory;
+            if (string.IsNullOrEmpty(RunnerFolder))
             {
-                location = Environment.GetCommandLineArgs().FirstOrDefault();
+                RunnerFolder = Path.GetDirectoryName(Environment.GetCommandLineArgs().FirstOrDefault());
             }
-
-            RunnerFolder = Path.GetDirectoryName(location);
 
             if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
             {

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Agent.Transports
                         using var sr = new StreamReader(memoryStream);
                         var headers = string.Join(", ", _request.Headers.Select(h => $"{h.Key}: {string.Join(", ", h.Value)}"));
 
-                        var payload = await sr.ReadToEndAsync();
+                        var payload = await sr.ReadToEndAsync().ConfigureAwait(false);
                         Log.Warning("AppSec event not correctly sent to backend {statusCode} by class {className} with response {responseText}, request headers: were {headers}, payload was: {payload}", new object[] { response.StatusCode, nameof(HttpClientRequest), await response.ReadAsStringAsync().ConfigureAwait(false), headers, payload });
                     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Agent/AppSecAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Agent/AppSecAgentWriter.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.AppSec.Agent
                         appsecEvents.Add(result);
                     }
 
-                    await _sender.Send(appsecEvents);
+                    await _sender.Send(appsecEvents).ConfigureAwait(false);
                 }
 
                 // see ThreadAbortAnalyzer and related .net framework bug
@@ -93,7 +93,7 @@ namespace Datadog.Trace.AppSec.Agent
                 }
                 finally
                 {
-                    await Task.Delay(BatchInterval, _batchCancelationSource.Token);
+                    await Task.Delay(BatchInterval, _batchCancelationSource.Token).ConfigureAwait(false);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AspNetCore/BlockingMiddleware.cs
@@ -36,18 +36,18 @@ namespace Datadog.Trace.AppSec.AspNetCore
             {
                 if (context.Items.ContainsKey(SecurityConstants.KillKey) && context.Items[SecurityConstants.KillKey] is bool killKey && killKey)
                 {
-                    await BlockRequest(context);
+                    await BlockRequest(context).ConfigureAwait(true);
                 }
                 else
                 {
                     try
                     {
                         context.Items[SecurityConstants.InHttpPipeKey] = true;
-                        await next.Invoke();
+                        await next.Invoke().ConfigureAwait(true);
                     }
                     catch (BlockActionException)
                     {
-                        await BlockRequest(context);
+                        await BlockRequest(context).ConfigureAwait(true);
                     }
                 }
             }
@@ -70,7 +70,7 @@ namespace Datadog.Trace.AppSec.AspNetCore
                 blockByThrow = false;
                 context.Response.StatusCode = 403;
                 context.Response.ContentType = "text/html";
-                await context.Response.WriteAsync(SecurityConstants.AttackBlockedHtml);
+                await context.Response.WriteAsync(SecurityConstants.AttackBlockedHtml).ConfigureAwait(true);
             }
 
             var callbackExists = context.Items.TryGetValue("Security", out var result);

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 try
                 {
                     // The only supported way to extract the cancellation exception is to await the task
-                    await previousTask;
+                    await previousTask.ConfigureAwait(_preserveContext);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator`1.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations
                 try
                 {
                     // The only supported way to extract the cancellation exception is to await the task
-                    await previousTask;
+                    await previousTask.ConfigureAwait(_preserveContext);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/AspNet/AspNetWebApi2Integration.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations
             {
                 // call the original method, inspecting (and rethrowing) any unhandled exceptions
                 var task = (Task<T>)instrumentedMethod(apiController, context, cancellationToken);
-                var responseMessage = await task;
+                var responseMessage = await task.ConfigureAwait(true);
 
                 if (scope != null)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Integrations/Testing/AsyncTool.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Integrations/Testing/AsyncTool.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 TResult result = default;
                 try
                 {
-                    result = await previousTask;
+                    result = await previousTask.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -145,15 +145,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
                 TResult result = default;
                 try
                 {
-                    result = await previousTask;
+                    result = await previousTask.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    await continuation(result, ex, state);
+                    await continuation(result, ex, state).ConfigureAwait(false);
                     throw;
                 }
 
-                return (TResult)await continuation(result, null, state);
+                return (TResult)await continuation(result, null, state).ConfigureAwait(false);
             }
         }
 
@@ -180,7 +180,7 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
             {
                 try
                 {
-                    await previousTask;
+                    await previousTask.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -205,15 +205,15 @@ namespace Datadog.Trace.ClrProfiler.Integrations.Testing
             {
                 try
                 {
-                    await previousTask;
+                    await previousTask.ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    await continuation(null, ex, state);
+                    await continuation(null, ex, state).ConfigureAwait(false);
                     throw;
                 }
 
-                await continuation(null, null, state);
+                await continuation(null, null, state).ConfigureAwait(false);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -94,6 +94,8 @@
   <!--The StatsdClient uses netstandard1.3 to exclude, but builds against net45 -->
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);NAMED_PIPE_AVAILABLE</DefineConstants>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
 </Project>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -95,7 +95,6 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);NAMED_PIPE_AVAILABLE</DefineConstants>
     <AnalysisLevel>latest</AnalysisLevel>
-    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
 
 </Project>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -94,7 +94,6 @@
   <!--The StatsdClient uses netstandard1.3 to exclude, but builds against net45 -->
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);NAMED_PIPE_AVAILABLE</DefineConstants>
-    <AnalysisLevel>latest</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/StreamContent.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.HttpOverStreams.HttpContent
             while (true)
             {
                 var bytesToRead = (int)Math.Min(remaining, int.MaxValue);
-                var bytesRead = await Stream.ReadAsync(buffer, offset: length, count: bytesToRead);
+                var bytesRead = await Stream.ReadAsync(buffer, offset: length, count: bytesToRead).ConfigureAwait(false);
 
                 length += bytesRead;
                 remaining -= bytesRead;

--- a/tracer/src/Directory.Build.props
+++ b/tracer/src/Directory.Build.props
@@ -5,6 +5,9 @@
     <TargetFrameworks>net45;net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
+    <!-- Code analysis -->
+    <AnalysisLevel>latest</AnalysisLevel>
+
     <!-- NuGet packages -->
     <IsPackable>true</IsPackable>
     <PackageIconUrl>https://github.com/DataDog/dd-trace-dotnet/raw/master/datadog-logo-64x64.png</PackageIconUrl>


### PR DESCRIPTION
Enable static analysis to detect missing `ConfigureAwait`.

For convenience, it's only enabled on the `tracer/src` folder (so tests and sample apps are excluded).