### PR TITLE
appsec: fix appsec event tag value

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace.AppSec
         {
             if (span != null)
             {
-                span.SetTag(Tags.AppSecEvent, "1");
+                span.SetTag(Tags.AppSecEvent, "true");
                 span.SetTraceSamplingPriority(SamplingPriority.AppSecKeep);
             }
 


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:

Fixes the value of the appsec event tag


@DataDog/apm-dotnet