### PR TITLE
[2.0] Relax duck type visibility requirements

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
@@ -127,15 +127,5 @@ namespace Datadog.Trace.DuckTyping
         {
             return UseDirectAccessTo((ModuleBuilder)builder?.Module, targetType);
         }
-
-        /// <summary>
-        /// Gets if the direct access method should be used or the indirect method (dynamic method)
-        /// </summary>
-        /// <param name="targetType">Target type</param>
-        /// <returns>true for direct method; otherwise, false.</returns>
-        private static bool UseDirectAccessTo(Type targetType)
-        {
-            return UseDirectAccessTo((ModuleBuilder)null, targetType);
-        }
     }
 }

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Utilities.cs
@@ -87,10 +87,10 @@ namespace Datadog.Trace.DuckTyping
         {
             // The condition to apply duck chaining is:
             // 1. Is a struct with the DuckCopy attribute
-            // 2. Both types must be differents.
+            // 2. Both types must be different.
             // 3. The proxy type (duck chaining proxy definition type) can't be a struct
             // 4. The proxy type can't be a generic parameter (should be a well known type)
-            // 5. Can't be a base type or an iterface implemented by the targetType type.
+            // 5. Can't be a base type or an interface implemented by the targetType type.
             // 6. The proxy type can't be a CLR type
             return proxyType.GetCustomAttribute<DuckCopyAttribute>() != null ||
                 (proxyType != targetType &&
@@ -101,7 +101,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         /// <summary>
-        /// Gets if the direct access method should be used or the inderect method (dynamic method)
+        /// Gets if the direct access method should be used or the indirect method (dynamic method)
         /// </summary>
         /// <param name="builder">Module builder</param>
         /// <param name="targetType">Target type</param>
@@ -118,7 +118,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         /// <summary>
-        /// Gets if the direct access method should be used or the inderect method (dynamic method)
+        /// Gets if the direct access method should be used or the indirect method (dynamic method)
         /// </summary>
         /// <param name="builder">Type builder</param>
         /// <param name="targetType">Target type</param>
@@ -129,7 +129,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         /// <summary>
-        /// Gets if the direct access method should be used or the inderect method (dynamic method)
+        /// Gets if the direct access method should be used or the indirect method (dynamic method)
         /// </summary>
         /// <param name="targetType">Target type</param>
         /// <returns>true for direct method; otherwise, false.</returns>

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -969,11 +969,6 @@ namespace Datadog.Trace.DuckTyping
             /// </summary>
             public static readonly Type Type = typeof(T);
 
-            /// <summary>
-            /// Gets if the T type is visible
-            /// </summary>
-            public static readonly bool IsVisible = Type.IsPublic || Type.IsNestedPublic;
-
             private static CreateTypeResult _fastPath = default;
 
             /// <summary>

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExceptions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExceptions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 #pragma warning disable SA1649 // File name must match first type name
@@ -40,6 +41,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw()
         {
             throw new DuckTypeProxyTypeDefinitionIsNull();
@@ -57,6 +59,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw()
         {
             throw new DuckTypeTargetObjectInstanceIsNull();
@@ -74,6 +77,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(Type actualType, Type expectedType)
         {
             throw new DuckTypeInvalidTypeConversionException(actualType, expectedType);
@@ -91,6 +95,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(PropertyInfo property)
         {
             throw new DuckTypePropertyCantBeReadException(property);
@@ -108,6 +113,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(PropertyInfo property)
         {
             throw new DuckTypePropertyCantBeWrittenException(property);
@@ -125,6 +131,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(PropertyInfo property)
         {
             throw new DuckTypePropertyArgumentsLengthException(property);
@@ -142,6 +149,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(FieldInfo field)
         {
             throw new DuckTypeFieldIsReadonlyException(field);
@@ -159,26 +167,10 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(string name, string duckAttributeName)
         {
             throw new DuckTypePropertyOrFieldNotFoundException(name, duckAttributeName);
-        }
-    }
-
-    /// <summary>
-    /// DuckType type is not public exception
-    /// </summary>
-    internal class DuckTypeTypeIsNotPublicException : DuckTypeException
-    {
-        private DuckTypeTypeIsNotPublicException(Type type, string argumentName)
-            : base($"The type '{type.FullName}' must be public, argument: '{argumentName}'")
-        {
-        }
-
-        [DebuggerHidden]
-        internal static void Throw(Type type, string argumentName)
-        {
-            throw new DuckTypeTypeIsNotPublicException(type, argumentName);
         }
     }
 
@@ -193,6 +185,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(Type type)
         {
             throw new DuckTypeStructMembersCannotBeChangedException(type);
@@ -210,6 +203,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo method)
         {
             throw new DuckTypeTargetMethodNotFoundException(method);
@@ -227,6 +221,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo proxyMethod, ParameterInfo targetParameterInfo)
         {
             throw new DuckTypeProxyMethodParameterIsMissingException(proxyMethod, targetParameterInfo);
@@ -244,6 +239,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo proxyMethod, MethodInfo targetMethod)
         {
             throw new DuckTypeProxyAndTargetMethodParameterSignatureMismatchException(proxyMethod, targetMethod);
@@ -261,6 +257,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo proxyMethod, MethodInfo targetMethod)
         {
             throw new DuckTypeProxyAndTargetMethodReturnTypeMismatchException(proxyMethod, targetMethod);
@@ -278,6 +275,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo proxyMethod)
         {
             throw new DuckTypeProxyMethodsWithGenericParametersNotSupportedInNonPublicInstancesException(proxyMethod);
@@ -295,6 +293,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo proxyMethod, MethodInfo targetMethod, MethodInfo targetMethod2)
         {
             throw new DuckTypeTargetMethodAmbiguousMatchException(proxyMethod, targetMethod, targetMethod2);
@@ -312,6 +311,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(Type type)
         {
             throw new DuckTypeReverseProxyBaseIsStructException(type);
@@ -329,6 +329,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(Type type)
         {
             throw new DuckTypeReverseProxyImplementorIsAbstractOrInterfaceException(type);
@@ -346,6 +347,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(PropertyInfo property)
         {
             throw new DuckTypeReverseProxyPropertyCannotBeAbstractException(property);
@@ -363,6 +365,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo method)
         {
             throw new DuckTypeIncorrectReverseMethodUsageException(method);
@@ -380,6 +383,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(PropertyInfo property)
         {
             throw new DuckTypeIncorrectReversePropertyUsageException(property);
@@ -397,6 +401,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(IEnumerable<MethodInfo> methods)
         {
             throw new DuckTypeReverseProxyMissingMethodImplementationException(methods);
@@ -414,6 +419,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo method)
         {
             throw new DuckTypeReverseAttributeParameterNamesMismatchException(method);
@@ -432,6 +438,7 @@ namespace Datadog.Trace.DuckTyping
         }
 
         [DebuggerHidden]
+        [DoesNotReturn]
         internal static void Throw(MethodInfo implementationMethod, MethodInfo targetMethod)
         {
             throw new DuckTypeReverseProxyMustImplementGenericMethodAsGenericException(implementationMethod, targetMethod);

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckTypeExtensions.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.DuckTyping
 {
@@ -49,14 +48,11 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (DuckType.CreateCache<T>.IsVisible)
+            DuckType.CreateTypeResult proxyResult = DuckType.CreateCache<T>.GetProxy(instance.GetType());
+            if (proxyResult.Success)
             {
-                DuckType.CreateTypeResult proxyResult = DuckType.CreateCache<T>.GetProxy(instance.GetType());
-                if (proxyResult.Success)
-                {
-                    value = proxyResult.CreateInstance<T>(instance);
-                    return true;
-                }
+                value = proxyResult.CreateInstance<T>(instance);
+                return true;
             }
 
             value = default;
@@ -78,7 +74,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (targetType != null && (targetType.IsPublic || targetType.IsNestedPublic))
+            if (targetType != null)
             {
                 DuckType.CreateTypeResult proxyResult = DuckType.GetOrCreateProxyType(targetType, instance.GetType());
                 if (proxyResult.Success)
@@ -107,13 +103,10 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (DuckType.CreateCache<T>.IsVisible)
+            DuckType.CreateTypeResult proxyResult = DuckType.CreateCache<T>.GetProxy(instance.GetType());
+            if (proxyResult.Success)
             {
-                DuckType.CreateTypeResult proxyResult = DuckType.CreateCache<T>.GetProxy(instance.GetType());
-                if (proxyResult.Success)
-                {
-                    return proxyResult.CreateInstance<T>(instance);
-                }
+                return proxyResult.CreateInstance<T>(instance);
             }
 
             return null;
@@ -133,7 +126,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (targetType != null && (targetType.IsPublic || targetType.IsNestedPublic))
+            if (targetType != null)
             {
                 DuckType.CreateTypeResult proxyResult = DuckType.GetOrCreateProxyType(targetType, instance.GetType());
                 if (proxyResult.Success)
@@ -159,12 +152,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (DuckType.CreateCache<T>.IsVisible)
-            {
-                return DuckType.CanCreate<T>(instance);
-            }
-
-            return false;
+            return DuckType.CanCreate<T>(instance);
         }
 
         /// <summary>
@@ -181,7 +169,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (targetType != null && (targetType.IsPublic || targetType.IsNestedPublic))
+            if (targetType != null)
             {
                 return DuckType.CanCreate(targetType, instance);
             }
@@ -217,7 +205,7 @@ namespace Datadog.Trace.DuckTyping
                 DuckTypeTargetObjectInstanceIsNull.Throw();
             }
 
-            if (typeToDeriveFrom != null && (typeToDeriveFrom.IsPublic || typeToDeriveFrom.IsNestedPublic))
+            if (typeToDeriveFrom != null)
             {
                 DuckType.CreateTypeResult proxyResult = DuckType.GetOrCreateReverseProxyType(typeToDeriveFrom, instance.GetType());
                 if (proxyResult.Success)

--- a/tracer/src/Datadog.Trace/Util/DoesNotReturnAttribute.cs
+++ b/tracer/src/Datadog.Trace/Util/DoesNotReturnAttribute.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="DoesNotReturnAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.ComponentModel;
+
+#if !NETCOREAPP3_0_OR_GREATER
+
+// ReSharper disable once CheckNamespace
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies that a method that will never return under any circumstance
+    /// This is a C# feature, but requires this attribute to be defined
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [AttributeUsage(AttributeTargets.Method)]
+    public class DoesNotReturnAttribute : Attribute
+    {
+    }
+}
+#endif


### PR DESCRIPTION
As we no longer support .NET 45, our duck types don't have to be public.

@DataDog/apm-dotnet