### PR TITLE
[2.0] Add Linux installer smoke tests

### DIFF
--- a/.azure-pipelines/steps/update-github-status-jobs.yml
+++ b/.azure-pipelines/steps/update-github-status-jobs.yml
@@ -8,7 +8,7 @@ jobs:
     pool:
       vmImage: windows-2019
     steps:
-    - template: install-dotnet.yml
+    - template: install-latest-dotnet-sdk.yml
     - script: tracer\build.cmd SendStatusUpdateToGitHub
       displayName: Set GitHub Status Pending
       condition: succeededOrFailed()
@@ -29,7 +29,7 @@ jobs:
       - ${{ job }}
     condition: succeeded()
     steps:
-    - template: install-dotnet.yml
+    - template: install-latest-dotnet-sdk.yml
     - script: tracer\build.cmd SendStatusUpdateToGitHub
       displayName: Set GitHub Status Failure
       condition: succeededOrFailed()
@@ -50,7 +50,7 @@ jobs:
           - ${{ job }}
     condition: not(succeeded())
     steps:
-      - template: install-dotnet.yml
+      - template: install-latest-dotnet-sdk.yml
       - script: tracer\build.cmd SendStatusUpdateToGitHub
         displayName: Set GitHub Status Failure
         condition: succeededOrFailed()

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1460,7 +1460,7 @@ stages:
           "net5.0 5.0-alpine3.13" \
           "netcoreapp3.1 3.1-alpine3.14" \
           "netcoreapp3.1 3.1-alpine3.13" \
-          "netcoreapp2.1 2.1-alpine3.11" \
+          "netcoreapp2.1 2.1-alpine3.12" \
         ; do fwAndImage=( $i )
           publishFramework="${fwAndImage[0]}";
           runtimeImageTag="${fwAndImage[1]}";

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1483,3 +1483,69 @@ stages:
 
     - script: docker run --rm dd-trace-dotnet/$(dockerTag)-smoke-test
       displayName: Test $(dockerTag) Docker image
+
+- stage: installer_smoke_tests_arm64
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  dependsOn: [build_arm64]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [linux]
+
+    - job: generator
+      pool:
+        vmImage: ubuntu-18.04
+      steps:
+        - checkout: none
+        - bash: |
+            matrix="{"
+            for i in \
+              "net6.0 6.0-bullseye-slim" \
+              "net5.0 5.0-bullseye-slim" \
+              "net5.0 5.0-buster-slim" \
+              "net5.0 5.0-focal" \
+            ; do fwAndImage=( $i )
+              publishFramework="${fwAndImage[0]}";
+              runtimeImageTag="${fwAndImage[1]}";
+              name="${runtimeImageTag//./_}"
+
+              matrix="${matrix} '${name}':"
+              matrix="${matrix} { 'installCmd': 'dpkg -i ./datadog-dotnet-apm_*_arm64.deb', "
+              matrix="${matrix} 'dockerTag': '${name}', "
+              matrix="${matrix} 'publishFramework': '${publishFramework}', "
+              matrix="${matrix} 'linuxArtifacts': 'linux-packages-arm64', "
+              matrix="${matrix} 'runtimeImage': 'mcr.microsoft.com/dotnet/aspnet:${runtimeImageTag}' },"
+            done;
+            matrix="${matrix::-1} }"
+            echo "##vso[task.setVariable variable=values;isOutput=true]${matrix}"
+          name: mtrx
+
+    - job: linux
+      dependsOn: [generator]
+      strategy:
+        matrix: $[ dependencies.generator.outputs['mtrx.values'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      pool:
+        name: Arm64
+
+      steps:
+        - task: DownloadPipelineArtifact@2
+          displayName: Download artifacts to smoke test directory
+          inputs:
+            artifact: $(linuxArtifacts)
+            path: $(smokeTestAppDir)/artifacts
+
+        - script: |
+            docker build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              --build-arg INSTALL_CMD="$(installCmd)" \
+              --tag dd-trace-dotnet/$(dockerTag)-smoke-test \
+              --file "$(System.DefaultWorkingDirectory)/tracer/build/_build/docker/smoke.dockerfile" \
+              "$(smokeTestAppDir)"
+          displayName: Build $(dockerTag) Docker image
+
+        - script: docker run --rm dd-trace-dotnet/$(dockerTag)-smoke-test
+          displayName: Test $(dockerTag) Docker image

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1392,3 +1392,94 @@ stages:
       inputs:
         targetType: 'inline'
         script: 'Start-Sleep -s 20'
+
+- stage: installer_smoke_tests
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  dependsOn: [build_linux]
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: [linux]
+
+  - job: generator
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+    - checkout: none
+    - bash: |
+        matrix="{"
+        for i in \
+          "net6.0 6.0-bullseye-slim" \
+          "net5.0 5.0-bullseye-slim" \
+          "net5.0 5.0-buster-slim" \
+          "net5.0 5.0-focal" \
+          "netcoreapp3.1 3.1-bullseye-slim" \
+          "netcoreapp3.1 3.1-buster-slim" \
+          "netcoreapp3.1 3.1-bionic" \
+          "netcoreapp2.1 2.1-bionic" \
+          "netcoreapp2.1 2.1-stretch-slim" \
+        ; do fwAndImage=( $i )
+          publishFramework="${fwAndImage[0]}";
+          runtimeImageTag="${fwAndImage[1]}";
+          name="${runtimeImageTag//./_}"
+
+          matrix="${matrix} '${name}':"
+          matrix="${matrix} { 'installCmd': 'dpkg -i ./datadog-dotnet-apm*_amd64.deb', "
+          matrix="${matrix} 'dockerTag': '${name}', "
+          matrix="${matrix} 'publishFramework': '${publishFramework}', "
+          matrix="${matrix} 'linuxArtifacts': 'linux-packages-debian', "
+          matrix="${matrix} 'runtimeImage': 'mcr.microsoft.com/dotnet/aspnet:${runtimeImageTag}' },"
+        done;
+
+        for i in \
+          "net6.0 6.0-alpine3.14" \
+          "net5.0 5.0-alpine3.14" \
+          "net5.0 5.0-alpine3.13" \
+          "netcoreapp3.1 3.1-alpine3.14" \
+          "netcoreapp3.1 3.1-alpine3.13" \
+          "netcoreapp2.1 2.1-alpine3.11" \
+        ; do fwAndImage=( $i )
+          publishFramework="${fwAndImage[0]}";
+          runtimeImageTag="${fwAndImage[1]}";
+          name="${runtimeImageTag//./_}"
+
+          matrix="${matrix} '${name}':"
+          matrix="${matrix} { 'installCmd': 'tar -C /opt/datadog -xzf ./datadog-dotnet-apm*-musl.tar.gz', "
+          matrix="${matrix} 'dockerTag': '${name}', "
+          matrix="${matrix} 'publishFramework': '${publishFramework}', "
+          matrix="${matrix} 'linuxArtifacts': 'linux-packages-alpine', "
+          matrix="${matrix} 'runtimeImage': 'mcr.microsoft.com/dotnet/aspnet:${runtimeImageTag}' },"
+        done;
+        matrix="${matrix::-1} }"
+        echo "##vso[task.setVariable variable=values;isOutput=true]${matrix}"
+      name: mtrx
+
+  - job: linux
+    dependsOn: [generator]
+    strategy:
+      matrix: $[ dependencies.generator.outputs['mtrx.values'] ]
+    variables:
+      smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+    pool:
+      vmImage: ubuntu-18.04
+
+    steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: Download artifacts to smoke test directory
+      inputs:
+        artifact: $(linuxArtifacts)
+        path: $(smokeTestAppDir)/artifacts
+
+    - script: |
+        docker build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg INSTALL_CMD="$(installCmd)" \
+          --tag dd-trace-dotnet/$(dockerTag)-smoke-test \
+          --file "$(System.DefaultWorkingDirectory)/tracer/build/_build/docker/smoke.dockerfile" \
+          "$(smokeTestAppDir)"
+      displayName: Build $(dockerTag) Docker image
+
+    - script: docker run --rm dd-trace-dotnet/$(dockerTag)-smoke-test
+      displayName: Test $(dockerTag) Docker image

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1432,6 +1432,29 @@ stages:
         done;
 
         for i in \
+          "net5.0 35-5.0" \
+          "netcoreapp3.1 35-3.1" \
+          "net6.0 34-6.0" \
+          "net5.0 34-5.0" \
+          "netcoreapp3.1 34-3.1" \
+          "net5.0 33-5.0" \
+          "netcoreapp3.1 33-3.1" \
+          "netcoreapp3.1 29-3.1" \
+          "netcoreapp2.1 29-2.1" \
+        ; do fwAndImage=( $i )
+          publishFramework="${fwAndImage[0]}";
+          runtimeImageTag="${fwAndImage[1]}";
+          name="${runtimeImageTag//./_}"
+
+          matrix="${matrix} 'fedora-${name}':"
+          matrix="${matrix} { 'installCmd': 'rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm', "
+          matrix="${matrix} 'dockerTag': '${name}', "
+          matrix="${matrix} 'publishFramework': '${publishFramework}', "
+          matrix="${matrix} 'linuxArtifacts': 'linux-packages-debian', "
+          matrix="${matrix} 'runtimeImage': 'andrewlock/dotnet-fedora:${runtimeImageTag}' },"
+        done;
+
+        for i in \
           "net6.0 6.0-alpine3.14" \
           "net5.0 5.0-alpine3.14" \
           "net5.0 5.0-alpine3.13" \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -473,6 +473,7 @@ stages:
     pool:
       vmImage: ubuntu-18.04
     steps:
+    - checkout: none
     - bash: |
         matrix="{"
         for framework in "net461" "netcoreapp2.1" "netcoreapp3.0" "netcoreapp3.1" "net5.0" "net6.0"; do
@@ -548,6 +549,7 @@ stages:
     pool:
       vmImage: ubuntu-18.04
     steps:
+      - checkout: none
       - bash: |
           matrix="{"
           for framework in "net461" "netcoreapp2.1" "netcoreapp3.0" "netcoreapp3.1" "net5.0" "net6.0"; do

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -432,6 +432,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MySqlConnector", "t
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNetCoreMinimalApis", "tracer\test\test-applications\integrations\Samples.AspNetCoreMinimalApis\Samples.AspNetCoreMinimalApis.csproj", "{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreSmokeTest", "tracer\test\test-applications\regression\AspNetCoreSmokeTest\AspNetCoreSmokeTest.csproj", "{BED94A61-6FD9-4103-BD35-70B4798C301C}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{24d3e547-8897-4111-baa2-b92f50cc13d4}*SharedItemsImports = 5
@@ -1844,6 +1846,18 @@ Global
 		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|x86.Build.0 = Release|x86
 		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}.Release|Any CPU.ActiveCfg = Release|x86
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|x64.Build.0 = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Debug|x86.Build.0 = Debug|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|x64.ActiveCfg = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|x64.Build.0 = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|x86.ActiveCfg = Release|Any CPU
+		{BED94A61-6FD9-4103-BD35-70B4798C301C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1994,6 +2008,7 @@ Global
 		{7DFDD339-30C5-4C1D-AB07-F9106256AF77} = {933F1D4B-1216-4BC1-956E-8C30818BAA0F}
 		{73252693-2563-4B20-A2F5-F8DB37B91DBE} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{BED94A61-6FD9-4103-BD35-70B4798C301C} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -1,0 +1,40 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-bullseye-slim as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY . .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+
+FROM $RUNTIME_IMAGE AS publish
+
+WORKDIR /app
+
+# Copy the installer files from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+COPY ./artifacts /app/install
+
+ARG INSTALL_CMD
+RUN mkdir -p /opt/datadog \
+    && mkdir -p /var/log/datadog \
+    && cd /app/install \
+    && $INSTALL_CMD \
+    && rm -rf /app/install
+
+# Set the required env vars
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
+ENV DD_INTEGRATIONS=/opt/datadog/integrations.json
+
+ENV ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/AspNetCoreSmokeTest.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;$(TargetFrameworks)</TargetFrameworks>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netcoreapp2'))">
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+  </ItemGroup>
+
+
+</Project>

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace AspNetCoreSmokeTest
+{
+    public class Program
+    {
+        public static volatile int ExitCode = 0;
+        public static async Task<int> Main(string[] args)
+        {
+            if (!IsProfilerAttached())
+            {
+                Console.WriteLine("Error: Profiler is required and is not loaded.");
+                return 1;
+            }
+
+            await CreateHostBuilder(args).Build().RunAsync();
+
+            return ExitCode;
+        }
+
+#if NETCOREAPP3_0_OR_GREATER
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureServices(ConfigureServices)
+                .ConfigureWebHostDefaults(webBuilder => webBuilder.Configure(Configure));
+
+        private static void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers()
+                    .AddApplicationPart(typeof(ValuesController).Assembly);
+            services.AddHostedService<Worker>();
+        }
+
+        private static void Configure(IApplicationBuilder app)
+        {
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+        }
+#else
+        public static IWebHostBuilder CreateHostBuilder(string[] args) =>
+            Microsoft.AspNetCore.WebHost.CreateDefaultBuilder(args)
+                     .ConfigureServices(ConfigureServices)
+                     .Configure(Configure);
+
+        private static void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddHostedService<Worker>();
+        }
+
+        private static void Configure(IApplicationBuilder app)
+        {
+            app.UseMvc();
+        }
+#endif
+
+        private static readonly Type NativeMethodsType = Type.GetType("Datadog.Trace.ClrProfiler.NativeMethods, Datadog.Trace");
+
+        public static bool IsProfilerAttached()
+        {
+            if(NativeMethodsType is null)
+            {
+                return false;
+            }
+
+            try
+            {
+                MethodInfo profilerAttachedMethodInfo = NativeMethodsType.GetMethod("IsProfilerAttached");
+                return (bool)profilerAttachedMethodInfo.Invoke(null, null);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+            }
+
+            return false;
+        }
+
+        public static string GetTracerAssemblyLocation()
+        {
+            return NativeMethodsType?.Assembly.Location ?? "(none)";
+        }
+    }
+}

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Properties/launchSettings.json
@@ -1,0 +1,21 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "AspNetCoreSmokeTest": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "api/values",
+      "applicationUrl": "http://localhost:5080",
+      "environmentVariables": {
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0"
+      }
+    }
+  }
+}

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/ValuesController.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/ValuesController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace AspNetCoreSmokeTest
+{
+    [ApiController]
+    public class ValuesController : ControllerBase
+    {
+        private readonly ILogger<ValuesController> _logger;
+
+        public ValuesController(ILogger<ValuesController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet("/api/values")]
+        public string Get()
+        {
+            _logger.LogInformation("Received request");
+            return Program.GetTracerAssemblyLocation();
+        }
+    }
+}

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Worker.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Worker.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace AspNetCoreSmokeTest
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+        private readonly IServiceProvider _serviceProvider;
+#pragma warning disable 618 // ignore obsolete IApplicationLifetime
+        private readonly IApplicationLifetime _lifetime;
+
+        private volatile bool _appListening;
+
+        public Worker(ILogger<Worker> logger, IApplicationLifetime lifetime, IServiceProvider serviceProvider)
+#pragma warning restore 618
+        {
+            _logger = logger;
+            _lifetime = lifetime;
+            _serviceProvider = serviceProvider;
+            lifetime.ApplicationStarted.Register(() =>
+            {
+                _appListening = true;
+            });
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!_appListening && !stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Waiting for app started handling requests");
+                await Task.Delay(100, stoppingToken);
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            try
+            {
+                using var serviceScope = _serviceProvider.CreateScope();
+                var server = serviceScope.ServiceProvider.GetRequiredService<IServer>();
+                var addressFeature = server.Features.Get<IServerAddressesFeature>();
+                var address = addressFeature!.Addresses.First();
+
+                var client = new HttpClient();
+
+                _logger.LogInformation("Sending request to self");
+                var response = await client.GetAsync($"{address}/api/values", stoppingToken);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError("Error sending request, status code did not indicate success");
+                    response.EnsureSuccessStatusCode();
+                }
+
+                var responseContent = await response.Content.ReadAsStringAsync();
+                var expected = Program.GetTracerAssemblyLocation();
+                if (responseContent != expected)
+                {
+                    throw new Exception($"Response content '{responseContent}' did not match expected '{expected}");
+                }
+
+                _logger.LogInformation("Request sent successfully");
+
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error sending request");
+                Program.ExitCode = 1;
+            }
+
+            _lifetime.StopApplication();
+
+        }
+    }
+}


### PR DESCRIPTION
In the upgrade to .NET 6 in #1885, we switched from building on `buster` to `bullseye`, as that's what the official .NET images used. Unfortunately, this caused the shared `.so` library to link to a newer `glibc` verision (updated from 2.28-10 to 2.31-13). Using the shared library on an older image (e.g. running it on a buster-based image) would result in a runtime error.

In #2032 we reverted back to using buster images, resolving the issue.

This PR adds tests to catch failures like the above. It builds a very simple ASP.NET Core app that does a self request, confirms the profiler is attached, and exits. We compile and run this application for multiple runtimes, and test in a variety of docker images.

This PR tests that we can install and run on 

* debian-based images:
  * Debian `bullsye` (`net6.0`, `net5.0`, `netcoreapp3.1`)
  * Debian `buster` (`net5.0`, `netcoreapp3.1`)
  * Debian `stretch` (`netcoreapp2.1`)
  * Ubuntu 20.04 `focal` (`net5.0`)
  * Ubuntu 18.04 `bionic` (`netcoreapp3.1`, `netcoreapp2.1`)
* alpine-based images
  * Alpine 3.14 (`net6.0`, `net5.0`, `netcoreapp3.1`)
  * Alpine 3.13 (`net5.0`, `netcoreapp3.1`)
  * Alpine 3.12 (`netcoreapp2.1`)
* Fedora-based images
  * Fedora 35 (`net5.0`,  `netcoreapp3.1`)
  * Fedora 34 (`net6.0` `net5.0`,  `netcoreapp3.1`)
  * Fedora 33 (`net5.0`,  `netcoreapp3.1`)
  * Fedora 29 (`netcoreapp3.1`, `netcoreapp2.1`)

Additionally, we test the following on ARM 64:
* Debian `bullsye` (`net6.0`, `net5.0`)
* Debian `buster` (`net5.0`)
* Ubuntu 20.04 `focal` (`net5.0`)

I confirmed that before merging #2032, these tests would fail. After merging, these tests pass.

@DataDog/apm-dotnet