### PR TITLE
No tests or coverage for fake dependabot PRs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -63,6 +63,7 @@ variables:
   ddApiKey: $(DD_API_KEY)
   isMainBranch: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
+  isMockDependabot: $[contains(variables['Build.SourceBranch'], 'dependabot/nuget/tracer/dependabot')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
@@ -202,7 +203,7 @@ stages:
       artifact: build-linux-arm64-working-directory
 
 - stage: build_macos
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: []
   jobs:
   - job: build
@@ -255,7 +256,7 @@ stages:
         artifact: nuget-packages
 
 - stage: unit_tests_windows
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_windows
   pool:
     vmImage: windows-2019
@@ -295,7 +296,7 @@ stages:
         condition: succeededOrFailed()
 
 - stage: unit_tests_macos
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_macos
   jobs:
   - job: managed
@@ -325,7 +326,7 @@ stages:
 
 
 - stage: unit_tests_linux
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_linux]
   jobs:
   - job: test
@@ -362,7 +363,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: unit_tests_arm64
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_arm64]
   jobs:
     - job: test
@@ -393,7 +394,7 @@ stages:
           condition: succeededOrFailed()
 
 - stage: integration_tests_windows
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: build_windows
 
   jobs:
@@ -454,7 +455,7 @@ stages:
       continueOnError: true
 
 - stage: integration_tests_windows_iis
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_windows, package_windows]
 
   jobs:
@@ -541,7 +542,7 @@ stages:
       continueOnError: true
 
 - stage: integration_tests_linux
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_linux]
   jobs:
   - job: Test
@@ -640,7 +641,7 @@ stages:
       condition: succeededOrFailed()
 
 - stage: integration_tests_arm64
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [build_arm64]
   jobs:
     - job: Test
@@ -718,7 +719,7 @@ stages:
           condition: succeededOrFailed()
 
 - stage: dotnet_tool
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [build_windows, build_linux, build_arm64, build_macos]
   jobs:
   - job: build_runner_tool_and_standalone
@@ -840,7 +841,7 @@ stages:
       displayName: Add $(dotnetToolTag) build tag
 
 - stage: upload_to_s3
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [package_windows, build_linux, build_arm64]
   jobs:
   - job: s3_upload
@@ -934,7 +935,7 @@ stages:
         )
 
 - stage: upload_to_azure
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'))
   dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool]
   jobs:
     - job: upload
@@ -1038,7 +1039,7 @@ stages:
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
 
 - stage: coverage
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
   dependsOn: [integration_tests_windows, integration_tests_windows_iis, integration_tests_linux, unit_tests_linux, unit_tests_macos, unit_tests_windows]
   jobs:
     - job: Windows
@@ -1071,7 +1072,7 @@ stages:
 
       - script: tracer\build.cmd CompareCodeCoverageReports
         displayName: Compare code coverage
-        condition: and(succeeded(), eq(variables.isPullRequest, true))
+        condition: and(succeeded(), eq(variables['isMockDependabot'], 'False'), eq(variables.isPullRequest, true))
         env:
           PR_NUMBER: $(System.PullRequest.PullRequestNumber)
           AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)


### PR DESCRIPTION
Prevents dependabot PRs from clogging up CI.
These csproj changes are fake and require us to make code/config changes in the tracer code before they apply.

@DataDog/apm-dotnet