### PR TITLE
Avoid NullReferenceException in `Tracer.GetApplicationName()`.

### DIFF
--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -648,7 +648,7 @@ namespace Datadog.Trace
                     Log.Error(ex, "Unable to get application name through ASP.NET settings");
                 }
 
-                return Assembly.GetEntryAssembly()?.GetName().Name ??
+                return Assembly.GetEntryAssembly()?.GetName()?.Name ??
                    ProcessHelpers.GetCurrentProcessName();
             }
             catch (Exception ex)


### PR DESCRIPTION
Just noticed this statement while copying that logic for the profiler:
`Assembly.GetEntryAssembly()?.GetName().Name`

It is probably a typo: if `GetEntryAssembly()` should ever return `null`, it will propagate and the `Name` accessor will throw.
I think it never actually returns `null` in practice (that is why we never had an issue), so the `null` check is not necessary.
But if we have it, we should have it correctly.