### PR TITLE
[CIVisibility] Update CI namespace types

### DIFF
--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -261,7 +261,7 @@ partial class Build
 
             var assembly = Assembly.LoadFrom(assemblyPath);
             var featureTrackingAttribute = assembly.GetType("Datadog.Trace.Ci.FeatureTrackingAttribute");
-            var types = new[] { "Datadog.Trace.Ci.CommonTags", "Datadog.Trace.Ci.TestTags" }
+            var types = new[] { "Datadog.Trace.Ci.Tags.CommonTags", "Datadog.Trace.Ci.Tags.TestTags" }
                        .Select(type => assembly.GetType(type))
                        .ToArray();
 


### PR DESCRIPTION
This PR fixes the exception when running `build CiAppFeatureTracking` caused by the CI Visibility refactor and namespace changes.


@DataDog/apm-dotnet