### PR TITLE
Handle the expected segfault in smoke tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -143,6 +143,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 }
             }
 
+#if NETCOREAPP2_1
+            if (result.ExitCode == 139)
+            {
+                // Segmentation faults are expected on .NET Core because of a bug in the runtime: https://github.com/dotnet/runtime/issues/11885
+                throw new SkipException("Segmentation fault on .NET Core 2.1");
+            }
+#endif
+
             var successCode = 0;
             Assert.True(successCode == result.ExitCode, $"Non-success exit code {result.ExitCode}");
             Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");


### PR DESCRIPTION
Following-up on https://github.com/DataDog/dd-trace-dotnet/pull/1835, I forgot to do the same thing on smoke tests.