### PR TITLE
Fix condition in Datadog.Trace.proj breaking the build on master

### DIFF
--- a/tracer/Datadog.Trace.proj
+++ b/tracer/Datadog.Trace.proj
@@ -125,7 +125,7 @@
     </MSBuild>
   </Target>
 
-  <Import Condition="'$(TestAllPackageVersions)'=='true' AND '$(IncludeMinorPackageVersions)'!='true'" Project="build\PackageVersionsLatestMinors.g.props" />
-  <Import Condition="'$(TestAllPackageVersions)'=='true' AND '$(IncludeMinorPackageVersions)'=='true'" Project="build\PackageVersionsLatestMajors.g.props" />
+  <Import Condition="'$(TestAllPackageVersions)'=='true' AND '$(IncludeMinorPackageVersions)'=='true'" Project="build\PackageVersionsLatestMinors.g.props" />
+  <Import Condition="'$(TestAllPackageVersions)'=='true' AND '$(IncludeMinorPackageVersions)'!='true'" Project="build\PackageVersionsLatestMajors.g.props" />
 
 </Project>


### PR DESCRIPTION
#1939 broke the build on `master` only 🙄 This should fix it

@DataDog/apm-dotnet