### PR TITLE
Stop writing warning to log about ServiceFabric if we're not running in ServiceFabric

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -142,9 +142,10 @@ namespace Datadog.Trace.ClrProfiler
             }
 
             // we only support Service Fabric Service Remoting instrumentation on .NET Core (including .NET 5+)
-            if (string.Equals(FrameworkDescription.Instance.Name, ".NET Core", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(FrameworkDescription.Instance.Name, ".NET", StringComparison.OrdinalIgnoreCase))
+            if (FrameworkDescription.Instance.IsCoreClr())
             {
+                Log.Information("Initializing ServiceFabric instrumentation");
+
                 try
                 {
                     ServiceRemotingClient.StartTracing();

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ServiceFabric.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ServiceFabric.cs
@@ -21,5 +21,7 @@ namespace Datadog.Trace.PlatformHelpers
         public static readonly string NodeId = EnvironmentHelpers.GetEnvironmentVariable("Fabric_NodeId");
 
         public static readonly string NodeName = EnvironmentHelpers.GetEnvironmentVariable("Fabric_NodeName");
+
+        public static bool IsRunningInServiceFabric() => ApplicationName is not null;
     }
 }

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
@@ -32,6 +32,7 @@ namespace Datadog.Trace.ServiceFabric
                     {
                         Log.Warning("Could not get type {typeName}.", typeName);
                     }
+
                     return false;
                 }
 
@@ -43,6 +44,7 @@ namespace Datadog.Trace.ServiceFabric
                     {
                         Log.Warning("Could not get event {eventName}.", fullEventName);
                     }
+
                     return false;
                 }
 

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
@@ -28,7 +28,10 @@ namespace Datadog.Trace.ServiceFabric
 
                 if (type == null)
                 {
-                    Log.Warning("Could not get type {typeName}.", typeName);
+                    if (PlatformHelpers.ServiceFabric.IsRunningInServiceFabric())
+                    {
+                        Log.Warning("Could not get type {typeName}.", typeName);
+                    }
                     return false;
                 }
 
@@ -36,7 +39,10 @@ namespace Datadog.Trace.ServiceFabric
 
                 if (eventInfo == null)
                 {
-                    Log.Warning("Could not get event {eventName}.", fullEventName);
+                    if (PlatformHelpers.ServiceFabric.IsRunningInServiceFabric())
+                    {
+                        Log.Warning("Could not get event {eventName}.", fullEventName);
+                    }
                     return false;
                 }
 


### PR DESCRIPTION
Currently we always write two Warning level logs on app-startup.

```log
2021-11-05 14:27:52.716 +00:00 [WRN] Could not get type Microsoft.ServiceFabric.Services.Remoting.V2.Client.ServiceRemotingClientEvents.
2021-11-05 14:27:52.716 +00:00 [WRN] Could not get type Microsoft.ServiceFabric.Services.Remoting.V2.Runtime.ServiceRemotingServiceEvents.
```

Originally I was going to just remove the logging, but there doesn't seem any point in doing service fabric setup if we're not in service fabric? It's easy to detect based on the presence of environment variables: https://docs.microsoft.com/en-us/azure/service-fabric/service-fabric-environment-variables-reference.

If we don't detect that environment variable, we can skip trying to initialize the service remoting client and service entirely, as we know we aren't running in Service Fabric.

Other minor changes:
- Switched to using the existing `IsCoreClrHelper()` to detect running on netcoreapp.
- Add an info-level log, to differentiate between "successful" and "skipped" ServiceFabric initialization when running in service fabric 

@DataDog/apm-dotnet