### PR TITLE
Add LifetimeManager for handling shutdown events

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.AppSec
                         _settings.Enabled = false;
                     }
 
-                    RegisterShutdownTasks();
+                    LifetimeManager.Instance.AddShutdownTask(RunShutdown);
                 }
             }
             catch (Exception ex)
@@ -217,58 +217,6 @@ namespace Datadog.Trace.AppSec
             }
 
             Dispose();
-        }
-
-        private void RegisterShutdownTasks()
-        {
-            // Register callbacks to make sure we flush the traces before exiting
-            AppDomain.CurrentDomain.ProcessExit += ProcessExit;
-            AppDomain.CurrentDomain.DomainUnload += DomainUnload;
-
-            try
-            {
-                // Registering for the AppDomain.UnhandledException event cannot be called by a security transparent method
-                // This will only happen if the Tracer is not run full-trust
-                AppDomain.CurrentDomain.UnhandledException += UnhandledException;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "Unable to register a callback to the AppDomain.UnhandledException event.");
-            }
-
-            try
-            {
-                // Registering for the cancel key press event requires the System.Security.Permissions.UIPermission
-                Console.CancelKeyPress += CancelKeyPress;
-            }
-            catch (Exception ex)
-            {
-                Log.Warning(ex, "Unable to register a callback to the Console.CancelKeyPress event.");
-            }
-        }
-
-        private void ProcessExit(object sender, EventArgs e)
-        {
-            AppDomain.CurrentDomain.ProcessExit -= ProcessExit;
-            RunShutdown();
-        }
-
-        private void DomainUnload(object sender, EventArgs e)
-        {
-            AppDomain.CurrentDomain.DomainUnload -= DomainUnload;
-            RunShutdown();
-        }
-
-        private void CancelKeyPress(object sender, EventArgs e)
-        {
-            Console.CancelKeyPress -= CancelKeyPress;
-            RunShutdown();
-        }
-
-        private void UnhandledException(object sender, EventArgs e)
-        {
-            AppDomain.CurrentDomain.UnhandledException -= UnhandledException;
-            RunShutdown();
         }
     }
 }

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -1,0 +1,103 @@
+﻿// <copyright file="LifetimeManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace
+{
+    /// <summary>
+    /// Used to run hooks on application shutdown
+    /// </summary>
+    internal class LifetimeManager
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
+        private static LifetimeManager _instance;
+        private readonly ConcurrentStack<Action> _shutdownHooks = new();
+
+        public LifetimeManager()
+        {
+            // Register callbacks to make sure we flush the traces before exiting
+            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
+            AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
+
+            try
+            {
+                // Registering for the AppDomain.UnhandledException event cannot be called by a security transparent method
+                // This will only happen if the Tracer is not run full-trust
+                AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Unable to register a callback to the AppDomain.UnhandledException event.");
+            }
+
+            try
+            {
+                // Registering for the cancel key press event requires the System.Security.Permissions.UIPermission
+                Console.CancelKeyPress += Console_CancelKeyPress;
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Unable to register a callback to the Console.CancelKeyPress event.");
+            }
+        }
+
+        public static LifetimeManager Instance
+        {
+            get
+            {
+                return LazyInitializer.EnsureInitialized(ref _instance);
+            }
+        }
+
+        public void AddShutdownTask(Action action)
+        {
+            _shutdownHooks.Push(action);
+        }
+
+        private void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        {
+            RunShutdownTasks();
+            AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
+        }
+
+        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            Log.Warning("Application threw an unhandled exception: {Exception}", e.ExceptionObject);
+            RunShutdownTasks();
+            AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
+        }
+
+        private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        {
+            RunShutdownTasks();
+            Console.CancelKeyPress -= Console_CancelKeyPress;
+        }
+
+        private void CurrentDomain_DomainUnload(object sender, EventArgs e)
+        {
+            RunShutdownTasks();
+            AppDomain.CurrentDomain.DomainUnload -= CurrentDomain_DomainUnload;
+        }
+
+        private void RunShutdownTasks()
+        {
+            try
+            {
+                while (_shutdownHooks.TryPop(out var action))
+                {
+                    action();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error running shutdown hooks");
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
         private static LifetimeManager _instance;
-        private readonly ConcurrentStack<Action> _shutdownHooks = new();
+        private readonly ConcurrentQueue<Action> _shutdownHooks = new();
 
         public LifetimeManager()
         {
@@ -57,7 +57,7 @@ namespace Datadog.Trace
 
         public void AddShutdownTask(Action action)
         {
-            _shutdownHooks.Push(action);
+            _shutdownHooks.Enqueue(action);
         }
 
         private void CurrentDomain_ProcessExit(object sender, EventArgs e)
@@ -89,7 +89,7 @@ namespace Datadog.Trace
         {
             try
             {
-                while (_shutdownHooks.TryPop(out var action))
+                while (_shutdownHooks.TryDequeue(out var action))
                 {
                     action();
                 }

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace
     /// </summary>
     internal class LifetimeManager
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LifetimeManager>();
         private static LifetimeManager _instance;
         private readonly ConcurrentQueue<Action> _shutdownHooks = new();
 


### PR DESCRIPTION
We currently have duplicated handling of shutdown events in the `Tracer` and `Security` classes. Future work (e.g. Direct log submission and Telemetry for example) will likely add further to this pattern.

Rather than keep duplicating this pattern, adding a `LifetimeManager` to register all the callbacks correctly should simplify things somewhat. It also provides a central location for working around the shutdown concerns we have later 

@DataDog/apm-dotnet