### PR TITLE
Add README for Datadog.Trace NuGet package

### DIFF
--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -103,7 +103,7 @@ Tracer.Configure(settings);
 
 ### ADO.NET integrations can be disabled individually
 
-In version 1.x, you could disable automatic instrumentation of all ADO.NET integrations using the `AdoNet` integration ID. From version 2.0, this integration ID has been removed and replaced with the following integration IDs:
+In version 1.x, you could disable automatic instrumentation of all ADO.NET integrations using the `AdoNet` integration ID. From version 2.0, you can now also disable specific integrations using the following integration IDs:
 
 * `MySql`
 * `Npgsql` (PostreSQL)
@@ -111,7 +111,7 @@ In version 1.x, you could disable automatic instrumentation of all ADO.NET integ
 * `SqlClient` (SQL Server)
 * `Sqlite`
 
-This allows you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations).
+This allows you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations). Note that you can still disable _all_ ADO.NET integrations using the `AdoNet` integration ID.
 
 This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting and the corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these with `TracerSettings.Integrations["<INTEGRATION_NAME>"].Enabled` and `DD_TRACE_<INTEGRATION_NAME>_ENABLED`, respectively: 
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -67,11 +67,11 @@ This section describes some of the most important breaking changes. For full det
 
 Version 2.0 of _Datadog.Trace_ added support for .NET Core 6.0 and raised the minimum supported version of .NET Framework from .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade [in line with Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
 
-For full details of supported versions, see [our documentation on .NET Framework compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-framework) and [.NET/.NET Core compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core).  
+For full details of supported versions, see [our documentation on .NET Framework compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-framework) and [.NET/.NET Core compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core).
 
 ### Singleton Tracer instances
 
-In version 1.x, you could create new `Tracer` instances with different settings for each instance, using `new Tracer()`. From version 2.0 this constructor is marked `[Obsolete]`, and it is no longer possible to create `Tracer` instances with different settings. This was done to avoid multiple problematic patterns that were hard for users to detect. 
+In version 1.x, you could create new `Tracer` instances with different settings for each instance, using `new Tracer()`. From version 2.0 this constructor is marked `[Obsolete]`, and it is no longer possible to create `Tracer` instances with different settings. This was done to avoid multiple problematic patterns that were hard for users to detect.
 
 Update your code to the following:
 
@@ -87,7 +87,7 @@ Tracer.Configure(settings);          // <- Add this line
 
 ### TracerSettings are immutable
 
-In version 1.x the `TracerSettings` object passed to a `Tracer` instance could be subsequently modified. Depending on the changes, these may or may not have been respected. In version 2.0, an `ImmutableTracerSettings` object is created when the `Tracer` instance is configured. Subsequent changes to the `TracerSettings` instance will not be observed by `Tracer`. 
+In version 1.x the `TracerSettings` object passed to a `Tracer` instance could be subsequently modified. Depending on the changes, these may or may not have been respected. In version 2.0, an `ImmutableTracerSettings` object is created when the `Tracer` instance is configured. Subsequent changes to the `TracerSettings` instance will not be observed by `Tracer`.
 
 This change should not generally require changes to your code, but the type of `Tracer.Settings` is now an `ImmutableTracerSettings` instance, not a `TracerSettings` instance.
 
@@ -115,7 +115,7 @@ In version 1.x, you could disable automatic instrumentation of all ADO.NET integ
 
 This allows you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations). Note that you can still disable _all_ ADO.NET integrations using the `AdoNet` integration ID.
 
-This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting and the corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these with `TracerSettings.Integrations["<INTEGRATION_NAME>"].Enabled` and `DD_TRACE_<INTEGRATION_NAME>_ENABLED`, respectively: 
+This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting and the corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these with `TracerSettings.Integrations["<INTEGRATION_NAME>"].Enabled` and `DD_TRACE_<INTEGRATION_NAME>_ENABLED`, respectively:
 
 ```csharp
 using Datadog.Trace;
@@ -147,11 +147,11 @@ The following deprecated APIs have been removed.
 
 * `TracerSettings.DebugEnabled`: Enable debug mode by setting the `DD_TRACE_DEBUG` environment variable to `1`
 * `Tags.ForceDrop` and `Tags.ForceKeep` have been removed. Use `Tags.ManualDrop` and `Tags.ManualKeep` respectively instead.
-* `SpanTypes` associated with automatic instrumentation spans, such as `MongoDb` and `Redis` have been removed.  
+* `SpanTypes` associated with automatic instrumentation spans, such as `MongoDb` and `Redis` have been removed.
 * `Tags` associated with automatic instrumentation spans, such as `AmqpCommand` and `CosmosDbContainer` have been removed.
 * `Tracer.Create()` has been removed. Use `Tracer.Configure()` instead.
 * `TracerSettings.AdoNetExcludedTypes` has been removed. Use `TracerSettings.Integrations` to disable automatic instrumentation for ADO.NET integrations in the same way as other integrations.
-* Various internal APIs that were not intended for public consumption have been removed. 
+* Various internal APIs that were not intended for public consumption have been removed.
 
 In addition, some settings have been marked obsolete:
 
@@ -208,9 +208,9 @@ bool? isEnabled = tracerSettings.Integrations["MyRandomIntegration"].Enabled;
 
 ### Default value of `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is now `true`
 
-Version 1.26.0 added support for the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` feature flag, which enabled improved span names for ASP.NET and ASP.NET Core automatic instrumentation spans, an additional span for ASP.NET Core requests, and additional tags. 
+Version 1.26.0 added support for the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` feature flag, which enabled improved span names for ASP.NET and ASP.NET Core automatic instrumentation spans, an additional span for ASP.NET Core requests, and additional tags.
 
-In version 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** by default. Due to the change in span names, you may need to update your monitors and dashboards to use the new resource names. 
+In version 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** by default. Due to the change in span names, you may need to update your monitors and dashboards to use the new resource names.
 
 If you do not wish to take advantage of the improved route names, you can disabled the feature by setting the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` environment variable to `0`.
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -35,8 +35,6 @@ Calling `Tracer.Configure()` will replace the settings for all subsequent traces
 
 > :warning: Replacing the configuration should be done once, as early as possible in your application. 
 
-If you used to set the settings programatically, also note that transport related settings have been isolated in the `ExporterSettings`. It is still encapsulated in `TracerSettings`.
-
  ### Create custom traces
 
 To create and activate a custom span, use `Tracer.Instance.StartActive()`. If a trace is already active (when created by automatic instrumentation, for example), the span will be part of the current trace. If there is no current trace, a new one will be started.
@@ -102,6 +100,8 @@ Tracer.Configure(settings);
 // All properties on Settings are now read-only 
 // Tracer.Instance.Settings.TraceEnabled = false; // <- DOES NOT COMPILE
 ```
+
+Also note that transport related settings have been isolated in the `ExporterSettings`. It is still encapsulated in `TracerSettings`.
 
 ### ADO.NET integrations can be disabled individually
 
@@ -206,7 +206,9 @@ settings.Enabled = false;
 bool? isEnabled = tracerSettings.Integrations["MyRandomIntegration"].Enabled;
 ```
 
-### Default value of `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is now `true`
+### Automatic instrumentation changes
+
+#### Default value of `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is now `true`
 
 Version 1.26.0 added support for the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` feature flag, which enabled improved span names for ASP.NET and ASP.NET Core automatic instrumentation spans, an additional span for ASP.NET Core requests, and additional tags.
 
@@ -214,11 +216,11 @@ In version 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** 
 
 If you do not wish to take advantage of the improved route names, you can disabled the feature by setting the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` environment variable to `0`.
 
-### Call-site instrumentation has been removed
+#### Call-site instrumentation has been removed
 
 From version 2.0, call-site automatic instrumentation has been removed and replaced with call-target instrumentation. This has been the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0). Call-target instrumentation provides performance improvements over call-site instrumentation, but we no longer support instrumenting some custom implementations of `DbCommand`. If you find spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
 
-### DD_INTEGRATIONS environment variable no longer needed
+#### DD_INTEGRATIONS environment variable no longer needed
 
 The `integrations.json` file is no longer required for instrumentation. You can remove references to this file, for example by deleting the `DD_INTEGRATIONS` environment variable.
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -2,12 +2,12 @@
 
 This package contains the Datadog .NET APM tracer for configuring custom instrumentation.
 
-> If you are only using automatic tracing, **you do not need this package**. Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for details on how to install the tracer for automatic instrumentation. 
+> If you are only using automatic tracing, **you do not need this package**. Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for details on how to install the tracer for automatic instrumentation.
 
 ## Getting Started
 
 1. Configure the Datadog agent for APM [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core#configure-the-datadog-agent-for-apm).
-2. For automatic instrumentation, install and enable the tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer). 
+2. For automatic instrumentation, install and enable the tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer).
 3. Configure custom instrumentation, as shown below
 4. [View your live data on Datadog](https://app.datadoghq.com/apm/traces).
 
@@ -20,7 +20,7 @@ To override configuration settings, create an instance of `TracerSettings`, and 
 ```csharp
 using Datadog.Trace;
 
-// Create a settings object using the existing 
+// Create a settings object using the existing
 // environment variables and config sources
 var settings = TracerSettings.FromDefaultSources();
 
@@ -33,13 +33,13 @@ Tracer.Configure(settings);
 
 Calling `Tracer.Configure()` will replace the settings for all subsequent traces, both for custom instrumentation and for automatic instrumentation.
 
-> :warning: Replacing the configuration should be done once, as early as possible in your application. 
+> :warning: Replacing the configuration should be done once, as early as possible in your application.
 
  ### Create custom traces
 
 To create and activate a custom span, use `Tracer.Instance.StartActive()`. If a trace is already active (when created by automatic instrumentation, for example), the span will be part of the current trace. If there is no current trace, a new one will be started.
 
-> :warning: Ensure you dispose of the scope returned from StartActive. Disposing the scope will close the span, and ensure the trace is flushed to Datadog once all its spans are closed. 
+> :warning: Ensure you dispose of the scope returned from StartActive. Disposing the scope will close the span, and ensure the trace is flushed to Datadog once all its spans are closed.
 
 ```csharp
 using Datadog.Trace;
@@ -53,7 +53,7 @@ using (var scope = Tracer.Instance.StartActive("custom-operation"))
 
 ## Release Notes
 
-You can view the [notes for the latest release on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases).  
+You can view the [notes for the latest release on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases).
 
 ## Upgrading from 1.x to 2.0
 
@@ -67,11 +67,11 @@ This section describes some of the most important breaking changes. For full det
 
 For full details of supported versions, see [our documentation on .NET Framework compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-framework) and [.NET/.NET Core compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core).
 
-### Singleton Tracer instances
+### Singleton `Tracer` instances
 
-In version 1.x, you could create new `Tracer` instances with different settings for each instance, using `new Tracer()`. In version 2.0 this constructor is marked `[Obsolete]` and it is no longer possible to create `Tracer` instances with different settings. This was done to avoid multiple problematic patterns that were hard for users to detect.
+In .NET Tracer 1.x, you could create new `Tracer` instances with different settings for each instance, using the `Tracer` constructor. In .NET Tracer 2.0 this constructor is marked `[Obsolete]` and it is no longer possible to create `Tracer` instances with different settings. This was done to avoid multiple problematic patterns that were hard for users to detect.
 
-Update your code to the following:
+To update your code:
 
 ```csharp
 using Datadog.Trace;
@@ -83,21 +83,21 @@ var settings = new TracerSettings();
 Tracer.Configure(settings);          // <- Add this line
 ```
 
-### TracerSettings are immutable
+### Immutable `Tracer.Settings`
 
-In version 1.x the `TracerSettings` object passed to a `Tracer` instance could be modified later. Depending on the changes, the tracer may or may respect them. In version 2.0, an `ImmutableTracerSettings` object is created when the `Tracer` instance is configured. Subsequent changes to the `TracerSettings` instance will not be observed by `Tracer`.
+In .NET Tracer 1.x the `TracerSettings` object passed into a `Tracer` instance could be modified later. Depending on the changes, the tracer may or may not respect the changes. In .NET Tracer 2.0, an `ImmutableTracerSettings` object is created when the `Tracer` instance is configured. The property `Tracer.Settings` now returns `ImmutableTracerSettings`, not `TracerSettings`. Subsequent changes to the original `TracerSettings` instance will not be observed by `Tracer`.
 
-This change should not require changes to your code, but the property `Tracer.Settings` now returns `ImmutableTracerSettings`, not `TracerSettings`.
+To update your code:
 
 ```csharp
 using Datadog.Trace;
 
 var settings = TracerSettings.FromDefaultSources();
-settings.TraceEnabled = false;   // TracerSettings are mutable 
+settings.TraceEnabled = false;   // TracerSettings are mutable
 
 Tracer.Configure(settings);
 
-// All properties on Tracer.Settings are now read-only 
+// All properties on Tracer.Settings are now read-only
 // Tracer.Instance.Settings.TraceEnabled = false; // <- DOES NOT COMPILE
 ```
 
@@ -105,17 +105,22 @@ Tracer.Configure(settings);
 
 Exporter-related settings were grouped into the `TracerSettings.Exporter` property.
 
+To update your code:
+
 ```csharp
 using Datadog.Trace;
 
 var settings = TracerSettings.FromDefaultSources();
+
 // settings.AgentUri = "http://localhost:8126";        // <- Delete this line
 settings.Exporter.AgentUri = "http://localhost:8126";  // <- Add this line
+
+Tracer.Configure(settings);
 ```
 
 ### Configure ADO.NET integrations individually
 
-In version 1.x, you could configure automatic instrumentation of all ADO.NET integrations using the `AdoNet` integration ID. In version 2.0, you can now also disable specific integrations using the following integration IDs:
+In .NET Tracer 1.x, you could configure automatic instrumentation of all ADO.NET integrations using the `AdoNet` integration ID. In .NET Tracer 2.0, you can now configure specific integrations using the following integration IDs:
 
 * `MySql`
 * `Npgsql` (PostgreSQL)
@@ -123,7 +128,7 @@ In version 1.x, you could configure automatic instrumentation of all ADO.NET int
 * `SqlClient` (SQL Server)
 * `Sqlite`
 
-This allows you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations). Note that you can still disable _all_ ADO.NET integrations using the `AdoNet` integration ID.
+See our documentation for a [complete list of supported integration IDs](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations). Note that you can still disable _all_ ADO.NET integrations using the `AdoNet` integration ID.
 
 This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting and the corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these with `TracerSettings.Integrations["<INTEGRATION_NAME>"].Enabled` and `DD_TRACE_<INTEGRATION_NAME>_ENABLED`, respectively:
 
@@ -132,15 +137,15 @@ using Datadog.Trace;
 
 var settings = TracerSettings.FromDefaultSources();
 
-// settings.AdoNetExcludedTypes.Add("MySql");      // <- Delete this line
-settings.Integrations["MySql"].Enabled = false; // <- Add this line
+// settings.AdoNetExcludedTypes.Add("MySql");    // <- Delete this line
+settings.Integrations["MySql"].Enabled = false;  // <- Add this line
 ```
 
-### `ElasticsearchNet5` integration ID has been removed
+### `ElasticsearchNet5` integration ID removed
 
-In version 1.x, the integration ID for version 5.x of `Elasticsearch.Net` was `ElasticsearchNet5`, and the integration ID for version 6.x+ was `ElasticsearchNet`. In version 2.0, `ElasticsearchNet5` has been removed. Use `ElasticsearchNet` for all versions of `Elasticsearch.Net`.
+In .NET Tracer 1.x, the integration ID for version 5.x of `Elasticsearch.Net` was `ElasticsearchNet5`, and the integration ID for versions 6 and above was `ElasticsearchNet`. In .NET Tracer 2.0, `ElasticsearchNet5` was removed. Use `ElasticsearchNet` for all versions of `Elasticsearch.Net`.
 
-Replace usages of `ElasticsearchNet5` with `ElasticsearchNet`
+To update your code:
 
 ```csharp
 using Datadog.Trace;
@@ -169,37 +174,72 @@ In addition, some settings were marked obsolete in 2.0:
 * `TracerSettings.AnalyticsEnabled`, `IntegrationSettings.AnalyticsEnabled`, and `IntegrationSettings.AnalyticsSampleRate` were marked obsolete.
 * Environment variable `DD_TRACE_LOG_PATH` is deprecated. Use `DD_TRACE_LOG_DIRECTORY` instead.
 
-### Introduction of `ISpan` and `IScope`
+### Introduction of interfaces `ISpan`, `IScope`, and `ITracer`
 
-Version 2.0 makes the public `Scope` and `Span` classes internal. Instead, we now expose public `IScope` and `ISpan` interfaces and the `Tracer` API was updated accordingly. If you are currently using explicit types (instead of inferring types with `var`), replace usages of `Scope` with `IScope` and `Span` with `ISpan`:
+.NET Tracer 2.0 makes the public `Scope` and `Span` classes internal. Instead, we now expose public `IScope` and `ISpan` interfaces and the tracer API was updated accordingly. If you are currently using explicit types (instead of inferring types with `var`), replace usages of `Scope` with `IScope` and `Span` with `ISpan`.
+
+This Tracer release also adds the new `ITracer` interface, implemented by the `Tracer` class. The type of static property `Tracer.Instance` is still `Tracer`, so use of `ITracer` is not required, but the new interface can be useful for testing with mocks and dependency injection.
+
+To update your `Scope/Span` code:
 
 ```csharp
 using Datadog.Trace;
 
-// No changes required here
+// No changes required here (using var)
 using (var scope = Tracer.Instance.StartActive("my-operation"))
 {
+    var span = scope.Span;
+    // ...
 }
 
-// No Longer compiles (incorrect usage of Scope)
+// No longer compiles (Scope and Span are no longer public)
 using (Scope scope = Tracer.Instance.StartActive("my-operation"))
 {
+    Span span = scope.Span;
+    // ...
 }
 
-// Correct usage with explicit type
+// Correct usage with explicit types (using IScope and ISpan)
 using (IScope scope = Tracer.Instance.StartActive("my-operation"))
 {
+    ISpan span = scope.Span;
+    // ...
 }
 ```
 
 ### Simplification of the tracer interface
 
-In addition to returning `IScope`, the `Tracer.StartActive` method was simplified by replacing several parameters with a single `SpanCreationSettings`. We have also removed the possibility to override the service name from `Tracer.StartActive`. Instead, set `Span.ServiceName` after creating the span.
+In addition to returning `IScope`, several parameters parameters in the `Tracer.StartActive` method signature were replaced with a single `SpanCreationSettings`. The span's service name can no longer be set from `Tracer.StartActive`. Instead, set `Span.ServiceName` after creating the span.
 
+To update your `Scope/Span` code:
+
+```csharp
+using Datadog.Trace;
+
+// No changes required here (using only operation name)
+using (var scope = Tracer.Instance.StartActive("my-operation"))
+{
+    // ...
+}
+
+// No longer compiles (most parameters removed)
+using (var scope = Tracer.Instance.StartActive("my-operation", serviceName: "my-service", ...))
+{
+    // ...
+}
+
+// Correct usage
+using (var scope = Tracer.Instance.StartActive("my-operation"))
+{
+    scope.Span.ServiceName = "my-service";
+    // ...
+}
+
+```
 
 ### Incorrect integration names are ignored
 
-In version 2.0, any changes made to an `IntegrationSettings` object for an unknown `IntegrationId` will not be persisted. Instead, a warning will be logged describing the invalid access.
+In .NET Tracer 2.0, any changes made to an `IntegrationSettings` object for an unknown `IntegrationId` will not be persisted. Instead, a warning will be logged describing the invalid access.
 
 ```csharp
 using Datadog.Trace;
@@ -207,10 +247,10 @@ using Datadog.Trace;
 var tracerSettings = TracerSettings.FromDefaultSources();
 
 // Accessing settings for an unknown integration will log a warning
-var settings = tracerSettings .Integrations["MyRandomIntegration"];
+var settings = tracerSettings.Integrations["MyRandomIntegration"];
 
 // changes are not persisted
-settings.Enabled = false; 
+settings.Enabled = false;
 
 // isEnabled is null, not false
 bool? isEnabled = tracerSettings.Integrations["MyRandomIntegration"].Enabled;
@@ -218,17 +258,19 @@ bool? isEnabled = tracerSettings.Integrations["MyRandomIntegration"].Enabled;
 
 ### Automatic instrumentation changes
 
-#### Default value of feature flag `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is now `true`
+#### `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` enabled by default
 
-Version 1.26.0 added support for the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` feature flag, which enabled improved span names for ASP.NET and ASP.NET Core automatic instrumentation spans, an additional span for ASP.NET Core requests, and additional tags.
+.NET Tracer 1.26.0 added the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` feature flag, which enables improved span names for ASP.NET and ASP.NET Core automatic instrumentation spans, an additional span for ASP.NET Core requests, and additional tags.
 
-In version 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** by default. Due to the change in span names, you may need to update your monitors and dashboards to use the new resource names.
+In .NET Tracer 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** by default. Due to the change in span names, you may need to update your monitors and dashboards to use the new resource names.
 
-If you do not wish to take advantage of the improved route names, you can disabled the feature by setting the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` environment variable to `0`.
+If you do not wish to take advantage of the improved route names, you can disable the feature by setting the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` environment variable to `0`.
 
 #### Call-site instrumentation removed
 
-Call-site automatic instrumentation was removed in .NET Tracer 2.0 and replaced with call-target instrumentation. This was the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0). Call-target instrumentation provides performance and reliability improvements over call-site instrumentation, but it does not support instrumenting custom implementations of `DbCommand` for now. If you find spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
+Call-site automatic instrumentation was removed in .NET Tracer 2.0 and replaced with call-target instrumentation. This was the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0) on .NET Framework 4.6 or above and .NET Core / .NET 5. Call-target instrumentation provides performance and reliability improvements over call-site instrumentation.
+
+Note: Call-target instrumentation does not support instrumenting custom implementations of `DbCommand` yet. If you find ADO.NET spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
 
 #### `DD_INTEGRATIONS` environment variable no longer needed
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -171,7 +171,7 @@ In addition, some settings were marked obsolete in 2.0:
 
 ### Introduction of `ISpan` and `IScope`
 
-Version 2.0 makes the public `Scope` and `Span` classes internal. Instead, we now expose public `IScope` and `ISpan` interfaces and the `Tracer` API was updated accordingly. If you are currently using explicit types (instead of interring types with `var`), replace usages of `Scope` with `IScope` and `Span` with `ISpan`:
+Version 2.0 makes the public `Scope` and `Span` classes internal. Instead, we now expose public `IScope` and `ISpan` interfaces and the `Tracer` API was updated accordingly. If you are currently using explicit types (instead of inferring types with `var`), replace usages of `Scope` with `IScope` and `Span` with `ISpan`:
 
 ```csharp
 using Datadog.Trace;

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -111,6 +111,7 @@ using Datadog.Trace;
 var settings = TracerSettings.FromDefaultSources();
 // settings.AgentUri = "http://localhost:8126";        // <- Delete this line
 settings.Exporter.AgentUri = "http://localhost:8126";  // <- Add this line
+```
 
 ### Configure ADO.NET integrations individually
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -193,7 +193,7 @@ using (IScope scope = Tracer.Instance.StartActive("my-operation"))
 
 ### Simplification of the tracer interface
 
-In addition to returning `IScope`, the `Tracer.StartActive` method was simplified by replacing several parameters with a single `SpanCreationSettings`. We also have remove the possibility to override the service name from `Tracer.StartActive`. Instead, set `Span.ServiceName` after creating the span.
+In addition to returning `IScope`, the `Tracer.StartActive` method was simplified by replacing several parameters with a single `SpanCreationSettings`. We have also removed the possibility to override the service name from `Tracer.StartActive`. Instead, set `Span.ServiceName` after creating the span.
 
 
 ### Incorrect integration names are ignored

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -111,9 +111,9 @@ In version 1.x, you could disable automatic instrumentation of all ADO.NET integ
 * `SqlClient` (SQL Server)
 * `Sqlite`
 
-This enables you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations).
+This allows you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations).
 
-This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting, and corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these (for an example integration ID `MyIntegrationId`) with `TracerSettings.Integrations["MyIntegrationId"].Enabled` and `DD_TRACE_MyIntegrationId_ENABLED` respectively: 
+This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting and the corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these with `TracerSettings.Integrations["<INTEGRATION_NAME>"].Enabled` and `DD_TRACE_<INTEGRATION_NAME>_ENABLED`, respectively: 
 
 ```csharp
 using Datadog.Trace;
@@ -124,9 +124,9 @@ settings.AdoNetExcludedTypes.Add("MySql");      // <- Delete this line
 settings.Integrations["MySql"].Enabled = false; // <- Add this line
 ```
 
-### ElasticsearchNet5 integration ID has been removed
+### `ElasticsearchNet5` integration ID has been removed
 
-In version 1.x, the integration ID for `Elasticsearch.Net` in version 5.x was `ElasticsearchNet5`, and for version 6.x+ was `ElasticsearchNet`. From version 2.0, support for the ID `ElasticsearchNet5` has been removed, and instead `ElasticsearchNet` now can be used to  
+In version 1.x, the integration ID for `Elasticsearch.Net` in version 5.x was `ElasticsearchNet5`, and for version 6.x+ was `ElasticsearchNet`. From version 2.0, support for the ID `ElasticsearchNet5` has been removed, and instead `ElasticsearchNet` now can be used for all versions of `Elasticsearch.Net`.
 
 Replace usages of `ElasticsearchNet5` with `ElasticsearchNet`
 
@@ -164,7 +164,7 @@ In version 2.0 the public `Tracer` API has been updated to expose `IScope` and `
 ```csharp
 using Datadog.Trace;
 
-// no changes required here
+// No changes required here
 using (var scope = Tracer.Instance.StartActive("my-operation")
 {
 }
@@ -207,9 +207,9 @@ In version 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** 
 
 If you do not wish to take advantage of the improved route names, you can disabled the feature by setting the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` environment variable to `0`.
 
-### CallSite instrumentation has been removed
+### Call-site instrumentation has been removed
 
-From version 2.0, callsite automatic instrumentation has been removed and replaced with calltarget instrumentation. This has been the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0). Calltarget provides performance improvements over callsite, but we no longer support instrumenting some custom implementations of `DbCommand`. If you find spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
+From version 2.0, call-site automatic instrumentation has been removed and replaced with call-target instrumentation. This has been the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0). Call-target instrumentation provides performance improvements over call-site instrumentation, but we no longer support instrumenting some custom implementations of `DbCommand`. If you find spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
 
 ### Integrations.json has been removed
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -1,0 +1,220 @@
+# Datadog.Trace NuGet package
+
+This package contains the Datadog .NET APM tracer for configuring custom instrumentation.
+
+> If you are only using automatic tracing, **you do not need this package**. Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for details on how to install the tracer for automatic instrumentation. 
+
+## Getting Started
+
+1. Configure the Datadog agent for APM [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core#configure-the-datadog-agent-for-apm).
+2. For automatic instrumentation, install and enable the tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer). 
+3. Configure custom instrumentation, as shown below
+4. [View your live data on Datadog](https://app.datadoghq.com/apm/traces).
+
+### Configuring Datadog in code
+
+There are multiple ways to configure your application, for example using Environment variables, _web.config_, or _datadog.json_, [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/#configuration). This NuGet package also allows you to configure settings in code.
+
+To override configuration settings, create an instance of `TracerSettings`, and pass it to the static `Tracer.Configure()` method:
+
+```csharp
+using Datadog.Trace;
+
+// Create a settings object using the existing 
+// environment variables and config sources
+var settings = TracerSettings.FromDefaultSources();
+
+// Override a value
+settings.GlobalTags.Add("SomeKey", "SomeValue");
+
+// Replace the tracer configuration
+Tracer.Configure(settings);
+```
+
+Calling `Tracer.Configure()` will replace the settings for all subsequent traces, both for custom instrumentation and for automatic instrumentation.
+
+> :warning: Replacing the configuration should be done once, as early as possible in your application. 
+
+ ### Create custom traces
+
+To create and activate a custom span, use `Tracer.Instance.StartActive()`. If a trace is already active (when created by automatic instrumentation, for example), the span will be part of the current trace. If there is no current trace, a new one will be started.
+
+> :warning: Ensure you dispose of the scope returned from StartActive. Disposing the scope will close the span, and ensure the trace is flushed to Datadog once all its spans are closed. 
+
+```csharp
+using Datadog.Trace;
+
+// Start a new span
+using (var scope = Tracer.Instance.StartActive("custom-operation")
+{
+    // Do something
+}
+```
+
+## Release Notes
+
+You can view the [notes for the latest release on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases).  
+
+## Upgrading from 1.x to 2.0
+
+Version 2.0 of this package introduced a number of breaking changes to the API which allowed various performance improvements, added new features, and deprecated problematic ways of using the package. Most of these changes will not require any changes to your code, but some patterns are no longer supported or recommended.
+
+This section describes some of the most important breaking changes. For full details see [the release notes on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.0.0).
+
+## Updates for supported .NET versions
+
+Version 2.0 of _Datadog.Trace_ added support for .NET Core 6.0 and raised the minimum supported version of .NET Framework from .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade [in line with Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
+
+For full details of supported versions, see [our documentation on .NET Framework compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-framework) and [.NET/.NET Core compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core).  
+
+### Singleton Tracer instances
+
+In version 1.x, you could create new `Tracer` instances with different settings for each instance, using `new Tracer()`. From version 2.0 this constructor is marked `[Obsolete]`, and it is no longer possible to create `Tracer` instances with different settings. This was done to avoid multiple problematic patterns that were hard for users to detect. 
+
+Update your code to the following:
+
+```csharp
+using Datadog.Trace;
+
+// Create your settings as before
+var settings = new TracerSettings();
+
+// var tracer = new Tracer(settings) // <- Delete this line
+Tracer.Configure(settings);          // <- Add this line
+```
+
+### TracerSettings are immutable
+
+In version 1.x the `TracerSettings` object passed to a `Tracer` instance could be subsequently modified. Depending on the changes, these may or may not have been respected. In version 2.0, an `ImmutableTracerSettings` object is created when the `Tracer` instance is configured. Subsequent changes to the `TracerSettings` instance will not be observed by `Tracer`. 
+
+This change should not generally require changes to your code, but the type of `Tracer.Settings` is now an `ImmutableTracerSettings` instance, not a `TracerSettings` instance.
+
+```csharp
+using Datadog.Trace;
+
+var settings = TracerSettings.FromDefaultSources();
+settings.TraceEnabled = false;   // TracerSettings are mutable 
+
+Tracer.Configure(settings);
+
+// All properties on Settings are now read-only 
+// Tracer.Instance.Settings.TraceEnabled = false; // <- DOES NOT COMPILE
+```
+
+### ADO.NET integrations can be disabled individually
+
+In version 1.x, you could disable automatic instrumentation of all ADO.NET integrations using the `AdoNet` integration ID. From version 2.0, this integration ID has been removed and replaced with the following integration IDs:
+
+* `MySql`
+* `Npgsql` (PostreSQL)
+* `Oracle`
+* `SqlClient` (SQL Server)
+* `Sqlite`
+
+This enables you to disable specific ADO.NET integrations if required. [See our documentation for a complete list of supported integration IDS](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core/#integrations).
+
+This change also removes the now-obsolete `TracerSettings.AdoNetExcludedTypes` setting, and corresponding environment variable `DD_TRACE_ADONET_EXCLUDED_TYPES`. Replace usages of these (for an example integration ID `MyIntegrationId`) with `TracerSettings.Integrations["MyIntegrationId"].Enabled` and `DD_TRACE_MyIntegrationId_ENABLED` respectively: 
+
+```csharp
+using Datadog.Trace;
+
+var settings = TracerSettings.FromDefaultSources();
+
+settings.AdoNetExcludedTypes.Add("MySql");      // <- Delete this line
+settings.Integrations["MySql"].Enabled = false; // <- Add this line
+```
+
+### ElasticsearchNet5 integration ID has been removed
+
+In version 1.x, the integration ID for `Elasticsearch.Net` in version 5.x was `ElasticsearchNet5`, and for version 6.x+ was `ElasticsearchNet`. From version 2.0, support for the ID `ElasticsearchNet5` has been removed, and instead `ElasticsearchNet` now can be used to  
+
+Replace usages of `ElasticsearchNet5` with `ElasticsearchNet`
+
+```csharp
+using Datadog.Trace;
+
+var settings = TracerSettings.FromDefaultSources();
+
+settings.Integrations["ElasticsearchNet5"].Enabled = false; // <- Delete this line
+settings.Integrations["ElasticsearchNet"].Enabled = false;  // <- Add this line
+```
+
+### Obsolete APIs have been removed
+
+The following deprecated APIs have been removed.
+
+* `TracerSettings.DebugEnabled`: Enable debug mode by setting the `DD_TRACE_DEBUG` environment variable to `1`
+* `Tags.ForceDrop` and `Tags.ForceKeep` have been removed. Use `Tags.ManualDrop` and `Tags.ManualKeep` respectively instead.
+* `SpanTypes` associated with automatic instrumentation spans, such as `MongoDb` and `Redis` have been removed.  
+* `Tags` associated with automatic instrumentation spans, such as `AmqpCommand` and `CosmosDbContainer` have been removed.
+* `Tracer.Create()` has been removed. Use `Tracer.Configure()` instead.
+* `TracerSettings.AdoNetExcludedTypes` has been removed. Use `TracerSettings.Integrations` to disable automatic instrumentation for ADO.NET integrations in the same way as other integrations.
+* Various internal APIs that were not intended for public consumption have been removed. 
+
+In addition, some settings have been marked obsolete:
+
+* Environment variables `DD_TRACE_ANALYTICS_ENABLED`, `DD_TRACE_{0}_ANALYTICS_ENABLED`, and `DD_TRACE_{0}_ANALYTICS_SAMPLE_RATE` for controlling App Analytics are obsolete. App Analytics has been replaced with Tracing Without Limits. See [our documentation for details](https://docs.datadoghq.com/tracing/legacy_app_analytics/).
+* Setting `TracerSettings.AnalyticsEnabled` has similarly been marked obsolete.
+* Environment variable `DD_TRACE_LOG_PATH` is deprecated. Use `DD_TRACE_LOG_DIRECTORY` instead.
+
+### Introduction of ISpan and IScope
+
+In version 2.0 the public `Tracer` API has been updated to expose `IScope` and `ISpan` instead of `Scope` and `Span`. In most cases, this should not require any changes to your code, but if you are currently using explicit types (instead of inferred types), then you will need to replace usages of `Scope` with `IScope` and `Span` with `ISpan`:
+
+```csharp
+using Datadog.Trace;
+
+// no changes required here
+using (var scope = Tracer.Instance.StartActive("my-operation")
+{
+}
+
+// No Longer compiles (incorrect usage of Scope)
+using (Scope scope = Tracer.Instance.StartActive("my-operation")
+{
+}
+
+// Correct usage with explicit type
+using (IScope scope = Tracer.Instance.StartActive("my-operation")
+{
+}
+```
+
+### Incorrect integration names are ignored
+
+In version 2.0, any changes made to an `IntegrationSettings` object for an unknown `IntegrationId` will not be persisted. Instead, a warning will be logged describing the invalid access.
+
+```csharp
+using Datadog.Trace;
+
+var tracerSettings = TracerSettings.FromDefaultSources();
+
+// Accessing settings for an unknown integration will log a warning
+var settings = tracerSettings .Integrations["MyRandomIntegration"];
+
+// changes are not persisted
+settings.Enabled = false; 
+
+// isEnabled is null, not false
+bool? isEnabled = tracerSettings.Integrations["MyRandomIntegration"].Enabled;
+```
+
+### Default value of `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is now `true`
+
+Version 1.26.0 added support for the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` feature flag, which enabled improved span names for ASP.NET and ASP.NET Core automatic instrumentation spans, an additional span for ASP.NET Core requests, and additional tags. 
+
+In version 2.0, `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` is **enabled** by default. Due to the change in span names, you may need to update your monitors and dashboards to use the new resource names. 
+
+If you do not wish to take advantage of the improved route names, you can disabled the feature by setting the `DD_TRACE_ROUTE_TEMPLATE_RESOURCE_NAMES_ENABLED` environment variable to `0`.
+
+### CallSite instrumentation has been removed
+
+From version 2.0, callsite automatic instrumentation has been removed and replaced with calltarget instrumentation. This has been the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0). Calltarget provides performance improvements over callsite, but we no longer support instrumenting some custom implementations of `DbCommand`. If you find spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
+
+### Integrations.json has been removed
+
+The _integrations.json_ file is no required for instrumentation. You can remove references to this file, for example by deleting the `DD_INTEGRATIONS` environment variable.
+
+## Get in touch
+
+If you have questions, feedback, or feature requests, reach our [support](https://docs.datadoghq.com/help).

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -35,6 +35,8 @@ Calling `Tracer.Configure()` will replace the settings for all subsequent traces
 
 > :warning: Replacing the configuration should be done once, as early as possible in your application. 
 
+If you used to set the settings programatically, also note that transport related settings have been isolated in the `ExporterSettings`. It is still encapsulated in `TracerSettings`.
+
  ### Create custom traces
 
 To create and activate a custom span, use `Tracer.Instance.StartActive()`. If a trace is already active (when created by automatic instrumentation, for example), the span will be part of the current trace. If there is no current trace, a new one will be started.
@@ -61,7 +63,7 @@ Version 2.0 of this package introduced a number of breaking changes to the API w
 
 This section describes some of the most important breaking changes. For full details see [the release notes on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.0.0).
 
-## Updates for supported .NET versions
+### Updates for supported .NET versions
 
 Version 2.0 of _Datadog.Trace_ added support for .NET Core 6.0 and raised the minimum supported version of .NET Framework from .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade [in line with Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
 
@@ -159,7 +161,7 @@ In addition, some settings have been marked obsolete:
 
 ### Introduction of ISpan and IScope
 
-In version 2.0 the public `Tracer` API has been updated to expose `IScope` and `ISpan` instead of `Scope` and `Span`. In most cases, this should not require any changes to your code, but if you are currently using explicit types (instead of inferred types), then you will need to replace usages of `Scope` with `IScope` and `Span` with `ISpan`:
+In version 2.0 the public `Scope` and `Span` classes have been made internal. We now expose `IScope` and `ISpan` instead. The `Tracer` API has been updated accordingly. In most cases, this should not require any changes to your code, but if you are currently using explicit types (instead of inferred types), then you will need to replace usages of `Scope` with `IScope` and `Span` with `ISpan`:
 
 ```csharp
 using Datadog.Trace;
@@ -179,6 +181,11 @@ using (IScope scope = Tracer.Instance.StartActive("my-operation")
 {
 }
 ```
+
+### Simplification of the tracer interface
+
+In addition to returning `IScope`, the `Tracer.StartActive` method has been simplified to provide a `SpanCreationSettings`. In addition, we have removed the possibility to override the service name.
+
 
 ### Incorrect integration names are ignored
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -2,7 +2,7 @@
 
 This package contains the Datadog .NET APM tracer for configuring custom instrumentation.
 
-> If you are only using automatic tracing, **you do not need this package**. Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for details on how to install the tracer for automatic instrumentation.
+> If you are only using automatic instrumentation, **you do not need this package**. Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for details on how to install the tracer for automatic instrumentation.
 
 ## Getting Started
 
@@ -57,7 +57,7 @@ You can view the [notes for the latest release on GitHub](https://github.com/Dat
 
 ## Upgrading from 1.x to 2.0
 
-.NET Tracer 2.0 introduces a number of breaking changes to the API which allow various performance improvements, add new features, and deprecate problematic ways of using the package. Most of these changes do not require any changes to your code, but some patterns are no longer supported or recommended.
+.NET Tracer 2.0 introduces several breaking changes to the API which allow various performance improvements, add new features, and deprecate problematic ways of using the package. Most of these changes do not require any changes to your code, but some patterns are no longer supported or recommended.
 
 This section describes some of the most important breaking changes. For full details see [the release notes on GitHub](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.0.0).
 

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -105,7 +105,7 @@ Tracer.Configure(settings);
 
 Exporter-related settings were grouped into the `TracerSettings.Exporter` property.
 
-csharp
+```csharp
 using Datadog.Trace;
 
 var settings = TracerSettings.FromDefaultSources();

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -223,13 +223,14 @@ using (var scope = Tracer.Instance.StartActive("my-operation"))
 }
 
 // No longer compiles (most parameters removed)
-using (var scope = Tracer.Instance.StartActive("my-operation", serviceName: "my-service", ...))
+using (var scope = Tracer.Instance.StartActive("my-operation", parent: spanContext, serviceName: "my-service", ...))
 {
     // ...
 }
 
 // Correct usage
-using (var scope = Tracer.Instance.StartActive("my-operation"))
+var spanCreationSettings = new SpanCreationSettings() { Parent = spanContext };
+using (var scope = Tracer.Instance.StartActive("my-operation", spanCreationSettings))
 {
     scope.Span.ServiceName = "my-service";
     // ...

--- a/docs/Datadog.Trace/README.md
+++ b/docs/Datadog.Trace/README.md
@@ -65,7 +65,7 @@ This section describes some of the most important breaking changes. For full det
 
 ### Updates for supported .NET versions
 
-Version 2.0 of _Datadog.Trace_ added support for .NET Core 6.0 and raised the minimum supported version of .NET Framework from .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade [in line with Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
+Version 2.0 of _Datadog.Trace_ added support for .NET 6.0 and raised the minimum supported version of .NET Framework from .NET Framework 4.5 to .NET Framework 4.6.1. If you are currently targeting version < 4.6.1, we suggest you upgrade [in line with Microsoft's guidance](https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework).
 
 For full details of supported versions, see [our documentation on .NET Framework compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-framework) and [.NET/.NET Core compatibility requirements](https://docs.datadoghq.com/tracing/setup_overview/compatibility_requirements/dotnet-core).
 
@@ -108,7 +108,7 @@ Tracer.Configure(settings);
 In version 1.x, you could disable automatic instrumentation of all ADO.NET integrations using the `AdoNet` integration ID. From version 2.0, you can now also disable specific integrations using the following integration IDs:
 
 * `MySql`
-* `Npgsql` (PostreSQL)
+* `Npgsql` (PostgreSQL)
 * `Oracle`
 * `SqlClient` (SQL Server)
 * `Sqlite`
@@ -122,7 +122,7 @@ using Datadog.Trace;
 
 var settings = TracerSettings.FromDefaultSources();
 
-settings.AdoNetExcludedTypes.Add("MySql");      // <- Delete this line
+// settings.AdoNetExcludedTypes.Add("MySql");      // <- Delete this line
 settings.Integrations["MySql"].Enabled = false; // <- Add this line
 ```
 
@@ -145,12 +145,12 @@ settings.Integrations["ElasticsearchNet"].Enabled = false;  // <- Add this line
 
 The following deprecated APIs have been removed.
 
-* `TracerSettings.DebugEnabled`: Enable debug mode by setting the `DD_TRACE_DEBUG` environment variable to `1`
+* `TracerSettings.DebugEnabled` has been removed. Set the `DD_TRACE_DEBUG` environment variable to `1` to enable debug mode.
 * `Tags.ForceDrop` and `Tags.ForceKeep` have been removed. Use `Tags.ManualDrop` and `Tags.ManualKeep` respectively instead.
 * `SpanTypes` associated with automatic instrumentation spans, such as `MongoDb` and `Redis` have been removed.
-* `Tags` associated with automatic instrumentation spans, such as `AmqpCommand` and `CosmosDbContainer` have been removed.
+* `Tags` associated with automatic instrumentation spans, such as `AmqpCommand` and `CosmosDbContainer`, have been removed.
 * `Tracer.Create()` has been removed. Use `Tracer.Configure()` instead.
-* `TracerSettings.AdoNetExcludedTypes` has been removed. Use `TracerSettings.Integrations` to disable automatic instrumentation for ADO.NET integrations in the same way as other integrations.
+* `TracerSettings.AdoNetExcludedTypes` has been removed. Use `TracerSettings.Integrations` to disable automatic instrumentation for ADO.NET integrations.
 * Various internal APIs that were not intended for public consumption have been removed.
 
 In addition, some settings have been marked obsolete:
@@ -218,9 +218,9 @@ If you do not wish to take advantage of the improved route names, you can disabl
 
 From version 2.0, call-site automatic instrumentation has been removed and replaced with call-target instrumentation. This has been the default mode [since version 1.28.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v1.28.0). Call-target instrumentation provides performance improvements over call-site instrumentation, but we no longer support instrumenting some custom implementations of `DbCommand`. If you find spans are missing from your traces after upgrading, please raise an issue on GitHub, or contact [support](https://docs.datadoghq.com/help).
 
-### Integrations.json has been removed
+### DD_INTEGRATIONS environment variable no longer needed
 
-The _integrations.json_ file is no required for instrumentation. You can remove references to this file, for example by deleting the `DD_INTEGRATIONS` environment variable.
+The `integrations.json` file is no longer required for instrumentation. You can remove references to this file, for example by deleting the `DD_INTEGRATIONS` environment variable.
 
 ## Get in touch
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the sources for the client-side components of the Datadog product suite for Application Telemetry Collection and Application Performance Monitoring for .NET Applications.
 
-**[Datadog .NET Tracer](https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer)**: A set of .NET libraries that let you trace any piece of your .NET code. It automatically instruments supported libraries out-of-the-box and also supports manual instrumentation to instrument your own code.
+**[Datadog .NET Tracer](https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer)**: A set of .NET libraries that let you trace any piece of your .NET code. It automatically instruments supported libraries out-of-the-box and also supports custom instrumentation to instrument your own code.
 
 **[Datadog .NET Continuous Profiler](https://github.com/DataDog/dd-trace-dotnet/tree/master/profiler)**: To be added.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,107 +1,32 @@
-# .NET Tracer for Datadog APM
+# Datadadog APM .Net client libraries
 
+This repository contains the sources for the client-side components of the Datadog product suite for Application Telemetry Collection and Application Performance Monitoring for .NET Applications.
 
-## Installation and Usage
+**[Datadog .NET Tracer](https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer)**: A set of .NET libraries that let you trace any piece of your .NET code. It automatically instruments supported libraries out-of-the-box and also supports manual instrumentation to instrument your own code.
 
-Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for instructions on setting up .NET tracing and details about supported frameworks.
+**[Datadog .NET Profiler](https://github.com/DataDog/dd-trace-dotnet/tree/master/profiler)**: To be added.
 
 ## Downloads
-|Package|Download|
-|-------|--------|
-Windows and Linux Installers|[See releases](https://github.com/DataDog/dd-trace-dotnet/releases)
-`Datadog.Trace`|[![Datadog.Trace](https://img.shields.io/nuget/vpre/Datadog.Trace.svg)](https://www.nuget.org/packages/Datadog.Trace)
-`Datadog.Trace.OpenTracing`|[![Datadog.Trace.OpenTracing](https://img.shields.io/nuget/vpre/Datadog.Trace.OpenTracing.svg)](https://www.nuget.org/packages/Datadog.Trace.OpenTracing)
 
-# Development
+| Package                      | Download                                                                                                                                                  |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Windows and Linux Installers | [See releases](https://github.com/DataDog/dd-trace-dotnet/releases)                                                                                       |
+| `Datadog.Trace`              | [![Datadog.Trace](https://img.shields.io/nuget/vpre/Datadog.Trace.svg)](https://www.nuget.org/packages/Datadog.Trace)                                     |
+| `Datadog.Trace.OpenTracing`  | [![Datadog.Trace.OpenTracing](https://img.shields.io/nuget/vpre/Datadog.Trace.OpenTracing.svg)](https://www.nuget.org/packages/Datadog.Trace.OpenTracing) |
+
+## Build status
 
 Build status on `master`: [![Build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
-
-## Components
-
-**[Datadog Agent](https://github.com/DataDog/datadog-agent)**: A service that runs on your application servers, accepting trace data from the Datadog Tracer and sending it to Datadog. The Agent is not part of this repo; it's the same Agent to which all Datadog tracers (e.g. Go, Python, Java, Ruby) send data.
-
-**[Datadog .NET Tracer](https://github.com/DataDog/dd-trace-dotnet)**: This repository. A set of .NET libraries that let you trace any piece of your .NET code. Supports manual instrumentation and can automatically instrument supported libraries out-of-the-box.
-
-## Windows
-
-### Minimum requirements
-
-- [Visual Studio 2019 (16.8)](https://visualstudio.microsoft.com/downloads/) or newer
-  - Workloads
-    - Desktop development with C++
-    - .NET desktop development
-    - .NET Core cross-platform development
-    - Optional: ASP.NET and web development (to build samples)
-  - Individual components
-    - .NET Framework 4.7 targeting pack
-- [.NET 5.0 SDK](https://dotnet.microsoft.com/download/dotnet/5.0)
-- [.NET 5.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/5.0) to run 32-bit tests locally
-- Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
-- Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
-- Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
-- Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
-- Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
-  - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio
-- Optional: [Docker for Windows](https://docs.docker.com/docker-for-windows/) to build Linux binaries and run integration tests on Linux containers. See [section on Docker Compose](#building-and-running-tests-with-docker-compose).
-  - Requires Windows 10 (1607 Anniversary Update, Build 14393 or newer)
-
-Microsoft provides [evaluation developer VMs](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines) with Windows 10 and Visual Studio pre-installed.
-
-### Building from a command line
-
-This repository uses [Nuke](https://nuke.build/) for build automation. To see a list of possible targets run:
-
-```cmd
-.\tracer\build.cmd --help
-```
-
-For example:
-
-```powershell
-# Clean and build the main tracer project
-.\tracer\build.cmd Clean BuildTracerHome
-
-# Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
-.\tracer\build.cmd BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
-
-# Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
-.\tracer\build.cmd PackageTracerHome 
-
-# Build and run integration tests. Requires BuildTracerHome to have previously been run
-.\tracer\build.cmd BuildAndRunWindowsIntegrationTests
-```
-
-## Linux
-
-The recommended approach for Linux is to build using Docker. You can use this approach for both Windows and Linux hosts. The _build_in_docker.sh_ script automates building a Docker image with the required dependencies, and running the specified Nuke targets. For example:
-
-```bash
-# Clean and build the main tracer project
-./tracer/build_in_docker.sh Clean BuildTracerHome
-
-# Build and run managed unit tests. Requires BuildTracerHome to have previously been run
-./tracer/build_in_docker.sh BuildAndRunManagedUnitTests 
-
-# Build and run integration tests. Requires BuildTracerHome to have previously been run
-./tracer/build_in_docker.sh BuildAndRunLinuxIntegrationTests
-```
-
-## Further Reading
-
-Datadog APM
-- [Datadog APM](https://docs.datadoghq.com/tracing/)
-- [Datadog APM - Tracing .NET Core and .NET 5 Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core)
-- [Datadog APM - Tracing .NET Framework Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-framework)
-
-Microsoft .NET Profiling APIs
-- [Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)
-- [Metadata API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/metadata/)
-- [The Book of the Runtime - Profiling](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/profiling.md)
-
-OpenTracing
-- [OpenTracing documentation](https://github.com/opentracing/opentracing-csharp)
-- [OpenTracing terminology](https://github.com/opentracing/specification/blob/master/specification.md)
 
 ## Get in touch
 
 If you have questions, feedback, or feature requests, reach our [support](https://docs.datadoghq.com/help).
+
+## Copyright
+
+Copyright (c) 2017 Datadog
+[https://www.datadoghq.com](https://www.datadoghq.com/)
+
+## License
+
+See [license information](../LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,20 @@
 # .NET Tracer for Datadog APM
 
+
 ## Installation and Usage
 
 Please [read our documentation](https://docs.datadoghq.com/tracing/setup/dotnet) for instructions on setting up .NET tracing and details about supported frameworks.
 
 ## Downloads
-Package|Download
--|-
+|Package|Download|
+|-------|--------|
 Windows and Linux Installers|[See releases](https://github.com/DataDog/dd-trace-dotnet/releases)
 `Datadog.Trace`|[![Datadog.Trace](https://img.shields.io/nuget/vpre/Datadog.Trace.svg)](https://www.nuget.org/packages/Datadog.Trace)
 `Datadog.Trace.OpenTracing`|[![Datadog.Trace.OpenTracing](https://img.shields.io/nuget/vpre/Datadog.Trace.OpenTracing.svg)](https://www.nuget.org/packages/Datadog.Trace.OpenTracing)
 
-## Build Status on `master`
-
-Pipeline Stage         | Windows     |Linux   |  
------------------------|-------------|--------|
-Build                  | [![Build Windows](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master) | [![Build Linux](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_linux)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master) 
-Unit Tests             | [![Build Status](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master) | [![Build Status](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=unit_tests_linux)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master) 
-Integration Tests       | [![Build Status](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=integration_tests_windows_iis)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master) [![Build Status](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=integration_tests_windows)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master) | [![Build Status](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=integration_tests_linux)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
-
 # Development
+
+Build status on `master`: [![Build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
 
 ## Components
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Datadadog APM .Net client libraries
+# Datadog APM .NET Client Libraries
 
 This repository contains the sources for the client-side components of the Datadog product suite for Application Telemetry Collection and Application Performance Monitoring for .NET Applications.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This repository contains the sources for the client-side components of the Datad
 
 **[Datadog .NET Tracer](https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer)**: A set of .NET libraries that let you trace any piece of your .NET code. It automatically instruments supported libraries out-of-the-box and also supports manual instrumentation to instrument your own code.
 
-**[Datadog .NET Profiler](https://github.com/DataDog/dd-trace-dotnet/tree/master/profiler)**: To be added.
+**[Datadog .NET Continuous Profiler](https://github.com/DataDog/dd-trace-dotnet/tree/master/profiler)**: To be added.
 
 ## Downloads
 

--- a/profiler/README.MD
+++ b/profiler/README.MD
@@ -2,4 +2,4 @@
 
 ## Note
 
-This directory is currently empty. It is a placeholder for the Continuous Profiler sources, which will be available here in the future. In the meantime, the Continuous Profiler is available as a private preview. To inquire about the preview, reach our [support](https://docs.datadoghq.com/help).
+This directory is currently empty. It is a placeholder for the Continuous Profiler source code, which will be available here in the future. In the meantime, the Continuous Profiler is available as a private preview. To inquire about the preview, reach our [support](https://docs.datadoghq.com/help).

--- a/profiler/README.MD
+++ b/profiler/README.MD
@@ -2,7 +2,4 @@
 
 ## Note
 
-Currently, this directory is empty.
-It is a placeholder for the Profiler sources, which will be available here in the future.
-In the meantime, the Profiler is available as a private preview via [dd-continuous-profiler-dotnet](https://github.com/DataDog/dd-continuous-profiler-dotnet).
- 
+This directory is currently empty. It is a placeholder for the Continuous Profiler sources, which will be available here in the future. In the meantime, the Continuous Profiler is available as a private preview. To inquire about the preview, reach our [support](https://docs.datadoghq.com/help).

--- a/profiler/README.MD
+++ b/profiler/README.MD
@@ -1,18 +1,5 @@
 ﻿# dd-trace-dotnet/profiler
 
-This repo ([dd-trace-dotnet](https://github.com/DataDog/dd-trace-dotnet)) contains the sources for the client-side components of the Datadog product suite for Application Telemetry Collection and Application Performance Monitoring for .NET Applications.
-
-This directory (`/profiler`) contains the source for the __Continuous Profiler for .NET__ product, which is a part of that product suite. 
-
-### Copyright
-
-Copyright (c) 2020 Datadog
-[https://www.datadoghq.com](https://www.datadoghq.com/)
-
-### License
-
-See [license information](../LICENSE).
-
 ## Note
 
 Currently, this directory is empty.

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -24,7 +24,6 @@ You can develop the tracer on various environments.
   - Workloads
     - Desktop development with C++
     - .NET desktop development
-    - .NET Core cross-platform development
     - Optional: ASP.NET and web development (to build samples)
   - Individual components
     - .NET Framework 4.7 targeting pack

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -1,16 +1,16 @@
 ﻿# dd-trace-dotnet/tracer
 
-This folder contains the sources of the Datadog .NET APM tracer. It automatically instruments supported libraries out-of-the-box and also supports manual instrumentation to instrument your own code.
+This folder contains the sources of the Datadog .NET APM Tracer. It automatically instruments supported libraries out-of-the-box and also supports custom instrumentation to instrument your own code.
 
 ## Installation and usage
 
 ### Getting Started
 
-Configure the Datadog agent for APM [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core#configure-the-datadog-agent-for-apm). For automatic instrumentation, install and enable the tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer).
+Configure the Datadog Agent for APM [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core#configure-the-datadog-agent-for-apm). For automatic instrumentation, install and enable the .NET Tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer).
 
 ### Custom instrumentation
 
-The Datadog .NET APM tracer allows you to manually instrument your application (in addition to automatic instrumentation). To use it, please follow [the nuget package documentation](https://github.com/DataDog/dd-trace-dotnet/tree/master/docs/Datadog.Trace/README.md)
+The Datadog .NET APM Tracer allows you to manually instrument your application (in addition to automatic instrumentation). To use it, please follow [the NuGet package documentation](https://github.com/DataDog/dd-trace-dotnet/tree/master/docs/Datadog.Trace/README.md)
 
 ## Development
 
@@ -80,9 +80,9 @@ The recommended approach for Linux is to build using Docker. You can use this ap
 ./build_in_docker.sh BuildAndRunLinuxIntegrationTests
 ```
 
-### MacOs
+### macOS
 
-You can use Rider and CLion to develop on MacOS. Building and testing can be done through the following Nuke targets:
+You can use Rider and CLion to develop on macOS. Building and testing can be done through the following Nuke targets:
 
 ```bash
 # Clean and build the main tracer project

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -1,20 +1,115 @@
 ﻿# dd-trace-dotnet/tracer
 
-This repo ([dd-trace-dotnet](https://github.com/DataDog/dd-trace-dotnet)) contains the sources for the client-side components of the Datadog product suite for Application Telemetry Collection and Application Performance Monitoring for .NET Applications.
+This folder contains the sources of the Datadog .NET APM tracer. It automatically instruments supported libraries out-of-the-box and also supports manual instrumentation to instrument your own code.
 
-This directory (`/tracer`) contains the source for the __Tracer for .NET__ product, which is a part of that product suite.
+## Installation and usage
 
-### Copyright
+### Getting Started
 
-Copyright (c) 2017 Datadog
-[https://www.datadoghq.com](https://www.datadoghq.com/)
+Configure the Datadog agent for APM [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core#configure-the-datadog-agent-for-apm). For automatic instrumentation, install and enable the tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer).
 
-### License
+### Custom instrumentation
 
-See [license information](../LICENSE).
+The Datadog .NET APM tracer allows you to manually instrument your application (in addition to automatic instrumentation). To use it, please follow [the nuget package documentation](https://github.com/DataDog/dd-trace-dotnet/tree/master/docs/Datadog.Trace/README.md)
 
-## Note
+## Development
 
-Currently, this directory is empty.
-It is a placeholder for the Tracer sources, which will be available here in the future.
-In the meantime, the Tracer is available directly in the root of this repo.
+You can develop the tracer on various environments.
+
+### Windows
+
+#### Minimum requirements
+
+- [Visual Studio 2019 (16.8)](https://visualstudio.microsoft.com/downloads/) or newer
+  - Workloads
+    - Desktop development with C++
+    - .NET desktop development
+    - .NET Core cross-platform development
+    - Optional: ASP.NET and web development (to build samples)
+  - Individual components
+    - .NET Framework 4.7 targeting pack
+- [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
+- [.NET 6.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to run 32-bit tests locally
+- Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
+- Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
+- Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
+- Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
+- Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
+  - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio
+- Optional: [Docker for Windows](https://docs.docker.com/docker-for-windows/) to build Linux binaries and run integration tests on Linux containers. See [section on Docker Compose](#building-and-running-tests-with-docker-compose).
+  - Requires Windows 10 (1607 Anniversary Update, Build 14393 or newer)
+
+Microsoft provides [evaluation developer VMs](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines) with Windows 10 and Visual Studio pre-installed.
+
+#### Building from a command line
+
+This repository uses [Nuke](https://nuke.build/) for build automation. To see a list of possible targets run:
+
+```cmd
+.\build.cmd --help
+```
+
+For example:
+
+```powershell
+# Clean and build the main tracer project
+.\build.cmd Clean BuildTracerHome
+
+# Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
+.\build.cmd BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
+
+# Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
+.\build.cmd PackageTracerHome 
+
+# Build and run integration tests. Requires BuildTracerHome to have previously been run
+.\build.cmd BuildAndRunWindowsIntegrationTests
+```
+
+### Linux
+
+The recommended approach for Linux is to build using Docker. You can use this approach for both Windows and Linux hosts. The _build_in_docker.sh_ script automates building a Docker image with the required dependencies, and running the specified Nuke targets. For example:
+
+```bash
+# Clean and build the main tracer project
+./build_in_docker.sh Clean BuildTracerHome
+
+# Build and run managed unit tests. Requires BuildTracerHome to have previously been run
+./build_in_docker.sh BuildAndRunManagedUnitTests 
+
+# Build and run integration tests. Requires BuildTracerHome to have previously been run
+./build_in_docker.sh BuildAndRunLinuxIntegrationTests
+```
+
+### MacOs
+
+You can use Rider and CLion to develop on MacOS. Building and testing can be done through the following Nuke targets:
+
+```bash
+# Clean and build the main tracer project
+.\build.sh Clean BuildTracerHome
+
+# Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
+.\build.sh BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
+
+# Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
+.\build.sh PackageTracerHome 
+
+# Build and run integration tests. Requires BuildTracerHome to have previously been run
+.\build.sh BuildAndRunIntegrationTests
+```
+
+## Further Reading
+
+Datadog APM
+- [Datadog APM](https://docs.datadoghq.com/tracing/)
+- [Datadog APM - Tracing .NET Core Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core)
+- [Datadog APM - Tracing .NET Framework Applications](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-framework)
+
+Microsoft .NET Profiling APIs
+- [Profiling API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/)
+- [Metadata API](https://docs.microsoft.com/en-us/dotnet/framework/unmanaged-api/metadata/)
+- [The Book of the Runtime - Profiling](https://github.com/dotnet/coreclr/blob/master/Documentation/botr/profiling.md)
+
+OpenTracing
+- [OpenTracing documentation](https://github.com/opentracing/opentracing-csharp)
+- [OpenTracing terminology](https://github.com/opentracing/specification/blob/master/specification.md)

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -30,11 +30,11 @@ You can develop the tracer on various environments.
     - .NET Framework 4.7 targeting pack
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
   - Optional: [.NET 6.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to run 32-bit tests locally
-- Optional: ASP.NET Core runtimes to run tests locally
-  - [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet/2.1)
-  - [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet/3.0)
-  - [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet/3.1)
-  - [ASP.NET Core 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0)
+- Optional: ASP.NET Core Runtimes to run tests locally
+  - [ASP.NET Core 2.1](https://dotnet.microsoft.com/download/dotnet/2.1)
+  - [ASP.NET Core 3.0](https://dotnet.microsoft.com/download/dotnet/3.0)
+  - [ASP.NET Core 3.1](https://dotnet.microsoft.com/download/dotnet/3.1)
+  - [ASP.NET Core 5.0](https://dotnet.microsoft.com/download/dotnet/5.0)
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -1,10 +1,10 @@
 ﻿# dd-trace-dotnet/tracer
 
-This folder contains the sources of the Datadog .NET APM Tracer. It automatically instruments supported libraries out-of-the-box and also supports custom instrumentation to instrument your own code.
+This folder contains the source code for the Datadog .NET APM Tracer. The .NET Tracer automatically instruments supported libraries out-of-the-box and also supports custom instrumentation to instrument your own code.
 
 ## Installation and usage
 
-### Getting Started
+### Getting started
 
 Configure the Datadog Agent for APM [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core#configure-the-datadog-agent-for-apm). For automatic instrumentation, install and enable the .NET Tracer [as described in our documentation](https://docs.datadoghq.com/tracing/setup_overview/setup/dotnet-core/?tab=windows#install-the-tracer).
 

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -20,7 +20,7 @@ You can develop the tracer on various environments.
 
 #### Minimum requirements
 
-- [Visual Studio 2019 (16.8)](https://visualstudio.microsoft.com/downloads/) or newer
+- [Visual Studio 2022 (v17)](https://visualstudio.microsoft.com/downloads/) or newer
   - Workloads
     - Desktop development with C++
     - .NET desktop development
@@ -30,9 +30,10 @@ You can develop the tracer on various environments.
     - .NET Framework 4.7 targeting pack
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
 - [.NET 6.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to run 32-bit tests locally
-- Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/2.1) to test in .NET Core 2.1 locally.
-- Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.0) to test in .NET Core 3.0 locally.
-- Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet-core/3.1) to test in .NET Core 3.1 locally.
+- Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet/2.1) to test locally in .NET Core 2.1.
+- Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet/3.0) to test locally in .NET Core 3.0.
+- Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet/3.1) to test locally in .NET Core 3.1.
+- Optional: [ASP.NET Core 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0) to test locally in .NET 5.0.
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio
@@ -56,10 +57,10 @@ For example:
 .\build.cmd Clean BuildTracerHome
 
 # Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
-.\build.cmd BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
+.\build.cmd BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests
 
 # Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
-.\build.cmd PackageTracerHome 
+.\build.cmd PackageTracerHome
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
 .\build.cmd BuildAndRunWindowsIntegrationTests
@@ -74,7 +75,7 @@ The recommended approach for Linux is to build using Docker. You can use this ap
 ./build_in_docker.sh Clean BuildTracerHome
 
 # Build and run managed unit tests. Requires BuildTracerHome to have previously been run
-./build_in_docker.sh BuildAndRunManagedUnitTests 
+./build_in_docker.sh BuildAndRunManagedUnitTests
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
 ./build_in_docker.sh BuildAndRunLinuxIntegrationTests
@@ -89,10 +90,10 @@ You can use Rider and CLion to develop on macOS. Building and testing can be don
 .\build.sh Clean BuildTracerHome
 
 # Build and run managed and native unit tests. Requires BuildTracerHome to have previously been run
-.\build.sh BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests 
+.\build.sh BuildAndRunManagedUnitTests BuildAndRunNativeUnitTests
 
 # Build NuGet packages and MSIs. Requires BuildTracerHome to have previously been run
-.\build.sh PackageTracerHome 
+.\build.sh PackageTracerHome
 
 # Build and run integration tests. Requires BuildTracerHome to have previously been run
 .\build.sh BuildAndRunIntegrationTests

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -29,18 +29,19 @@ You can develop the tracer on various environments.
   - Individual components
     - .NET Framework 4.7 targeting pack
 - [.NET 6.0 SDK](https://dotnet.microsoft.com/download/dotnet/6.0)
-- [.NET 6.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to run 32-bit tests locally
-- Optional: [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet/2.1) to test locally in .NET Core 2.1.
-- Optional: [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet/3.0) to test locally in .NET Core 3.0.
-- Optional: [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet/3.1) to test locally in .NET Core 3.1.
-- Optional: [ASP.NET Core 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0) to test locally in .NET 5.0.
+  - Optional: [.NET 6.0 x86 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) to run 32-bit tests locally
+- Optional: ASP.NET Core runtimes to run tests locally
+  - [ASP.NET Core 2.1 Runtime](https://dotnet.microsoft.com/download/dotnet/2.1)
+  - [ASP.NET Core 3.0 Runtime](https://dotnet.microsoft.com/download/dotnet/3.0)
+  - [ASP.NET Core 3.1 Runtime](https://dotnet.microsoft.com/download/dotnet/3.1)
+  - [ASP.NET Core 5.0 Runtime](https://dotnet.microsoft.com/download/dotnet/5.0)
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio
 - Optional: [Docker for Windows](https://docs.docker.com/docker-for-windows/) to build Linux binaries and run integration tests on Linux containers. See [section on Docker Compose](#building-and-running-tests-with-docker-compose).
   - Requires Windows 10 (1607 Anniversary Update, Build 14393 or newer)
 
-Microsoft provides [evaluation developer VMs](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines) with Windows 10 and Visual Studio pre-installed.
+Microsoft provides [evaluation developer VMs](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines) with Windows and Visual Studio pre-installed.
 
 #### Building from a command line
 

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -9,7 +9,12 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\docs\Datadog.Trace\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
Adds a README for the Datadog.Trace NuGet package, [as described here](https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/). 

This README focuses on the "getting started" process for custom instrumentation, as that (should be) the main consumers of this package. It also includes details of the breaking changes in 2.0, and how to adjust your code to account for them. We likely want to replicate this information elsewhere (e.g. in the 2.0 release notes), but I think having it viewable from the NuGet page directly is also useful.

Also made minor tweaks to the main README to account for changes in our build process (we only have a single pipeline for all stages and platforms)

> I added the `do-not-merge` tag for now, so we remember to update it before we do the 2.0 release, in case we merge any other breaking changes

The following image is a preview of what the Readme will look like on NuGet.org:

![www nuget org_packages_manage_upload](https://user-images.githubusercontent.com/18755388/142891967-fce1ab8e-3c62-4c6f-8ae4-3d943dd6b718.png)

@DataDog/apm-dotnet