### PR TITLE
[2.0] Mark deprecated settings obsolete

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+
 namespace Datadog.Trace.Configuration
 {
     /// <summary>
@@ -153,6 +155,7 @@ namespace Datadog.Trace.Configuration
         /// Configuration key for enabling or disabling default Analytics.
         /// </summary>
         /// <seealso cref="TracerSettings.AnalyticsEnabled"/>
+        [Obsolete(DeprecationMessages.AppAnalytics)]
         public const string GlobalAnalyticsEnabled = "DD_TRACE_ANALYTICS_ENABLED";
 
         /// <summary>
@@ -382,11 +385,13 @@ namespace Datadog.Trace.Configuration
             /// <summary>
             /// Configuration key pattern for enabling or disabling Analytics in an integration.
             /// </summary>
+            [Obsolete(DeprecationMessages.AppAnalytics)]
             public const string AnalyticsEnabled = "DD_TRACE_{0}_ANALYTICS_ENABLED";
 
             /// <summary>
             /// Configuration key pattern for setting Analytics sampling rate in an integration.
             /// </summary>
+            [Obsolete(DeprecationMessages.AppAnalytics)]
             public const string AnalyticsSampleRate = "DD_TRACE_{0}_ANALYTICS_SAMPLE_RATE";
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -279,6 +279,7 @@ namespace Datadog.Trace.Configuration
         /// This also determines the output folder of the .NET Tracer managed log files.
         /// Overridden by <see cref="LogDirectory"/> if present.
         /// </summary>
+        [Obsolete(DeprecationMessages.LogPath)]
         public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/DeprecationMessages.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DeprecationMessages.cs
@@ -1,0 +1,12 @@
+﻿// <copyright file="DeprecationMessages.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Configuration
+{
+    internal static class DeprecationMessages
+    {
+        public const string AppAnalytics = "App Analytics has been replaced by Tracing without Limits. For more information see https://docs.datadoghq.com/tracing/legacy_app_analytics/";
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/DeprecationMessages.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DeprecationMessages.cs
@@ -8,5 +8,6 @@ namespace Datadog.Trace.Configuration
     internal static class DeprecationMessages
     {
         public const string AppAnalytics = "App Analytics has been replaced by Tracing without Limits. For more information see https://docs.datadoghq.com/tracing/legacy_app_analytics/";
+        public const string LogPath = "DD_TRACE_LOG_PATH is deprecated. Use DD_TRACE_LOG_DIRECTORY instead";
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -29,6 +29,7 @@ namespace Datadog.Trace.Configuration
             Enabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.Enabled, integrationName)) ??
                       source.GetBool(string.Format("DD_{0}_ENABLED", integrationName));
 
+#pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabled = source.GetBool(string.Format(ConfigurationKeys.Integrations.AnalyticsEnabled, integrationName)) ??
                                source.GetBool(string.Format("DD_{0}_ANALYTICS_ENABLED", integrationName));
 
@@ -36,6 +37,7 @@ namespace Datadog.Trace.Configuration
                                   source.GetDouble(string.Format("DD_{0}_ANALYTICS_SAMPLE_RATE", integrationName)) ??
                                   // default value
                                   1.0;
+#pragma warning restore 618
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -118,9 +118,11 @@ namespace Datadog.Trace.Configuration
                 AgentUri = builder.Uri;
             }
 
+#pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabled = source?.GetBool(ConfigurationKeys.GlobalAnalyticsEnabled) ??
                                // default value
                                false;
+#pragma warning restore 618
 
             LogsInjectionEnabled = source?.GetBool(ConfigurationKeys.LogsInjectionEnabled) ??
                                    // default value
@@ -305,6 +307,7 @@ namespace Datadog.Trace.Configuration
         /// See the documentation for more details.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.GlobalAnalyticsEnabled"/>
+        [Obsolete(DeprecationMessages.AppAnalytics)]
         public bool AnalyticsEnabled { get; set; }
 
         /// <summary>
@@ -554,6 +557,7 @@ namespace Datadog.Trace.Configuration
             return false;
         }
 
+        [Obsolete(DeprecationMessages.AppAnalytics)]
         internal double? GetIntegrationAnalyticsSampleRate(IntegrationInfo integration, bool enabledWithGlobalSetting)
         {
             var integrationSettings = Integrations[integration];

--- a/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -171,7 +171,9 @@ namespace Datadog.Trace.Logging
             string logDirectory = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.LogDirectory);
             if (logDirectory == null)
             {
+#pragma warning disable 618 // ProfilerLogPath is deprecated but still supported
                 var nativeLogFile = EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilerLogPath);
+#pragma warning restore 618
 
                 if (!string.IsNullOrEmpty(nativeLogFile))
                 {

--- a/tracer/src/Datadog.Trace/Tagging/InstrumentationTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/InstrumentationTags.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 
@@ -26,7 +27,9 @@ namespace Datadog.Trace.Tagging
         {
             if (settings != null)
             {
+#pragma warning disable 618 // App analytics is deprecated, but still used
                 AnalyticsSampleRate = settings.GetIntegrationAnalyticsSampleRate(integration, enabledWithGlobalSetting);
+#pragma warning restore 618
             }
         }
 

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -534,8 +534,10 @@ namespace Datadog.Trace
                     writer.WritePropertyName("health_checks_enabled");
                     writer.WriteValue(Settings.TracerMetricsEnabled);
 
+#pragma warning disable 618 // App analytics is deprecated, but still used
                     writer.WritePropertyName("analytics_enabled");
                     writer.WriteValue(Settings.AnalyticsEnabled);
+#pragma warning restore 618
 
                     writer.WritePropertyName("sample_rate");
                     writer.WriteValue(Settings.GlobalSamplingRate);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -58,7 +58,9 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.DisabledIntegrationNames.Count), 0 };
             yield return new object[] { CreateFunc(s => s.LogsInjectionEnabled), false };
             yield return new object[] { CreateFunc(s => s.GlobalTags.Count), 0 };
+#pragma warning disable 618 // App analytics is deprecated but supported
             yield return new object[] { CreateFunc(s => s.AnalyticsEnabled), false };
+#pragma warning restore 618
             yield return new object[] { CreateFunc(s => s.CustomSamplingRules), null };
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
             yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
@@ -89,8 +91,10 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { "DD_TRACE_GLOBAL_TAGS", "k1:v1, k2:v2", CreateFunc(s => s.GlobalTags), TagsK1V1K2V2 };
             yield return new object[] { ConfigurationKeys.GlobalTags, "k1:v1,k1:v2", CreateFunc(s => s.GlobalTags.Count), 1 };
 
+#pragma warning disable 618 // App Analytics is deprecated but still supported
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "true", CreateFunc(s => s.AnalyticsEnabled), true };
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "false", CreateFunc(s => s.AnalyticsEnabled), false };
+#pragma warning restore 618
 
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:Content-Type,header3: Content-Type ,header4:C!!!ont_____ent----tYp!/!e,header5:Some.Header,header6:9invalidtagname,:invalidtagonly,validheaderonly:,validheaderwithoutcolon,:", CreateFunc(s => s.HeaderTags), HeaderTagsWithOptionalMappings };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:tag1", CreateFunc(s => s.HeaderTags), HeaderTagsSameTag };

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_net4.verified.txt
@@ -37,6 +37,8 @@ namespace Datadog.Trace.Configuration
         public const string DogStatsDPath = "DD_DOGSTATSD_PATH";
         public const string DogStatsdPort = "DD_DOGSTATSD_PORT";
         public const string Environment = "DD_ENV";
+        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public const string GlobalAnalyticsEnabled = "DD_TRACE_ANALYTICS_ENABLED";
         public const string GlobalSamplingRate = "DD_TRACE_SAMPLE_RATE";
         public const string GlobalTags = "DD_TAGS";
@@ -53,6 +55,7 @@ namespace Datadog.Trace.Configuration
         public const string MetricsPipeName = "DD_DOGSTATSD_PIPE_NAME";
         public const string PartialFlushEnabled = "DD_TRACE_PARTIAL_FLUSH_ENABLED";
         public const string PartialFlushMinSpans = "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS";
+        [System.Obsolete("DD_TRACE_LOG_PATH is deprecated. Use DD_TRACE_LOG_DIRECTORY instead")]
         public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
         public const string RuntimeMetricsEnabled = "DD_RUNTIME_METRICS_ENABLED";
         public const string SerializationBatchInterval = "DD_TRACE_BATCH_INTERVAL";
@@ -70,7 +73,11 @@ namespace Datadog.Trace.Configuration
         public const string TracesTransport = "DD_TRACE_TRANSPORT";
         public static class Integrations
         {
+            [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+                "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
             public const string AnalyticsEnabled = "DD_TRACE_{0}_ANALYTICS_ENABLED";
+            [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+                "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
             public const string AnalyticsSampleRate = "DD_TRACE_{0}_ANALYTICS_SAMPLE_RATE";
             public const string Enabled = "DD_TRACE_{0}_ENABLED";
         }
@@ -142,6 +149,8 @@ namespace Datadog.Trace.Configuration
         public TracerSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
         public System.Collections.Generic.HashSet<string> AdoNetExcludedTypes { get; set; }
         public System.Uri AgentUri { get; set; }
+        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public bool AnalyticsEnabled { get; set; }
         public string CustomSamplingRules { get; set; }
         [System.Obsolete]

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged_netcoreapp.verified.txt
@@ -74,6 +74,8 @@ namespace Datadog.Trace.Configuration
         public const string DogStatsDPath = "DD_DOGSTATSD_PATH";
         public const string DogStatsdPort = "DD_DOGSTATSD_PORT";
         public const string Environment = "DD_ENV";
+        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public const string GlobalAnalyticsEnabled = "DD_TRACE_ANALYTICS_ENABLED";
         public const string GlobalSamplingRate = "DD_TRACE_SAMPLE_RATE";
         public const string GlobalTags = "DD_TAGS";
@@ -90,6 +92,7 @@ namespace Datadog.Trace.Configuration
         public const string MetricsPipeName = "DD_DOGSTATSD_PIPE_NAME";
         public const string PartialFlushEnabled = "DD_TRACE_PARTIAL_FLUSH_ENABLED";
         public const string PartialFlushMinSpans = "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS";
+        [System.Obsolete("DD_TRACE_LOG_PATH is deprecated. Use DD_TRACE_LOG_DIRECTORY instead")]
         public const string ProfilerLogPath = "DD_TRACE_LOG_PATH";
         public const string RuntimeMetricsEnabled = "DD_RUNTIME_METRICS_ENABLED";
         public const string SerializationBatchInterval = "DD_TRACE_BATCH_INTERVAL";
@@ -107,7 +110,11 @@ namespace Datadog.Trace.Configuration
         public const string TracesTransport = "DD_TRACE_TRANSPORT";
         public static class Integrations
         {
+            [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+                "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
             public const string AnalyticsEnabled = "DD_TRACE_{0}_ANALYTICS_ENABLED";
+            [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+                "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
             public const string AnalyticsSampleRate = "DD_TRACE_{0}_ANALYTICS_SAMPLE_RATE";
             public const string Enabled = "DD_TRACE_{0}_ENABLED";
         }
@@ -179,6 +186,8 @@ namespace Datadog.Trace.Configuration
         public TracerSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
         public System.Collections.Generic.HashSet<string> AdoNetExcludedTypes { get; set; }
         public System.Uri AgentUri { get; set; }
+        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
+            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public bool AnalyticsEnabled { get; set; }
         public string CustomSamplingRules { get; set; }
         [System.Obsolete]


### PR DESCRIPTION
As per the docs, [App Analytics is deprecated](https://docs.datadoghq.com/tracing/legacy_app_analytics/) so we should mark those configuration keys as deprecated.

Also marks `DD_TRACE_LOG_PATH` as deprecated

@DataDog/apm-dotnet