### PR TITLE
Include the package version in all the MySqlConnector tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -95,10 +95,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
+        [MemberData(nameof(GetMySqlConnector))]
         [Trait("Category", "EndToEnd")]
-        public void SpansDisabledByAdoNetExcludedTypes(bool enableCallTarget)
+        public void SpansDisabledByAdoNetExcludedTypes(string packageVersion, bool enableCallTarget)
         {
             SetCallTargetSettings(enableCallTarget);
 
@@ -112,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             int agentPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = new MockTracerAgent(agentPort))
-            using (RunSampleAndWaitForExit(agent.Port))
+            using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
                 Assert.NotEmpty(spans);


### PR DESCRIPTION
We have to include the package version in _all_ the tests. When the MySqlConnector sample is built for the multi-api packages, it's _not_ built for the default package, which causes failures on master only

@DataDog/apm-dotnet 
