### PR TITLE
[2.0] Add .NET 6 WebApplicationBuilder tests

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -430,6 +430,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MySqlConnector", "tracer\test\test-applications\integrations\Samples.MySqlConnector\Samples.MySqlConnector.csproj", "{73252693-2563-4B20-A2F5-F8DB37B91DBE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNetCoreMinimalApis", "tracer\test\test-applications\integrations\Samples.AspNetCoreMinimalApis\Samples.AspNetCoreMinimalApis.csproj", "{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{24d3e547-8897-4111-baa2-b92f50cc13d4}*SharedItemsImports = 5
@@ -1832,6 +1834,16 @@ Global
 		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Release|x64.Build.0 = Release|x64
 		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Release|x86.ActiveCfg = Release|x86
 		{73252693-2563-4B20-A2F5-F8DB37B91DBE}.Release|x86.Build.0 = Release|x86
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|x64.ActiveCfg = Debug|x64
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|x64.Build.0 = Debug|x64
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|x86.ActiveCfg = Debug|x86
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|x86.Build.0 = Debug|x86
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|x64.ActiveCfg = Release|x64
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|x64.Build.0 = Release|x64
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|x86.ActiveCfg = Release|x86
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|x86.Build.0 = Release|x86
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|Any CPU.ActiveCfg = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1981,6 +1993,7 @@ Global
 		{5A806F4B-39E7-4F38-B36F-F5CFC4F8760A} = {9518425A-36A5-4B8F-B0B8-6137DB88441D}
 		{7DFDD339-30C5-4C1D-AB07-F9106256AF77} = {933F1D4B-1216-4BC1-956E-8C30818BAA0F}
 		{73252693-2563-4B20-A2F5-F8DB37B91DBE} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -299,6 +299,8 @@ services:
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
+      - Verify_DisableClipboard=true
+      - DiffEngine_Disabled=true
       - MONGO_HOST=mongo
       - SERVICESTACK_REDIS_HOST=servicestackredis:6379
       - STACKEXCHANGE_REDIS_HOST=stackexchangeredis:6379
@@ -371,7 +373,9 @@ services:
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-debian}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
-      - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
+      - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}0
+      - Verify_DisableClipboard=true
+      - DiffEngine_Disabled=true
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - MONGO_HOST=mongo_arm64
       - SERVICESTACK_REDIS_HOST=servicestackredis_arm64:6379

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1081,6 +1081,7 @@ partial class Build
                         "Samples.AspNetCoreMvc21" => Framework == TargetFramework.NETCOREAPP2_1,
                         "Samples.AspNetCoreMvc30" => Framework == TargetFramework.NETCOREAPP3_0,
                         "Samples.AspNetCoreMvc31" => Framework == TargetFramework.NETCOREAPP3_1,
+                        "Samples.AspNetCoreMinimalApis" => Framework == TargetFramework.NET6_0,
                         "Samples.AspNetCore2" => Framework == TargetFramework.NETCOREAPP2_1,
                         "Samples.AspNetCore5" => Framework == TargetFramework.NET6_0 || Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NETCOREAPP3_0,
                         "Samples.GraphQL4" => Framework == TargetFramework.NETCOREAPP3_1 || Framework == TargetFramework.NET5_0 || Framework == TargetFramework.NET6_0,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
@@ -1,0 +1,89 @@
+// <copyright file="AspNetCoreIisMinimalApisTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    [Collection("IisTests")]
+    public class AspNetCoreIisMinimalApisTestsInProcess : AspNetCoreIisMinimalApisTests
+    {
+        public AspNetCoreIisMinimalApisTestsInProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMinimalApisTestsInProcessWithFeatureFlag : AspNetCoreIisMinimalApisTests
+    {
+        public AspNetCoreIisMinimalApisTestsInProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: true, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMinimalApisTestsOutOfProcess : AspNetCoreIisMinimalApisTests
+    {
+        public AspNetCoreIisMinimalApisTestsOutOfProcess(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    [Collection("IisTests")]
+    public class AspNetCoreIisMinimalApisTestsOutOfProcessWithFeatureFlag : AspNetCoreIisMinimalApisTests
+    {
+        public AspNetCoreIisMinimalApisTestsOutOfProcessWithFeatureFlag(IisFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, inProcess: false, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreIisMinimalApisTests : AspNetCoreIisMvcTestBase
+    {
+        private readonly IisFixture _iisFixture;
+        private readonly string _testName;
+
+        protected AspNetCoreIisMinimalApisTests(IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMinimalApis", fixture, output, inProcess, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName(nameof(AspNetCoreIisMinimalApisTests));
+            _iisFixture = fixture;
+            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("Category", "LinuxUnsupported")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            // We actually sometimes expect 2, but waiting for 1 is good enough
+            var spans = await GetWebServerSpans(path, _iisFixture.Agent, _iisFixture.HttpPort, statusCode, expectedSpanCount: 1);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreMinimalApisTests.cs
@@ -1,0 +1,66 @@
+// <copyright file="AspNetCoreMinimalApisTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET6_0_OR_GREATER
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+using System.Net;
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
+{
+    public class AspNetCoreMinimalApisTestsCallTarget : AspNetCoreMinimalApisTests
+    {
+        public AspNetCoreMinimalApisTestsCallTarget(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableRouteTemplateResourceNames: false)
+        {
+        }
+    }
+
+    public class AspNetCoreMinimalApisTestsCallTargetWithFeatureFlag : AspNetCoreMinimalApisTests
+    {
+        public AspNetCoreMinimalApisTestsCallTargetWithFeatureFlag(AspNetCoreTestFixture fixture, ITestOutputHelper output)
+            : base(fixture, output, enableRouteTemplateResourceNames: true)
+        {
+        }
+    }
+
+    public abstract class AspNetCoreMinimalApisTests : AspNetCoreMvcTestBase
+    {
+        private readonly string _testName;
+
+        protected AspNetCoreMinimalApisTests(AspNetCoreTestFixture fixture, ITestOutputHelper output, bool enableRouteTemplateResourceNames)
+            : base("AspNetCoreMinimalApis", fixture, output, enableRouteTemplateResourceNames)
+        {
+            _testName = GetTestName(nameof(AspNetCoreMinimalApisTests));
+        }
+
+        [SkippableTheory]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        [MemberData(nameof(Data))]
+        public async Task MeetsAllAspNetCoreMvcExpectations(string path, HttpStatusCode statusCode)
+        {
+            await Fixture.TryStartApp(this);
+
+            var spans = await Fixture.WaitForSpans(path);
+
+            var sanitisedPath = VerifyHelper.SanitisePathsForVerify(path);
+
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedPath, (int)statusCode);
+
+            // Overriding the type name here as we have multiple test classes in the file
+            // Ensures that we get nice file nesting in Solution Explorer
+            await Verifier.Verify(spans, settings)
+                          .UseMethodName("_")
+                          .UseTypeName(_testName);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/ErrorHandlingHelper.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/ErrorHandlingHelper.cs
@@ -5,10 +5,12 @@
 
 #if !NETFRAMEWORK
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
 #pragma warning disable SA1402 // File may only contain a single class
@@ -88,6 +90,38 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             return app;
         }
 
+        public static void AddErrorHandlerInline(IApplicationBuilder app, string path)
+        {
+            if (path.StartsWith(CustomHandlerPrefix))
+            {
+                app.UsePathBase(CustomHandlerPrefix);
+                app.UseExceptionHandler(new ExceptionHandlerOptions { ExceptionHandler = CustomHandler });
+            }
+            else if (path.StartsWith(ReExecuteHandlerPrefix))
+            {
+                app.UsePathBase(ReExecuteHandlerPrefix);
+                app.UseExceptionHandler("/");
+            }
+            else if (path.StartsWith(StatusCodeReExecutePrefix))
+            {
+                app.UsePathBase(StatusCodeReExecutePrefix);
+                app.UseStatusCodePagesWithReExecute("/");
+            }
+            else if (path.StartsWith(ExceptionPagePrefix))
+            {
+                app.UsePathBase(ExceptionPagePrefix);
+                // developer exception page added by default in .NET 6
+            }
+        }
+
+        public static PathBaseCorrectorStartupFilter GetStartupFilter(string path)
+        {
+            return new[] { CustomHandlerPrefix, ReExecuteHandlerPrefix, StatusCodeReExecutePrefix, ExceptionPagePrefix }
+                  .Where(x => path.StartsWith(x))
+                  .Select(x => new PathBaseCorrectorStartupFilter(x))
+                  .FirstOrDefault();
+        }
+
         private static IApplicationBuilder Apply(
             this IApplicationBuilder app,
             Action<IApplicationBuilder> configure)
@@ -107,6 +141,25 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
 
             context.Response.StatusCode = 500;
             await context.Response.WriteAsync("An error occured in the app");
+        }
+
+        public class PathBaseCorrectorStartupFilter : IStartupFilter
+        {
+            private readonly string _pathBase;
+
+            public PathBaseCorrectorStartupFilter(string pathBase)
+            {
+                _pathBase = pathBase;
+            }
+
+            public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+            {
+                return app =>
+                {
+                    app.UsePathBase(_pathBase);
+                    next(app);
+                };
+            }
         }
     }
 }

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/?,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: HTTP: GET /api/delay/{seconds},
+      aspnet_core.route: /api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.InProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/?,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,29 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: HTTP: GET /api/delay/{seconds},
+      aspnet_core.route: /api/delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,27 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,48 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreIisMinimalApisTests.OutOfProcess.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,50 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET Home/Index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/?,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,35 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,31 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.NoFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET status-code/{statusCode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=__statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=__statusCode=200.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: index,
+      aspnet_core.controller: home,
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /home/index,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Index (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: {controller=home}/{action=index}/{id?},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_api_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,33 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /api/delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: HTTP: GET /api/delay/{seconds},
+      aspnet_core.route: /api/delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/api/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_bad-request_statusCode=500.verified.txt
@@ -1,0 +1,56 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: throwexception,
+      aspnet_core.controller: home,
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /bad-request,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: bad-request,
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: This was a bad request.,
+      error.stack: 
+System.Exception: This was a bad request.
+at Samples.AspNetCoreMvc.Controllers.HomeController.ThrowException(),
+      error.type: System.Exception,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.status_code: 500,
+      http.url: http://localhost:00000/bad-request,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_not-found_statusCode=404.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/branch/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_branch_ping_statusCode=200.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /branch/ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/branch/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_delay_0_statusCode=200.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: delay,
+      aspnet_core.controller: home,
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /delay/{seconds},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.Delay (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: delay/{seconds},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/delay/0,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_not-found_statusCode=404.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_not-found_statusCode=404.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /not-found,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 404,
+      http.url: http://localhost:00000/not-found,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_ping_statusCode=200.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_ping_statusCode=200.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /ping,
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 200,
+      http.url: http://localhost:00000/ping,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_203_statusCode=203.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 203,
+      http.url: http://localhost:00000/status-code/203,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_402_statusCode=402.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 402.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 402,
+      http.url: http://localhost:00000/status-code/402,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
+++ b/tracer/test/snapshots/AspNetCoreMinimalApisTests.WithFF.__path=_status-code_500_statusCode=500.verified.txt
@@ -1,0 +1,54 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.action: statuscodetest,
+      aspnet_core.controller: home,
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core.request,
+    Resource: GET /status-code/{statuscode},
+    Service: Samples.AspNetCoreMinimalApis,
+    Type: web,
+    Error: 1,
+    Tags: {
+      aspnet_core.endpoint: Samples.AspNetCoreMvc.Controllers.HomeController.StatusCodeTest (Samples.AspNetCoreMinimalApis),
+      aspnet_core.route: status-code/{statuscode},
+      component: aspnet_core,
+      datadog-header-tag: asp-net-core,
+      env: integration_tests,
+      error.msg: The HTTP response has status code 500.,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.sample_correlation_identifier: 0000-0000-0000,
+      http.response.headers.server: Kestrel,
+      http.status_code: 500,
+      http.url: http://localhost:00000/status-code/500,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      version: 1.0.0
+    },
+    Metrics: {
+      _sampling_priority_v1: 1.0,
+      _dd.tracer_kr: 1.0,
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Program.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Samples.AspNetCoreMvc.Shared;
+using static Microsoft.AspNetCore.Http.Results;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddControllersWithViews();
+var app = builder.Build();
+
+app.UseMiddleware<PingMiddleware>();
+
+app.MapControllerRoute("default", "{controller=Home}/{action=Index}/{id?}");
+app.Map("/branch", x => x.UseMiddleware<PingMiddleware>());
+
+app.Map("/shutdown", x =>
+{
+    x.Run(async context =>
+    {
+        var hostApplicationLifetime = context.RequestServices.GetRequiredService<IHostApplicationLifetime>();
+        await context.Response.WriteAsync("Shutting down");
+        _ = Task.Run(() => hostApplicationLifetime.StopApplication());
+    });
+});
+
+app.MapGet("/api/delay/{seconds}", (int seconds, HttpContext context) =>
+{
+    Thread.Sleep(TimeSpan.FromSeconds(seconds));
+    AddCorrelationIdentifierToResponse(context);
+    return Ok(seconds);
+});
+app.MapGet("/api/delay-async/{seconds}", async (int seconds, HttpContext context) =>
+{
+    await Task.Delay(TimeSpan.FromSeconds(seconds));
+    AddCorrelationIdentifierToResponse(context);
+    return Ok(seconds);
+});
+
+app.Run();
+
+void AddCorrelationIdentifierToResponse(HttpContext context)
+{
+    const string CorrelationIdentifierHeaderName = "sample.correlation.identifier";
+
+    if (context.Request.Headers.ContainsKey(CorrelationIdentifierHeaderName))
+    {
+        context.Response.Headers.Add(CorrelationIdentifierHeaderName, context.Request.Headers[CorrelationIdentifierHeaderName]);
+    }
+}

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+﻿{
+  "profiles": {
+    "Samples.AspNetCoreMinimalApis": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7205;http://localhost:5071",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Samples.AspNetCoreMinimalApis.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/Samples.AspNetCoreMinimalApis.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Samples.AspNetCoreMvc21\Controllers\**\HomeController.cs" Link="Controllers\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Compile Include="..\Samples.AspNetCoreMvc21\Shared\**\*.*" Link="Shared\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Content Include="..\Samples.AspNetCoreMvc21\Views\**\*.*" Link="Views\%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\Samples.AspNetCoreMvc21\web.config" Link="web.config" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+</Project>

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/appsettings.json
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Add integration tests for .NET 6's new `WebApplication` and `WebApplicationBuilder` hosting mechanism. 

> This requires the fixes in #2012.

Note that the minimal API `NoFF /api/delay/0` tests have a different resource name than the equivalent ApiController version:  `GET /api/delay/?` instead of `GET api/delay/{seconds}`. This is because we don't run the endpoint routing events when the FF is disabled, so we end up using the "default" resource names, which don't include the route templates. This is fine I think, esp as the FF is on by default now

The most annoying thing here is [how `WebApplication` adds an implicit `UseRouting()` call at the start of the pipeline](https://andrewlock.net/exploring-dotnet-6-part-4-building-a-middleware-pipeline-with-webapplication/) (before our existing middleware). That messes up the `UseMultipleErrorHandlerPipelines()` helper we had for testing multiple types of pipeline re-execution.

The upshot is that to handle the same paths, we need to build the pipeline in slightly different ways. This is "fine", just a bit annoying. I couldn't see a good alternative way around it, other than separating the executions to entirely different apps (but didn't want to do that large a refactor here)

@DataDog/apm-dotnet