### PR TITLE
[release/1.x] Cherry-pick WAF fixes from master

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -706,13 +706,7 @@ partial class Build
                 .ToList();
 
             testProjects.ForEach(EnsureResultsDirectory);
-            var filter = (string.IsNullOrEmpty(Filter), IsArm64, IsAlpine) switch
-            {
-                (true, true, false) => "(Category!=ArmUnsupported)",
-                (true, false, true) => "(Category!=AlpineUnsupported)",
-                (true, true, true) => "(Category!=AlpineUnsupported)&(Category!=ArmUnsupported)",
-                _ => Filter
-            };
+            var filter = string.IsNullOrEmpty(Filter) && IsArm64 ? "(Category!=ArmUnsupported)" : Filter;
             try
             {
                 DotNetTest(x => x

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/ReducedRegistryAccess.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/ReducedRegistryAccess.cs
@@ -148,7 +148,8 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                 if (hresult != 0)
                 {
                     // warning as the call could fail because the key is missing, which is expected in many situations
-                    Log.Warning<string, string>("registring access for key: {Key} failed with 0x{HResult}", key, hresult.ToString("X8"));
+                    Log.Warning("registering access for key: {Key} failed with 0x{HResult}", key, hresult.ToString("X8"));
+                    return null;
                 }
 
                 result = Marshal.PtrToStringUni(pvData);

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafNative.cs
@@ -488,25 +488,6 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             return success;
         }
 
-        private static bool IsMuslBasedLinux()
-        {
-            var muslDistros = new[] { "alpine" };
-
-            var files =
-                Directory.GetFiles("/etc", "*release")
-                    .Concat(Directory.GetFiles("/etc", "*version"))
-                    .ToList();
-
-            if (File.Exists("/etc/issue"))
-            {
-                files.Add("/etc/issue");
-            }
-
-            return files
-                .Select(File.ReadAllText)
-                .Any(fileContents => muslDistros.Any(distroId => fileContents.ToLowerInvariant().Contains(distroId)));
-        }
-
         private static void GetLibNameAndRuntimeId(FrameworkDescription frameworkDescription, out string libName, out string runtimeId)
         {
             string runtimeIdPart1, libPrefix, libExt;
@@ -519,10 +500,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
                     libExt = "dylib";
                     break;
                 case OSPlatform.Linux:
-                    runtimeIdPart1 =
-                        IsMuslBasedLinux() ?
-                            "linux-musl" :
-                            "linux";
+                    runtimeIdPart1 = "linux";
                     libPrefix = "lib";
                     libExt = "so";
                     break;

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.AppSec.Waf
                 }
                 else
                 {
-                    Log.Error(ex, "AppSec could not read the rule file emmbeded in the manifest as it was invalid. AppSec will not run any protections in this application.");
+                    Log.Error(ex, "AppSec could not read the rule file embedded in the manifest as it was invalid. AppSec will not run any protections in this application.");
                 }
 
                 return null;
@@ -75,6 +75,12 @@ namespace Datadog.Trace.AppSec.Waf
             {
                 DdwafConfigStruct args = default;
                 var ruleHandle = WafNative.Init(configObj.RawPtr, ref args);
+                // can happen for example if ruleset file and waf version aren't compatible
+                if (ruleHandle == IntPtr.Zero)
+                {
+                    return null;
+                }
+
                 return new Waf(new WafHandle(ruleHandle));
             }
             finally

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
-using Datadog.Trace.Configuration;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
@@ -21,7 +20,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 
         [Theory]
         [Trait("Category", "ArmUnsupported")]
-        [Trait("Category", "AlpineUnsupported")]
         [InlineData("args", "[$slice]", "nosqli", "crs-942-290")]
         [InlineData("attack", "appscan_fingerprint", "security_scanner", "crs-913-120")]
         [InlineData("key", "<script>", "xss", "crs-941-110")]
@@ -44,7 +42,6 @@ namespace Datadog.Trace.Security.Unit.Tests
         }
 
         [Fact]
-        [Trait("Category", "AlpineUnsupported")]
         [Trait("Category", "ArmUnsupported")]
         public void UrlRawAttack()
         {
@@ -57,7 +54,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 
         [Theory]
         [Trait("Category", "ArmUnsupported")]
-        [Trait("Category", "AlpineUnsupported")]
         [InlineData("user-agent", "Arachni/v1", "security_scanner", "ua0-600-12x")]
         [InlineData("referer", "<script >", "xss", "crs-941-110")]
         [InlineData("x-file-name", "routing.yml", "command_injection", "crs-932-180")]
@@ -79,7 +75,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 
         [Theory]
         [Trait("Category", "ArmUnsupported")]
-        [Trait("Category", "AlpineUnsupported")]
         [InlineData("attack", ".htaccess", "lfi", "crs-930-120")]
         [InlineData("value", "/*!*/", "sqli", "crs-942-500")]
         [InlineData("value", ";shutdown--", "sqli", "crs-942-280")]
@@ -103,7 +98,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 
         [Theory]
         [Trait("Category", "ArmUnsupported")]
-        [Trait("Category", "AlpineUnsupported")]
         [InlineData("/.adsensepostnottherenonobook", "security_scanner", "crs-913-120")]
         public void BodyAttack(string body, string flow, string rule) => Execute(AddressesConstants.RequestBody, body, flow, rule);
 


### PR DESCRIPTION
Original PR: [AppSec] Waf fixes: reading register for waf and unit tests for alpine (#2060)

* Remove musl suffix in TryLoadLibrary too
* Don't read memory if no reg key could be read
* typo fix
* Remove logging info
* simplify filter switch

@DataDog/apm-dotnet