### PR TITLE
Send status check updates to GitHub for performance pipeline

### DIFF
--- a/.azure-pipelines/performance.yml
+++ b/.azure-pipelines/performance.yml
@@ -48,57 +48,13 @@ variables:
 
 # Stages
 stages:
-- stage: benchmarks
+- stage: set_vars
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
   condition: succeeded()
+  pool:
+    vmImage: ubuntu-18.04
   jobs:
-
-  #### Windows
-
-  - job: Windows
-    timeoutInMinutes: 100
-    pool: Benchmarks
-
-    # Enable the Datadog Agent service for this job
-    services:
-      dd_agent: dd_agent
-
-    steps:
-
-    - template: steps/install-dotnet-5-sdk.yml
-    - template: steps/restore-working-directory.yml
-      parameters:
-        pipelineRunId: $(resources.pipeline.build_pipeline.runID)
-
-    - script: tracer\build.cmd RunBenchmarks
-      displayName: RunBenchmarks
-
-    - publish: tracer/build_data/benchmarks
-      artifact: benchmarks_results
-      continueOnError: true
-
-    - script: tracer\build.cmd CompareBenchmarksResults
-      continueOnError: true
-      displayName: Compare Benchmarks
-      condition: and(succeeded(), eq(variables.isPullRequest, true))
-      env:
-        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
-        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
-        GITHUB_TOKEN: $(GITHUB_TOKEN)
-
-    ## Is this really necessary?
-    - task: PowerShell@2
-      inputs:
-        targetType: 'inline'
-        script: 'Start-Sleep -s 120'
-
-- stage: throughput
-  dependsOn: [ ]    # this removes the implicit dependency on previous stage and causes this to run in parallel
-  condition: succeeded()
-  pool: Throughput
-  jobs:
-
-  - job: get_values
+  - job: setVars
     steps:
     - task: DownloadPipelineArtifact@2
       displayName: Download source details
@@ -124,14 +80,91 @@ stages:
       displayName: Set repository values
       name: setVars
 
+- stage: benchmarks
+  dependsOn: [set_vars]
+  condition: succeeded()
+  variables:
+    original_repo: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_repo'] ]
+    original_commit_sha: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_commit_sha'] ]
+  jobs:
+
+  #### Windows
+
+  - job: Windows
+    timeoutInMinutes: 100
+    pool: Benchmarks
+
+    # Enable the Datadog Agent service for this job
+    services:
+      dd_agent: dd_agent
+
+    steps:
+
+    - template: steps/install-dotnet-5-sdk.yml
+    - template: steps/restore-working-directory.yml
+      parameters:
+        pipelineRunId: $(resources.pipeline.build_pipeline.runID)
+    - template: steps/update-github-status.yml
+      parameters:
+        check: Benchmarks
+        status: Pending
+
+    - script: tracer\build.cmd RunBenchmarks
+      displayName: RunBenchmarks
+
+    - publish: tracer/build_data/benchmarks
+      artifact: benchmarks_results
+      continueOnError: true
+
+    - template: steps/update-github-status.yml
+      parameters:
+        check: Benchmarks
+        ${{ if succeeded() }}:
+          status: Success
+        ${{ else }}:
+          status: Failure
+
+    - script: tracer\build.cmd CompareBenchmarksResults
+      continueOnError: true
+      displayName: Compare Benchmarks
+      condition: and(succeeded(), eq(variables.isPullRequest, true))
+      env:
+        PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+        AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+        GITHUB_TOKEN: $(GITHUB_TOKEN)
+
+    ## Is this really necessary?
+    - task: PowerShell@2
+      inputs:
+        targetType: 'inline'
+        script: 'Start-Sleep -s 120'
+
+- stage: throughput
+  dependsOn: [set_vars]
+  condition: succeeded()
+  pool: Throughput
+  variables:
+    original_repo: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_repo'] ]
+    original_commit_sha: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_commit_sha'] ]
+
+  jobs:
+  - job: Update status
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+    - template: steps/install-dotnet-5-sdk.yml
+    - template: steps/restore-working-directory.yml
+      parameters:
+        pipelineRunId: $(resources.pipeline.build_pipeline.runID)
+    - template: steps/update-github-status.yml
+      parameters:
+        check: Throughput
+        status: Pending
+
     #### Throughput Linux 64, windows 64, linux arm 64
 
   - job: Linux64
     timeoutInMinutes: 60
-    dependsOn: get_values
-    variables:
-      original_repo: $[ dependencies.get_values.outputs['setVars.original_repo'] ]
-      original_commit_sha: $[ dependencies.get_values.outputs['setVars.original_commit_sha'] ]
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -160,10 +193,6 @@ stages:
 
   - job: Windows64
     timeoutInMinutes: 60
-    dependsOn: get_values
-    variables:
-      original_repo: $[ dependencies.get_values.outputs['setVars.original_repo'] ]
-      original_commit_sha: $[ dependencies.get_values.outputs['setVars.original_commit_sha'] ]
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -192,10 +221,6 @@ stages:
 
   - job: LinuxArm64
     timeoutInMinutes: 60
-    dependsOn: get_values
-    variables:
-      original_repo: $[ dependencies.get_values.outputs['setVars.original_repo'] ]
-      original_commit_sha: $[ dependencies.get_values.outputs['setVars.original_commit_sha'] ]
 
     steps:
     - task: DownloadPipelineArtifact@2
@@ -222,9 +247,30 @@ stages:
         DD_SERVICE: dd-trace-dotnet
         DD_ENV: CI
 
+  - job: Update status
+    dependsOn: [Linux64, Windows64, LinuxArm64]
+    condition: succeededOrFailed()
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+      - template: steps/install-dotnet-5-sdk.yml
+      - template: steps/restore-working-directory.yml
+        parameters:
+          pipelineRunId: $(resources.pipeline.build_pipeline.runID)
+      - template: steps/update-github-status.yml
+        parameters:
+          check: Throughput
+          ${{ if succeeded() }}:
+            status: Success
+          ${{ else }}:
+            status: Failure
+
 - stage: execution_benchmarks
-  dependsOn: [ ]    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  dependsOn: [set_vars]
   condition: succeeded()
+  variables:
+    original_repo: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_repo'] ]
+    original_commit_sha: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_commit_sha'] ]
   jobs:
   - job: windows
     pool:
@@ -237,6 +283,10 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         pipelineRunId: $(resources.pipeline.build_pipeline.runID)
+    - template: steps/update-github-status.yml
+      parameters:
+        check: ExecutionBenchmarks
+        status: Pending
 
     - task: DownloadPipelineArtifact@2
       displayName: Download windows native binary
@@ -290,6 +340,14 @@ stages:
       displayName: Execute Samples.FakeDbCommand benchmark
       env:
         DD_SERVICE: dd-trace-dotnet
+
+    - template: steps/update-github-status.yml
+      parameters:
+        check: ExecutionBenchmarks
+        ${{ if succeeded() }}:
+          status: Success
+        ${{ else }}:
+          status: Failure
 
     - task: PowerShell@2
       displayName: Wait 20 seconds to agent flush before finishing pipeline

--- a/.azure-pipelines/performance.yml
+++ b/.azure-pipelines/performance.yml
@@ -259,7 +259,7 @@ stages:
     dependsOn: [Linux64, Windows64, LinuxArm64]
     condition: succeededOrFailed()
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: windows-2019
     steps:
       - template: steps/install-dotnet-5-sdk.yml
       - template: steps/restore-working-directory.yml

--- a/.azure-pipelines/performance.yml
+++ b/.azure-pipelines/performance.yml
@@ -107,7 +107,7 @@ stages:
     - template: steps/update-github-status.yml
       parameters:
         check: Benchmarks
-        status: Pending
+        isPending: true
 
     - script: tracer\build.cmd RunBenchmarks
       displayName: RunBenchmarks
@@ -119,10 +119,6 @@ stages:
     - template: steps/update-github-status.yml
       parameters:
         check: Benchmarks
-        ${{ if succeeded() }}:
-          status: Success
-        ${{ else }}:
-          status: Failure
 
     - script: tracer\build.cmd CompareBenchmarksResults
       continueOnError: true
@@ -148,7 +144,7 @@ stages:
     original_commit_sha: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_commit_sha'] ]
 
   jobs:
-  - job: Update status
+  - job: set_status_pending
     pool:
       vmImage: ubuntu-18.04
     steps:
@@ -159,7 +155,7 @@ stages:
     - template: steps/update-github-status.yml
       parameters:
         check: Throughput
-        status: Pending
+        isPending: true
 
     #### Throughput Linux 64, windows 64, linux arm 64
 
@@ -247,7 +243,7 @@ stages:
         DD_SERVICE: dd-trace-dotnet
         DD_ENV: CI
 
-  - job: Update status
+  - job: update_status
     dependsOn: [Linux64, Windows64, LinuxArm64]
     condition: succeededOrFailed()
     pool:
@@ -260,10 +256,6 @@ stages:
       - template: steps/update-github-status.yml
         parameters:
           check: Throughput
-          ${{ if succeeded() }}:
-            status: Success
-          ${{ else }}:
-            status: Failure
 
 - stage: execution_benchmarks
   dependsOn: [set_vars]
@@ -286,7 +278,7 @@ stages:
     - template: steps/update-github-status.yml
       parameters:
         check: ExecutionBenchmarks
-        status: Pending
+        isPending: true
 
     - task: DownloadPipelineArtifact@2
       displayName: Download windows native binary
@@ -344,10 +336,6 @@ stages:
     - template: steps/update-github-status.yml
       parameters:
         check: ExecutionBenchmarks
-        ${{ if succeeded() }}:
-          status: Success
-        ${{ else }}:
-          status: Failure
 
     - task: PowerShell@2
       displayName: Wait 20 seconds to agent flush before finishing pipeline

--- a/.azure-pipelines/performance.yml
+++ b/.azure-pipelines/performance.yml
@@ -80,6 +80,35 @@ stages:
       displayName: Set repository values
       name: setVars
 
+- stage: statuses
+  dependsOn: [ set_vars ]
+  condition: succeeded()
+  variables:
+    original_repo: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_repo'] ]
+    original_commit_sha: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_commit_sha'] ]
+  jobs:
+  - job: mark_pending
+    pool:
+      vmImage: windows-2019
+
+    steps:
+    - template: steps/install-dotnet-5-sdk.yml
+    - template: steps/restore-working-directory.yml
+      parameters:
+        pipelineRunId: $(resources.pipeline.build_pipeline.runID)
+    - template: steps/update-github-status.yml
+      parameters:
+        check: Benchmarks
+        isPending: true
+    - template: steps/update-github-status.yml
+      parameters:
+        check: Throughput
+        isPending: true
+    - template: steps/update-github-status.yml
+      parameters:
+        check: ExecutionBenchmarks
+        isPending: true
+
 - stage: benchmarks
   dependsOn: [set_vars]
   condition: succeeded()
@@ -104,10 +133,6 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         pipelineRunId: $(resources.pipeline.build_pipeline.runID)
-    - template: steps/update-github-status.yml
-      parameters:
-        check: Benchmarks
-        isPending: true
 
     - script: tracer\build.cmd RunBenchmarks
       displayName: RunBenchmarks
@@ -144,19 +169,6 @@ stages:
     original_commit_sha: $[ stageDependencies.set_vars.setVars.outputs['setVars.original_commit_sha'] ]
 
   jobs:
-  - job: set_status_pending
-    pool:
-      vmImage: ubuntu-18.04
-    steps:
-    - template: steps/install-dotnet-5-sdk.yml
-    - template: steps/restore-working-directory.yml
-      parameters:
-        pipelineRunId: $(resources.pipeline.build_pipeline.runID)
-    - template: steps/update-github-status.yml
-      parameters:
-        check: Throughput
-        isPending: true
-
     #### Throughput Linux 64, windows 64, linux arm 64
 
   - job: Linux64
@@ -275,10 +287,6 @@ stages:
     - template: steps/restore-working-directory.yml
       parameters:
         pipelineRunId: $(resources.pipeline.build_pipeline.runID)
-    - template: steps/update-github-status.yml
-      parameters:
-        check: ExecutionBenchmarks
-        isPending: true
 
     - task: DownloadPipelineArtifact@2
       displayName: Download windows native binary

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -1,0 +1,17 @@
+parameters:
+  - name: 'status'
+    type: 'string'
+
+  - name: 'check'
+    type: 'string'
+
+steps:
+- script: tracer\build.cmd SendStatusUpdateToGitHub
+  displayName: Update GitHub Status
+  condition: succeededOrFailed()
+  continueOnError: true
+  env:
+    GITHUB_TOKEN: $(GITHUB_TOKEN)
+    CheckStatus: ${{ parameters.status }}
+    CheckType: ${{ parameters.check }}
+    CommitSha: $(original_commit_sha)

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -1,17 +1,40 @@
 parameters:
-  - name: 'status'
-    type: 'string'
-
   - name: 'check'
     type: 'string'
 
+  - name: isPending
+    type: boolean
+    default: false
+
 steps:
-- script: tracer\build.cmd SendStatusUpdateToGitHub
-  displayName: Update GitHub Status
-  condition: succeededOrFailed()
-  continueOnError: true
-  env:
-    GITHUB_TOKEN: $(GITHUB_TOKEN)
-    CheckStatus: ${{ parameters.status }}
-    CheckType: ${{ parameters.check }}
-    CommitSha: $(original_commit_sha)
+- ${{ if eq(parameters.isPending, true) }}:
+  - script: tracer\build.cmd SendStatusUpdateToGitHub
+    displayName: Update GitHub Status
+    condition: succeededOrFailed()
+    continueOnError: true
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      CheckStatus: Pending
+      CheckType: ${{ parameters.check }}
+      CommitSha: $(original_commit_sha)
+
+- ${{ if eq(parameters.isPending, false) }}:
+  - script: tracer\build.cmd SendStatusUpdateToGitHub
+    displayName: Set GitHub Status Success
+    condition: succeeded()
+    continueOnError: true
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      CheckStatus: Success
+      CheckType: ${{ parameters.check }}
+      CommitSha: $(original_commit_sha)
+
+  - script: tracer\build.cmd SendStatusUpdateToGitHub
+    displayName: Set GitHub Status Failure
+    condition: not(succeeded())
+    continueOnError: true
+    env:
+      GITHUB_TOKEN: $(GITHUB_TOKEN)
+      CheckStatus: Failure
+      CheckType: ${{ parameters.check }}
+      CommitSha: $(original_commit_sha)

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -496,10 +496,15 @@ partial class Build
          .Requires(() => CheckStatus)
          .Executes(async () =>
          {
-             var buildUrl = Environment.GetEnvironmentVariable("Build.BuildUri");
-             if(string.IsNullOrEmpty(buildUrl))
+             string buildUrl = null;
+             var buildId = Environment.GetEnvironmentVariable("Build.BuildId");
+             if(string.IsNullOrEmpty(buildId))
              {
-                 Logger.Warn("No 'Build.BuildUri' variable found. Check status will not have link to build");
+                 Logger.Warn("No 'Build.BuildId' variable found. Check status will not have link to build");
+             }
+             else
+             {
+                 buildUrl = $"{AzureDevopsOrganisation}/dd-trace-dotnet/_build/results?buildId={buildId}";
              }
 
              var status = CheckStatus.Value;

--- a/tracer/build/_build/NukeExtensions/GitHubCheckStatus.cs
+++ b/tracer/build/_build/NukeExtensions/GitHubCheckStatus.cs
@@ -1,0 +1,7 @@
+﻿public enum GitHubCheckStatus
+{
+    Error,
+    Failure,
+    Pending,
+    Success,
+}

--- a/tracer/build/_build/NukeExtensions/GitHubCheckType.cs
+++ b/tracer/build/_build/NukeExtensions/GitHubCheckType.cs
@@ -1,0 +1,8 @@
+﻿public enum GitHubCheckType
+{
+    Unknown,
+    Benchmarks,
+    Throughput,
+    ExecutionBenchmarks,
+
+}


### PR DESCRIPTION
One of the downsides of splitting out the performance pipeline into a 'dependent' build is that we don't have any visibility of the progress or status in the PR anymore.

This uses the status check API to add that visibility back. It's kinda horrible, as it's pretty much duplicating a 'normal' AzDo/GitHub connection, but I don't think there's a better approach here.

@DataDog/apm-dotnet