### PR TITLE
Remove dependency from the shared project to main project

### DIFF
--- a/shared/src/native-src/loader.cpp
+++ b/shared/src/native-src/loader.cpp
@@ -1,7 +1,9 @@
 #include "loader.h"
 
 #ifdef _WIN32
-#include "DllMain.h"
+#include <windows.h>
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+#define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
 #endif
 
 #include "il_rewriter_wrapper.h"
@@ -1746,7 +1748,7 @@ namespace shared
         _loadersLoadedSet.insert(appDomainId);
 
 #ifdef _WIN32
-        HINSTANCE hInstance = DllHandle;
+        HINSTANCE hInstance = HINST_THISCOMPONENT;
         LPCWSTR dllLpName;
         LPCWSTR symbolsLpName;
 


### PR DESCRIPTION
By including the dllmain.h file, we add a dependency from the shared project to the main project (that contains the loader)(today, the Profiler C++ project).


Changes proposed in this pull request:

In this PR, we will use a Windows linker trick (`__ImageBase`) to get the current HINSTANCE/HMODULE to break that dependency.
The constraint is that the resource file must be embedded in the shared library that uses the loader.



@DataDog/apm-dotnet