### PR TITLE
Disable buffering for GetRequestStream test

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -30,8 +30,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var (ignoreAsync, expectedSpanCount) = (EnvironmentHelper.IsCoreClr(), enableCallTarget) switch
             {
-                (false, false) => (true, 28), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
-                _ => (false, 74)
+                (false, false) => (true, 30), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
+                _ => (false, 76)
             };
 
             const string expectedOperationName = "http.request";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -34,8 +34,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var (ignoreAsync, expectedSpanCount) = (EnvironmentHelper.IsCoreClr(), enableCallTarget) switch
             {
-                (false, false) => (true, 28), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
-                _ => (false, 74)
+                (false, false) => (true, 30), // .NET Framework CallSite instrumentation doesn't cover Async / TaskAsync operations
+                _ => (false, 76)
             };
 
             const string expectedOperationName = "http.request";


### PR DESCRIPTION
I just realized that the test wasn't actually testing the case when headers can't be written in GetResponse 🙄 