### PR TITLE
Fix bug logging response even if successful

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Agent.Transports
                 {
                     var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
                     var apiWebResponse = new ApiWebResponse(httpWebResponse);
-                    if (httpWebResponse.StatusCode != HttpStatusCode.OK || httpWebResponse.StatusCode != HttpStatusCode.Accepted)
+                    if (httpWebResponse.StatusCode != HttpStatusCode.OK && httpWebResponse.StatusCode != HttpStatusCode.Accepted)
                     {
                         var sb = Util.StringBuilderCache.Acquire(0);
                         foreach (var item in _request.Headers)

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Agent.Transports
                     await writer.FlushAsync().ConfigureAwait(false);
                     memoryStream.Seek(0, SeekOrigin.Begin);
                     var response = new HttpClientResponse(await _client.SendAsync(_request).ConfigureAwait(false));
-                    if (response.StatusCode != 200 || response.StatusCode != 202)
+                    if (response.StatusCode != 200 && response.StatusCode != 202)
                     {
                         memoryStream.Seek(0, SeekOrigin.Begin);
                         using var sr = new StreamReader(memoryStream);

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Agent.Transports
                 var result = await PostSegmentAsync(new ArraySegment<byte>(buffer, 0, (int)memoryStream.Length)).ConfigureAwait(false);
                 var response = result.Item1;
                 var request = result.Item2;
-                if (response.StatusCode != 200 || response.StatusCode != 202)
+                if (response.StatusCode != 200 && response.StatusCode != 202)
                 {
                     memoryStream.Seek(0, SeekOrigin.Begin);
                     using var sr = new StreamReader(memoryStream);


### PR DESCRIPTION
Fixes #
It was the wrong condition, logging even when 202 or 200... 

Changes proposed in this pull request:




@DataDog/apm-dotnet