### PR TITLE
Improve testing for Aerospike

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AerospikeCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AerospikeCommon.cs
@@ -90,18 +90,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Aerospike
 
         private static string ExtractResourceName(Type type)
         {
-            const string syncPrefix = "Sync";
             const string asyncPrefix = "Async";
             const string commandSuffix = "Command";
 
             var typeName = type.Name;
             var startIndex = 0;
 
-            if (typeName.StartsWith(syncPrefix))
-            {
-                startIndex = syncPrefix.Length;
-            }
-            else if (typeName.StartsWith(asyncPrefix))
+            if (typeName.StartsWith(asyncPrefix))
             {
                 startIndex = asyncPrefix.Length;
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -43,6 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     "Exists",
                     "BatchGetArray",
                     "BatchExistsArray",
+                    "QueryRecord",
                     "Delete",
 
                     // Asynchronous
@@ -77,6 +78,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (span.Resource.Contains("Batch"))
             {
                 return span.Tags[Tags.AerospikeKey] == "test:myset1:mykey1;test:myset2:mykey2;test:myset3:mykey3";
+            }
+            else if (span.Resource.Contains("Record"))
+            {
+                return span.Tags[Tags.AerospikeKey] == "test:myset1"
+                    && span.Tags[Tags.AerospikeNamespace] == "test"
+                    && span.Tags[Tags.AerospikeSetName] == "myset1";
             }
             else
             {

--- a/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Aerospike/Program.cs
@@ -33,7 +33,21 @@ namespace Samples.Aerospike
             _ = client.Exists(null, key1);
             _ = client.Get(null, new[] { key1, key2, key3 });
             _ = client.Exists(null, new[] { key1, key2, key3 });
-            
+
+            client.CreateIndex(null, "test", "myset1", indexName: "age", binName: "age", IndexType.NUMERIC).Wait();
+
+            var statement = new Statement
+            {
+                Namespace = "test",
+                SetName = "myset1",
+                BinNames = new[] { "name", "age" },
+                Filter = Filter.Range("age", 20, 30)
+            };
+
+            var result = client.Query(new QueryPolicy(), statement);
+
+            while (result.Next()) ; // Force the query to execute
+
             client.Delete(null, key1);
 
             // Asynchronous methods
@@ -48,6 +62,8 @@ namespace Samples.Aerospike
             _ = await client.Exists(null, CancellationToken.None, new[] { key1, key2, key3 });
 
             await client.Delete(null, CancellationToken.None, key1);
+
+            client.DropIndex(null, "test", "myset1", indexName: "age").Wait();
 
             client.Close();
         }


### PR DESCRIPTION
- Add a test case for queries with statements
- Stop looking for the "Sync" prefix (the only command with this prefix is actually an abstract class, so that path was never hit)

