### PR TITLE
Remove the newline between the log message and properties

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Logging
                        .MinimumLevel.ControlledBy(LoggingLevelSwitch)
                        .WriteTo.File(
                             managedLogPath,
-                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}{Properties}{NewLine}",
+                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{Exception}{Properties}{NewLine}",
                             rollingInterval: RollingInterval.Day,
                             rollOnFileSizeLimit: true,
                             fileSizeLimitBytes: MaxLogFileSize,


### PR DESCRIPTION
Currently the properties (e.g. `{ MachineName: ".", Process: "[44096 iisexpress]", AppDomain: "[2 /LM/W3SVC/1/ROOT-1-132820633973714685]", TracerVersion: "1.30.0.0" }`) are written on a new line _after_ the log line. This can make it difficult to tell whether a given set of properties is related to the line above or the line below. This change removes the newline.

@DataDog/apm-dotnet