### PR TITLE
Initialize LocalDB ahead of time in the CI

### DIFF
--- a/.azure-pipelines/prepare_localdb.sql
+++ b/.azure-pipelines/prepare_localdb.sql
@@ -1,0 +1,11 @@
+sp_configure 'show advanced options', 1;
+GO
+
+RECONFIGURE;
+GO
+
+sp_configure 'user instance timeout', 30;
+GO
+
+RECONFIGURE;
+GO

--- a/.azure-pipelines/prepare_localdb.sql
+++ b/.azure-pipelines/prepare_localdb.sql
@@ -4,7 +4,7 @@ GO
 RECONFIGURE;
 GO
 
-sp_configure 'user instance timeout', 30;
+sp_configure 'user instance timeout', 60;
 GO
 
 RECONFIGURE;

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -442,6 +442,13 @@ stages:
         Start-CosmosDbEmulator -Timeout 300
       displayName: 'Start CosmosDB Emulator'
       workingDirectory: $(Pipeline.Workspace)
+      
+    - powershell: |
+        Write-Host "Initializing LocalDB"
+        sqllocaldb.exe start
+        sqlcmd.exe -S "(localdb)\MSSQLLocalDB" -i $(Build.Repository.LocalPath)\.azure-pipelines\prepare_localdb.sql
+      displayName: 'Initialize LocalDB'
+      workingDirectory: $(Build.Repository.LocalPath)
 
     - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --PrintDriveSpace --code-coverage
       displayName: Run integration tests


### PR DESCRIPTION
This changes initializes LocalDB before running the integration tests, with the hope of reducing connection timeouts.

It also changes the auto-shutdown delay from 5 minutes to 30, to make sure it's still alive when the tests actually execute.