### PR TITLE
Don't throw in AgentWriterBenchmark

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -120,10 +120,7 @@ namespace Benchmarks.Trace
 
             public long ContentLength => 0;
 
-            public string GetHeader(string headerName)
-            {
-                throw new NotImplementedException();
-            }
+            public string GetHeader(string headerName) => string.Empty;
 
             public Task<string> ReadAsStringAsync()
             {


### PR DESCRIPTION
Currently we're throwing every time we flush in the `AgentWriterBenchmark`. That's obviously very expensive, variable, and makes for difficult comparisons.

@DataDog/apm-dotnet