### PR TITLE
[2.0] Use buster-based debian for building

### DIFF
--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -1,13 +1,26 @@
+# We used a fixed, older version of debian for linking reasons
+FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim as base
 ARG DOTNETSDK_VERSION
-# debian 10 image
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-bullseye-slim as base
-# ubuntu image
-# FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-focal
+
+# Based on https://github.com/dotnet/dotnet-docker/blob/34c81d5f9c8d56b36cc89da61702ccecbf00f249/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
+# and https://github.com/dotnet/dotnet-docker/blob/1eab4cad6e2d42308bd93d3f0cc1f7511ac75882/src/sdk/5.0/buster-slim/amd64/Dockerfile
+ENV \
+    # Unset ASPNETCORE_URLS from aspnet base image
+    ASPNETCORE_URLS= \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
+    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
+    NUGET_XMLDOC_MODE=skip
 
 RUN apt-get update \
     && apt-get -y upgrade \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing \
         git \
+        procps \
         wget \
         curl \
         cmake \
@@ -20,8 +33,17 @@ RUN apt-get update \
         ruby \
         ruby-dev \
         rubygems \
-    && gem install --no-document fpm
+    && gem install --no-document fpm \
+    && rm -rf /var/lib/apt/lists/*
 
+# Install the .NET SDK
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \
+    && chmod +x ./dotnet-install.sh \
+    && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
+    && rm ./dotnet-install.sh \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+# Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 ENV CXX=clang++
 ENV CC=clang

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -9,7 +9,7 @@ BUILD_DIR="$ROOT_DIR/tracer/build/_build"
 IMAGE_NAME="dd-trace-dotnet/debian-base"
 
 docker build \
-   --build-arg DOTNETSDK_VERSION=5.0.401 \
+   --build-arg DOTNETSDK_VERSION=6.0.100 \
    --tag $IMAGE_NAME \
    --file "$BUILD_DIR/docker/debian.dockerfile" \
    "$BUILD_DIR"


### PR DESCRIPTION
In #1885, when we updated to use the latest .NET SDK, we had to update out debian-based docker images to bullseye instead of buster, as that's the minimum version supported by the official .NET 6 docker images.

Unfortunately, this causes the shared `.so` library to link to a newer `glibc` verision (updated from 2.28-10 to 2.31-13). Using the shared library on an older image (e.g. running it on a buster-based image) would result in

` dotnet: symbol lookup error: /opt/datadog/Datadog.Trace.ClrProfiler.Native.so: undefined symbol: pthread_cond_clockwait`

As mentioned [here ](https://github.com/pypa/manylinux#docker-images):

> Building manylinux-compatible wheels is not trivial; as a general rule, binaries built on one Linux distro will only work on other Linux distros that are the same age or newer. Therefore, if we want to make binaries that run on most Linux distros, we have to use an old enough distro.

Consequently, in this PR we revert to using a buster-based image, as before, and installing the .NET 6 SDK manually. 


@DataDog/apm-dotnet