### PR TITLE
Add lookup for `LocalRootSpanId` property and tests for `SpanId` and `LocalRootSpanId`. 

### DIFF
--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -36,10 +36,6 @@ namespace Datadog.Trace
             Tags = tags ?? new CommonTags();
             Context = context;
             StartTime = start ?? Context.TraceContext.UtcNow;
-            SpanId = Context.SpanId;
-
-            Span localRootSpan = Context.TraceContext?.RootSpan;
-            LocalRootSpanId = (localRootSpan == null || localRootSpan == this) ? SpanId : localRootSpan.SpanId;
 
             Log.Debug(
                 "Span started: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
@@ -87,13 +83,20 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the span's unique identifier.
         /// </summary>
-        public ulong SpanId { get; }
+        public ulong SpanId => Context.SpanId;
 
         /// <summary>
         /// Gets the id of the span that is the root of the local, non-reentrant
         /// part of the distributed trace that contains this span.
         /// </summary>
-        internal ulong LocalRootSpanId { get; }
+        internal ulong LocalRootSpanId
+        {
+            get
+            {
+                Span localRootSpan = Context.TraceContext?.RootSpan;
+                return (localRootSpan == null || localRootSpan == this) ? SpanId : localRootSpan.SpanId;
+            }
+        }
 
         internal ITags Tags { get; set; }
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -86,10 +86,15 @@ namespace Datadog.Trace
         public ulong SpanId => Context.SpanId;
 
         /// <summary>
-        /// Gets the id of the span that is the root of the local, non-reentrant
-        /// part of the distributed trace that contains this span.
+        /// Gets <i>local root span id</i>, i.e. the <c>SpanId</c> of the span that is the root of the local, non-reentrant
+        /// sub-operation of the distributed operation that is represented by the trace that contains this span.
         /// </summary>
-        internal ulong LocalRootSpanId
+        /// <remarks>
+        /// <para>If the trace has been propagated from a remote service, the <i>remote global root</i> is not relevant for this API.</para>
+        /// <para>A distributed operation represented by a trace may be re-entrant (e.g. service-A calls service-B, which calls service-A again).
+        /// In such cases, the local process may be concurrently executing multiple local root spans.
+        /// This API returns the if of the root span of the non-reentrant trace sub-set.</para></remarks>
+        internal ulong RootSpanId
         {
             get
             {

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -36,6 +36,10 @@ namespace Datadog.Trace
             Tags = tags ?? new CommonTags();
             Context = context;
             StartTime = start ?? Context.TraceContext.UtcNow;
+            SpanId = Context.SpanId;
+
+            Span localRootSpan = Context.TraceContext?.RootSpan;
+            LocalRootSpanId = (localRootSpan == null || localRootSpan == this) ? SpanId : localRootSpan.SpanId;
 
             Log.Debug(
                 "Span started: [s_id: {SpanID}, p_id: {ParentId}, t_id: {TraceId}]",
@@ -83,7 +87,13 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the span's unique identifier.
         /// </summary>
-        public ulong SpanId => Context.SpanId;
+        public ulong SpanId { get; }
+
+        /// <summary>
+        /// Gets the id of the span that is the root of the local, non-reentrant
+        /// part of the distributed trace that contains this span.
+        /// </summary>
+        internal ulong LocalRootSpanId { get; }
 
         internal ITags Tags { get; set; }
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace
         /// <para>If the trace has been propagated from a remote service, the <i>remote global root</i> is not relevant for this API.</para>
         /// <para>A distributed operation represented by a trace may be re-entrant (e.g. service-A calls service-B, which calls service-A again).
         /// In such cases, the local process may be concurrently executing multiple local root spans.
-        /// This API returns the if of the root span of the non-reentrant trace sub-set.</para></remarks>
+        /// This API returns the id of the root span of the non-reentrant trace sub-set.</para></remarks>
         internal ulong RootSpanId
         {
             get

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -218,9 +218,9 @@ namespace Datadog.Trace.Tests
                     span2.SpanId.Should().NotBe(0);
                     span3.SpanId.Should().NotBe(0);
 
-                    span1.SpanId.Should().NotBe(remoteParentSpanId);    // There is an expected 1 in 2^64 chance of this line failing
-                    span2.SpanId.Should().NotBe(remoteParentSpanId);    // There is an expected 1 in 2^64 chance of this line failing
-                    span3.SpanId.Should().NotBe(remoteParentSpanId);    // There is an expected 1 in 2^64 chance of this line failing
+                    span1.SpanId.Should().NotBe(remoteParentSpanId);            // There is an expected 1 in 2^64 chance of this line failing
+                    span2.SpanId.Should().NotBe(remoteParentSpanId);            // There is an expected 1 in 2^64 chance of this line failing
+                    span3.SpanId.Should().NotBe(remoteParentSpanId);            // There is an expected 1 in 2^64 chance of this line failing
 
                     span1.LocalRootSpanId.Should().Be(span1.SpanId);
                     span2.LocalRootSpanId.Should().Be(span1.SpanId);

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.Tests
                 using (span)
                 {
                     span.SpanId.Should().NotBe(0);
-                    span.LocalRootSpanId.Should().Be(span.SpanId);
+                    span.RootSpanId.Should().Be(span.SpanId);
                 }
             }
 
@@ -178,7 +178,7 @@ namespace Datadog.Trace.Tests
                 using (scope)
                 {
                     scope.Span.SpanId.Should().NotBe(0);
-                    scope.Span.LocalRootSpanId.Should().Be(scope.Span.SpanId);
+                    scope.Span.RootSpanId.Should().Be(scope.Span.SpanId);
                 }
             }
 
@@ -190,7 +190,7 @@ namespace Datadog.Trace.Tests
                 {
                     span.SpanId.Should().NotBe(0);
                     span.SpanId.Should().NotBe(remoteParentSpanId);             // There is an expected 1 in 2^64 chance of this line failing
-                    span.LocalRootSpanId.Should().Be(span.SpanId);
+                    span.RootSpanId.Should().Be(span.SpanId);
                 }
             }
 
@@ -202,7 +202,7 @@ namespace Datadog.Trace.Tests
                 {
                     scope.Span.SpanId.Should().NotBe(0);
                     scope.Span.SpanId.Should().NotBe(remoteParentSpanId);       // There is an expected 1 in 2^64 chance of this line failing
-                    scope.Span.LocalRootSpanId.Should().Be(scope.Span.SpanId);
+                    scope.Span.RootSpanId.Should().Be(scope.Span.SpanId);
                 }
             }
 
@@ -222,9 +222,9 @@ namespace Datadog.Trace.Tests
                     span2.SpanId.Should().NotBe(remoteParentSpanId);            // There is an expected 1 in 2^64 chance of this line failing
                     span3.SpanId.Should().NotBe(remoteParentSpanId);            // There is an expected 1 in 2^64 chance of this line failing
 
-                    span1.LocalRootSpanId.Should().Be(span1.SpanId);
-                    span2.LocalRootSpanId.Should().Be(span1.SpanId);
-                    span3.LocalRootSpanId.Should().Be(span1.SpanId);
+                    span1.RootSpanId.Should().Be(span1.SpanId);
+                    span2.RootSpanId.Should().Be(span1.SpanId);
+                    span3.RootSpanId.Should().Be(span1.SpanId);
                 }
             }
 
@@ -237,9 +237,9 @@ namespace Datadog.Trace.Tests
                     scope2.Span.SpanId.Should().NotBe(0);
                     scope3.Span.SpanId.Should().NotBe(0);
 
-                    scope1.Span.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
-                    scope2.Span.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
-                    scope3.Span.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
+                    scope1.Span.RootSpanId.Should().Be(scope1.Span.SpanId);
+                    scope2.Span.RootSpanId.Should().Be(scope1.Span.SpanId);
+                    scope3.Span.RootSpanId.Should().Be(scope1.Span.SpanId);
                 }
             }
 
@@ -262,10 +262,10 @@ namespace Datadog.Trace.Tests
                     scope3.Span.SpanId.Should().NotBe(remoteParentSpanId);      // There is an expected 1 in 2^64 chance of this line failing
                     span4.SpanId.Should().NotBe(remoteParentSpanId);            // There is an expected 1 in 2^64 chance of this line failing
 
-                    scope1.Span.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
-                    span2.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
-                    scope3.Span.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
-                    span4.LocalRootSpanId.Should().Be(scope1.Span.SpanId);
+                    scope1.Span.RootSpanId.Should().Be(scope1.Span.SpanId);
+                    span2.RootSpanId.Should().Be(scope1.Span.SpanId);
+                    scope3.Span.RootSpanId.Should().Be(scope1.Span.SpanId);
+                    span4.RootSpanId.Should().Be(scope1.Span.SpanId);
                 }
             }
         }


### PR DESCRIPTION
A [recent PR](https://github.com/DataDog/dd-trace-dotnet/pull/1831) suggested to add direct access properties to Span to access the id and the id of the root span of the local non-reentrant sub-trace. That PR added private fields to `Span` to store those values, to avoid dereferencing multiple pointers at every lookup. However, it was not clear, whether that memory increase was justified, however small it was.

To address that, _this_ PR provides and tests those properties without using additional memory. We are adding using tests, and will keep https://github.com/DataDog/dd-trace-dotnet/pull/1831 archived in case we need to get back to using private fields.