### PR TITLE
Use UserKeep(2)/UserReject(-1) in the rules-based sampler

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -79,15 +79,19 @@ namespace Datadog.Trace.Sampling
 
         private SamplingPriority GetSamplingPriority(Span span, float rate, bool agentSampling)
         {
+            // make a sampling decision
             var sample = ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
-            var priority = SamplingPriority.AutoReject;
 
-            if (sample && (agentSampling || _limiter.Allowed(span)))
+            // legacy sampling based on data from agent
+            if (agentSampling)
             {
-                priority = SamplingPriority.AutoKeep;
+                return sample ? SamplingPriority.AutoKeep : SamplingPriority.AutoReject;
             }
 
-            return priority;
+            // rules-based sampling + rate limiter
+            // NOTE: all tracers are changing this from AutoKeep/AutoReject to UserKeep/UserReject
+            // to prevent the agent from overriding user configuration
+            return sample && _limiter.Allowed(span) ? SamplingPriority.UserKeep : SamplingPriority.UserReject;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RuleBasedSampler.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.Sampling
 
         private SamplingPriority GetSamplingPriority(Span span, float rate, bool agentSampling)
         {
-            // make a sampling decision
+            // make a sampling decision as a function of traceId and sampling rate
             var sample = ((span.TraceId * KnuthFactor) % TracerConstants.MaxTraceId) <= (rate * TracerConstants.MaxTraceId);
 
             // legacy sampling based on data from agent

--- a/tracer/src/Datadog.Trace/SamplingPriority.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriority.cs
@@ -6,32 +6,44 @@
 namespace Datadog.Trace
 {
     /// <summary>
-    /// A traces sampling priority determines whether is should be kept and stored.
+    /// Sampling "priorities" indicate whether a trace should be kept (sampled) or dropped (not sampled).
+    /// Trace statistics are computed based on all traces, even if they are sampled out.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Currently, all traces are still sent to the Agent (for stats computation, etc),
+    /// but this will change in future versions of the tracer if the Agent supports it.
+    /// </para>
+    /// <para>
+    /// Despite the name, there is no relative priority between the different values.
+    /// All the "keep" and "reject" values have the same weight, they only indicate where
+    /// the decision originated from.
+    /// </para>
+    /// </remarks>
     public enum SamplingPriority
     {
         /// <summary>
-        /// Explicitly ask the backend to not store a trace.
+        /// Trace should be dropped (not sampled) due to a user request through code or configuration (e.g. the rules sampler).
         /// </summary>
         UserReject = -1,
 
         /// <summary>
-        /// Used by the built-in sampler to inform the backend that a trace should be rejected and not stored.
+        /// Trace should be dropped (not sampled) due according to the built-in sampler.
         /// </summary>
         AutoReject = 0,
 
         /// <summary>
-        /// Used by the built-in sampler to inform the backend that a trace should be kept and stored.
+        /// Trace should be kept (sampled) due according to the built-in sampler.
         /// </summary>
         AutoKeep = 1,
 
         /// <summary>
-        /// Explicitly ask the backend to keep a trace.
+        /// Trace should be kept (sampled) due to a user request through code or configuration (e.g. the rules sampler).
         /// </summary>
         UserKeep = 2,
 
         /// <summary>
-        /// Explicitly ask the backend to keep a trace because it was part of an application security event.
+        /// Trace should be kept (sampled) due to an application security event.
         /// </summary>
         AppSecKeep = 4,
     }

--- a/tracer/src/Datadog.Trace/SamplingPriority.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriority.cs
@@ -7,12 +7,12 @@ namespace Datadog.Trace
 {
     /// <summary>
     /// Sampling "priorities" indicate whether a trace should be kept (sampled) or dropped (not sampled).
-    /// Trace statistics are computed based on all traces, even if they are sampled out.
+    /// Trace statistics are computed based on all traces, even if they are dropped
     /// </summary>
     /// <remarks>
     /// <para>
     /// Currently, all traces are still sent to the Agent (for stats computation, etc),
-    /// but this will change in future versions of the tracer if the Agent supports it.
+    /// but this may change in future versions of the tracer.
     /// </para>
     /// <para>
     /// Despite the name, there is no relative priority between the different values.

--- a/tracer/src/Datadog.Trace/SamplingPriority.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriority.cs
@@ -23,27 +23,34 @@ namespace Datadog.Trace
     public enum SamplingPriority
     {
         /// <summary>
-        /// Trace should be dropped (not sampled) due to a user request through code or configuration (e.g. the rules sampler).
+        /// Trace should be dropped (not sampled).
+        /// Sampling decision made explicitly by user through
+        /// code or configuration (e.g. the rules sampler).
         /// </summary>
         UserReject = -1,
 
         /// <summary>
-        /// Trace should be dropped (not sampled) due according to the built-in sampler.
+        /// Trace should be dropped (not sampled).
+        /// Sampling decision made by the built-in sampler.
         /// </summary>
         AutoReject = 0,
 
         /// <summary>
-        /// Trace should be kept (sampled) due according to the built-in sampler.
+        /// Trace should be kept (sampled).
+        /// Sampling decision made by the built-in sampler.
         /// </summary>
         AutoKeep = 1,
 
         /// <summary>
-        /// Trace should be kept (sampled) due to a user request through code or configuration (e.g. the rules sampler).
+        /// Trace should be kept (sampled).
+        /// Sampling decision made explicitly by user through
+        /// code or configuration (e.g. the rules sampler).
         /// </summary>
         UserKeep = 2,
 
         /// <summary>
-        /// Trace should be kept (sampled) due to an application security event.
+        /// Trace should be kept (sampled).
+        /// Sampling decision made due to an application security event.
         /// </summary>
         AppSecKeep = 4,
     }

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -284,6 +284,9 @@ namespace Datadog.Trace
             {
                 if (int.TryParse(headerValue, out var result))
                 {
+                    // note this int value may not be defined in the enum,
+                    // but we should pass it along without validation
+                    // for forward compatibility
                     return (SamplingPriority)result;
                 }
 
@@ -311,6 +314,9 @@ namespace Datadog.Trace
             {
                 if (int.TryParse(headerValue, out var result))
                 {
+                    // note this int value may not be defined in the enum,
+                    // but we should pass it along without validation
+                    // for forward compatibility
                     return (SamplingPriority)result;
                 }
 

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -284,10 +284,7 @@ namespace Datadog.Trace
             {
                 if (int.TryParse(headerValue, out var result))
                 {
-                    if (MinimumSamplingPriority <= result && result <= MaximumSamplingPriority)
-                    {
-                        return (SamplingPriority)result;
-                    }
+                    return (SamplingPriority)result;
                 }
 
                 hasValue = true;
@@ -314,10 +311,7 @@ namespace Datadog.Trace
             {
                 if (int.TryParse(headerValue, out var result))
                 {
-                    if (MinimumSamplingPriority <= result && result <= MaximumSamplingPriority)
-                    {
-                        return (SamplingPriority)result;
-                    }
+                    return (SamplingPriority)result;
                 }
 
                 hasValue = true;

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -6,9 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Linq;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
@@ -17,23 +15,14 @@ namespace Datadog.Trace
 {
     internal class SpanContextPropagator
     {
-        internal static readonly string HttpRequestHeadersTagPrefix = "http.request.headers";
-        internal static readonly string HttpResponseHeadersTagPrefix = "http.response.headers";
+        internal const string HttpRequestHeadersTagPrefix = "http.request.headers";
+        internal const string HttpResponseHeadersTagPrefix = "http.response.headers";
 
         private const NumberStyles NumberStyles = System.Globalization.NumberStyles.Integer;
-        private const int MinimumSamplingPriority = (int)SamplingPriority.UserReject;
-        private const int MaximumSamplingPriority = (int)SamplingPriority.UserKeep;
 
         private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SpanContextPropagator>();
         private static readonly ConcurrentDictionary<Key, string> DefaultTagMappingCache = new ConcurrentDictionary<Key, string>();
-
-        private static readonly int[] SamplingPriorities;
-
-        static SpanContextPropagator()
-        {
-            SamplingPriorities = Enum.GetValues(typeof(SamplingPriority)).Cast<int>().ToArray();
-        }
 
         private SpanContextPropagator()
         {

--- a/tracer/test/Datadog.Trace.TestHelpers/HeadersCollectionTestHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/HeadersCollectionTestHelpers.cs
@@ -22,13 +22,17 @@ namespace Datadog.Trace.TestHelpers
 
         public static IEnumerable<object[]> GetInvalidIntegerSamplingPriorities()
         {
-            // keep these values large since we may add new values like -2 or +3 in the future
+            // these are valid integers, but not values defined in the sampling priority enum.
+            // when we see this values in distributed tracing, we pass them along unchanged
+            // to allow for forward compatibility (in case new valid enum values are added in the future).
+            // keep these test values to avoid conflicts if we may add new valid values like -2 or +3.
             yield return new object[] { "-100" };
             yield return new object[] { "100" };
         }
 
         public static IEnumerable<object[]> GetInvalidNonIntegerSamplingPriorities()
         {
+            // these are not valid integers and will be ignored if found in distributed tracing
             yield return new object[] { "1.0" };
             yield return new object[] { "1,0" };
             yield return new object[] { "sampling.priority" };

--- a/tracer/test/Datadog.Trace.TestHelpers/HeadersCollectionTestHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/HeadersCollectionTestHelpers.cs
@@ -20,10 +20,17 @@ namespace Datadog.Trace.TestHelpers
             yield return new object[] { "id" };
         }
 
-        public static IEnumerable<object[]> GetInvalidSamplingPriorities()
+        public static IEnumerable<object[]> GetInvalidIntegerSamplingPriorities()
         {
-            yield return new object[] { "-2" };
-            yield return new object[] { "3" };
+            // keep these values large since we may add new values like -2 or +3 in the future
+            yield return new object[] { "-100" };
+            yield return new object[] { "100" };
+        }
+
+        public static IEnumerable<object[]> GetInvalidNonIntegerSamplingPriorities()
+        {
+            yield return new object[] { "1.0" };
+            yield return new object[] { "1,0" };
             yield return new object[] { "sampling.priority" };
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/HeadersCollectionTestHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/HeadersCollectionTestHelpers.cs
@@ -25,9 +25,9 @@ namespace Datadog.Trace.TestHelpers
             // these are valid integers, but not values defined in the sampling priority enum.
             // when we see this values in distributed tracing, we pass them along unchanged
             // to allow for forward compatibility (in case new valid enum values are added in the future).
-            // keep these test values to avoid conflicts if we may add new valid values like -2 or +3.
-            yield return new object[] { "-100" };
-            yield return new object[] { "100" };
+            // keep these test values large to avoid conflicts when we may add new valid values like -2 or +3.
+            yield return new object[] { "-1000" };
+            yield return new object[] { "1000" };
         }
 
         public static IEnumerable<object[]> GetInvalidNonIntegerSamplingPriorities()

--- a/tracer/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
@@ -3,12 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.TestHelpers;
@@ -222,7 +222,7 @@ namespace Datadog.Trace.Tests
 
             Assert.NotNull(resultContext);
             Assert.Equal(traceId, resultContext.TraceId);
-            Assert.Equal(default(ulong), resultContext.SpanId);
+            Assert.Equal(default, resultContext.SpanId);
             Assert.Equal(samplingPriority, resultContext.SamplingPriority);
             Assert.Equal(origin, resultContext.Origin);
         }

--- a/tracer/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
@@ -231,7 +231,7 @@ namespace Datadog.Trace.Tests
         [MemberData(nameof(GetHeadersInvalidIntegerSamplingPrioritiesCartesianProduct))]
         internal void Extract_InvalidIntegerSamplingPriority(IHeadersCollection headers, string samplingPriority)
         {
-            // is the extracted sampling priority is a valid integer, pass it along as is,
+            // if the extracted sampling priority is a valid integer, pass it along as is,
             // even if we don't recognize its value to allow forward compatibility with newly added values.
             const ulong traceId = 9;
             const ulong spanId = 7;

--- a/tracer/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HeadersCollectionTests.cs
@@ -28,30 +28,35 @@ namespace Datadog.Trace.Tests
 
         public static IEnumerable<object[]> GetHeaderCollectionImplementations()
         {
-            yield return new object[] { WebRequest.CreateHttp("http://localhost").Headers.Wrap() };
-            yield return new object[] { new NameValueCollection().Wrap() };
-            yield return new object[] { new DictionaryHeadersCollection() };
+            return GetHeaderCollectionFactories().Select(factory => new object[] { factory() });
         }
 
         public static IEnumerable<object[]> GetHeadersInvalidIdsCartesianProduct()
         {
-            return from header in GetHeaderCollectionImplementations().SelectMany(i => i)
+            return from headersFactory in GetHeaderCollectionFactories()
                    from invalidId in HeadersCollectionTestHelpers.GetInvalidIds().SelectMany(i => i)
-                   select new[] { header, invalidId };
+                   select new[] { headersFactory(), invalidId };
         }
 
         public static IEnumerable<object[]> GetHeadersInvalidIntegerSamplingPrioritiesCartesianProduct()
         {
-            return from header in GetHeaderCollectionImplementations().SelectMany(i => i)
+            return from headersFactory in GetHeaderCollectionFactories()
                    from invalidSamplingPriority in HeadersCollectionTestHelpers.GetInvalidIntegerSamplingPriorities().SelectMany(i => i)
-                   select new[] { header, invalidSamplingPriority };
+                   select new[] { headersFactory(), invalidSamplingPriority };
         }
 
         public static IEnumerable<object[]> GetHeadersInvalidNonIntegerSamplingPrioritiesCartesianProduct()
         {
-            return from header in GetHeaderCollectionImplementations().SelectMany(i => i)
+            return from headersFactory in GetHeaderCollectionFactories()
                    from invalidSamplingPriority in HeadersCollectionTestHelpers.GetInvalidNonIntegerSamplingPriorities().SelectMany(i => i)
-                   select new[] { header, invalidSamplingPriority };
+                   select new[] { headersFactory(), invalidSamplingPriority };
+        }
+
+        internal static IEnumerable<Func<IHeadersCollection>> GetHeaderCollectionFactories()
+        {
+            yield return () => WebRequest.CreateHttp("http://localhost").Headers.Wrap();
+            yield return () => new NameValueCollection().Wrap();
+            yield return () => new DictionaryHeadersCollection();
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RuleBasedSamplerTests.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Keep_Half_Rule()
         {
             var sampler = new RuleBasedSampler(new NoLimits());
-            sampler.RegisterRule(new CustomSamplingRule(0.5f, "Allow_nothing", ".*", ".*"));
+            sampler.RegisterRule(new CustomSamplingRule(0.5f, "Allow_half", ".*", ".*"));
             RunSamplerTest(
                 sampler,
                 iterations: 50_000, // Higher number for lower variance


### PR DESCRIPTION
see also
- https://github.com/DataDog/dd-trace-go/pull/1030
- https://github.com/DataDog/dd-opentracing-cpp/pull/205

To quote @dgoffredo from the `DataDog/dd-opentracing-cpp` PR above:
> The immediate goal is to prevent the agent from overriding sampling decisions made based on sampling rules. Eventually there will be a new data structure associated with each trace at the root, and information like "who made the sampling decision" will go there. Until that work is done, though, as an interim measure we'll change the sampling priority of sampling rule based decisions. Currently they are "sampler" type, i.e. priority {0, 1}. The agent can override these. Instead, we change them to "user" type, i.e. priority {2, -1}. The agent will not override these.