### PR TITLE
CallTarget ByRef

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.def
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.def
@@ -6,3 +6,4 @@ EXPORTS
     IsProfilerAttached
     GetAssemblyAndSymbolsBytes
     InitializeProfiler
+    EnableByRefInstrumentation

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.cpp
@@ -899,7 +899,7 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
         unsigned callTargetStateBuffer;
         auto callTargetStateSize = CorSigCompressToken(callTargetStateTypeRef, &callTargetStateBuffer);
 
-        auto signatureLength = 6 + (numArguments * 2) + callTargetStateSize;
+        auto signatureLength = 6 + (numArguments * 3) + callTargetStateSize;
         COR_SIGNATURE signature[signatureBufferSize];
         unsigned offset = 0;
 
@@ -916,6 +916,7 @@ HRESULT CallTargetTokens::WriteBeginMethod(void* rewriterWrapperPtr, mdTypeRef i
 
         for (auto i = 0; i < numArguments; i++)
         {
+            signature[offset++] = ELEMENT_TYPE_BYREF;
             signature[offset++] = ELEMENT_TYPE_MVAR;
             signature[offset++] = 0x01 + (i + 1);
         }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/calltarget_tokens.h
@@ -26,6 +26,7 @@ class CallTargetTokens
 {
 private:
     ModuleMetadata* module_metadata_ptr = nullptr;
+    const bool enable_by_ref_instrumentation = false;
 
     // CorLib tokens
     mdAssemblyRef corLibAssemblyRef = mdAssemblyRefNil;
@@ -73,7 +74,7 @@ private:
                                                const TypeInfo* currentType, ILInstr** instruction);
 
 public:
-    CallTargetTokens(ModuleMetadata* module_metadata_ptr);
+    CallTargetTokens(ModuleMetadata* module_metadata_ptr, const bool enableByRefInstrumentation);
 
     mdTypeRef GetObjectTypeRef();
     mdTypeRef GetExceptionTypeRef();

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2587,7 +2587,7 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
         // Load the arguments directly (FastPath)
         for (int i = 0; i < numArgs; i++)
         {
-            reWriterWrapper.LoadArgument(i + (isStatic ? 0 : 1));
+            reWriterWrapper.LoadArgumentRef(i + (isStatic ? 0 : 1));
             const auto& argTypeFlags = methodArguments[i].GetTypeFlags(elementType);
             if (argTypeFlags & TypeFlagByRef)
             {

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -2587,13 +2587,14 @@ HRESULT CorProfiler::CallTarget_RewriterCallback(RejitHandlerModule* moduleHandl
         // Load the arguments directly (FastPath)
         for (int i = 0; i < numArgs; i++)
         {
-            reWriterWrapper.LoadArgumentRef(i + (isStatic ? 0 : 1));
             const auto& argTypeFlags = methodArguments[i].GetTypeFlags(elementType);
             if (argTypeFlags & TypeFlagByRef)
             {
-                Logger::Warn("*** CallTarget_RewriterCallback(): Methods with ref parameters "
-                             "cannot be instrumented. ");
-                return S_FALSE;
+                reWriterWrapper.LoadArgument(i + (isStatic ? 0 : 1));
+            }
+            else
+            {
+                reWriterWrapper.LoadArgumentRef(i + (isStatic ? 0 : 1));
             }
         }
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -44,6 +44,7 @@ private:
     // CallTarget Members
     //
     std::unique_ptr<RejitHandler> rejit_handler = nullptr;
+    bool enable_by_ref_instrumentation = false;
 
     // Cor assembly properties
     AssemblyProperty corAssemblyProperty{};
@@ -137,6 +138,7 @@ public:
     // Add Integrations methods
     //
     void InitializeProfiler(WCHAR* id, CallTargetDefinition* items, int size);
+    void EnableByRefInstrumentation();
 };
 
 // Note: Generally you should not have a single, global callback implementation,

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.cpp
@@ -95,6 +95,25 @@ ILInstr* ILRewriterWrapper::LoadArgument(const UINT16 index) const
     return pNewInstr;
 }
 
+ILInstr* ILRewriterWrapper::LoadArgumentRef(const UINT16 index) const
+{
+    ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
+
+    if (index <= 255)
+    {
+        pNewInstr->m_opcode = CEE_LDARGA_S;
+        pNewInstr->m_Arg8 = static_cast<UINT8>(index);
+    }
+    else
+    {
+        pNewInstr->m_opcode = CEE_LDARGA;
+        pNewInstr->m_Arg16 = index;
+    }
+
+    m_ILRewriter->InsertBefore(m_ILInstr, pNewInstr);
+    return pNewInstr;
+}
+
 void ILRewriterWrapper::Cast(const mdTypeRef type_ref) const
 {
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/il_rewriter_wrapper.h
@@ -23,6 +23,7 @@ public:
     void LoadInt64(INT64 value) const;
     void LoadInt32(INT32 value) const;
     ILInstr* LoadArgument(UINT16 index) const;
+    ILInstr* LoadArgumentRef(UINT16 index) const;
     void Cast(mdTypeRef type_ref) const;
     void Box(mdTypeRef type_ref) const;
     void UnboxAny(mdTypeRef type_ref) const;

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/interop.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/interop.cpp
@@ -28,6 +28,11 @@ EXTERN_C VOID STDAPICALLTYPE InitializeProfiler(WCHAR* id, trace::CallTargetDefi
     return trace::profiler->InitializeProfiler(id, items, size);
 }
 
+EXTERN_C VOID STDAPICALLTYPE EnableByRefInstrumentation()
+{
+    return trace::profiler->EnableByRefInstrumentation();
+}
+
 #ifndef _WIN32
 EXTERN_C void *dddlopen (const char *__file, int __mode)
 {

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/module_metadata.h
@@ -32,12 +32,13 @@ public:
     const AppDomainID app_domain_id;
     const GUID module_version_id;
     const AssemblyProperty* corAssemblyProperty = nullptr;
+    const bool enable_by_ref_instrumentation = false;
 
     ModuleMetadata(ComPtr<IMetaDataImport2> metadata_import, ComPtr<IMetaDataEmit2> metadata_emit,
                    ComPtr<IMetaDataAssemblyImport> assembly_import, ComPtr<IMetaDataAssemblyEmit> assembly_emit,
                    const WSTRING& assembly_name, const AppDomainID app_domain_id, const GUID module_version_id,
                    std::unique_ptr<std::vector<IntegrationDefinition>>&& integrations,
-                   const AssemblyProperty* corAssemblyProperty) :
+                   const AssemblyProperty* corAssemblyProperty, const bool enableByRefInstrumentation) :
         metadata_import(metadata_import),
         metadata_emit(metadata_emit),
         assembly_import(assembly_import),
@@ -46,13 +47,15 @@ public:
         app_domain_id(app_domain_id),
         module_version_id(module_version_id),
         integrations(std::move(integrations)),
-        corAssemblyProperty(corAssemblyProperty)
+        corAssemblyProperty(corAssemblyProperty),
+        enable_by_ref_instrumentation(enableByRefInstrumentation)
     {
     }
 
     ModuleMetadata(ComPtr<IMetaDataImport2> metadata_import, ComPtr<IMetaDataEmit2> metadata_emit,
                    ComPtr<IMetaDataAssemblyImport> assembly_import, ComPtr<IMetaDataAssemblyEmit> assembly_emit,
-                   const WSTRING& assembly_name, const AppDomainID app_domain_id, const AssemblyProperty* corAssemblyProperty) :
+                   const WSTRING& assembly_name, const AppDomainID app_domain_id,
+                   const AssemblyProperty* corAssemblyProperty, const bool enableByRefInstrumentation) :
         metadata_import(metadata_import),
         metadata_emit(metadata_emit),
         assembly_import(assembly_import),
@@ -60,7 +63,8 @@ public:
         assemblyName(assembly_name),
         app_domain_id(app_domain_id),
         module_version_id(),
-        corAssemblyProperty(corAssemblyProperty)
+        corAssemblyProperty(corAssemblyProperty),
+        enable_by_ref_instrumentation(enableByRefInstrumentation)
     {
     }
 
@@ -97,7 +101,7 @@ public:
     {
         if (calltargetTokens == nullptr)
         {
-            calltargetTokens = std::make_unique<CallTargetTokens>(this);
+            calltargetTokens = std::make_unique<CallTargetTokens>(this, enable_by_ref_instrumentation);
         }
         return calltargetTokens.get();
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.cpp
@@ -790,7 +790,7 @@ ULONG RejitHandler::ProcessModuleForRejit(const std::vector<ModuleID>& modules,
 
                     const auto moduleMetadata = new ModuleMetadata(
                         metadataImport, metadataEmit, assemblyImport, assemblyEmit, moduleInfo.assembly.name,
-                        moduleInfo.assembly.app_domain_id, m_pCorAssemblyProperty);
+                        moduleInfo.assembly.app_domain_id, m_pCorAssemblyProperty, enable_by_ref_instrumentation);
 
                     Logger::Info("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
                                  " AppDomain ", moduleInfo.assembly.app_domain_id, " ",
@@ -839,6 +839,11 @@ ULONG RejitHandler::ProcessModuleForRejit(const std::vector<ModuleID>& modules,
     }
 
     return rejitCount;
+}
+
+void RejitHandler::SetEnableByRefInstrumentation(bool enableByRefInstrumentation)
+{
+    enable_by_ref_instrumentation = enableByRefInstrumentation;
 }
 
 } // namespace trace

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/rejit_handler.h
@@ -123,6 +123,7 @@ private:
 
     std::unique_ptr<UniqueBlockingQueue<RejitItem>> m_rejit_queue;
     std::unique_ptr<std::thread> m_rejit_queue_thread;
+    bool enable_by_ref_instrumentation = false;
 
     std::mutex m_ngenModules_lock;
     std::vector<ModuleID> m_ngenModules;
@@ -139,6 +140,7 @@ public:
                  std::function<HRESULT(RejitHandlerModule*, RejitHandlerModuleMethod*)> rewriteCallback);
 
     RejitHandlerModule* GetOrAddModule(ModuleID moduleId);
+    void SetEnableByRefInstrumentation(bool enableByRefInstrumentation);
 
     void RemoveModule(ModuleID moduleId);
     bool HasModuleAndMethod(ModuleID moduleId, mdMethodDef methodDef);

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -47,6 +47,222 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg1">First argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget instance, TArg1 arg1)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1>.Invoke(instance, ref arg1);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2>(TTarget instance, TArg1 arg1, TArg2 arg2)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2>.Invoke(instance, ref arg1, ref arg2);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <typeparam name="TArg3">Third argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <param name="arg3">Third argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3>.Invoke(instance, ref arg1, ref arg2, ref arg3);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <typeparam name="TArg3">Third argument type</typeparam>
+        /// <typeparam name="TArg4">Fourth argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <param name="arg3">Third argument value</param>
+        /// <param name="arg4">Fourth argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <typeparam name="TArg3">Third argument type</typeparam>
+        /// <typeparam name="TArg4">Fourth argument type</typeparam>
+        /// <typeparam name="TArg5">Fifth argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <param name="arg3">Third argument value</param>
+        /// <param name="arg4">Fourth argument value</param>
+        /// <param name="arg5">Fifth argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <typeparam name="TArg3">Third argument type</typeparam>
+        /// <typeparam name="TArg4">Fourth argument type</typeparam>
+        /// <typeparam name="TArg5">Fifth argument type</typeparam>
+        /// <typeparam name="TArg6">Sixth argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <param name="arg3">Third argument value</param>
+        /// <param name="arg4">Fourth argument value</param>
+        /// <param name="arg5">Fifth argument value</param>
+        /// <param name="arg6">Sixth argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <typeparam name="TArg3">Third argument type</typeparam>
+        /// <typeparam name="TArg4">Fourth argument type</typeparam>
+        /// <typeparam name="TArg5">Fifth argument type</typeparam>
+        /// <typeparam name="TArg6">Sixth argument type</typeparam>
+        /// <typeparam name="TArg7">Seventh argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <param name="arg3">Third argument value</param>
+        /// <param name="arg4">Fourth argument value</param>
+        /// <param name="arg5">Fifth argument value</param>
+        /// <param name="arg6">Sixth argument value</param>
+        /// <param name="arg7">Seventh argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <typeparam name="TArg2">Second argument type</typeparam>
+        /// <typeparam name="TArg3">Third argument type</typeparam>
+        /// <typeparam name="TArg4">Fourth argument type</typeparam>
+        /// <typeparam name="TArg5">Fifth argument type</typeparam>
+        /// <typeparam name="TArg6">Sixth argument type</typeparam>
+        /// <typeparam name="TArg7">Seventh argument type</typeparam>
+        /// <typeparam name="TArg8">Eighth argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <param name="arg2">Second argument value</param>
+        /// <param name="arg3">Third argument value</param>
+        /// <param name="arg4">Fourth argument value</param>
+        /// <param name="arg5">Fifth argument value</param>
+        /// <param name="arg6">Sixth argument value</param>
+        /// <param name="arg7">Seventh argument value</param>
+        /// <param name="arg8">Eighth argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
+        {
+            if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
+            {
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        /// <summary>
+        /// Begin Method Invoker
+        /// </summary>
+        /// <typeparam name="TIntegration">Integration type</typeparam>
+        /// <typeparam name="TTarget">Target type</typeparam>
+        /// <typeparam name="TArg1">First argument type</typeparam>
+        /// <param name="instance">Instance value</param>
+        /// <param name="arg1">First argument value</param>
+        /// <returns>Call target state</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget instance, ref TArg1 arg1)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
@@ -47,11 +47,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg1">First argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget instance, TArg1 arg1)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1>(TTarget instance, ref TArg1 arg1)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1>.Invoke(instance, arg1);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1>.Invoke(instance, ref arg1);
             }
 
             return CallTargetState.GetDefault();
@@ -69,11 +69,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg2">Second argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2>(TTarget instance, TArg1 arg1, TArg2 arg2)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2>.Invoke(instance, arg1, arg2);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2>.Invoke(instance, ref arg1, ref arg2);
             }
 
             return CallTargetState.GetDefault();
@@ -93,11 +93,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg3">Third argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3>.Invoke(instance, arg1, arg2, arg3);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3>.Invoke(instance, ref arg1, ref arg2, ref arg3);
             }
 
             return CallTargetState.GetDefault();
@@ -119,11 +119,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg4">Fourth argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>.Invoke(instance, arg1, arg2, arg3, arg4);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4);
             }
 
             return CallTargetState.GetDefault();
@@ -147,11 +147,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg5">Fifth argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>.Invoke(instance, arg1, arg2, arg3, arg4, arg5);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5);
             }
 
             return CallTargetState.GetDefault();
@@ -177,11 +177,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg6">Sixth argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>.Invoke(instance, arg1, arg2, arg3, arg4, arg5, arg6);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6);
             }
 
             return CallTargetState.GetDefault();
@@ -209,11 +209,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg7">Seventh argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>.Invoke(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7);
             }
 
             return CallTargetState.GetDefault();
@@ -243,11 +243,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         /// <param name="arg8">Eighth argument value</param>
         /// <returns>Call target state</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
+        public static CallTargetState BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8)
         {
             if (IntegrationOptions<TIntegration, TTarget>.IsIntegrationEnabled)
             {
-                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>.Invoke(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                return BeginMethodHandler<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>.Invoke(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8);
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -18,7 +18,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -18,7 +18,9 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -18,7 +18,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                Type tArg3ByRef = typeof(TArg3).IsByRef ? typeof(TArg3) : typeof(TArg3).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef, tArg3ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2), typeof(TArg3) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2, arg3) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2), typeof(TArg3), typeof(TArg4) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2, arg3, arg4) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -18,7 +18,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                Type tArg3ByRef = typeof(TArg3).IsByRef ? typeof(TArg3) : typeof(TArg3).MakeByRefType();
+                Type tArg4ByRef = typeof(TArg4).IsByRef ? typeof(TArg4) : typeof(TArg4).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef, tArg3ByRef, tArg4ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2), typeof(TArg3), typeof(TArg4), typeof(TArg5) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2, arg3, arg4, arg5) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -18,7 +18,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                Type tArg3ByRef = typeof(TArg3).IsByRef ? typeof(TArg3) : typeof(TArg3).MakeByRefType();
+                Type tArg4ByRef = typeof(TArg4).IsByRef ? typeof(TArg4) : typeof(TArg4).MakeByRefType();
+                Type tArg5ByRef = typeof(TArg5).IsByRef ? typeof(TArg5) : typeof(TArg5).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef, tArg3ByRef, tArg4ByRef, tArg5ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -18,7 +18,13 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType(), typeof(TArg6).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                Type tArg3ByRef = typeof(TArg3).IsByRef ? typeof(TArg3) : typeof(TArg3).MakeByRefType();
+                Type tArg4ByRef = typeof(TArg4).IsByRef ? typeof(TArg4) : typeof(TArg4).MakeByRefType();
+                Type tArg5ByRef = typeof(TArg5).IsByRef ? typeof(TArg5) : typeof(TArg5).MakeByRefType();
+                Type tArg6ByRef = typeof(TArg6).IsByRef ? typeof(TArg6) : typeof(TArg6).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef, tArg3ByRef, tArg4ByRef, tArg5ByRef, tArg6ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2), typeof(TArg3), typeof(TArg4), typeof(TArg5), typeof(TArg6) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType(), typeof(TArg6).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2, arg3, arg4, arg5, arg6) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2), typeof(TArg3), typeof(TArg4), typeof(TArg5), typeof(TArg6), typeof(TArg7) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType(), typeof(TArg6).MakeByRefType(), typeof(TArg7).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -18,7 +18,14 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType(), typeof(TArg6).MakeByRefType(), typeof(TArg7).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                Type tArg3ByRef = typeof(TArg3).IsByRef ? typeof(TArg3) : typeof(TArg3).MakeByRefType();
+                Type tArg4ByRef = typeof(TArg4).IsByRef ? typeof(TArg4) : typeof(TArg4).MakeByRefType();
+                Type tArg5ByRef = typeof(TArg5).IsByRef ? typeof(TArg5) : typeof(TArg5).MakeByRefType();
+                Type tArg6ByRef = typeof(TArg6).IsByRef ? typeof(TArg6) : typeof(TArg6).MakeByRefType();
+                Type tArg7ByRef = typeof(TArg7).IsByRef ? typeof(TArg7) : typeof(TArg7).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef, tArg3ByRef, tArg4ByRef, tArg5ByRef, tArg6ByRef, tArg7ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1), typeof(TArg2), typeof(TArg3), typeof(TArg4), typeof(TArg5), typeof(TArg6), typeof(TArg7), typeof(TArg8) });
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType(), typeof(TArg6).MakeByRefType(), typeof(TArg7).MakeByRefType(), typeof(TArg8).MakeByRefType() });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));
@@ -32,17 +32,17 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 if (_invokeDelegate is null)
                 {
-                    _invokeDelegate = (instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8) => CallTargetState.GetDefault();
+                    _invokeDelegate = (TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8) => CallTargetState.GetDefault();
                 }
             }
         }
 
-        internal delegate CallTargetState InvokeDelegate(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8);
+        internal delegate CallTargetState InvokeDelegate(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static CallTargetState Invoke(TTarget instance, TArg1 arg1, TArg2 arg2, TArg3 arg3, TArg4 arg4, TArg5 arg5, TArg6 arg6, TArg7 arg7, TArg8 arg8)
+        internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8)
         {
-            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8));
+            return new CallTargetState(Tracer.Instance.ActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -18,7 +18,15 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             try
             {
-                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { typeof(TArg1).MakeByRefType(), typeof(TArg2).MakeByRefType(), typeof(TArg3).MakeByRefType(), typeof(TArg4).MakeByRefType(), typeof(TArg5).MakeByRefType(), typeof(TArg6).MakeByRefType(), typeof(TArg7).MakeByRefType(), typeof(TArg8).MakeByRefType() });
+                Type tArg1ByRef = typeof(TArg1).IsByRef ? typeof(TArg1) : typeof(TArg1).MakeByRefType();
+                Type tArg2ByRef = typeof(TArg2).IsByRef ? typeof(TArg2) : typeof(TArg2).MakeByRefType();
+                Type tArg3ByRef = typeof(TArg3).IsByRef ? typeof(TArg3) : typeof(TArg3).MakeByRefType();
+                Type tArg4ByRef = typeof(TArg4).IsByRef ? typeof(TArg4) : typeof(TArg4).MakeByRefType();
+                Type tArg5ByRef = typeof(TArg5).IsByRef ? typeof(TArg5) : typeof(TArg5).MakeByRefType();
+                Type tArg6ByRef = typeof(TArg6).IsByRef ? typeof(TArg6) : typeof(TArg6).MakeByRefType();
+                Type tArg7ByRef = typeof(TArg7).IsByRef ? typeof(TArg7) : typeof(TArg7).MakeByRefType();
+                Type tArg8ByRef = typeof(TArg8).IsByRef ? typeof(TArg8) : typeof(TArg8).MakeByRefType();
+                DynamicMethod dynMethod = IntegrationMapper.CreateBeginMethodDelegate(typeof(TIntegration), typeof(TTarget), new[] { tArg1ByRef, tArg2ByRef, tArg3ByRef, tArg4ByRef, tArg5ByRef, tArg6ByRef, tArg7ByRef, tArg8ByRef });
                 if (dynMethod != null)
                 {
                     _invokeDelegate = (InvokeDelegate)dynMethod.CreateDelegate(typeof(InvokeDelegate));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -113,6 +113,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             for (var i = mustLoadInstance ? 1 : 0; i < onMethodBeginParameters.Length; i++)
             {
                 Type sourceParameterType = argumentsTypes[mustLoadInstance ? i - 1 : i];
+                sourceParameterType = sourceParameterType.GetElementType();
+
                 Type targetParameterType = onMethodBeginParameters[i].ParameterType;
                 Type targetParameterTypeConstraint = null;
                 Type parameterProxyType = null;
@@ -138,6 +140,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 }
 
                 WriteLoadArgument(ilWriter, i, mustLoadInstance);
+                ilWriter.Emit(OpCodes.Ldobj, sourceParameterType);
+
                 if (parameterProxyType != null)
                 {
                     WriteCreateNewProxyInstance(ilWriter, parameterProxyType, sourceParameterType);

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -156,7 +156,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 }
                 else if (parameterProxyType == null)
                 {
-                    WriteLoadArgumentRef(ilWriter, i, mustLoadInstance);
+                    WriteLoadArgument(ilWriter, i, mustLoadInstance);
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -132,11 +132,12 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                         callGenericTypes.Add(parameterProxyType);
                     }
                 }
-                else if (!(sourceParameterType.IsEnum && targetParameterType.IsEnum))
+                else
                 {
                     var srcParameterType = sourceParameterType.IsByRef ? sourceParameterType.GetElementType() : sourceParameterType;
                     var trgParameterType = targetParameterType.IsByRef ? targetParameterType.GetElementType() : targetParameterType;
-                    if (!trgParameterType.IsAssignableFrom(srcParameterType))
+
+                    if (!trgParameterType.IsAssignableFrom(srcParameterType) && (!(srcParameterType.IsEnum && trgParameterType.IsEnum)))
                     {
                         throw new InvalidCastException($"The target parameter {targetParameterType} can't be assigned from {sourceParameterType}");
                     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -71,6 +71,17 @@ namespace Datadog.Trace.ClrProfiler
 
             try
             {
+                Log.Debug("Enabling by ref instrumentation.");
+                NativeMethods.EnableByRefInstrumentation();
+                Log.Information("ByRef instrumentation enabled.");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "ByRef instrumentation cannot be enabled: ");
+            }
+
+            try
+            {
                 Log.Debug("Sending CallTarget integration definitions to native library.");
                 var payload = InstrumentationDefinitions.GetAllDefinitions();
                 NativeMethods.InitializeProfiler(payload.DefinitionsId, payload.Definitions);

--- a/tracer/src/Datadog.Trace/ClrProfiler/NativeMethods.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/NativeMethods.cs
@@ -35,6 +35,18 @@ namespace Datadog.Trace.ClrProfiler
             }
         }
 
+        public static void EnableByRefInstrumentation()
+        {
+            if (IsWindows)
+            {
+                Windows.EnableByRefInstrumentation();
+            }
+            else
+            {
+                NonWindows.EnableByRefInstrumentation();
+            }
+        }
+
         // the "dll" extension is required on .NET Framework
         // and optional on .NET Core
         private static class Windows
@@ -44,6 +56,9 @@ namespace Datadog.Trace.ClrProfiler
 
             [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
             public static extern void InitializeProfiler([MarshalAs(UnmanagedType.LPWStr)] string id, [In] NativeCallTargetDefinition[] methodArrays, int size);
+
+            [DllImport("Datadog.Trace.ClrProfiler.Native.dll")]
+            public static extern void EnableByRefInstrumentation();
         }
 
         // assume .NET Core if not running on Windows
@@ -54,6 +69,9 @@ namespace Datadog.Trace.ClrProfiler
 
             [DllImport("Datadog.Trace.ClrProfiler.Native")]
             public static extern void InitializeProfiler([MarshalAs(UnmanagedType.LPWStr)] string id, [In] NativeCallTargetDefinition[] methodArrays, int size);
+
+            [DllImport("Datadog.Trace.ClrProfiler.Native")]
+            public static extern void EnableByRefInstrumentation();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -79,5 +79,60 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
             }
         }
+
+        [SkippableFact]
+        public void MethodRefArguments()
+        {
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (new MockTracerAgent(agentPort))
+            using (var processResult = RunSampleAndWaitForExit(agentPort, arguments: "withref"))
+            {
+                string beginMethodString = $"ProfilerOK: BeginMethod\\({2}\\)";
+                int beginMethodCount = Regex.Matches(processResult.StandardOutput, beginMethodString).Count;
+                int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
+
+                string[] typeNames = new string[]
+                {
+                    ".VoidMethod",
+                    ".VoidRefMethod",
+                };
+
+                Assert.Equal(2, beginMethodCount);
+                Assert.Equal(2, endMethodCount);
+
+                foreach (var typeName in typeNames)
+                {
+                    Assert.Contains(typeName, processResult.StandardOutput);
+                }
+            }
+        }
+
+        [SkippableFact]
+        public void MethodOutArguments()
+        {
+            int agentPort = TcpPortProvider.GetOpenPort();
+
+            using (new MockTracerAgent(agentPort))
+            using (var processResult = RunSampleAndWaitForExit(agentPort, arguments: "without"))
+            {
+                string beginMethodString = $"ProfilerOK: BeginMethod\\({2}\\)";
+                int beginMethodCount = Regex.Matches(processResult.StandardOutput, beginMethodString).Count;
+                int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
+
+                string[] typeNames = new string[]
+                {
+                    ".VoidMethod",
+                };
+
+                Assert.Equal(1, beginMethodCount);
+                Assert.Equal(1, endMethodCount);
+
+                foreach (var typeName in typeNames)
+                {
+                    Assert.Contains(typeName, processResult.StandardOutput);
+                }
+            }
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Native.Tests/metadata_builder_test.cpp
@@ -60,7 +60,7 @@ class MetadataBuilderTest : public ::testing::Test {
     const std::vector<IntegrationDefinition> integrations;
     module_metadata_ =
         new ModuleMetadata(metadataImport, metadataEmit, assemblyImport, assemblyEmit, assemblyName, app_domain_id,
-                           module_version_id, std::make_unique<std::vector<IntegrationDefinition>>(integrations), NULL);
+                           module_version_id, std::make_unique<std::vector<IntegrationDefinition>>(integrations), NULL, true);
 
     mdModule module;
     hr = metadataImport->GetModuleFromScope(&module);

--- a/tracer/test/benchmarks/Benchmarks.Trace/CallTarget.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/CallTarget.cs
@@ -67,7 +67,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1>(targetInstance, arg1);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1>(targetInstance, ref arg1);
                 }
                 catch (Exception ex)
                 {
@@ -108,7 +108,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2>(targetInstance, arg1, arg2);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2>(targetInstance, ref arg1, ref arg2);
                 }
                 catch (Exception ex)
                 {
@@ -149,7 +149,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(targetInstance, arg1, arg2, arg3);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(targetInstance, ref arg1, ref arg2, ref arg3);
                 }
                 catch (Exception ex)
                 {
@@ -190,7 +190,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(targetInstance, arg1, arg2, arg3, arg4);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4);
                 }
                 catch (Exception ex)
                 {
@@ -231,7 +231,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(targetInstance, arg1, arg2, arg3, arg4, arg5);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5);
                 }
                 catch (Exception ex)
                 {
@@ -272,7 +272,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(targetInstance, arg1, arg2, arg3, arg4, arg5, arg6);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6);
                 }
                 catch (Exception ex)
                 {
@@ -313,7 +313,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(targetInstance, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7);
                 }
                 catch (Exception ex)
                 {
@@ -354,7 +354,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(targetInstance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8);
                 }
                 catch (Exception ex)
                 {
@@ -436,7 +436,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1>(targetInstance, arg1);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1>(targetInstance, ref arg1);
                 }
                 catch (Exception ex)
                 {
@@ -474,7 +474,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2>(targetInstance, arg1, arg2);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2>(targetInstance, ref arg1, ref arg2);
                 }
                 catch (Exception ex)
                 {
@@ -512,7 +512,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(targetInstance, arg1, arg2, arg3);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3>(targetInstance, ref arg1, ref arg2, ref arg3);
                 }
                 catch (Exception ex)
                 {
@@ -550,7 +550,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(targetInstance, arg1, arg2, arg3, arg4);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4);
                 }
                 catch (Exception ex)
                 {
@@ -588,7 +588,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(targetInstance, arg1, arg2, arg3, arg4, arg5);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5);
                 }
                 catch (Exception ex)
                 {
@@ -626,7 +626,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(targetInstance, arg1, arg2, arg3, arg4, arg5, arg6);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6);
                 }
                 catch (Exception ex)
                 {
@@ -664,7 +664,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(targetInstance, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7);
                 }
                 catch (Exception ex)
                 {
@@ -702,7 +702,7 @@ namespace Benchmarks.Trace
             {
                 try
                 {
-                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(targetInstance, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                    state = CallTargetInvoker.BeginMethod<TIntegration, TTarget, TArg1, TArg2, TArg3, TArg4, TArg5, TArg6, TArg7, TArg8>(targetInstance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntOutVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntOutVoidIntegration.cs
@@ -1,0 +1,26 @@
+using System;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace CallTargetNativeTest.NoOp
+{
+    public static class StringAndIntOutVoidIntegration
+    {
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, out string stringValue, out int intValue)
+        {
+            CallTargetState returnValue = CallTargetState.GetDefault();
+            Console.WriteLine($"ProfilerOK: BeginMethod(2)<{typeof(StringAndIntOutVoidIntegration)}, {typeof(TTarget)}>({instance})");
+
+            stringValue = "stringValue";
+            intValue = 12;
+
+            return returnValue;
+        }
+
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            CallTargetReturn returnValue = CallTargetReturn.GetDefault();
+            Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(StringAndIntOutVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            return returnValue;
+        }
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntRefModificationVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/StringAndIntRefModificationVoidIntegration.cs
@@ -1,0 +1,27 @@
+using System;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace CallTargetNativeTest.NoOp
+{
+    public static class StringAndIntRefModificationVoidIntegration
+    {
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance, ref string stringValue, ref int intValue)
+        {
+            CallTargetState returnValue = CallTargetState.GetDefault();
+            Console.WriteLine($"ProfilerOK: BeginMethod(2)<{typeof(StringAndIntRefModificationVoidIntegration)}, {typeof(TTarget)}>({instance})");
+            
+            // Let's modify the method arguments
+            stringValue = stringValue + " (Modified)";
+            intValue = 42;
+
+            return returnValue;
+        }
+
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            CallTargetReturn returnValue = CallTargetReturn.GetDefault();
+            Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(StringAndIntRefModificationVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            return returnValue;
+        }
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
@@ -14,7 +14,6 @@
         "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
         "DD_VERSION": "1.0.0",
         "DD_CLR_ENABLE_INLINING": "1",
-        "DD_TRACE_DEBUG": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
       },
       "nativeDebugging": true

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
@@ -14,6 +14,7 @@
         "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
         "DD_VERSION": "1.0.0",
         "DD_CLR_ENABLE_INLINING": "1",
+        "DD_TRACE_DEBUG": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
       },
       "nativeDebugging": true

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithOutArguments.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithOutArguments.cs
@@ -1,0 +1,11 @@
+﻿namespace CallTargetNativeTest
+{
+    internal class WithOutArguments
+    {
+        public void VoidMethod(out string arg1, out int arg2)
+        {
+            arg1 = "Arg01";
+            arg2 = 12;
+        }
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefArguments.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefArguments.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CallTargetNativeTest
+{
+    internal class WithRefArguments
+    {
+        public string StringValue { get; set; }
+        public int IntValue { get; set; }
+
+        public void VoidMethod(string arg1, int arg2)
+        {
+            StringValue = arg1;
+            IntValue = arg2;
+        }
+
+        public void VoidRefMethod(ref string arg1, ref int arg2)
+        {
+            StringValue = arg1;
+            IntValue = arg2;
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the implementation of CallTarget to pass all arguments by ref. 

It's an optional feature so no changes are required to existing integrations.

This add supports to:

- Avoid copying big structs values.
- Support to Integrations with ref or out parameters.
- Arguments modifications.

Limitations:

- Automatic DuckTyping by generic constraints is not supported on by ref arguments.

@DataDog/apm-dotnet