### PR TITLE
[2.0] Add ImmutableTracerSettings

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -297,7 +297,7 @@ namespace Datadog.Trace.Tools.Runner
             var globalSettings = GlobalSettings.CreateDefaultConfigurationSource();
             globalSettings.Add(new NameValueConfigurationSource(env));
             var tracerSettings = new TracerSettings(globalSettings);
-            var agentWriter = new CIAgentWriter(tracerSettings, new CISampler());
+            var agentWriter = new CIAgentWriter(tracerSettings.Build(), new CISampler());
 
             try
             {

--- a/tracer/src/Datadog.Trace/Agent/TransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TransportStrategy.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Agent
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
 
-        public static IApiRequestFactory Get(TracerSettings settings)
+        public static IApiRequestFactory Get(ImmutableTracerSettings settings)
         {
             var strategy = settings.TracesTransport?.ToUpperInvariant();
 

--- a/tracer/src/Datadog.Trace/AppSec/Transports/Sender.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Transports/Sender.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.AppSec.Transports
 
         internal Sender()
         {
-            _apiRequestFactory = TransportStrategy.Get(TracerSettings.FromDefaultSources()) ?? Api.CreateRequestFactory();
+            _apiRequestFactory = TransportStrategy.Get(ImmutableTracerSettings.FromDefaultSources()) ?? Api.CreateRequestFactory();
             var settings = Tracer.Instance.Settings;
             // todo: read from configuration key?
             _uri = new Uri(settings.AgentUri, "appsec/proxy/api/v2/appsecevts");

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIAgentWriter.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Ci.Agent
         private readonly AgentWriter _agentWriter = null;
         private readonly bool _isPartialFlushEnabled = false;
 
-        public CIAgentWriter(TracerSettings settings, ISampler sampler)
+        public CIAgentWriter(ImmutableTracerSettings settings, ISampler sampler)
         {
             _isPartialFlushEnabled = settings.PartialFlushEnabled;
             var api = new Api(settings.AgentUri, TransportStrategy.Get(settings), null, rates => sampler.SetDefaultSampleRates(rates), _isPartialFlushEnabled);

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Ci
 {
     internal class CITracerManager : TracerManager, ILockedTracer
     {
-        public CITracerManager(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, LibLogScopeEventSubscriber libLogSubscriber, string defaultServiceName)
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, LibLogScopeEventSubscriber libLogSubscriber, string defaultServiceName)
             : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, libLogSubscriber, defaultServiceName)
         {
         }

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Ci
     internal class CITracerManagerFactory : TracerManagerFactory
     {
         protected override TracerManager CreateTracerManagerFrom(
-            TracerSettings settings,
+            ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
             ISampler sampler,
             IScopeManager scopeManager,
@@ -29,12 +29,12 @@ namespace Datadog.Trace.Ci
             return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, libLogSubscriber, defaultServiceName);
         }
 
-        protected override ISampler GetSampler(TracerSettings settings)
+        protected override ISampler GetSampler(ImmutableTracerSettings settings)
         {
             return new CISampler();
         }
 
-        protected override IAgentWriter GetAgentWriter(TracerSettings settings, IDogStatsd statsd, ISampler sampler)
+        protected override IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, ISampler sampler)
         {
             return new CIAgentWriter(settings, sampler);
         }

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -52,8 +52,7 @@ namespace Datadog.Trace.Ci
 
             // Initialize Tracer
             Log.Information("Initialize Test Tracer instance");
-            tracerSettings.Freeze();
-            TracerManager.ReplaceGlobalManager(tracerSettings, new CITracerManagerFactory());
+            TracerManager.ReplaceGlobalManager(tracerSettings.Build(), new CITracerManagerFactory());
         }
 
         internal static void FlushSpans()

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettings.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether
         /// this integration is enabled.
         /// </summary>
-        public bool? Enabled { get; internal set; }
+        public bool? Enabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettings.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="ImmutableIntegrationSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Configuration
+{
+    /// <summary>
+    /// Contains integration-specific settings.
+    /// </summary>
+    public class ImmutableIntegrationSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmutableIntegrationSettings"/> class from an instance of
+        /// <see cref="IntegrationSettings"/>.
+        /// </summary>
+        /// <param name="settings">The values to use.</param>
+        /// <param name="isExplicitlyDisabled">If true forces the setting Enabled = false. Otherwise, uses <see cref="IntegrationSettings.Enabled"/></param>
+        internal ImmutableIntegrationSettings(IntegrationSettings settings, bool isExplicitlyDisabled)
+        {
+            IntegrationName = settings.IntegrationName;
+            Enabled = isExplicitlyDisabled ? false : settings.Enabled;
+            AnalyticsEnabled = settings.AnalyticsEnabled;
+            AnalyticsSampleRate = settings.AnalyticsSampleRate;
+        }
+
+        /// <summary>
+        /// Gets the name of the integration. Used to retrieve integration-specific settings.
+        /// </summary>
+        public string IntegrationName { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether
+        /// this integration is enabled.
+        /// </summary>
+        public bool? Enabled { get; internal set; }
+
+        /// <summary>
+        /// Gets a value indicating whether
+        /// Analytics are enabled for this integration.
+        /// </summary>
+        public bool? AnalyticsEnabled { get; }
+
+        /// <summary>
+        /// Gets a value between 0 and 1 (inclusive)
+        /// that determines the sampling rate for this integration.
+        /// </summary>
+        public double AnalyticsSampleRate { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettingsCollection.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableIntegrationSettingsCollection.cs
@@ -1,0 +1,104 @@
+﻿// <copyright file="ImmutableIntegrationSettingsCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Datadog.Trace.Configuration
+{
+    /// <summary>
+    /// A collection of <see cref="ImmutableIntegrationSettings"/> instances, referenced by name.
+    /// </summary>
+    public class ImmutableIntegrationSettingsCollection
+    {
+        private readonly IConfigurationSource _source;
+        private readonly HashSet<string> _disabledIntegrations;
+        private readonly ConcurrentDictionary<string, ImmutableIntegrationSettings> _settingsByName;
+        private readonly Func<string, ImmutableIntegrationSettings> _valueFactory;
+        private readonly ImmutableIntegrationSettings[] _settingsById;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmutableIntegrationSettingsCollection"/> class.
+        /// </summary>
+        /// <param name="settings">The <see cref="IntegrationSettingsCollection"/> to populate the immutable settings.</param>
+        /// <param name="disabledIntegrationNames">Additional integrations that should be disabled</param>
+        public ImmutableIntegrationSettingsCollection(
+            IntegrationSettingsCollection settings,
+            HashSet<string> disabledIntegrationNames)
+        {
+            _source = settings.Source;
+            _disabledIntegrations = disabledIntegrationNames ?? throw new ArgumentNullException(nameof(disabledIntegrationNames));
+            _settingsById = GetIntegrationSettingsById(settings, disabledIntegrationNames);
+            _settingsByName = GetIntegrationSettingsByName(settings, disabledIntegrationNames);
+            _valueFactory = name =>
+            {
+                if (IntegrationRegistry.Ids.TryGetValue(name, out var id))
+                {
+                    return _settingsById[id];
+                }
+
+                // We have no id for this integration, it will only be available in _settingsByName
+                var initialSettings = new IntegrationSettings(name, _source);
+                var isExplicitlyDisabled = _disabledIntegrations.Contains(name);
+
+                return new ImmutableIntegrationSettings(initialSettings, isExplicitlyDisabled);
+            };
+        }
+
+        internal ICollection<string> DisabledIntegrations => _disabledIntegrations;
+
+        /// <summary>
+        /// Gets the <see cref="IntegrationSettings"/> for the specified integration.
+        /// </summary>
+        /// <param name="integrationName">The name of the integration.</param>
+        /// <returns>The integration-specific settings for the specified integration.</returns>
+        public ImmutableIntegrationSettings this[string integrationName] => this[new IntegrationInfo(integrationName)];
+
+        internal ImmutableIntegrationSettings this[IntegrationInfo integration]
+        {
+            get
+            {
+                return integration.Name == null
+                           ? _settingsById[integration.Id]
+                           : _settingsByName.GetOrAdd(integration.Name, _valueFactory);
+            }
+        }
+
+        private static ImmutableIntegrationSettings[] GetIntegrationSettingsById(
+            IntegrationSettingsCollection settings,
+            HashSet<string> disabledIntegrationNames)
+        {
+            var allExistingSettings = settings.SettingsById;
+            var integrations = new ImmutableIntegrationSettings[allExistingSettings.Length];
+
+            for (int i = 0; i < integrations.Length; i++)
+            {
+                var existingSettings = allExistingSettings[i];
+                var explicitlyDisabled = disabledIntegrationNames.Contains(existingSettings.IntegrationName);
+
+                integrations[i] = new ImmutableIntegrationSettings(existingSettings, explicitlyDisabled);
+            }
+
+            return integrations;
+        }
+
+        private static ConcurrentDictionary<string, ImmutableIntegrationSettings> GetIntegrationSettingsByName(
+            IntegrationSettingsCollection settings,
+            HashSet<string> disabledIntegrationNames)
+        {
+            var existingSettings = settings
+                                  .SettingsByName
+                                  .Values
+                                  .Select(
+                                       setting => new KeyValuePair<string, ImmutableIntegrationSettings>(
+                                           setting.IntegrationName,
+                                           new ImmutableIntegrationSettings(setting, disabledIntegrationNames.Contains(setting.IntegrationName))));
+
+            return new ConcurrentDictionary<string, ImmutableIntegrationSettings>(existingSettings);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -36,7 +36,6 @@ namespace Datadog.Trace.Configuration
             ServiceName = settings.ServiceName;
             ServiceVersion = settings.ServiceVersion;
             TraceEnabled = settings.TraceEnabled;
-            AdoNetExcludedTypes = settings.AdoNetExcludedTypes;
             AgentUri = settings.AgentUri;
             TracesTransport = settings.TracesTransport;
             TracesPipeName = settings.TracesPipeName;
@@ -92,12 +91,6 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
         public bool TraceEnabled { get; }
-
-        /// <summary>
-        /// Gets the AdoNet types to exclude from automatic instrumentation.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.AdoNetExcludedTypes"/>
-        public HashSet<string> AdoNetExcludedTypes { get; }
 
         /// <summary>
         /// Gets the Uri where the Tracer can connect to the Agent.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -35,7 +36,6 @@ namespace Datadog.Trace.Configuration
             ServiceName = settings.ServiceName;
             ServiceVersion = settings.ServiceVersion;
             TraceEnabled = settings.TraceEnabled;
-            DisabledIntegrationNames = settings.DisabledIntegrationNames;
             AdoNetExcludedTypes = settings.AdoNetExcludedTypes;
             AgentUri = settings.AgentUri;
             TracesTransport = settings.TracesTransport;
@@ -49,9 +49,9 @@ namespace Datadog.Trace.Configuration
             MaxTracesSubmittedPerSecond = settings.MaxTracesSubmittedPerSecond;
             CustomSamplingRules = settings.CustomSamplingRules;
             GlobalSamplingRate = settings.GlobalSamplingRate;
-            Integrations = settings.Integrations;
-            GlobalTags = settings.GlobalTags;
-            HeaderTags = settings.HeaderTags;
+            Integrations = new ImmutableIntegrationSettingsCollection(settings.Integrations, settings.DisabledIntegrationNames);
+            GlobalTags = new ReadOnlyDictionary<string, string>(settings.GlobalTags);
+            HeaderTags = new ReadOnlyDictionary<string, string>(settings.HeaderTags);
             DogStatsdPort = settings.DogStatsdPort;
             TracerMetricsEnabled = settings.TracerMetricsEnabled;
             RuntimeMetricsEnabled = settings.RuntimeMetricsEnabled;
@@ -92,12 +92,6 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
         public bool TraceEnabled { get; }
-
-        /// <summary>
-        /// Gets the names of disabled integrations.
-        /// </summary>
-        /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
-        public HashSet<string> DisabledIntegrationNames { get; }
 
         /// <summary>
         /// Gets the AdoNet types to exclude from automatic instrumentation.
@@ -149,6 +143,7 @@ namespace Datadog.Trace.Configuration
         /// See the documentation for more details.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.GlobalAnalyticsEnabled"/>
+        [Obsolete(DeprecationMessages.AppAnalytics)]
         public bool AnalyticsEnabled { get; }
 
         /// <summary>
@@ -181,7 +176,7 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets a collection of <see cref="Integrations"/> keyed by integration name.
         /// </summary>
-        public IntegrationSettingsCollection Integrations { get; }
+        public ImmutableIntegrationSettingsCollection Integrations { get; }
 
         /// <summary>
         /// Gets the global tags, which are applied to all <see cref="Span"/>s.
@@ -211,13 +206,6 @@ namespace Datadog.Trace.Configuration
         /// are enabled and sent to DogStatsd.
         /// </summary>
         public bool RuntimeMetricsEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the use
-        /// of System.Diagnostics.DiagnosticSource is enabled.
-        /// Default is <c>true</c>.
-        /// </summary>
-        public bool DiagnosticSourceEnabled => GlobalSettings.Source.DiagnosticSourceEnabled;
 
         /// <summary>
         /// Gets a value indicating whether partial flush is enabled

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -174,12 +174,12 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Gets the global tags, which are applied to all <see cref="Span"/>s.
         /// </summary>
-        public IDictionary<string, string> GlobalTags { get; }
+        public IReadOnlyDictionary<string, string> GlobalTags { get; }
 
         /// <summary>
         /// Gets the map of header keys to tag names, which are applied to the root <see cref="Span"/> of incoming requests.
         /// </summary>
-        public IDictionary<string, string> HeaderTags { get; }
+        public IReadOnlyDictionary<string, string> HeaderTags { get; }
 
         /// <summary>
         /// Gets the port where the DogStatsd server is listening for connections.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -1,0 +1,345 @@
+﻿// <copyright file="ImmutableTracerSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Configuration
+{
+    /// <summary>
+    /// Contains Tracer settings.
+    /// </summary>
+    public class ImmutableTracerSettings
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmutableTracerSettings"/> class
+        /// using the specified <see cref="IConfigurationSource"/> to initialize values.
+        /// </summary>
+        /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
+        public ImmutableTracerSettings(IConfigurationSource source)
+            : this(new TracerSettings(source))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmutableTracerSettings"/> class from
+        /// a TracerSettings instance.
+        /// </summary>
+        /// <param name="settings">The tracer settings to use to populate the immutable tracer settings</param>
+        public ImmutableTracerSettings(TracerSettings settings)
+        {
+            Environment = settings.Environment;
+            ServiceName = settings.ServiceName;
+            ServiceVersion = settings.ServiceVersion;
+            TraceEnabled = settings.TraceEnabled;
+            DisabledIntegrationNames = settings.DisabledIntegrationNames;
+            AdoNetExcludedTypes = settings.AdoNetExcludedTypes;
+            AgentUri = settings.AgentUri;
+            TracesTransport = settings.TracesTransport;
+            TracesPipeName = settings.TracesPipeName;
+            TracesPipeTimeoutMs = settings.TracesPipeTimeoutMs;
+            MetricsPipeName = settings.MetricsPipeName;
+#pragma warning disable 618 // App analytics is deprecated, but still used
+            AnalyticsEnabled = settings.AnalyticsEnabled;
+#pragma warning restore 618
+            LogsInjectionEnabled = settings.LogsInjectionEnabled;
+            MaxTracesSubmittedPerSecond = settings.MaxTracesSubmittedPerSecond;
+            CustomSamplingRules = settings.CustomSamplingRules;
+            GlobalSamplingRate = settings.GlobalSamplingRate;
+            Integrations = settings.Integrations;
+            GlobalTags = settings.GlobalTags;
+            HeaderTags = settings.HeaderTags;
+            DogStatsdPort = settings.DogStatsdPort;
+            TracerMetricsEnabled = settings.TracerMetricsEnabled;
+            RuntimeMetricsEnabled = settings.RuntimeMetricsEnabled;
+            PartialFlushEnabled = settings.PartialFlushEnabled;
+            PartialFlushMinSpans = settings.PartialFlushMinSpans;
+            KafkaCreateConsumerScopeEnabled = settings.KafkaCreateConsumerScopeEnabled;
+            StartupDiagnosticLogEnabled = settings.StartupDiagnosticLogEnabled;
+            HttpClientExcludedUrlSubstrings = settings.HttpClientExcludedUrlSubstrings;
+            HttpServerErrorStatusCodes = settings.HttpServerErrorStatusCodes;
+            HttpClientErrorStatusCodes = settings.HttpClientErrorStatusCodes;
+            ServiceNameMappings = settings.ServiceNameMappings;
+            TraceBufferSize = settings.TraceBufferSize;
+            TraceBatchInterval = settings.TraceBatchInterval;
+            RouteTemplateResourceNamesEnabled = settings.RouteTemplateResourceNamesEnabled;
+        }
+
+        /// <summary>
+        /// Gets the default environment name applied to all spans.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.Environment"/>
+        public string Environment { get; }
+
+        /// <summary>
+        /// Gets the service name applied to top-level spans and used to build derived service names.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.ServiceName"/>
+        public string ServiceName { get; }
+
+        /// <summary>
+        /// Gets the version tag applied to all spans.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.ServiceVersion"/>
+        public string ServiceVersion { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether tracing is enabled.
+        /// Default is <c>true</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
+        public bool TraceEnabled { get; }
+
+        /// <summary>
+        /// Gets the names of disabled integrations.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DisabledIntegrations"/>
+        public HashSet<string> DisabledIntegrationNames { get; }
+
+        /// <summary>
+        /// Gets the AdoNet types to exclude from automatic instrumentation.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.AdoNetExcludedTypes"/>
+        public HashSet<string> AdoNetExcludedTypes { get; }
+
+        /// <summary>
+        /// Gets the Uri where the Tracer can connect to the Agent.
+        /// Default is <c>"http://localhost:8126"</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.AgentUri"/>
+        /// <seealso cref="ConfigurationKeys.AgentHost"/>
+        /// <seealso cref="ConfigurationKeys.AgentPort"/>
+        public Uri AgentUri { get; }
+
+        /// <summary>
+        /// Gets the key used to determine the transport for sending traces.
+        /// Default is <c>null</c>, which will use the default path decided in <see cref="Agent.Api"/>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TracesTransport"/>
+        public string TracesTransport { get; }
+
+        /// <summary>
+        /// Gets the windows pipe name where the Tracer can connect to the Agent.
+        /// Default is <c>null</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TracesPipeName"/>
+        public string TracesPipeName { get; }
+
+        /// <summary>
+        /// Gets the timeout in milliseconds for the windows named pipe requests.
+        /// Default is <c>100</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.TracesPipeTimeoutMs"/>
+        public int TracesPipeTimeoutMs { get; }
+
+        /// <summary>
+        /// Gets the windows pipe name where the Tracer can send stats.
+        /// Default is <c>null</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.MetricsPipeName"/>
+        public string MetricsPipeName { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether default Analytics are enabled.
+        /// Settings this value is a shortcut for setting
+        /// <see cref="Configuration.IntegrationSettings.AnalyticsEnabled"/> on some predetermined integrations.
+        /// See the documentation for more details.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.GlobalAnalyticsEnabled"/>
+        public bool AnalyticsEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether correlation identifiers are
+        /// automatically injected into the logging context.
+        /// Default is <c>false</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.LogsInjectionEnabled"/>
+        public bool LogsInjectionEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating the maximum number of traces set to AutoKeep (p1) per second.
+        /// Default is <c>100</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.MaxTracesSubmittedPerSecond"/>
+        public int MaxTracesSubmittedPerSecond { get; }
+
+        /// <summary>
+        /// Gets a value indicating custom sampling rules.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.CustomSamplingRules"/>
+        public string CustomSamplingRules { get; }
+
+        /// <summary>
+        /// Gets a value indicating a global rate for sampling.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.GlobalSamplingRate"/>
+        public double? GlobalSamplingRate { get; }
+
+        /// <summary>
+        /// Gets a collection of <see cref="Integrations"/> keyed by integration name.
+        /// </summary>
+        public IntegrationSettingsCollection Integrations { get; }
+
+        /// <summary>
+        /// Gets the global tags, which are applied to all <see cref="Span"/>s.
+        /// </summary>
+        public IDictionary<string, string> GlobalTags { get; }
+
+        /// <summary>
+        /// Gets the map of header keys to tag names, which are applied to the root <see cref="Span"/> of incoming requests.
+        /// </summary>
+        public IDictionary<string, string> HeaderTags { get; }
+
+        /// <summary>
+        /// Gets the port where the DogStatsd server is listening for connections.
+        /// Default is <c>8125</c>.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DogStatsdPort"/>
+        public int DogStatsdPort { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether internal metrics
+        /// are enabled and sent to DogStatsd.
+        /// </summary>
+        public bool TracerMetricsEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether runtime metrics
+        /// are enabled and sent to DogStatsd.
+        /// </summary>
+        public bool RuntimeMetricsEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the use
+        /// of System.Diagnostics.DiagnosticSource is enabled.
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool DiagnosticSourceEnabled => GlobalSettings.Source.DiagnosticSourceEnabled;
+
+        /// <summary>
+        /// Gets a value indicating whether partial flush is enabled
+        /// </summary>
+        public bool PartialFlushEnabled { get; }
+
+        /// <summary>
+        /// Gets the minimum number of closed spans in a trace before it's partially flushed
+        /// </summary>
+        public int PartialFlushMinSpans { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether a span context should be created on exiting a successful Kafka
+        /// Consumer.Consume() call, and closed on entering Consumer.Consume().
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.KafkaCreateConsumerScopeEnabled"/>
+        public bool KafkaCreateConsumerScopeEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the diagnostic log at startup is enabled
+        /// </summary>
+        public bool StartupDiagnosticLogEnabled { get; }
+
+        /// <summary>
+        /// Gets the comma separated list of url patterns to skip tracing.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpClientExcludedUrlSubstrings"/>
+        internal string[] HttpClientExcludedUrlSubstrings { get; }
+
+        /// <summary>
+        /// Gets the HTTP status code that should be marked as errors for server integrations.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpServerErrorStatusCodes"/>
+        internal bool[] HttpServerErrorStatusCodes { get; }
+
+        /// <summary>
+        /// Gets the HTTP status code that should be marked as errors for client integrations.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.HttpClientErrorStatusCodes"/>
+        internal bool[] HttpClientErrorStatusCodes { get; }
+
+        /// <summary>
+        /// Gets configuration values for changing service names based on configuration
+        /// </summary>
+        internal ServiceNames ServiceNameMappings { get; }
+
+        /// <summary>
+        /// Gets a value indicating the size in bytes of the trace buffer
+        /// </summary>
+        internal int TraceBufferSize { get; }
+
+        /// <summary>
+        /// Gets a value indicating the batch interval for the serialization queue, in milliseconds
+        /// </summary>
+        internal int TraceBatchInterval { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the feature flag to enable the updated ASP.NET resource names is enabled
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled"/>
+        internal bool RouteTemplateResourceNamesEnabled { get; }
+
+        /// <summary>
+        /// Create a <see cref="ImmutableTracerSettings"/> populated from the default sources
+        /// returned by <see cref="GlobalSettings.CreateDefaultConfigurationSource()"/>.
+        /// </summary>
+        /// <returns>A <see cref="ImmutableTracerSettings"/> populated from the default sources.</returns>
+        public static ImmutableTracerSettings FromDefaultSources()
+        {
+            var source = GlobalSettings.CreateDefaultConfigurationSource();
+            return new ImmutableTracerSettings(source);
+        }
+
+        internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
+        {
+            var source = serverStatusCode ? HttpServerErrorStatusCodes : HttpClientErrorStatusCodes;
+
+            if (source == null)
+            {
+                return false;
+            }
+
+            if (statusCode >= source.Length)
+            {
+                return false;
+            }
+
+            return source[statusCode];
+        }
+
+        internal bool IsIntegrationEnabled(IntegrationInfo integration, bool defaultValue = true)
+        {
+            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
+            {
+                return Integrations[integration].Enabled ?? defaultValue;
+            }
+
+            return false;
+        }
+
+        internal bool IsIntegrationEnabled(string integrationName)
+        {
+            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
+            {
+                bool? enabled = Integrations[integrationName].Enabled;
+                return enabled != false;
+            }
+
+            return false;
+        }
+
+        [Obsolete(DeprecationMessages.AppAnalytics)]
+        internal double? GetIntegrationAnalyticsSampleRate(IntegrationInfo integration, bool enabledWithGlobalSetting)
+        {
+            var integrationSettings = Integrations[integration];
+            var analyticsEnabled = integrationSettings.AnalyticsEnabled ?? (enabledWithGlobalSetting && AnalyticsEnabled);
+            return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : (double?)null;
+        }
+
+        internal string GetServiceName(Tracer tracer, string serviceName)
+        {
+            return ServiceNameMappings.GetServiceName(tracer.DefaultServiceName, serviceName);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -36,6 +36,7 @@ namespace Datadog.Trace.Configuration
             ServiceName = settings.ServiceName;
             ServiceVersion = settings.ServiceVersion;
             TraceEnabled = settings.TraceEnabled;
+            AdoNetExcludedTypes = settings.AdoNetExcludedTypes;
             AgentUri = settings.AgentUri;
             TracesTransport = settings.TracesTransport;
             TracesPipeName = settings.TracesPipeName;
@@ -91,6 +92,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
         public bool TraceEnabled { get; }
+
+        /// <summary>
+        /// Gets the AdoNet types to exclude from automatic instrumentation.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.AdoNetExcludedTypes"/>
+        public HashSet<string> AdoNetExcludedTypes { get; }
 
         /// <summary>
         /// Gets the Uri where the Tracer can connect to the Agent.

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettingsCollection.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettingsCollection.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Datadog.Trace.Configuration
 {
@@ -19,7 +17,6 @@ namespace Datadog.Trace.Configuration
         private readonly ConcurrentDictionary<string, IntegrationSettings> _settingsByName;
         private readonly Func<string, IntegrationSettings> _valueFactory;
         private readonly IntegrationSettings[] _settingsById;
-        private ICollection<string> _disabledIntegrations;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegrationSettingsCollection"/> class.
@@ -38,16 +35,15 @@ namespace Datadog.Trace.Configuration
                 }
 
                 // We have no id for this integration, it will only be available in _settingsByName
-                var settings = new IntegrationSettings(name, _source);
-
-                if (_disabledIntegrations?.Contains(name) == true)
-                {
-                    settings.Enabled = false;
-                }
-
-                return settings;
+                return new IntegrationSettings(name, _source);
             };
         }
+
+        internal IConfigurationSource Source => _source;
+
+        internal ConcurrentDictionary<string, IntegrationSettings> SettingsByName => _settingsByName;
+
+        internal IntegrationSettings[] SettingsById => _settingsById;
 
         /// <summary>
         /// Gets the <see cref="IntegrationSettings"/> for the specified integration.
@@ -61,24 +57,6 @@ namespace Datadog.Trace.Configuration
             get
             {
                 return integration.Name == null ? _settingsById[integration.Id] : _settingsByName.GetOrAdd(integration.Name, _valueFactory);
-            }
-        }
-
-        internal void SetDisabledIntegrations(HashSet<string> disabledIntegrationNames)
-        {
-            if (disabledIntegrationNames == null || disabledIntegrationNames.Count == 0)
-            {
-                return;
-            }
-
-            _disabledIntegrations = disabledIntegrationNames;
-
-            foreach (var settings in _settingsById.Concat(_settingsByName.Values))
-            {
-                if (disabledIntegrationNames.Contains(settings.IntegrationName))
-                {
-                    settings.Enabled = false;
-                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -512,14 +512,6 @@ namespace Datadog.Trace.Configuration
             return new ImmutableTracerSettings(this);
         }
 
-        [Obsolete(DeprecationMessages.AppAnalytics)]
-        internal double? GetIntegrationAnalyticsSampleRate(IntegrationInfo integration, bool enabledWithGlobalSetting)
-        {
-            var integrationSettings = Integrations[integration];
-            var analyticsEnabled = integrationSettings.AnalyticsEnabled ?? (enabledWithGlobalSetting && AnalyticsEnabled);
-            return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : (double?)null;
-        }
-
         private static IDictionary<string, string> InitializeHeaderTags(IDictionary<string, string> configurationDictionary)
         {
             var headerTags = new Dictionary<string, string>();

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -504,49 +504,12 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <summary>
-        /// Populate the internal structures. Modifying the settings past this point is not supported
+        /// Create an instance of <see cref="ImmutableTracerSettings"/> that can be used to build a <see cref="Tracer"/>
         /// </summary>
-        internal void Freeze()
+        /// <returns>The <see cref="ImmutableTracerSettings"/> that can be passed to a <see cref="Tracer"/> instance</returns>
+        public ImmutableTracerSettings Build()
         {
-            Integrations.SetDisabledIntegrations(DisabledIntegrationNames);
-        }
-
-        internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
-        {
-            var source = serverStatusCode ? HttpServerErrorStatusCodes : HttpClientErrorStatusCodes;
-
-            if (source == null)
-            {
-                return false;
-            }
-
-            if (statusCode >= source.Length)
-            {
-                return false;
-            }
-
-            return source[statusCode];
-        }
-
-        internal bool IsIntegrationEnabled(IntegrationInfo integration, bool defaultValue = true)
-        {
-            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
-            {
-                return Integrations[integration].Enabled ?? defaultValue;
-            }
-
-            return false;
-        }
-
-        internal bool IsIntegrationEnabled(string integrationName)
-        {
-            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
-            {
-                bool? enabled = Integrations[integrationName].Enabled;
-                return enabled != false;
-            }
-
-            return false;
+            return new ImmutableTracerSettings(this);
         }
 
         [Obsolete(DeprecationMessages.AppAnalytics)]
@@ -557,7 +520,7 @@ namespace Datadog.Trace.Configuration
             return analyticsEnabled ? integrationSettings.AnalyticsSampleRate : (double?)null;
         }
 
-        internal IDictionary<string, string> InitializeHeaderTags(IDictionary<string, string> configurationDictionary)
+        private static IDictionary<string, string> InitializeHeaderTags(IDictionary<string, string> configurationDictionary)
         {
             var headerTags = new Dictionary<string, string>();
 
@@ -576,7 +539,8 @@ namespace Datadog.Trace.Configuration
             return headerTags;
         }
 
-        internal IEnumerable<string> TrimSplitString(string textValues, char separator)
+        // internal for testing
+        internal static IEnumerable<string> TrimSplitString(string textValues, char separator)
         {
             var values = textValues.Split(separator);
 
@@ -589,7 +553,7 @@ namespace Datadog.Trace.Configuration
             }
         }
 
-        internal bool[] ParseHttpCodesToArray(string httpStatusErrorCodes)
+        internal static bool[] ParseHttpCodesToArray(string httpStatusErrorCodes)
         {
             bool[] httpErrorCodesArray = new bool[600];
 
@@ -639,11 +603,6 @@ namespace Datadog.Trace.Configuration
             }
 
             return httpErrorCodesArray;
-        }
-
-        internal string GetServiceName(Tracer tracer, string serviceName)
-        {
-            return ServiceNameMappings.GetServiceName(tracer.DefaultServiceName, serviceName);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        public static bool IsEmpty<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+        public static bool IsEmpty<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary)
         {
             if (dictionary is ConcurrentDictionary<TKey, TValue> concurrentDictionary)
             {
@@ -80,6 +80,6 @@ namespace Datadog.Trace.ExtensionMethods
             return dictionary.Count == 0;
         }
 
-        public static bool IsNullOrEmpty<TKey, TValue>(this IDictionary<TKey, TValue> dictionary) => dictionary?.IsEmpty() ?? true;
+        public static bool IsNullOrEmpty<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary) => dictionary?.IsEmpty() ?? true;
     }
 }

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static void SetHttpStatusCode(this Span span, int statusCode, bool isServer, TracerSettings tracerSettings)
+        internal static void SetHttpStatusCode(this Span span, int statusCode, bool isServer, ImmutableTracerSettings tracerSettings)
         {
             string statusCodeString = ConvertStatusCodeToString(statusCode);
 

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static void SetHeaderTags<T>(this Span span, T headers, IDictionary<string, string> headerTags, string defaultTagPrefix)
+        internal static void SetHeaderTags<T>(this Span span, T headers, IReadOnlyDictionary<string, string> headerTags, string defaultTagPrefix)
             where T : IHeadersCollection
         {
             if (headerTags is not null && !headerTags.IsEmpty())

--- a/tracer/src/Datadog.Trace/IDatadogTracer.cs
+++ b/tracer/src/Datadog.Trace/IDatadogTracer.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace
 
         ISampler Sampler { get; }
 
-        TracerSettings Settings { get; }
+        ImmutableTracerSettings Settings { get; }
 
         Span StartSpan(string operationName);
 

--- a/tracer/src/Datadog.Trace/Tagging/InstrumentationTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/InstrumentationTags.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tagging
 
         public double? AnalyticsSampleRate { get; set; }
 
-        public void SetAnalyticsSampleRate(IntegrationInfo integration, TracerSettings settings, bool enabledWithGlobalSetting)
+        public void SetAnalyticsSampleRate(IntegrationInfo integration, ImmutableTracerSettings settings, bool enabledWithGlobalSetting)
         {
             if (settings != null)
             {

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, libLogSubscriber: null))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, libLogSubscriber: null))
         {
         }
 
@@ -159,7 +159,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets this tracer's settings.
         /// </summary>
-        public TracerSettings Settings => TracerManager.Settings;
+        public ImmutableTracerSettings Settings => TracerManager.Settings;
 
         /// <summary>
         /// Gets the tracer's scope manager, which determines which span is currently active, if any.
@@ -185,8 +185,7 @@ namespace Datadog.Trace
         /// or null to use the default configuration sources. This is used to configure global settings</param>
         public static void Configure(TracerSettings settings)
         {
-            // TODO: Switch to immutable settings
-            TracerManager.ReplaceGlobalManager(settings, TracerManagerFactory.Instance);
+            TracerManager.ReplaceGlobalManager(settings?.Build(), TracerManagerFactory.Instance);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace
         private volatile bool _isClosing = false;
 
         public TracerManager(
-            TracerSettings settings,
+            ImmutableTracerSettings settings,
             IAgentWriter agentWriter,
             ISampler sampler,
             IScopeManager scopeManager,
@@ -81,7 +81,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets this tracer's settings.
         /// </summary>
-        public TracerSettings Settings { get; }
+        public ImmutableTracerSettings Settings { get; }
 
         public IAgentWriter AgentWriter { get; }
 
@@ -107,7 +107,7 @@ namespace Datadog.Trace
         /// </summary>
         /// <param name="settings">The settings to use </param>
         /// <param name="factory">The factory to use to create the <see cref="TracerManager"/></param>
-        public static void ReplaceGlobalManager(TracerSettings settings, TracerManagerFactory factory)
+        public static void ReplaceGlobalManager(ImmutableTracerSettings settings, TracerManagerFactory factory)
         {
             TracerManager oldManager;
             TracerManager newManager;
@@ -342,7 +342,7 @@ namespace Datadog.Trace
         }
 
         // should only be called inside a global lock, i.e. by TracerManager.Instance or ReplaceGlobalManager
-        private static TracerManager CreateInitializedTracer(TracerSettings settings, TracerManagerFactory factory)
+        private static TracerManager CreateInitializedTracer(ImmutableTracerSettings settings, TracerManagerFactory factory)
         {
             if (_instance is ILockedTracer)
             {

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -292,7 +292,10 @@ namespace Datadog.Trace
                     writer.WritePropertyName("disabled_integrations");
                     writer.WriteStartArray();
 
-                    foreach (var integration in instanceSettings.DisabledIntegrationNames)
+                    // For consistency with previous diagnostic log, this only includes integrations
+                    // that were disabled with DD_DISABLED_INTEGRATIONS, not integrations disabled with
+                    // DD_INTEGRATION_{0}_DISABLED
+                    foreach (var integration in instanceSettings.Integrations.DisabledIntegrations)
                     {
                         writer.WriteValue(integration);
                     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableIntegrationSettingsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableIntegrationSettingsCollectionTests.cs
@@ -1,0 +1,92 @@
+﻿// <copyright file="ImmutableIntegrationSettingsCollectionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class ImmutableIntegrationSettingsCollectionTests
+    {
+        [Fact]
+        public void PopulatesFromBuilderCorrectly()
+        {
+            var source = new NameValueConfigurationSource(new NameValueCollection
+            {
+                { "DD_TRACE_FOO_ENABLED", "true" },
+                { "DD_TRACE_FOO_ANALYTICS_ENABLED", "true" },
+                { "DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE", "0.2" },
+                { "DD_TRACE_BAR_ENABLED", "false" },
+                { "DD_TRACE_BAR_ANALYTICS_ENABLED", "false" },
+                { "DD_BAZ_ENABLED", "false" },
+                { "DD_BAZ_ANALYTICS_ENABLED", "false" },
+                { "DD_BAZ_ANALYTICS_SAMPLE_RATE", "0.6" },
+                { "DD_TRACE_Kafka_ENABLED", "true" },
+                { "DD_TRACE_Kafka_ANALYTICS_ENABLED", "true" },
+                { "DD_TRACE_Kafka_ANALYTICS_SAMPLE_RATE", "0.2" },
+                { "DD_TRACE_GraphQL_ENABLED", "false" },
+                { "DD_TRACE_GraphQL_ANALYTICS_ENABLED", "false" },
+                { "DD_Wcf_ENABLED", "false" },
+                { "DD_Wcf_ANALYTICS_ENABLED", "false" },
+                { "DD_Wcf_ANALYTICS_SAMPLE_RATE", "0.2" },
+                { "DD_Msmq_ENABLED", "true" },
+            });
+
+            var disabledIntegrations = new HashSet<string> { "foobar", "MongoDb", "Msmq" };
+
+            var builderCollection = new IntegrationSettingsCollection(source);
+
+            var final = new ImmutableIntegrationSettingsCollection(builderCollection, disabledIntegrations);
+
+            var foo = final["foo"];
+            foo.Enabled.Should().BeTrue();
+            foo.AnalyticsEnabled.Should().BeTrue();
+            foo.AnalyticsSampleRate.Should().Be(0.2);
+
+            var bar = final["bar"];
+            bar.Enabled.Should().BeFalse();
+            bar.AnalyticsEnabled.Should().BeFalse();
+            bar.AnalyticsSampleRate.Should().Be(1.0);
+
+            var baz = final["baz"];
+            baz.Enabled.Should().BeFalse();
+            baz.AnalyticsEnabled.Should().BeFalse();
+            baz.AnalyticsSampleRate.Should().Be(0.6);
+
+            var foobar = final["foobar"];
+            foobar.Enabled.Should().BeFalse();
+
+            var unknown = final["unknown"];
+            unknown.Enabled.Should().BeNull();
+
+            var kafka = final[nameof(IntegrationIds.Kafka)];
+            kafka.Enabled.Should().BeTrue();
+            kafka.AnalyticsEnabled.Should().BeTrue();
+            kafka.AnalyticsSampleRate.Should().Be(0.2);
+
+            var graphql = final[nameof(IntegrationIds.GraphQL)];
+            graphql.Enabled.Should().BeFalse();
+            graphql.AnalyticsEnabled.Should().BeFalse();
+            graphql.AnalyticsSampleRate.Should().Be(1.0);
+
+            var wcf = final[nameof(IntegrationIds.Wcf)];
+            wcf.Enabled.Should().BeFalse();
+            wcf.AnalyticsEnabled.Should().BeFalse();
+            wcf.AnalyticsSampleRate.Should().Be(0.2);
+
+            var mongodb = final[nameof(IntegrationIds.MongoDb)];
+            mongodb.Enabled.Should().BeFalse();
+
+            var msmq = final[nameof(IntegrationIds.Msmq)];
+            msmq.Enabled.Should().BeFalse();
+
+            var consmos = final[nameof(IntegrationIds.CosmosDb)];
+            consmos.Enabled.Should().BeNull();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableIntegrationSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableIntegrationSettingsTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="ImmutableIntegrationSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class ImmutableIntegrationSettingsTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ImmutableSettingsRespectsOverride(bool initiallyEnabled)
+        {
+            var name = nameof(IntegrationIds.Kafka);
+            var settings = new IntegrationSettings(name, source: null)
+            {
+                Enabled = initiallyEnabled
+            };
+
+            var immutableSettings = new ImmutableIntegrationSettings(settings, isExplicitlyDisabled: true);
+
+            immutableSettings.Enabled.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ImmutableSettingsRespectsOriginalIfNotOverridden(bool initiallyEnabled)
+        {
+            var name = nameof(IntegrationIds.Kafka);
+            var settings = new IntegrationSettings(name, source: null)
+            {
+                Enabled = initiallyEnabled
+            };
+
+            var immutableSettings = new ImmutableIntegrationSettings(settings, isExplicitlyDisabled: false);
+
+            immutableSettings.Enabled.Should().Be(initiallyEnabled);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.Tests.Configuration
         // These properties are present on TracerSettings, but not on ImmutableTracerSettings
         private static readonly string[] ExcludedProperties =
         {
+            nameof(TracerSettings.AdoNetExcludedTypes),
             nameof(TracerSettings.DisabledIntegrationNames),
             nameof(TracerSettings.DiagnosticSourceEnabled),
         };

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Configuration;
 using FluentAssertions;
@@ -13,26 +14,48 @@ namespace Datadog.Trace.Tests.Configuration
 {
     public class ImmutableTracerSettingsTests
     {
+        private const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+
+        // These properties are present on TracerSettings, but not on ImmutableTracerSettings
+        private static readonly string[] ExcludedProperties =
+        {
+            nameof(TracerSettings.DisabledIntegrationNames),
+            nameof(TracerSettings.DiagnosticSourceEnabled),
+        };
+
         [Fact]
         public void OnlyHasReadOnlyProperties()
         {
             var type = typeof(ImmutableTracerSettings);
 
-            var flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
-
             using var scope = new AssertionScope();
 
-            var properties = type.GetProperties(flags);
+            var properties = type.GetProperties(Flags);
             foreach (var propertyInfo in properties)
             {
                 propertyInfo.CanWrite.Should().BeFalse($"{propertyInfo.Name} should be read only");
             }
 
-            var fields = type.GetFields(flags);
+            var fields = type.GetFields(Flags);
             foreach (var field in fields)
             {
                 field.IsInitOnly.Should().BeTrue($"{field.Name} should be read only");
             }
+        }
+
+        [Fact]
+        public void HasSamePropertiesAsTracerSettings()
+        {
+            var mutableProperties = typeof(TracerSettings)
+                                   .GetProperties(Flags)
+                                   .Select(x => x.Name)
+                                   .Where(x => !ExcludedProperties.Contains(x));
+
+            var immutableProperties = typeof(ImmutableTracerSettings)
+                                     .GetProperties(Flags)
+                                     .Select(x => x.Name);
+
+            immutableProperties.Should().Contain(mutableProperties);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ImmutableTracerSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Reflection;
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class ImmutableTracerSettingsTests
+    {
+        [Fact]
+        public void OnlyHasReadOnlyProperties()
+        {
+            var type = typeof(ImmutableTracerSettings);
+
+            var flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
+
+            using var scope = new AssertionScope();
+
+            var properties = type.GetProperties(flags);
+            foreach (var propertyInfo in properties)
+            {
+                propertyInfo.CanWrite.Should().BeFalse($"{propertyInfo.Name} should be read only");
+            }
+
+            var fields = type.GetFields(flags);
+            foreach (var field in fields)
+            {
+                field.IsInitOnly.Should().BeTrue($"{field.Name} should be read only");
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
@@ -19,7 +19,6 @@ namespace Datadog.Trace.Tests.Configuration
         // These properties are present on TracerSettings, but not on ImmutableTracerSettings
         private static readonly string[] ExcludedProperties =
         {
-            nameof(TracerSettings.AdoNetExcludedTypes),
             nameof(TracerSettings.DisabledIntegrationNames),
             nameof(TracerSettings.DiagnosticSourceEnabled),
         };

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -103,6 +103,51 @@ namespace Datadog.Trace.Configuration
         int? GetInt32(string key);
         string GetString(string key);
     }
+    public class ImmutableIntegrationSettings
+    {
+        public bool? AnalyticsEnabled { get; }
+        public double AnalyticsSampleRate { get; }
+        public bool? Enabled { get; }
+        public string IntegrationName { get; }
+    }
+    public class ImmutableIntegrationSettingsCollection
+    {
+        public ImmutableIntegrationSettingsCollection(Datadog.Trace.Configuration.IntegrationSettingsCollection settings, System.Collections.Generic.HashSet<string> disabledIntegrationNames) { }
+        public Datadog.Trace.Configuration.ImmutableIntegrationSettings this[string integrationName] { get; }
+    }
+    public class ImmutableTracerSettings
+    {
+        public ImmutableTracerSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
+        public ImmutableTracerSettings(Datadog.Trace.Configuration.TracerSettings settings) { }
+        public System.Collections.Generic.HashSet<string> AdoNetExcludedTypes { get; }
+        public System.Uri AgentUri { get; }
+        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
+        public bool AnalyticsEnabled { get; }
+        public string CustomSamplingRules { get; }
+        public int DogStatsdPort { get; }
+        public string Environment { get; }
+        public double? GlobalSamplingRate { get; }
+        public System.Collections.Generic.IDictionary<string, string> GlobalTags { get; }
+        public System.Collections.Generic.IDictionary<string, string> HeaderTags { get; }
+        public Datadog.Trace.Configuration.ImmutableIntegrationSettingsCollection Integrations { get; }
+        public bool KafkaCreateConsumerScopeEnabled { get; }
+        public bool LogsInjectionEnabled { get; }
+        public int MaxTracesSubmittedPerSecond { get; }
+        public string MetricsPipeName { get; }
+        public bool PartialFlushEnabled { get; }
+        public int PartialFlushMinSpans { get; }
+        public bool RuntimeMetricsEnabled { get; }
+        public string ServiceName { get; }
+        public string ServiceVersion { get; }
+        public bool StartupDiagnosticLogEnabled { get; }
+        public bool TraceEnabled { get; }
+        public bool TracerMetricsEnabled { get; }
+        public string TracesPipeName { get; }
+        public int TracesPipeTimeoutMs { get; }
+        public string TracesTransport { get; }
+        public static Datadog.Trace.Configuration.ImmutableTracerSettings FromDefaultSources() { }
+    }
     public class IntegrationSettings
     {
         public IntegrationSettings(string integrationName, Datadog.Trace.Configuration.IConfigurationSource source) { }
@@ -176,6 +221,7 @@ namespace Datadog.Trace.Configuration
         public string TracesPipeName { get; set; }
         public int TracesPipeTimeoutMs { get; set; }
         public string TracesTransport { get; set; }
+        public Datadog.Trace.Configuration.ImmutableTracerSettings Build() { }
         public void SetHttpClientErrorStatusCodes(System.Collections.Generic.IEnumerable<int> statusCodes) { }
         public void SetHttpServerErrorStatusCodes(System.Collections.Generic.IEnumerable<int> statusCodes) { }
         public void SetServiceNameMappings(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> mappings) { }
@@ -302,7 +348,7 @@ namespace Datadog.Trace
         public Tracer(Datadog.Trace.Configuration.TracerSettings settings) { }
         public Datadog.Trace.Scope ActiveScope { get; }
         public string DefaultServiceName { get; }
-        public Datadog.Trace.Configuration.TracerSettings Settings { get; }
+        public Datadog.Trace.Configuration.ImmutableTracerSettings Settings { get; }
         [set: System.Obsolete("Use Tracer.Configure to configure the global Tracer instance in code.")]
         public static Datadog.Trace.Tracer Instance { get; set; }
         public Datadog.Trace.Scope ActivateSpan(Datadog.Trace.Span span, bool finishOnClose = true) { }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -128,8 +128,8 @@ namespace Datadog.Trace.Configuration
         public int DogStatsdPort { get; }
         public string Environment { get; }
         public double? GlobalSamplingRate { get; }
-        public System.Collections.Generic.IDictionary<string, string> GlobalTags { get; }
-        public System.Collections.Generic.IDictionary<string, string> HeaderTags { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> GlobalTags { get; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, string> HeaderTags { get; }
         public Datadog.Trace.Configuration.ImmutableIntegrationSettingsCollection Integrations { get; }
         public bool KafkaCreateConsumerScopeEnabled { get; }
         public bool LogsInjectionEnabled { get; }

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tests
             {
                 PartialFlushEnabled = partialFlush,
                 PartialFlushMinSpans = 5
-            });
+            }.Build());
 
             var traceContext = new TraceContext(tracer.Object);
 
@@ -125,7 +125,7 @@ namespace Datadog.Trace.Tests
             {
                 PartialFlushEnabled = true,
                 PartialFlushMinSpans = partialFlushThreshold
-            });
+            }.Build());
 
             ArraySegment<Span>? spans = null;
 
@@ -175,7 +175,7 @@ namespace Datadog.Trace.Tests
             {
                 PartialFlushEnabled = true,
                 PartialFlushMinSpans = partialFlushThreshold
-            });
+            }.Build());
 
             ArraySegment<Span>? spans = null;
 

--- a/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerSettingsTests.cs
@@ -112,8 +112,7 @@ namespace Datadog.Trace.Tests
         [InlineData("", new string[0])]
         public void ParseStringArraySplit(string input, string[] expected)
         {
-            var tracerSettings = new TracerSettings();
-            var result = tracerSettings.TrimSplitString(input, ',').ToArray();
+            var result = TracerSettings.TrimSplitString(input, ',').ToArray();
             Assert.Equal(expected: expected, actual: result);
         }
 
@@ -125,9 +124,7 @@ namespace Datadog.Trace.Tests
         [InlineData("400-403, 500-501-234, s342, 500-503", "400,401,402,403,500,501,502,503")]
         public void ParseHttpCodes(string original, string expected)
         {
-            var tracerSettings = new TracerSettings();
-
-            bool[] errorStatusCodesArray = tracerSettings.ParseHttpCodesToArray(original);
+            bool[] errorStatusCodesArray = TracerSettings.ParseHttpCodesToArray(original);
             string[] expectedKeysArray = expected.Split(new[] { ',' }, System.StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var value in expectedKeysArray)


### PR DESCRIPTION
Changing `TracerSettings` after they've been passed to a Tracer instance is not valid and could lead to unpredictable results. To try and emphasise that, this adds a new `ImmutableTracerSettings` type, that does not allow changing any properties.

For backwards compatibility, I've kept the `TracerSettings` object as not-obsolete, as the de-facto "builder" for `ImmutableTracerSettings`. This has other benefits 

* Avoids the need to use a base class or / interface to maintain backwards compat
* Avoids having to duplicate initialization code
* Avoids the need for a dedicated "builder" type for the immutable settings (we can't use `init set;` properties because of missing references unfortunately)

@DataDog/apm-dotnet