### PR TITLE
Add space in log line

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Logging
                        .MinimumLevel.ControlledBy(LoggingLevelSwitch)
                        .WriteTo.File(
                             managedLogPath,
-                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{Exception}{Properties}{NewLine}",
+                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{Exception} {Properties}{NewLine}",
                             rollingInterval: RollingInterval.Day,
                             rollOnFileSizeLimit: true,
                             fileSizeLimitBytes: MaxLogFileSize,


### PR DESCRIPTION
In #2070 we moved the properties onto the same line in log messages, but didn't add a space before the properties:

`Registering Datadog.Trace.ClrProfiler.ManualTracer as child tracer{ MachineName: ".", Process: "[150492 iisexpress]", AppDomain: "[2 /LM/W3SVC/1/ROOT-1-132824141385306813]", TracerVersion: "1.30.0.0" }`

This upsets some peoples aesthetic sensibilities, so this PR adds a space

@DataDog/apm-dotnet