### PR TITLE
Add helper for collecting host metadata

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
@@ -1,0 +1,149 @@
+﻿// <copyright file="HostMetadata.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+
+namespace Datadog.Trace.PlatformHelpers
+{
+    internal class HostMetadata
+    {
+        static HostMetadata()
+        {
+            TryGetKernelInformation(out var kernel, out var release, out var version);
+
+            Instance = new HostMetadata(
+                hostname: GetHostInternal(),
+                kernelName: kernel,
+                kernelRelease: release,
+                kernelVersion: version);
+        }
+
+        private HostMetadata(string hostname, string kernelName, string kernelRelease, string kernelVersion)
+        {
+            Hostname = hostname;
+            KernelName = kernelName;
+            KernelRelease = kernelRelease;
+            KernelVersion = kernelVersion;
+        }
+
+        public static HostMetadata Instance { get; }
+
+        /// <summary>
+        /// Gets the name of the host on which the code is running
+        /// Returns <c>null</c> if the host name can not be determined
+        /// </summary>
+        public string Hostname { get; }
+
+        /// <summary>
+        /// Gets the name of the kernel, e.g. Linux
+        /// Returns <c>null</c> if it can not be determined
+        /// </summary>
+        public string KernelName { get; }
+
+        /// <summary>
+        /// Gets the release name of the kernel, e.g. 3.2.0-4-686-pae
+        /// Returns <c>null</c> if it can not be determined
+        /// </summary>
+        public string KernelRelease { get; }
+
+        /// <summary>
+        /// Gets the version number of the kernel, e.g. #1 SMP Debian 3.2.63-2+deb7u2
+        /// Returns <c>null</c> if it can not be determined
+        /// </summary>
+        public string KernelVersion { get; }
+
+        // internal for testing
+        internal static void ParseKernel(string fullVersion, out string kernel, out string kernelRelease, out string kernelVersion)
+        {
+            kernel = null;
+            kernelRelease = null;
+            kernelVersion = null;
+
+            if (string.IsNullOrEmpty(fullVersion))
+            {
+                return;
+            }
+
+            var firstWord = fullVersion.IndexOf(value: " ", StringComparison.OrdinalIgnoreCase);
+            if (firstWord < 0)
+            {
+                return;
+            }
+
+            kernel = fullVersion.Substring(0, firstWord);
+
+            var releaseStart = fullVersion.IndexOf("version ", StringComparison.OrdinalIgnoreCase);
+            if (releaseStart < 0)
+            {
+                return;
+            }
+
+            releaseStart += 8; // "version ".Length
+
+            var releaseEnd = fullVersion.IndexOf(" ", startIndex: releaseStart, StringComparison.OrdinalIgnoreCase);
+            if (releaseEnd < 0)
+            {
+                return;
+            }
+
+            kernelRelease = fullVersion.Substring(releaseStart, releaseEnd - releaseStart);
+
+            var versionIndex = fullVersion.LastIndexOf("#", StringComparison.OrdinalIgnoreCase);
+            if (versionIndex < releaseEnd)
+            {
+                return;
+            }
+
+            kernelVersion = fullVersion.Substring(versionIndex);
+        }
+
+        private static void TryGetKernelInformation(out string kernel, out string kernelRelease, out string kernelVersion)
+        {
+            try
+            {
+                if (File.Exists(@"/proc/version"))
+                {
+                    // e.g. Linux version 5.10.60.1-microsoft-standard-WSL2 (oe-user@oe-host) (x86_64-msft-linux-gcc (GCC) 9.3.0, GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP Wed Aug 25 23:20:18 UTC 2021
+                    var fullVersion = File.ReadAllText("/proc/version");
+
+                    ParseKernel(fullVersion, out kernel, out kernelRelease, out kernelVersion);
+                }
+            }
+            catch
+            {
+                // May be permissions issues etc
+            }
+
+            kernel = null;
+            kernelRelease = null;
+            kernelVersion = null;
+        }
+
+        private static string GetHostInternal()
+        {
+            try
+            {
+                var host = Environment.MachineName;
+                if (!string.IsNullOrEmpty(host))
+                {
+                    return host;
+                }
+
+                return Environment.GetEnvironmentVariable("COMPUTERNAME");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            catch (System.Security.SecurityException)
+            {
+                // We may get a security exception looking up the machine name
+                // You must have Unrestricted EnvironmentPermission to access resource
+            }
+
+            return null;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.IO;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.PlatformHelpers
 {
@@ -12,7 +13,10 @@ namespace Datadog.Trace.PlatformHelpers
     {
         static HostMetadata()
         {
-            TryGetKernelInformation(out var kernel, out var release, out var version);
+            TryGetKernelInformation(
+                kernel: out var kernel,
+                kernelRelease: out var release,
+                kernelVersion: out var version);
 
             Instance = new HostMetadata(
                 hostname: GetHostInternal(),
@@ -126,13 +130,13 @@ namespace Datadog.Trace.PlatformHelpers
         {
             try
             {
-                var host = Environment.MachineName;
+                var host = EnvironmentHelpers.GetMachineName();
                 if (!string.IsNullOrEmpty(host))
                 {
                     return host;
                 }
 
-                return Environment.GetEnvironmentVariable("COMPUTERNAME");
+                return EnvironmentHelpers.GetEnvironmentVariable("COMPUTERNAME");
             }
             catch (InvalidOperationException)
             {

--- a/tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/EnvironmentHelpers.cs
@@ -37,6 +37,24 @@ namespace Datadog.Trace.Util
         }
 
         /// <summary>
+        /// Safe wrapper around Environment.MachineName
+        /// </summary>
+        /// <returns>The value of <see cref="Environment.MachineName"/>, or null if an error occured</returns>
+        public static string GetMachineName()
+        {
+            try
+            {
+                return Environment.MachineName;
+            }
+            catch (Exception ex)
+            {
+                Logger.Value.Warning(ex, "Error while reading machine name");
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Safe wrapper around Environment.GetEnvironmentVariable
         /// </summary>
         /// <param name="key">Name of the environment variable to fetch</param>

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/HostMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/HostMetadataTests.cs
@@ -1,0 +1,95 @@
+﻿// <copyright file="HostMetadataTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.PlatformHelpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.PlatformHelpers
+{
+    public class HostMetadataTests
+    {
+        [Fact]
+        public void CanGetHostMetadata()
+        {
+            HostMetadata.Instance.Hostname.Should().NotBeNullOrEmpty();
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData.ValidKernels), MemberType = typeof(TestData))]
+        public void CanParseKernelVersion(
+            string fullVersion,
+            string expectedKernel,
+            string expectedRelease,
+            string expectedVersion)
+        {
+            HostMetadata.ParseKernel(fullVersion, out var kernel, out var release, out var version);
+
+            using var scope = new AssertionScope();
+            kernel.Should().Be(expectedKernel);
+            release.Should().Be(expectedRelease);
+            version.Should().Be(expectedVersion);
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData.InvalidKernels), MemberType = typeof(TestData))]
+        public void CanParseMalformedKernels(
+            string fullVersion,
+            string expectedKernel,
+            string expectedRelease,
+            string expectedVersion)
+        {
+            HostMetadata.ParseKernel(fullVersion, out var kernel, out var release, out var version);
+
+            using var scope = new AssertionScope();
+            kernel.Should().Be(expectedKernel);
+            release.Should().Be(expectedRelease);
+            version.Should().Be(expectedVersion);
+        }
+
+        public static class TestData
+        {
+            /// <summary>
+            /// Gets /proc/version string, kernel, release, version
+            /// </summary>
+            public static TheoryData<string, string, string, string> ValidKernels { get; } = new()
+            {
+                {
+                    "Linux version 3.2.0-4-686-pae (debian-kernel@lists.debian.org) (gcc version 4.6.3 (Debian 4.6.3-14) ) #1 SMP Debian 3.2.63-2+deb7u2",
+                    "Linux",
+                    "3.2.0-4-686-pae",
+                    "#1 SMP Debian 3.2.63-2+deb7u2"
+                },
+                {
+                    "Linux version 5.10.60.1-microsoft-standard-WSL2 (oe-user@oe-host) (x86_64-msft-linux-gcc (GCC) 9.3.0, GNU ld (GNU Binutils) 2.34.0.20200220) #1 SMP Wed Aug 25 23:20:18 UTC 2021",
+                    "Linux",
+                    "5.10.60.1-microsoft-standard-WSL2",
+                    "#1 SMP Wed Aug 25 23:20:18 UTC 2021"
+                },
+                {
+                    "Linux version 4.9.32-0-hardened (buildozer@build-3-6-x86_64) (gcc version 6.3.0 (Alpine 6.3.0) ) #1-Alpine SMP Fri Jun 16 12:20:58 GMT 2017",
+                    "Linux",
+                    "4.9.32-0-hardened",
+                    "#1-Alpine SMP Fri Jun 16 12:20:58 GMT 2017"
+                },
+            };
+
+            /// <summary>
+            /// Gets /proc/version string, canBeParsed, kernel, release, version for invalid kernel strings
+            /// </summary>
+            public static TheoryData<string, string, string, string> InvalidKernels { get; } = new()
+            {
+                { "MALFORMED", null, null, null },
+                { "MALFORMED hjfdshh", "MALFORMED", null, null },
+                { "MALFORMED version", "MALFORMED", null, null },
+                { "MALFORMED version fhdjkhf", "MALFORMED", null, null },
+                { "MALFORMED version fhdjkhf#1", "MALFORMED", null, null },
+                { "MALFORMED version fhdjkhf #1", "MALFORMED", "fhdjkhf", "#1" },
+                { "MALFORMED version #1", "MALFORMED", null, null },
+            };
+        }
+    }
+}


### PR DESCRIPTION
i.e. Hostname, Linux kernel information
Required for some new features (e.g. log shipping, telemetry)

Could add these to `FrameworkDescription`, but given we only need them in some relatively niche cases, seemed like keeping them separate made sense.

@DataDog/apm-dotnet