### PR TITLE
Skip WriteTrace call when no there's no spans and improve filtering

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -107,6 +107,12 @@ namespace Datadog.Trace.Agent
 
         public void WriteTrace(ArraySegment<Span> trace)
         {
+            if (trace.Count == 0)
+            {
+                // If the ArraySegment doesn't have any span we skip it.
+                return;
+            }
+
             if (_serializationTask.IsCompleted)
             {
                 // Serialization thread is not running, serialize the trace in the current thread

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -93,7 +93,7 @@ namespace Datadog.Trace.Ci.Agent
 
             if (spanIdsToRemove != null)
             {
-                CIVisibility.Log.Warning($"Spans dropped because not having a test or benchmark root span: {spanIdsToRemove.Count}");
+                CIVisibility.Log.Warning<int>("Spans dropped because not having a test or benchmark root span: {Count}", spanIdsToRemove.Count);
             }
 
             if (idx > 0)

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.Ci.Agent
             if (!_isPartialFlushEnabled)
             {
                 // Check if the last span (the root) is a test, bechmark or build span
-                Span lastSpan = trace.Array[trace.Count - trace.Offset - 1];
+                Span lastSpan = trace.Array[trace.Offset + trace.Count - 1];
                 if (lastSpan.Context.Parent is null &&
                     lastSpan.Type != SpanTypes.Test &&
                     lastSpan.Type != SpanTypes.Benchmark &&


### PR DESCRIPTION
Fixes the NullReferenceException when there's no span data and improves the filtering.


@DataDog/apm-dotnet