### PR TITLE
fold `IntegrationIds.ElasticsearchNet5` into `ElasticsearchNet`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V5/ElasticsearchV5Constants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V5/ElasticsearchV5Constants.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V5
         internal const string ElasticsearchAssemblyName = "Elasticsearch.Net";
         internal const string RequestPipelineTypeName = "Elasticsearch.Net.RequestPipeline";
 
-        internal const string IntegrationName = nameof(IntegrationIds.ElasticsearchNet5);
+        internal const string IntegrationName = nameof(IntegrationIds.ElasticsearchNet);
         internal static readonly IntegrationInfo IntegrationId = IntegrationRegistry.GetIntegrationInfo(IntegrationName);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationIds.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationIds.cs
@@ -23,8 +23,7 @@ namespace Datadog.Trace.Configuration
         MsTestV2,
         Wcf,
         WebRequest,
-        ElasticsearchNet5,
-        ElasticsearchNet, // NOTE: keep this name without the 6 to avoid breaking changes
+        ElasticsearchNet,
         ServiceStackRedis,
         StackExchangeRedis,
         ServiceRemoting,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -140,6 +141,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
             }
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "ArmUnsupported")]
+        public void IntegrationDisabled()
+        {
+            int agentPort = TcpPortProvider.GetOpenPort();
+            string packageVersion = PackageVersions.ElasticSearch5.First()[0] as string;
+
+            SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationIds.ElasticsearchNet)}_ENABLED", "false");
+
+            using var agent = new MockTracerAgent(agentPort);
+            using var process = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion);
+            var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
+
+            Assert.Empty(spans);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -148,6 +149,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
             }
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "ArmUnsupported")]
+        public void IntegrationDisabled()
+        {
+            int agentPort = TcpPortProvider.GetOpenPort();
+            string packageVersion = PackageVersions.ElasticSearch6.First()[0] as string;
+
+            SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationIds.ElasticsearchNet)}_ENABLED", "false");
+
+            using var agent = new MockTracerAgent(agentPort);
+            using var process = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion);
+            var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
+
+            Assert.Empty(spans);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -146,6 +147,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateSpans(spans, (span) => span.Resource, expected);
             }
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "ArmUnsupported")]
+        public void IntegrationDisabled()
+        {
+            int agentPort = TcpPortProvider.GetOpenPort();
+            string packageVersion = PackageVersions.ElasticSearch7.First()[0] as string;
+
+            SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationIds.ElasticsearchNet)}_ENABLED", "false");
+
+            using var agent = new MockTracerAgent(agentPort);
+            using var process = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion);
+            var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
+
+            Assert.Empty(spans);
         }
     }
 }


### PR DESCRIPTION
Remove `IntegrationIds.ElasticsearchNet5` and replace uses with `ElasticsearchNet`. This way we have a single setting for users to configure the Elasticsearch.NET integration regardless of client version:

```
DD_TRACE_ElasticsearchNet_ENABLED=false
```

```csharp
tracerSettings.Integrations["ElasticsearchNet"].Enabled = false;
```

Notes
- `ElasticsearchNet` already covered Elasticsearch.NET versions 6 and 7, now it will include 5 as well
- The `IntegrationIds` enum is `internal`, but this is a breaking change for users for Elasticsearch.NET who are using integration configuration because it changes the integration name, so we're targeting Tracer 2.0

TODO:
- [x] tests