### PR TITLE
[2.0] - Detect current module at runtime and use it for PInvoke rewriting

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -225,6 +225,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     managed_profiler_assembly_reference = AssemblyReference::GetFromCache(managed_profiler_full_assembly_version);
 
     // we're in!
+    Logger::Info("Module FileName: ", GetCurrentModuleFileName());
     Logger::Info("Profiler attached.");
     this->info_->AddRef();
     is_attached_.store(true);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -224,8 +224,15 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     //
     managed_profiler_assembly_reference = AssemblyReference::GetFromCache(managed_profiler_full_assembly_version);
 
+    const auto currentModuleFileName = GetCurrentModuleFileName();
+    if (currentModuleFileName == EmptyWStr)
+    {
+        Logger::Error("Profiler filepath: cannot be calculated.");
+        return E_FAIL;
+    }
+
     // we're in!
-    Logger::Info("Profiler FilePath: ", GetCurrentModuleFileName());
+    Logger::Info("Profiler filepath: ", currentModuleFileName);
     Logger::Info("Profiler attached.");
     this->info_->AddRef();
     is_attached_.store(true);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -225,7 +225,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     managed_profiler_assembly_reference = AssemblyReference::GetFromCache(managed_profiler_full_assembly_version);
 
     // we're in!
-    Logger::Info("Module FileName: ", GetCurrentModuleFileName());
+    Logger::Info("Profiler FilePath: ", GetCurrentModuleFileName());
     Logger::Info("Profiler attached.");
     this->info_->AddRef();
     is_attached_.store(true);
@@ -369,8 +369,8 @@ void CorProfiler::RewritingPInvokeMaps(const ModuleMetadata& module_metadata, co
     if (foundType)
     {
         // Define the actual profiler file path as a ModuleRef
-        WSTRING native_profiler_file = GetEnvironmentValue(environment::internal_trace_profiler_path);
-        if (native_profiler_file.empty())
+        WSTRING native_profiler_file = GetCurrentModuleFileName();
+        /*if (native_profiler_file.empty())
         {
             native_profiler_file = GetCLRProfilerPath();
         }
@@ -378,7 +378,7 @@ void CorProfiler::RewritingPInvokeMaps(const ModuleMetadata& module_metadata, co
         if (native_profiler_file.empty())
         {
             native_profiler_file = native_dll_filename;
-        }
+        }*/
 
         Logger::Info("Rewriting PInvokes to native: ", native_profiler_file);
 
@@ -1727,11 +1727,10 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
         return hr;
     }
 
-    WSTRING native_profiler_file = GetEnvironmentValue(environment::internal_trace_profiler_path);
-    Logger::Debug("GenerateVoidILStartupMethod: ", environment::internal_trace_profiler_path,
-                  " defined as: ", native_profiler_file);
+    WSTRING native_profiler_file = GetCurrentModuleFileName();
+    Logger::Debug("GenerateVoidILStartupMethod: GetCurrentModuleFileName returned: ", native_profiler_file);
 
-    if (native_profiler_file.empty())
+    /*if (native_profiler_file.empty())
     {
         native_profiler_file = GetCLRProfilerPath();
     }
@@ -1739,7 +1738,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     if (native_profiler_file.empty())
     {
         native_profiler_file = native_dll_filename;
-    }
+    }*/
 
     Logger::Debug("GenerateVoidILStartupMethod: Setting the PInvoke native profiler library path to ",
                   native_profiler_file);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -64,8 +64,6 @@ private:
     // Helper methods
     //
     void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const WSTRING& nativemethods_type_name);
-    WSTRING GetCLRProfilerPath();
-    void CheckFilenameDefinitions();
     bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -29,8 +29,7 @@ const WSTRING env_vars_to_display[]{environment::tracing_enabled,
                                     environment::dump_il_rewrite_enabled,
                                     environment::azure_app_services,
                                     environment::azure_app_services_app_pool_id,
-                                    environment::azure_app_services_cli_telemetry_profile_value,
-                                    environment::internal_trace_profiler_path};
+                                    environment::azure_app_services_cli_telemetry_profile_value};
 
 const WSTRING skip_assembly_prefixes[]{
     WStr("Microsoft.AI"),

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables.h
@@ -100,9 +100,6 @@ namespace environment
     // Sets whether to enable JIT inlining
     const WSTRING clr_enable_inlining = WStr("DD_CLR_ENABLE_INLINING");
 
-    // Custom internal tracer profiler path
-    const WSTRING internal_trace_profiler_path = WStr("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH");
-
     // Sets whether to enable NGEN images.
     const WSTRING clr_enable_ngen = WStr("DD_CLR_ENABLE_NGEN");
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -11,6 +11,7 @@
 
 #include <fstream>
 #include <unistd.h>
+#include <dlfcn.h>
 
 #endif
 
@@ -111,8 +112,13 @@ inline WSTRING GetCurrentModuleFileName()
             return WSTRING(lpFileName, lpFileNameLength);
         }
     }
-#elif MACOS
+// #elif MACOS
 #else
+    Dl_info info;
+    if (dladdr((void*)GetCurrentModuleFileName, &info))
+    {
+        return ToWSTRING(ToString(info.dli_fname));
+    }
 #endif
 
     return EmptyWStr;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -97,6 +97,27 @@ inline int GetPID()
 #endif
 }
 
+inline WSTRING GetCurrentModuleFileName()
+{
+#ifdef _WIN32
+    HMODULE hModule;
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModuleFileName,
+                           &hModule))
+    {
+        WCHAR lpFileName[1024];
+        DWORD lpFileNameLength = GetModuleFileNameW(hModule, lpFileName, 1024);
+        if (lpFileNameLength > 0)
+        {
+            return WSTRING(lpFileName, lpFileNameLength);
+        }
+    }
+#elif MACOS
+#else
+#endif
+
+    return EmptyWStr;
+}
+
 } // namespace trace
 
 #endif // DD_CLR_PROFILER_PAL_H_

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -100,6 +100,13 @@ inline int GetPID()
 
 inline WSTRING GetCurrentModuleFileName()
 {
+    static WSTRING moduleFileName = EmptyWStr;
+    if (moduleFileName != EmptyWStr)
+    {
+        // use cached version
+        return moduleFileName;
+    }
+
 #ifdef _WIN32
     HMODULE hModule;
     if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModuleFileName,
@@ -109,15 +116,16 @@ inline WSTRING GetCurrentModuleFileName()
         DWORD lpFileNameLength = GetModuleFileNameW(hModule, lpFileName, 1024);
         if (lpFileNameLength > 0)
         {
-            return WSTRING(lpFileName, lpFileNameLength);
+            moduleFileName = WSTRING(lpFileName, lpFileNameLength);
+            return moduleFileName;
         }
     }
-// #elif MACOS
 #else
     Dl_info info;
     if (dladdr((void*)GetCurrentModuleFileName, &info))
     {
-        return ToWSTRING(ToString(info.dli_fname));
+        moduleFileName = ToWSTRING(ToString(info.dli_fname));
+        return moduleFileName;
     }
 #endif
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/pal.h
@@ -109,7 +109,8 @@ inline WSTRING GetCurrentModuleFileName()
 
 #ifdef _WIN32
     HMODULE hModule;
-    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)GetCurrentModuleFileName,
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                           (LPCTSTR) GetCurrentModuleFileName,
                            &hModule))
     {
         WCHAR lpFileName[1024];


### PR DESCRIPTION
Fixes #2042 


@DataDog/apm-dotnet