### PR TITLE
Fix buffer overflow reported by Clang Address Sanitizer

### DIFF
--- a/shared/src/native-src/loader.cpp
+++ b/shared/src/native-src/loader.cpp
@@ -1,3 +1,4 @@
+#define NOMINMAX
 #include "loader.h"
 
 #ifdef _WIN32
@@ -37,8 +38,11 @@ namespace shared
         WStr("Datadog.AutoInstrumentation.Profiler.Managed"),
     };
 
-    constexpr const WCHAR* SpecificTypeToInjectName = WStr("System.AppDomain");
-    constexpr const WCHAR* SpecificMethodToInjectName = WStr("IsCompatibilitySwitchSet");
+    const WCHAR* SpecificTypeToInjectName = WStr("System.AppDomain");
+    const size_t SpecificTypeToInjectNameSize = WStrLen(SpecificTypeToInjectName);
+
+    const WCHAR* SpecificMethodToInjectName = WStr("IsCompatibilitySwitchSet");
+    const size_t SpecificMethodToInjectNameSize = WStrLen(SpecificMethodToInjectName);
 
 
     static Enumerator<mdMethodDef> EnumMethodsWithName(
@@ -644,7 +648,7 @@ namespace shared
         const ComPtr<IMetaDataImport2> metadataImport = metadataInterfaces.As<IMetaDataImport2>(IID_IMetaDataImport);
         const ComPtr<IMetaDataAssemblyImport> assemblyImport = metadataInterfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
 
-        constexpr DWORD NameBuffSize = 1024;
+        const size_t NameBuffSize = 1024;
 
         mdToken functionParentToken;
         WCHAR functionName[NameBuffSize]{};
@@ -667,8 +671,8 @@ namespace shared
             return S_FALSE;
         }
 
-        bool disableNGenForFunction = (0 == memcmp(functionName, SpecificMethodToInjectName, sizeof(WCHAR) * (std::min)(NameBuffSize, functionNameLength)))
-                                        && (0 == memcmp(typeName, SpecificTypeToInjectName, sizeof(WCHAR) * (std::min)(NameBuffSize, typeNameLength)));
+        bool disableNGenForFunction = (0 == memcmp(functionName, SpecificMethodToInjectName, sizeof(WCHAR) * std::min( { SpecificMethodToInjectNameSize, NameBuffSize, (size_t)functionNameLength } )))
+                                   && (0 == memcmp(typeName, SpecificTypeToInjectName, sizeof(WCHAR) * std::min( { SpecificTypeToInjectNameSize, NameBuffSize, (size_t)typeNameLength } )));
 
         if (disableNGenForFunction)
         {


### PR DESCRIPTION
## Context
When using memcmp, we limited the number of characters to compare. We choose the min between NameBuffer (1024)
and the size of the functionName (functionNameLength). But, if the SpecificMethodToInjectName size
(and SpecificTypeToInjectName) is less than the max number of characters, we will read memory beyond.
```
==21348==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7fff40460ab2 at pc 0x7fff402c3682 bp 0x00c823dfc460 sp 0x00c823dfbbe8
READ of size 74 at 0x7fff40460ab2 thread T0
    #0 0x7fff402c36b0 in MemcmpInterceptorCommon(void *, int (__cdecl *)(void const *, void const *, unsigned __int64), void const *, void const *, unsigned __int64) D:\a01\_work\2\s\src\vctools\crt\asan\llvm\compiler-rt\lib\sanitizer_common\sanitizer_common_interceptors.inc:851
    #1 0x7fff402c5b71 in __asan_wrap_memcmp D:\a01\_work\2\s\src\vctools\crt\asan\llvm\compiler-rt\lib\sanitizer_common\sanitizer_common_interceptors.inc:882
    #2 0x7fff4027e8d1 in shared::Loader::HandleJitCachedFunctionSearchStarted(unsigned __int64, int *) C:\Users\gregory.leocadie\repos\dd-trace-dotnet\shared\src\native-src\loader.cpp:670
    #3 0x7fff401ea649 in CorProfilerCallback::JITCachedFunctionSearchStarted(unsigned __int64, int *) C:\Users\gregory.leocadie\repos\dd-continuous-profiler-dotnet\src\ProfilerEngine\Datadog.AutoInstrumentation.Profiler.Native.Shared\CorProfilerCallback.cpp:647
    #4 0x7fffd09799ae  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x1805299ae)
    #5 0x7fffd06620b0  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x1802120b0)
    #6 0x7fffd045f05b  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x18000f05b)
    #7 0x7fffd0454854  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180004854)
    #8 0x7fffcb70ac4c  (C:\Windows\assembly\NativeImages_v4.0.30319_64\mscorlib\16234675ede351917e6b94c968a734df\mscorlib.ni.dll+0x6447857ac4c)
    #9 0x7fffcb70a88d  (C:\Windows\assembly\NativeImages_v4.0.30319_64\mscorlib\16234675ede351917e6b94c968a734df\mscorlib.ni.dll+0x6447857a88d)
    #10 0x7fffcb713b70  (C:\Windows\assembly\NativeImages_v4.0.30319_64\mscorlib\16234675ede351917e6b94c968a734df\mscorlib.ni.dll+0x64478583b70)
    #11 0x7fffd0456952  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180006952)
    #12 0x7fffd0456857  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180006857)
    #13 0x7fffd0457117  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180007117)
    #14 0x7fffd0581bf9  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180131bf9)
    #15 0x7fffd0590970  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180140970)
    #16 0x7fffd0592176  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180142176)
    #17 0x7fffd0591f63  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180141f63)
    #18 0x7fffd0591cbc  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180141cbc)
    #19 0x7fffd0592ea3  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\clr.dll+0x180142ea3)
    #20 0x7fffd13f8c00  (C:\Windows\Microsoft.NET\Framework64\v4.0.30319\mscoreei.dll+0x180008c00)
    #21 0x7fffd17dac41  (C:\Windows\SYSTEM32\MSCOREE.DLL+0x18000ac41)
    #22 0x7fffe7947033  (C:\Windows\System32\KERNEL32.dll+0x180017033)
    #23 0x7fffe92a2650  (C:\Windows\SYSTEM32\ntdll.dll+0x180052650)
```
## Fixes

Compute the minimal number of characters to read between `SpecificMethodToInjectNameSize, NameBuffSize, (size_t)functionNameLength `





@DataDog/apm-dotnet