### PR TITLE
[2.0] - Native stats fixes

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/stats.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/stats.h
@@ -25,7 +25,9 @@ public:
     }
     void Refresh()
     {
-        auto increment = (std::chrono::steady_clock::now() - _startTime).count();
+        auto now = std::chrono::steady_clock::now();
+        auto increment = (now - _startTime).count();
+        _startTime = now;
         _value->fetch_add(increment);
     }
 };


### PR DESCRIPTION
Fixes an issue that can crash the application if `SWStats::ToString()` is called more than once.



@DataDog/apm-dotnet