### PR TITLE
[2.0] - Adds a simple agent port checker on CI Visibility scenarios.

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Standalone.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Standalone.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Version>1.29.0</Version>
     <Title>Datadog APM Auto-instrumentation Runner</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64</RuntimeIdentifiers>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>NU5100</NoWarn>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Standalone.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.Standalone.csproj
@@ -5,7 +5,7 @@
     <Title>Datadog APM Auto-instrumentation Runner</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64</RuntimeIdentifiers>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NoWarn>NU5100</NoWarn>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -124,6 +124,12 @@ namespace Datadog.Trace.Tools.Runner
                 string cmdLine = string.Join(' ', args);
                 if (!string.IsNullOrWhiteSpace(cmdLine))
                 {
+                    // CI Visibility mode is enabled we check if we have connection to the agent before running the process.
+                    if (options.EnableCIVisibilityMode && !Utils.CheckAgentConnection(options.AgentUrl))
+                    {
+                        return 1;
+                    }
+
                     Console.WriteLine("Running: " + cmdLine);
 
                     ProcessStartInfo processInfo = Utils.GetProcessStartInfo(args[0], Environment.CurrentDirectory, profilerEnvironmentVariables);

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -125,7 +125,7 @@ namespace Datadog.Trace.Tools.Runner
                 if (!string.IsNullOrWhiteSpace(cmdLine))
                 {
                     // CI Visibility mode is enabled we check if we have connection to the agent before running the process.
-                    if (options.EnableCIVisibilityMode && !Utils.CheckAgentConnection(options.AgentUrl))
+                    if (options.EnableCIVisibilityMode && !Utils.CheckAgentConnectionAsync(options.AgentUrl).GetAwaiter().GetResult())
                     {
                         return 1;
                     }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -300,11 +300,7 @@ namespace Datadog.Trace.Tools.Runner
 
             try
             {
-                if (await agentWriter.Ping().ConfigureAwait(false))
-                {
-                    Console.WriteLine($"Connection with the Datadog Agent at {tracerSettings.AgentUri} was successful.");
-                }
-                else
+                if (!await agentWriter.Ping().ConfigureAwait(false))
                 {
                     Console.WriteLine($"Error connecting to the Datadog Agent at {tracerSettings.AgentUri}.");
                     return false;


### PR DESCRIPTION
A recurring issue on CI Visibility support tickets are related to the test process not being able to connect to the datadog agent in CI Sass providers, failing silently with no spans showing in the UI.

This PR adds a simple tcp port checker before running the test runner only on CI Visibility scenarios, notifying the user when the tracer is not able to reach the agent.

@DataDog/apm-dotnet