### PR TITLE
Use sensible default service name in AAS (Functions & WebApps)

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -53,6 +53,11 @@ namespace Datadog.Trace.Configuration
                           // backwards compatibility for names used in the past
                           source?.GetString("DD_SERVICE_NAME");
 
+            if (AzureAppServices.Metadata.IsRelevant)
+            {
+                ServiceName = ServiceName ?? AzureAppServices.Metadata.SiteName;
+            }
+
             ServiceVersion = source?.GetString(ConfigurationKeys.ServiceVersion);
 
             TraceEnabled = source?.GetBool(ConfigurationKeys.TraceEnabled) ??

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -53,11 +53,6 @@ namespace Datadog.Trace.Configuration
                           // backwards compatibility for names used in the past
                           source?.GetString("DD_SERVICE_NAME");
 
-            if (AzureAppServices.Metadata.IsRelevant)
-            {
-                ServiceName = ServiceName ?? AzureAppServices.Metadata.SiteName;
-            }
-
             ServiceVersion = source?.GetString(ConfigurationKeys.ServiceVersion);
 
             TraceEnabled = source?.GetBool(ConfigurationKeys.TraceEnabled) ??

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -647,6 +647,11 @@ namespace Datadog.Trace
             {
                 try
                 {
+                    if (AzureAppServices.Metadata.IsRelevant)
+                    {
+                        return AzureAppServices.Metadata.SiteName;
+                    }
+
                     if (TryLoadAspNetSiteName(out var siteName))
                     {
                         return siteName;


### PR DESCRIPTION
Fixes missing service names in AAS (Web Apps and Functions) when `DD_SERVICE` is not set

Before change:
![image](https://user-images.githubusercontent.com/1801443/140815417-af64ed15-db2a-4889-aab6-8af148e5bd7e.png)

After change:
![image](https://user-images.githubusercontent.com/1801443/140815876-f85e8333-b231-4d3f-a255-0da3f0d40059.png)


@DataDog/apm-dotnet