### PR TITLE
[2.0] Rename ReplaceGlobalSettings() -> Configure()

### DIFF
--- a/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.OpenTracing
                 configuration.ServiceName = defaultServiceName;
             }
 
-            Tracer.ReplaceGlobalSettings(configuration);
+            Tracer.Configure(configuration);
             return new OpenTracingTracer(Tracer.Instance);
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
                         tracerSettings.ServiceName = "crank";
                     }
 
-                    Tracer.ReplaceGlobalSettings(tracerSettings);
+                    Tracer.Configure(tracerSettings);
                     Tracer tracer = Tracer.Instance;
 
                     foreach (var jobItem in result.JobResults.Jobs)

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -60,11 +60,11 @@ namespace Datadog.Trace
         /// </param>
         [Obsolete("This API is deprecated, as it replaces the global settings for all Tracer instances in the application. " +
                   "If you were using this API to configure the global Tracer.Instance in code, use the static "
-                + nameof(Tracer) + "." + nameof(ReplaceGlobalSettings) + "() to replace the global Tracer settings for the application")]
+                + nameof(Tracer) + "." + nameof(Configure) + "() to replace the global Tracer settings for the application")]
         public Tracer(TracerSettings settings)
         {
             // TODO: Switch to immutable settings
-            ReplaceGlobalSettings(settings);
+            Configure(settings);
 
             // update the count of Tracer instances
             Interlocked.Increment(ref _liveTracerCount);
@@ -127,7 +127,7 @@ namespace Datadog.Trace
             }
 
             // TODO: Make this API internal
-            [Obsolete("Use " + nameof(Tracer) + "." + nameof(ReplaceGlobalSettings) + " to configure the global Tracer" +
+            [Obsolete("Use " + nameof(Tracer) + "." + nameof(Configure) + " to configure the global Tracer" +
                       " instance in code.")]
             set
             {
@@ -183,7 +183,7 @@ namespace Datadog.Trace
         /// </summary>
         /// <param name="settings"> A <see cref="TracerSettings"/> instance with the desired settings,
         /// or null to use the default configuration sources. This is used to configure global settings</param>
-        public static void ReplaceGlobalSettings(TracerSettings settings)
+        public static void Configure(TracerSettings settings)
         {
             // TODO: Switch to immutable settings
             TracerManager.ReplaceGlobalManager(settings, TracerManagerFactory.Instance);

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -298,20 +298,19 @@ namespace Datadog.Trace
         [System.Obsolete("This API is deprecated. Use Tracer.Instance to obtain a Tracer instance to create" +
             " spans.")]
         public Tracer() { }
-        [System.Obsolete(@"This API is deprecated, as it replaces the global settings for all Tracer instances in the application. If you were using this API to configure the global Tracer.Instance in code, use the static Tracer.ReplaceGlobalSettings() to replace the global Tracer settings for the application")]
+        [System.Obsolete(@"This API is deprecated, as it replaces the global settings for all Tracer instances in the application. If you were using this API to configure the global Tracer.Instance in code, use the static Tracer.Configure() to replace the global Tracer settings for the application")]
         public Tracer(Datadog.Trace.Configuration.TracerSettings settings) { }
         public Datadog.Trace.Scope ActiveScope { get; }
         public string DefaultServiceName { get; }
         public Datadog.Trace.Configuration.TracerSettings Settings { get; }
-        [set: System.Obsolete("Use Tracer.ReplaceGlobalSettings to configure the global Tracer instance in code." +
-            "")]
+        [set: System.Obsolete("Use Tracer.Configure to configure the global Tracer instance in code.")]
         public static Datadog.Trace.Tracer Instance { get; set; }
         public Datadog.Trace.Scope ActivateSpan(Datadog.Trace.Span span, bool finishOnClose = true) { }
         protected override void Finalize() { }
         public System.Threading.Tasks.Task ForceFlushAsync() { }
         public Datadog.Trace.Scope StartActive(string operationName, Datadog.Trace.ISpanContext parent = null, string serviceName = null, System.DateTimeOffset? startTime = default, bool ignoreActiveScope = false, bool finishOnClose = true) { }
         public Datadog.Trace.Span StartSpan(string operationName, Datadog.Trace.ISpanContext parent = null, string serviceName = null, System.DateTimeOffset? startTime = default, bool ignoreActiveScope = false) { }
-        public static void ReplaceGlobalSettings(Datadog.Trace.Configuration.TracerSettings settings) { }
+        public static void Configure(Datadog.Trace.Configuration.TracerSettings settings) { }
     }
 }
 namespace Datadog.Trace.ExtensionMethods

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Tests
                     StartupDiagnosticLogEnabled = false,
                     GlobalTags = new Dictionary<string, string> { { "test-tag", "original-value" } },
                 };
-                Tracer.ReplaceGlobalSettings(oldSettings);
+                Tracer.Configure(oldSettings);
 
                 var span = Tracer.Instance.StartActive("Test span");
 
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Tests
                     GlobalTags = new Dictionary<string, string> { { "test-tag", "new-value" } },
                 };
 
-                Tracer.ReplaceGlobalSettings(newSettings);
+                Tracer.Configure(newSettings);
 
                 span.Dispose();
 

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -40,7 +40,7 @@ namespace PluginApplication
             var settings = TracerSettings.FromDefaultSources();
             settings.Environment ??= "dev"; // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when Environment=null
             settings.ServiceVersion ??= "1.0.0"; // Ensure that we have an env value. In CI, this will automatically be assigned. Later we can test that everything is fine when when ServiceVersion=null
-            Tracer.ReplaceGlobalSettings(settings);
+            Tracer.Configure(settings);
 
             try
             {

--- a/tracer/test/test-applications/regression/DataDogThreadTest/Program.cs
+++ b/tracer/test/test-applications/regression/DataDogThreadTest/Program.cs
@@ -25,7 +25,7 @@ namespace DataDogThreadTest
                 var ddTraceSettings = TracerSettings.FromDefaultSources();
                 ddTraceSettings.LogsInjectionEnabled = true;
                 ddTraceSettings.TraceEnabled = true;
-                Tracer.ReplaceGlobalSettings(ddTraceSettings);
+                Tracer.Configure(ddTraceSettings);
                 var tracer = Tracer.Instance;
 
                 var totalIterations = 10_000;

--- a/tracer/test/test-applications/regression/TraceContext.InvalidOperationException/Program.cs
+++ b/tracer/test/test-applications/regression/TraceContext.InvalidOperationException/Program.cs
@@ -25,7 +25,7 @@ namespace TraceContext.InvalidOperationException
                 var ddTraceSettings = TracerSettings.FromDefaultSources();
                 ddTraceSettings.LogsInjectionEnabled = true;
                 ddTraceSettings.TraceEnabled = true;
-                Tracer.ReplaceGlobalSettings(ddTraceSettings);
+                Tracer.Configure(ddTraceSettings);
                 var tracer = Tracer.Instance;
 
                 var totalIterations = 400_000;


### PR DESCRIPTION
Follow up from https://github.com/DataDog/dd-trace-dotnet/pull/1990 after [I was defeated](https://github.com/DataDog/dd-trace-dotnet/pull/1990#discussion_r745485061) with the naming decision

@DataDog/apm-dotnet