### PR TITLE
Update Datadog.Trace to 1.19.1 in regression test

### DIFF
--- a/tracer/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
+++ b/tracer/test/test-applications/regression/NetCoreAssemblyLoadFailureOlderNuGet/NetCoreAssemblyLoadFailureOlderNuGet.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="1.19.0" />
+    <PackageReference Include="Datadog.Trace" Version="1.19.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1.19.0 uses a WebResponse after disposing it, which causes errors to be logged.

I don't know if we need to use a version of Datadog.Trace that is so old, but at the very least it should use 1.19.1 which was just a hotfix for that particular issue.