### PR TITLE
Fix errors in the CI when the startup log thread gets aborted

### DIFF
--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net/Program.cs
@@ -1,4 +1,5 @@
 
+using System;
 using System.IO;
 using log4net;
 using log4net.Config;
@@ -12,6 +13,13 @@ namespace LogsInjection.Log4Net
 
         public static int Main(string[] args)
         {
+            // This test creates and unloads an appdomain
+            // It seems that in some (unknown) conditions the tracer gets loader into the child appdomain
+            // When that happens, there is a risk that the startup log thread gets aborted during appdomain unload,
+            // adding error logs which in turn cause a failure in CI.
+            // Disabling the startup log at the process level should prevent this.
+            Environment.SetEnvironmentVariable("DD_TRACE_STARTUP_LOGS", "0");
+
             LoggingMethods.DeleteExistingLogs();
 
             // Initialize log4net

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
@@ -1,4 +1,5 @@
 
+using System;
 using System.IO;
 using NLog;
 using NLog.Config;
@@ -10,6 +11,13 @@ namespace LogsInjection.NLog
     {
         public static int Main(string[] args)
         {
+            // This test creates and unloads an appdomain
+            // It seems that in some (unknown) conditions the tracer gets loader into the child appdomain
+            // When that happens, there is a risk that the startup log thread gets aborted during appdomain unload,
+            // adding error logs which in turn cause a failure in CI.
+            // Disabling the startup log at the process level should prevent this.
+            Environment.SetEnvironmentVariable("DD_TRACE_STARTUP_LOGS", "0");
+
             LoggingMethods.DeleteExistingLogs();
 
             // Initialize NLog

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/Program.cs
@@ -13,6 +13,13 @@ namespace LogsInjection.Serilog
     {
         public static int Main(string[] args)
         {
+            // This test creates and unloads an appdomain
+            // It seems that in some (unknown) conditions the tracer gets loader into the child appdomain
+            // When that happens, there is a risk that the startup log thread gets aborted during appdomain unload,
+            // adding error logs which in turn cause a failure in CI.
+            // Disabling the startup log at the process level should prevent this.
+            Environment.SetEnvironmentVariable("DD_TRACE_STARTUP_LOGS", "0");
+
             LoggingMethods.DeleteExistingLogs();
 
             // Initialize Serilog


### PR DESCRIPTION
The log injection integration tests create and unload an appdomain. It seems that in some (unknown) conditions the tracer gets loader into the child appdomain. When that happens, there is a risk that the startup log thread gets aborted during appdomain unload, adding error logs which in turn cause a failure in CI. Disabling the startup log at the process level should prevent this.
