### PR TITLE
Update Gitlab build image to use 5.0.401 SDK

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - binary_build
   
 variables:
-  DATADOG_AGENT_WINBUILDIMAGES: v4603787-d533a1c
+  DATADOG_AGENT_WINBUILDIMAGES: v5596310-06c310e
     
 driver_build:
   only:

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -348,7 +348,7 @@ partial class Build
 
            var sb = new StringBuilder();
            sb.AppendLine($"⚠ 1. Download the NuGet packages for the release from [this link]({artifactsLink}) and upload to nuget.org");
-           sb.AppendLine("⚠ 2. Download the signed MSI assets from GitLab and attach to this release before publishing");
+           sb.AppendLine("⚠ 2. Download the signed MSI assets and native symbols from GitLab and attach to this release before publishing");
            sb.AppendLine();
            sb.Append(changelog, firstContent, releaseNotesEnd - firstContent);
 

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using Nuke.Common;
+using Nuke.Common.CI;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
@@ -17,6 +18,7 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
 // #pragma warning disable SA1400
 // #pragma warning disable SA1401
 
+[ShutdownDotNetAfterServerBuild]
 partial class Build : NukeBuild
 {
     /// Support plugins are available for:


### PR DESCRIPTION
Update GitLab to use the 5.0.401 SDK using the build image created in https://github.com/DataDog/datadog-agent-buildimages/pull/166

Also a couple of extra build-related tweaks:
* Shutdown the .NET host process after building with Nuke (might help with occasional locked file issues)
* Update the description in the create draft release to remind about adding the native symbols
* Ignore some types in the code coverage report comment (types where we often see minor changes depending on the run, e.g. logging and metrics)

@DataDog/apm-dotnet