### PR TITLE
Improves DomainMetadata class

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -31,6 +31,7 @@ namespace Datadog.Trace.Configuration
         public const int DefaultAgentPort = 8126;
 
         private int _partialFlushMinSpans;
+        private DomainMetadata _domainMetadata;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
@@ -217,6 +218,10 @@ namespace Datadog.Trace.Configuration
 
             DelayWcfInstrumentationEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
                                             ?? false;
+
+            // we cached the static instance here, because is being used in the hotpath
+            // by IsIntegrationEnabled method (called from all integrations)
+            _domainMetadata = DomainMetadata.Instance;
         }
 
         /// <summary>
@@ -544,7 +549,7 @@ namespace Datadog.Trace.Configuration
 
         internal bool IsIntegrationEnabled(IntegrationInfo integration, bool defaultValue = true)
         {
-            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
+            if (TraceEnabled && !_domainMetadata.ShouldAvoidAppDomain())
             {
                 return Integrations[integration].Enabled ?? defaultValue;
             }
@@ -554,7 +559,7 @@ namespace Datadog.Trace.Configuration
 
         internal bool IsIntegrationEnabled(string integrationName)
         {
-            if (TraceEnabled && !DomainMetadata.ShouldAvoidAppDomain())
+            if (TraceEnabled && !_domainMetadata.ShouldAvoidAppDomain())
             {
                 bool? enabled = Integrations[integrationName].Enabled;
                 return enabled != false;

--- a/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/DatadogLogging.cs
@@ -67,8 +67,10 @@ namespace Datadog.Trace.Logging
                     return;
                 }
 
+                var domainMetadata = DomainMetadata.Instance;
+
                 // Ends in a dash because of the date postfix
-                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-managed-{DomainMetadata.ProcessName}-.log");
+                var managedLogPath = Path.Combine(logDirectory, $"dotnet-tracer-managed-{domainMetadata.ProcessName}-.log");
 
                 var loggerConfiguration =
                     new LoggerConfiguration()
@@ -84,9 +86,9 @@ namespace Datadog.Trace.Logging
 
                 try
                 {
-                    loggerConfiguration.Enrich.WithProperty("MachineName", DomainMetadata.MachineName);
-                    loggerConfiguration.Enrich.WithProperty("Process", $"[{DomainMetadata.ProcessId} {DomainMetadata.ProcessName}]");
-                    loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{DomainMetadata.AppDomainId} {DomainMetadata.AppDomainName}]");
+                    loggerConfiguration.Enrich.WithProperty("MachineName", domainMetadata.MachineName);
+                    loggerConfiguration.Enrich.WithProperty("Process", $"[{domainMetadata.ProcessId} {domainMetadata.ProcessName}]");
+                    loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{domainMetadata.AppDomainId} {domainMetadata.AppDomainName}]");
 #if NETCOREAPP
                     loggerConfiguration.Enrich.WithProperty("AssemblyLoadContext", System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(DatadogLogging).Assembly).Name);
 #endif

--- a/tracer/src/Datadog.Trace/TracingProcessManager.cs
+++ b/tracer/src/Datadog.Trace/TracingProcessManager.cs
@@ -65,9 +65,9 @@ namespace Datadog.Trace
                     return;
                 }
 
-                if (DomainMetadata.ShouldAvoidAppDomain())
+                if (DomainMetadata.Instance.ShouldAvoidAppDomain())
                 {
-                    Log.Information("Skipping process manager initialization for AppDomain: {AppDomain}", DomainMetadata.AppDomainName);
+                    Log.Information("Skipping process manager initialization for AppDomain: {AppDomain}", DomainMetadata.Instance.AppDomainName);
                     return;
                 }
 
@@ -77,7 +77,7 @@ namespace Datadog.Trace
                     return;
                 }
 
-                Log.Debug("Starting child processes from process {ProcessName}, AppDomain {AppDomain}.", DomainMetadata.ProcessName, DomainMetadata.AppDomainName);
+                Log.Debug("Starting child processes from process {ProcessName}, AppDomain {AppDomain}.", DomainMetadata.Instance.ProcessName, DomainMetadata.Instance.AppDomainName);
                 StartProcesses();
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Util/DomainMetadata.cs
+++ b/tracer/src/Datadog.Trace/Util/DomainMetadata.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.Util
     /// </summary>
     internal class DomainMetadata
     {
-        private static readonly Lazy<DomainMetadata> _instance = new(isThreadSafe: true);
+        private static readonly Lazy<DomainMetadata> _instance = new(() => new DomainMetadata(), isThreadSafe: true);
 
         private string _currentProcessName;
         private string _currentProcessMachineName;

--- a/tracer/test/Datadog.Trace.Tests/Util/DomainMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/DomainMetadataTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tests.Util
         {
             static void AppDomainCallback()
             {
-                var result = DomainMetadata.ShouldAvoidAppDomain();
+                var result = DomainMetadata.Instance.ShouldAvoidAppDomain();
                 AppDomain.CurrentDomain.SetData(TestDataKey, result);
             }
 


### PR DESCRIPTION
This PR optimize the DomainMetadata class, by:

1. Pre caching values in the ctor. (There’s no AppDomain in .NET Core so these values are not expected to change)
2. Removal of Try/Catch block in getter. (Try/catch blocks prevents inlining of a methods)

Both changes improves the codegen for this class and enables inlining.

@DataDog/apm-dotnet