### PR TITLE
Treat release/ branches as the "main" branch

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -72,7 +72,7 @@ variables:
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts
   ddApiKey: $(DD_API_KEY)
-  isMainBranch: $[eq(variables['Build.SourceBranch'], 'refs/heads/master')]
+  isMainBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages


### PR DESCRIPTION
This ensures we run the full test suite etc on merges to release/2.0 and release/1.x

Same PR as #1962, but merging into master instead of release/2.0 

@DataDog/apm-dotnet