### PR TITLE
[2.0] Various small DiagnosticObserver optimisations

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -29,13 +29,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         public static CallTargetState OnFunctionMiddlewareBegin<TTarget>(TTarget instance, HttpContext httpContext)
         {
             var tracer = Tracer.Instance;
-            var security = Security.Instance;
 
-            var scope = AspNetCoreRequestHandler.StartAspNetCorePipelineScope(tracer, security, httpContext);
-
-            if (scope != null)
+            if (tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
-                return new CallTargetState(scope);
+                var scope = AspNetCoreRequestHandler.StartAspNetCorePipelineScope(tracer, httpContext, httpContext.Request, resourceName: null);
+
+                if (scope != null)
+                {
+                    return new CallTargetState(scope);
+                }
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -455,8 +455,7 @@ namespace Datadog.Trace.DiagnosticListeners
             if (isFirstExecution)
             {
                 trackingFeature.IsFirstPipelineExecution = false;
-                var url = httpContext.Request.GetUrl();
-                if (!string.Equals(url, parentTags.HttpUrl))
+                if (!trackingFeature.MatchesOriginalPath(httpContext.Request))
                 {
                     // URL has changed from original, so treat this execution as a "subsequent" request
                     // Typically occurs for 404s for example
@@ -606,8 +605,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     trackingFeature.IsUsingEndpointRouting = true;
                     trackingFeature.IsFirstPipelineExecution = false;
 
-                    var url = httpContext.Request.GetUrl();
-                    if (!string.Equals(url, trackingFeature.OriginalPath))
+                    if (!trackingFeature.MatchesOriginalPath(httpContext.Request))
                     {
                         // URL has changed from original, so treat this execution as a "subsequent" request
                         // Typically occurs for 404s for example

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -43,7 +43,6 @@ namespace Datadog.Trace.DiagnosticListeners
         private const string DiagnosticListenerName = "Microsoft.AspNetCore";
         private const string HttpRequestInOperationName = "aspnet_core.request";
         private const string MvcOperationName = "aspnet_core_mvc.request";
-        private const string NoHostSpecified = "UNKNOWN_HOST";
 
         private static readonly int PrefixLength = "Microsoft.AspNetCore.".Length;
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -292,16 +292,13 @@ namespace Datadog.Trace.DiagnosticListeners
             {
                 foreach (var part in pathSegment.DuckCast<RoutePatternPathSegmentStruct>().Parts)
                 {
-                    if (DuckType.CanCreate<RoutePatternContentPartStruct>(part))
+                    if (part.TryDuckCast(out RoutePatternContentPartStruct contentPart))
                     {
-                        var contentPart = part.DuckCast<RoutePatternContentPartStruct>();
                         sb.Append('/');
                         sb.Append(contentPart.Content);
                     }
-                    else if (DuckType.CanCreate<RoutePatternParameterPartStruct>(part))
+                    else if (part.TryDuckCast(out RoutePatternParameterPartStruct parameter))
                     {
-                        var parameter = part.DuckCast<RoutePatternParameterPartStruct>();
-
                         var parameterName = parameter.Name;
                         if (parameterName.Equals("area", StringComparison.OrdinalIgnoreCase))
                         {

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -626,7 +626,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
                 RouteEndpoint? endpoint = null;
 
-                if (rawEndpointFeature.TryDuckCast<IEndpointFeature>(out var endpointFeatureInterface))
+                if (rawEndpointFeature.TryDuckCast<EndpointFeatureProxy>(out var endpointFeatureInterface))
                 {
                     endpoint = endpointFeatureInterface.GetEndpoint();
                 }
@@ -854,7 +854,7 @@ namespace Datadog.Trace.DiagnosticListeners
         /// <summary>
         /// Proxy for ducktyping IEndpointFeature when the interface is not implemented explicitly
         /// </summary>
-        /// <seealso cref="IEndpointFeature"/>
+        /// <seealso cref="EndpointFeatureProxy"/>
         [DuckCopy]
         public struct EndpointFeatureStruct
         {

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -440,7 +440,7 @@ namespace Datadog.Trace.DiagnosticListeners
         private static Span StartMvcCoreSpan(Tracer tracer, Span parentSpan, BeforeActionStruct typedArg, HttpContext httpContext, HttpRequest request)
         {
             // Create a child span for the MVC action
-            var mvcSpanTags = new AspNetCoreEndpointTags();
+            var mvcSpanTags = new AspNetCoreMvcTags();
             var mvcScope = tracer.StartActiveWithTags(MvcOperationName, parentSpan.Context, tags: mvcSpanTags);
             var span = mvcScope.Span;
             span.Type = SpanTypes.Web;

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -513,7 +513,7 @@ namespace Datadog.Trace.DiagnosticListeners
                         controllerName: controllerName,
                         actionName: actionName);
 
-                    resourceName = $"{trackingFeature.HttpMethod} {request.PathBase}{resourcePathName}";
+                    resourceName = $"{trackingFeature.HttpMethod} {request.PathBase.Value}{resourcePathName}";
                     aspNetRoute = routeTemplate?.TemplateText.ToLowerInvariant();
                 }
             }

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/EndpointFeatureProxy.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/EndpointFeatureProxy.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IEndpointFeature.cs" company="Datadog">
+﻿// <copyright file="EndpointFeatureProxy.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -15,12 +15,13 @@ namespace Datadog.Trace.DiagnosticListeners
     /// </summary>
     [Browsable(false)]
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public interface IEndpointFeature
+    public class EndpointFeatureProxy
     {
         /// <summary>
         /// Delegates to IEndpointFeature.Endpoint;
         /// </summary>
+        /// <returns>The <see cref="RouteEndpoint"/> proxy</returns>
         [Duck(Name = "Microsoft.AspNetCore.Http.Features.IEndpointFeature.get_Endpoint")]
-        RouteEndpoint GetEndpoint();
+        public virtual RouteEndpoint GetEndpoint() => default;
     }
 }

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -110,12 +110,7 @@ namespace Datadog.Trace.PlatformHelpers
 
             if (tracer.Settings.RouteTemplateResourceNamesEnabled)
             {
-                httpContext.Features.Set(new RequestTrackingFeature
-                {
-                    HttpMethod = httpMethod,
-                    OriginalUrl = url,
-                });
-
+                httpContext.Features.Set(new RequestTrackingFeature());
                 tags = new AspNetCoreEndpointTags();
             }
             else
@@ -191,16 +186,6 @@ namespace Datadog.Trace.PlatformHelpers
             /// Gets or sets a value indicating the resource name as calculated by the endpoint routing(if available)
             /// </summary>
             public string ResourceName { get; set; }
-
-            /// <summary>
-            /// Gets or sets the HTTP method, as it requires normalization, so avoids repeatedly calculations
-            /// </summary>
-            public string HttpMethod { get; set; }
-
-            /// <summary>
-            /// Gets or Sets the original URL received by the pipeline
-            /// </summary>
-            public string OriginalUrl { get; set; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tagging/AspNetCoreEndpointTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AspNetCoreEndpointTags.cs
@@ -10,23 +10,7 @@ namespace Datadog.Trace.Tagging
     internal class AspNetCoreEndpointTags : AspNetCoreTags
     {
         private static readonly IProperty<string>[] AspNetCoreEndpointTagsProperties =
-            AspNetCoreTagsProperties.Concat(
-                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreRoute, t => t.AspNetCoreRoute, (t, v) => t.AspNetCoreRoute = v),
-                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreArea, t => t.AspNetCoreArea, (t, v) => t.AspNetCoreArea = v),
-                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreController, t => t.AspNetCoreController, (t, v) => t.AspNetCoreController = v),
-                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreEndpoint, t => t.AspNetCoreEndpoint, (t, v) => t.AspNetCoreEndpoint = v),
-                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCorePage, t => t.AspNetCorePage, (t, v) => t.AspNetCorePage = v),
-                new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreAction, t => t.AspNetCoreAction, (t, v) => t.AspNetCoreAction = v));
-
-        public string AspNetCoreRoute { get; set; }
-
-        public string AspNetCoreController { get; set; }
-
-        public string AspNetCoreAction { get; set; }
-
-        public string AspNetCoreArea { get; set; }
-
-        public string AspNetCorePage { get; set; }
+            AspNetCoreTagsProperties.Concat(new Property<AspNetCoreEndpointTags, string>(Trace.Tags.AspNetCoreEndpoint, t => t.AspNetCoreEndpoint, (t, v) => t.AspNetCoreEndpoint = v));
 
         public string AspNetCoreEndpoint { get; set; }
 

--- a/tracer/src/Datadog.Trace/Tagging/AspNetCoreMvcTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AspNetCoreMvcTags.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="AspNetCoreMvcTags.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.ExtensionMethods;
+
+namespace Datadog.Trace.Tagging
+{
+    internal class AspNetCoreMvcTags : AspNetCoreTags
+    {
+        private static readonly IProperty<string>[] AspNetCoreEndpointTagsProperties =
+            AspNetCoreTagsProperties.Concat(
+                new Property<AspNetCoreMvcTags, string>(Trace.Tags.AspNetCoreArea, t => t.AspNetCoreArea, (t, v) => t.AspNetCoreArea = v),
+                new Property<AspNetCoreMvcTags, string>(Trace.Tags.AspNetCoreController, t => t.AspNetCoreController, (t, v) => t.AspNetCoreController = v),
+                new Property<AspNetCoreMvcTags, string>(Trace.Tags.AspNetCorePage, t => t.AspNetCorePage, (t, v) => t.AspNetCorePage = v),
+                new Property<AspNetCoreMvcTags, string>(Trace.Tags.AspNetCoreAction, t => t.AspNetCoreAction, (t, v) => t.AspNetCoreAction = v));
+
+        public string AspNetCoreController { get; set; }
+
+        public string AspNetCoreAction { get; set; }
+
+        public string AspNetCoreArea { get; set; }
+
+        public string AspNetCorePage { get; set; }
+
+        protected override IProperty<string>[] GetAdditionalTags() => AspNetCoreEndpointTagsProperties;
+    }
+}

--- a/tracer/src/Datadog.Trace/Tagging/AspNetCoreTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AspNetCoreTags.cs
@@ -11,11 +11,14 @@ namespace Datadog.Trace.Tagging
     {
         private protected static readonly IProperty<string>[] AspNetCoreTagsProperties =
             WebTagsProperties.Concat(
-                new ReadOnlyProperty<AspNetCoreTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName));
+                new ReadOnlyProperty<AspNetCoreTags, string>(Trace.Tags.InstrumentationName, t => t.InstrumentationName),
+                new Property<AspNetCoreTags, string>(Trace.Tags.AspNetCoreRoute, t => t.AspNetCoreRoute, (t, v) => t.AspNetCoreRoute = v));
 
         private const string ComponentName = "aspnet_core";
 
         public string InstrumentationName => ComponentName;
+
+        public string AspNetCoreRoute { get; set; }
 
         protected override IProperty<string>[] GetAdditionalTags() => AspNetCoreTagsProperties;
     }

--- a/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -82,12 +82,15 @@ namespace Datadog.Trace.Tests.DiagnosticListeners
             Assert.Equal("aspnet_core.request", span.OperationName);
             Assert.Equal("aspnet_core", span.GetTag(Tags.InstrumentationName));
             Assert.Equal(SpanTypes.Web, span.Type);
-            Assert.Equal("GET /home/?/action", span.ResourceName);
             Assert.Equal(SpanKinds.Server, span.GetTag(Tags.SpanKind));
             Assert.Equal("GET", span.GetTag(Tags.HttpMethod));
             Assert.Equal("localhost", span.GetTag(Tags.HttpRequestHeadersHost));
             Assert.Equal("http://localhost/home/1/action", span.GetTag(Tags.HttpUrl));
             Assert.Equal(TracerConstants.Language, span.GetTag(Tags.Language));
+
+            // Resource isn't populated until request end
+            observer.OnNext(new KeyValuePair<string, object>("Microsoft.AspNetCore.Hosting.HttpRequestIn.Stop", context));
+            Assert.Equal("GET /home/?/action", span.ResourceName);
         }
 
         private static Tracer GetTracer()

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AspNetCoreHttpRequestHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AspNetCoreHttpRequestHandlerTests.cs
@@ -1,0 +1,69 @@
+﻿// <copyright file="AspNetCoreHttpRequestHandlerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETFRAMEWORK
+using Datadog.Trace.PlatformHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Internal;
+using Xunit;
+
+namespace Datadog.Trace.Tests.PlatformHelpers
+{
+    public class AspNetCoreHttpRequestHandlerTests
+    {
+        public const string OriginalPath = "/somepath/Home/Index";
+
+        [Theory]
+        [InlineData(null, "/somepath/Home/Index")]
+        [InlineData("", "/somepath/Home/Index")]
+        [InlineData("", "/somepath/home/index")]
+        [InlineData("/somepath", "/home/index")]
+        [InlineData("/somePath", "/home/index")]
+        [InlineData("/somepath/home", "/index")]
+        [InlineData("/somepath/Home", "/index")]
+        [InlineData("/somepath/home", "/Index")]
+        [InlineData("/somepath/home/index", "")]
+        [InlineData("/somepath/home/Index", "")]
+        [InlineData("/somepath/home/Index", null)]
+        public void MatchesUrl(string pathBase, string path)
+        {
+            var feature = new AspNetCoreHttpRequestHandler.RequestTrackingFeature(new PathString(OriginalPath));
+
+            var request = new DefaultHttpRequest(new DefaultHttpContext())
+            {
+                PathBase = new PathString(pathBase),
+                Path = new PathString(path),
+            };
+
+            feature.MatchesOriginalPath(request).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(null, "/somepath/Home/Index/Tada")]
+        [InlineData("", "/somepath/Home/Index/Tada")]
+        [InlineData("", "/somepath/home/")]
+        [InlineData("/NOPEpath", "/home/index")]
+        [InlineData("/somePath", "/homeyindex")]
+        [InlineData("/somepath/home", "/")]
+        [InlineData("/somepath/Home", "/Nope")]
+        [InlineData("/somepath/home/Nope", "")]
+        [InlineData("/somepath/homeIndeed", "")]
+        [InlineData("/somepath/homeIndeed", null)]
+        public void DoesNotMatchDifferentUrl(string pathBase, string path)
+        {
+            var feature = new AspNetCoreHttpRequestHandler.RequestTrackingFeature(new PathString(OriginalPath));
+
+            var request = new DefaultHttpRequest(new DefaultHttpContext())
+            {
+                PathBase = new PathString(pathBase),
+                Path = new PathString(path),
+            };
+
+            feature.MatchesOriginalPath(request).Should().BeFalse();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
A bunch of small optimisations:
- Use virtual class for duck typing instead of interface
- Avoid `string.Format()` by using `PathBase.Value`
- Avoid recalculating url multiple times per request
- Only calculate "default" obfuscated URL on request end, as normally discarded
- Use `TryDuckCast` instead of `CanCreate` + `DuckCast`

Throughput tests only show a small (~3%) improvement from these, but it's better than nothing

@DataDog/apm-dotnet