### PR TITLE
Use anyCPU on Mac as well for target: CompileRegressionDependencyLibs

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -735,7 +735,7 @@ partial class Build
         .Executes(() =>
         {
             // We run linux integration tests in AnyCPU, but Windows on the specific architecture
-            var platform = IsLinux ? MSBuildTargetPlatform.MSIL : TargetPlatform;
+            var platform = !IsWin ? MSBuildTargetPlatform.MSIL : TargetPlatform;
 
             DotNetMSBuild(x => x
                 .SetTargetPath(MsBuildProject)


### PR DESCRIPTION
Use anyCPU on Mac as well for target: CompileRegressionDependencyLibs


@DataDog/apm-dotnet