### PR TITLE
Mock the active span when using multiple versions of the tracer

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -17,6 +17,12 @@ namespace Datadog.Trace.ClrProfiler
 
         private ICommonTracer _child;
 
+        IScope IDistributedTracer.GetActiveScope()
+        {
+            // The automatic tracer doesn't need to get the manual active trace
+            return null;
+        }
+
         SpanContext IDistributedTracer.GetSpanContext()
         {
             if (_child is null)
@@ -51,6 +57,11 @@ namespace Datadog.Trace.ClrProfiler
             }
 
             return (SamplingPriority?)_child.TrySetSamplingPriority((int?)samplingPriority);
+        }
+
+        public object GetActiveScope()
+        {
+            return Tracer.Instance.InternalActiveScope;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler
             return (SamplingPriority?)_child.TrySetSamplingPriority((int?)samplingPriority);
         }
 
-        public object GetActiveScope()
+        public object GetAutomaticActiveScope()
         {
             return Tracer.Instance.InternalActiveScope;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
@@ -9,7 +9,7 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal interface IAutomaticTracer : ICommonTracer
     {
-        object GetActiveScope();
+        object GetAutomaticActiveScope();
 
         IReadOnlyDictionary<string, string> GetDistributedTrace();
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal interface IAutomaticTracer : ICommonTracer
     {
+        object GetActiveScope();
+
         IReadOnlyDictionary<string, string> GetDistributedTrace();
 
         void SetDistributedTrace(IReadOnlyDictionary<string, string> trace);

--- a/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.ClrProfiler
     {
         SpanContext GetSpanContext();
 
+        IScope GetActiveScope();
+
         void SetSpanContext(SpanContext value);
 
         void LockSamplingPriority();

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler
             }
 
             // We don't own the active trace, get the scope from the parent and mock it
-            var activeScope = _parent.GetActiveScope();
+            var activeScope = _parent.GetAutomaticActiveScope();
 
             if (activeScope is null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -36,7 +36,6 @@ namespace Datadog.Trace.ClrProfiler
 
             if (activeScope is null)
             {
-                Log.Warning("Parent tracer owns the active trace, yet the scope is null");
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -4,17 +4,51 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler
 {
     internal class ManualTracer : CommonTracer, IDistributedTracer
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(ManualTracer));
+
         private readonly IAutomaticTracer _parent;
 
         internal ManualTracer(IAutomaticTracer parent)
         {
             _parent = parent ?? throw new ArgumentNullException(nameof(parent));
             _parent.Register(this);
+        }
+
+        IScope IDistributedTracer.GetActiveScope()
+        {
+            var activeTrace = _parent.GetDistributedTrace();
+
+            if (activeTrace is SpanContext)
+            {
+                // This is a local trace, no need to mock anything
+                return null;
+            }
+
+            // We don't own the active trace, get the scope from the parent and mock it
+            var activeScope = _parent.GetActiveScope();
+
+            if (activeScope is null)
+            {
+                Log.Warning("Parent tracer owns the active trace, yet the scope is null");
+                return null;
+            }
+
+            try
+            {
+                return activeScope.DuckCast<IScope>();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Error while trying to ducktype the parent scope");
+                return null;
+            }
         }
 
         SpanContext IDistributedTracer.GetSpanContext()

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -150,7 +150,13 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the active scope
         /// </summary>
-        public IScope ActiveScope => InternalActiveScope;
+        public IScope ActiveScope
+        {
+            get
+            {
+                return DistributedTracer.Instance.GetActiveScope() ?? InternalActiveScope;
+            }
+        }
 
         /// <summary>
         /// Gets the active scope

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using System.Reflection;
 using System.Web.Mvc;
 using Datadog.Trace;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Samples.AspNet.VersionConflict.Controllers
 {
@@ -46,7 +48,7 @@ namespace Samples.AspNet.VersionConflict.Controllers
 
             scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");
 
-            return Json(scope.Span);
+            return Content(JsonConvert.SerializeObject(scope.Span, typeof(ISpan), new JsonSerializerSettings()));
         }
 
         public ActionResult SendRequest()

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
@@ -10,7 +10,7 @@ namespace Samples.AspNet.VersionConflict.Controllers
 {
     public class HomeController : Controller
     {
-        private static readonly Version _manualTracingVersion = new Version("2.255.251.0");
+        private static readonly Version _manualTracingVersion = new Version("2.255.0.0");
 
         public ActionResult Index()
         {
@@ -26,11 +26,33 @@ namespace Samples.AspNet.VersionConflict.Controllers
             return RedirectToAction("Index");
         }
 
+        public ActionResult ParentScope()
+        {
+            var scope = Tracer.Instance.ActiveScope;
+
+            if (scope == null)
+            {
+                throw new Exception("Tracer.Instance.ActiveScope is null");
+            }
+
+            scope.Span.SetTag("Test", "OK");
+
+            var tagValue = scope.Span.GetTag("Test");
+
+            if (tagValue != "OK")
+            {
+                throw new Exception("Roundtrip tag test failed: " + (tagValue ?? "{null}"));
+            }
+
+            scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");
+
+            return Json(scope.Span);
+        }
+
         public ActionResult SendRequest()
         {
-            int result = 0;
+            int result;
 
-            // Create two nested manual spans to make sure the parent-child relationship is maintained
             using (Tracer.Instance.StartActive("Manual"))
             {
                 using (var innerScope = Tracer.Instance.StartActive("Manual-Inner"))

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -27,8 +27,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Datadog.Trace, Version=2.255.251.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.251\lib\net461\Datadog.Trace.dll</HintPath>
+    <Reference Include="Datadog.Trace, Version=2.255.250.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.250\lib\net461\Datadog.Trace.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -27,8 +27,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Datadog.Trace, Version=2.255.250.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.250\lib\net461\Datadog.Trace.dll</HintPath>
+    <Reference Include="Datadog.Trace, Version=2.255.249.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.249\lib\net461\Datadog.Trace.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Web.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   For more information on how to configure your ASP.NET application, please visit
   https://go.microsoft.com/fwlink/?LinkId=301880
@@ -6,9 +6,9 @@
 <configuration>
   <configSections>
     <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false"/>
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
-  <appSettings/>
+  <appSettings />
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
 
@@ -18,55 +18,55 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.6.1"/>
-    <httpRuntime targetFramework="4.5"/>
+    <compilation debug="true" targetFramework="4.6.1" />
+    <httpRuntime targetFramework="4.5" />
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="1.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0"/>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0"/>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="mssqllocaldb"/>
+        <parameter value="mssqllocaldb" />
       </parameters>
     </defaultConnectionFactory>
     <providers>
-      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
     </providers>
   </entityFramework>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701"/>
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:6 /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:14 /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
     </compilers>
   </system.codedom>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
-      <remove name="OPTIONSVerbHandler"/>
-      <remove name="TRACEVerbHandler"/>
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
     </handlers>
   </system.webServer>
 </configuration>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Datadog.Trace" version="2.255.251" targetFramework="net461" />
+  <package id="Datadog.Trace" version="2.255.250" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Datadog.Trace" version="2.255.250" targetFramework="net461" />
+  <package id="Datadog.Trace" version="2.255.249" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.1x/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.1x/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Datadog.Trace;
@@ -10,6 +11,13 @@ namespace Samples.VersionConflict_1x
         {
             using (WebServer.Start(out var url))
             {
+                // Attempt to access the ActiveScope while the automatic ActiveScope is null
+                var activeScope = Tracer.Instance.ActiveScope;
+                if (activeScope is null)
+                {
+                    Console.WriteLine("As expected, initial Tracer.Instance.ActiveScope == null");
+                }
+
                 using (var scope = Tracer.Instance.StartActive("Manual"))
                 {
                     scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.1x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.1x/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+    "profiles": {
+      "Samples.VersionConflict.1x": {
+        "commandName": "Project",
+        "environmentVariables": {
+          "COR_ENABLE_PROFILING": "1",
+          "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+          "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+  
+          "CORECLR_ENABLE_PROFILING": "1",
+          "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+          "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+  
+          "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+          "DD_VERSION": "1.0.0"
+        },
+        "nativeDebugging": true
+      }
+    }
+  }

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Program.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Datadog.Trace;
@@ -11,6 +11,13 @@ namespace Samples.VersionConflict_2x
         {
             using (WebServer.Start(out var url))
             {
+                // Attempt to access the ActiveScope while the automatic ActiveScope is null
+                var activeScope = Tracer.Instance.ActiveScope;
+                if (activeScope is null)
+                {
+                    Console.WriteLine("As expected, initial Tracer.Instance.ActiveScope == null");
+                }
+
                 using (var scope = Tracer.Instance.StartActive("Manual"))
                 {
                     scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+    "profiles": {
+      "Samples.VersionConflict.2x": {
+        "commandName": "Project",
+        "environmentVariables": {
+          "COR_ENABLE_PROFILING": "1",
+          "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+          "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+  
+          "CORECLR_ENABLE_PROFILING": "1",
+          "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+          "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+  
+          "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+          "DD_VERSION": "1.0.0"
+        },
+        "nativeDebugging": true
+      }
+    }
+  }

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
@@ -2,7 +2,7 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.255.251" />
+    <PackageReference Include="Datadog.Trace" Version="2.255.249" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
With this change, `Tracer.ActiveScope` is capable of fetching the active scope from the automatic tracer in case of version conflict, allowing users to decorate the parent span as they normally could.