### PR TITLE
Fix disabled integrations log message

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -300,7 +300,7 @@ namespace Datadog.Trace
                     {
                         if (integration.Enabled == false)
                         {
-                            writer.WriteValue(integration);
+                            writer.WriteValue(integration.IntegrationName);
                         }
                     }
 


### PR DESCRIPTION
We were trying to serialize the whole integration setting instead of just writing the name

@DataDog/apm-dotnet