### PR TITLE
Don't push artifacts to AWS/Azure unless on main/master

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -72,7 +72,8 @@ variables:
   monitoringHome: $(System.DefaultWorkingDirectory)/shared/bin/monitoring-home
   artifacts: $(System.DefaultWorkingDirectory)/tracer/src/bin/artifacts
   ddApiKey: $(DD_API_KEY)
-  isMainBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
+  isMainBranch: $[in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main')]
+  isMainOrReleaseBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
@@ -666,7 +667,7 @@ stages:
 
     variables:
       TestAllPackageVersions: true
-      IncludeMinorPackageVersions:  $[or(eq(variables.isMainBranch, 'true'), eq(variables.perform_comprehensive_testing, 'true'))]
+      IncludeMinorPackageVersions:  $[or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.perform_comprehensive_testing, 'true'))]
 
     pool:
       vmImage: ubuntu-18.04
@@ -750,7 +751,7 @@ stages:
     - job: Test
       variables:
         TestAllPackageVersions: true
-        IncludeMinorPackageVersions:  $[or(eq(variables.isMainBranch, 'true'), eq(variables.perform_comprehensive_testing, 'true'))]
+        IncludeMinorPackageVersions:  $[or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.perform_comprehensive_testing, 'true'))]
         publishTargetFramework: net5.0
         baseImage: debian
       workspace:


### PR DESCRIPTION
In #1962 and #1963, we recently updated the isMainBranch variable to treat `release/*` branches as "main". This was so that we run the "full" integration tests suite on merges to release branches.

However, this change meant we also started pushing those assets to Azure and AWS, meaning the assets there are a mix of both `release/2.0` bits and `master` bits. This makes some of the other automation problematic, so we should revert to only pushing those bits if we're on `master`.


@DataDog/apm-dotnet