### PR TITLE
Switch to using curl to send AzDo build GitHub status

### DIFF
--- a/.azure-pipelines/steps/update-github-status-jobs.yml
+++ b/.azure-pipelines/steps/update-github-status-jobs.yml
@@ -6,58 +6,43 @@ parameters:
 jobs:
   - job: set_pending
     pool:
-      vmImage: windows-2019
+      vmImage: ubuntu-18.04
     steps:
-    - template: install-latest-dotnet-sdk.yml
-    - script: tracer\build.cmd SendStatusUpdateToGitHub
-      displayName: Set GitHub Status Pending
-      condition: succeededOrFailed()
-      continueOnError: true
-      env:
-        GITHUB_TOKEN: $(GITHUB_TOKEN)
-        CheckStatus: Pending
-        CheckName: $(System.StageName)
-        CommitSha: $(OriginalCommitId)
-        Build.BuildId: $(Build.BuildId)
+    - checkout: none
+    - template: update-github-status.yml
+      parameters:
+        checkName: $(System.StageName)
+        status: 'pending'
+        description: 'Run in progress'
 
   - job: set_succeeded
     pool:
-      vmImage: windows-2019
+      vmImage: ubuntu-18.04
     dependsOn:
     - set_pending
     - ${{ each job in parameters.jobs }}:
       - ${{ job }}
     condition: succeeded()
     steps:
-    - template: install-latest-dotnet-sdk.yml
-    - script: tracer\build.cmd SendStatusUpdateToGitHub
-      displayName: Set GitHub Status Failure
-      condition: succeededOrFailed()
-      continueOnError: true
-      env:
-        GITHUB_TOKEN: $(GITHUB_TOKEN)
-        CheckStatus: Success
-        CheckName: $(System.StageName)
-        CommitSha: $(OriginalCommitId)
-        Build.BuildId: $(Build.BuildId)
+    - checkout: none
+    - template: update-github-status.yml
+      parameters:
+        checkName: $(System.StageName)
+        status: 'success'
+        description: 'Run succeeded'
 
   - job: set_failed
     pool:
-      vmImage: windows-2019
+      vmImage: ubuntu-18.04
     dependsOn:
       - set_pending
       - ${{ each job in parameters.jobs }}:
           - ${{ job }}
     condition: not(succeeded())
     steps:
-      - template: install-latest-dotnet-sdk.yml
-      - script: tracer\build.cmd SendStatusUpdateToGitHub
-        displayName: Set GitHub Status Failure
-        condition: succeededOrFailed()
-        continueOnError: true
-        env:
-          GITHUB_TOKEN: $(GITHUB_TOKEN)
-          CheckStatus: Failure
-          CheckName: $(System.StageName)
-          CommitSha: $(OriginalCommitId)
-          Build.BuildId: $(Build.BuildId)
+    - checkout: none
+    - template: update-github-status.yml
+      parameters:
+        checkName: $(System.StageName)
+        status: 'failure'
+        description: 'Run failed'

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -1,0 +1,23 @@
+﻿parameters:
+  - name: 'checkName'
+    type: string
+
+  - name: 'status'
+    type: string
+
+  - name: 'description'
+    type: string
+
+steps:
+- script: |
+    TARGET_URL="https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$(Build.BuildId)"
+    curl -X POST \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H "Authorization: Bearer $(GITHUB_TOKEN)" \
+    https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$(OriginalCommitId) \
+    -d '{"state":"${{ parameters.status }}","context":"${{ parameters.checkName }}","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'
+  displayName: Set GitHub Status ${{ parameters.status }}
+  condition: and(succeededOrFailed(), ne(variables['Build.BuildId'], ''))
+  continueOnError: true
+  env:
+    GITHUB_TOKEN: $(GITHUB_TOKEN)


### PR DESCRIPTION
Installing .NET 6 and using Nuke for this is a bit heavyweight, as it potentially slows down every stage by 2/3 mins. Using curl reduces that to 2s

@DataDog/apm-dotnet