### PR TITLE
Fix typo in comments

### DIFF
--- a/shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
+++ b/shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader/public/AssemblyLoader.cs
@@ -163,7 +163,7 @@ namespace Datadog.AutoInstrumentation.ManagedLoader
         /// As a result, the target framework moniker and the binary compatibility flags are initialized correctly.
         /// </summary>
         /// <remarks>
-        /// The above logic is further specialised, depending on the kind of the currnent AppDomain and where the app is hosted:
+        /// The above logic is further specialized, depending on the kind of the current AppDomain and where the app is hosted:
         /// <br />
         /// * On non-default AD:
         ///   we do not wait.


### PR DESCRIPTION
Just merged https://github.com/DataDog/dd-trace-dotnet/commit/ea5e046488c612f8d4a4bee04a7c66532efa58b3, and subsequently discovered a typo in the comments.
Sorry about that.
This fixes the typo.