### PR TITLE
Exclude tracer/dependabot directory from triggering the CI pipeline

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -11,6 +11,7 @@ trigger:
     exclude:
       - docs/*
       - .github/*
+      - tracer/dependabot/*
 # The following is a list of shared asset locations.
 # This is the config for the Tracer CI pipeline,
 # so we are excluding shared assets that are not currently used by the Tracer.


### PR DESCRIPTION
Another approach to solving the issue, would supersede https://github.com/DataDog/dd-trace-dotnet/pull/1855

@DataDog/apm-dotnet