### PR TITLE
Try switch dependabot generation to use pull_request_target

### DIFF
--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: "Assign to vNext Milestone"
         run: ./tracer/build.sh AssignPullRequestToMilestone

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -1,7 +1,7 @@
 name: Auto bump test package versions
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [master, main]
   workflow_dispatch:
 
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: master
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 UpdateIntegrationsJson GeneratePackageVersions

--- a/.github/workflows/auto_tag_version_bump_commit.yml
+++ b/.github/workflows/auto_tag_version_bump_commit.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: "Output current version"
         id: versions

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: "Get current version"
         id: version

--- a/.github/workflows/create_version_bump_pr.yml
+++ b/.github/workflows/create_version_bump_pr.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
+          dotnet-version: '6.0.x'
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog


### PR DESCRIPTION
This is all a bit confusing, but I think this will resolve our permission issues, and it's safe because we're only checking out code from `master/main`, never the PR code itself. Worth a try 🤷 

References:
* https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
* https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

@DataDog/apm-dotnet