### PR TITLE
[2.0] Update GitLab build to use .NET 6 SDK

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - binary_build
   
 variables:
-  DATADOG_AGENT_WINBUILDIMAGES: v5782992-59363bf
+  DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
     
 driver_build:
   only:


### PR DESCRIPTION
Updates the GitLab build to use the build image defined in https://github.com/DataDog/datadog-agent-buildimages/pull/179

TODO:
 - [x] Confirm the GitLab build passes 

@DataDog/apm-dotnet