### PR TITLE
[Appsec] Fix duplicate key in cookies when building waf args

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -89,6 +89,7 @@ namespace Datadog.Trace.AppSec.Waf
                     IEnumerable<KeyValuePair<string, JToken>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
                     IEnumerable<KeyValuePair<string, string>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
                     IEnumerable<KeyValuePair<string, List<string>>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
+                    IEnumerable<KeyValuePair<string, string[]>> objDict => EncodeDictionary(objDict.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)), argCache, remainingDepth),
                     IEnumerable<KeyValuePair<string, object>> objDict => EncodeDictionary(objDict, argCache, remainingDepth),
                     IList<JToken> objs => EncodeList(objs.Select(x => (object)x), argCache, remainingDepth),
                     IList<string> objs => EncodeList(objs.Select(x => (object)x), argCache, remainingDepth),

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -65,9 +65,9 @@ namespace Datadog.Trace.Util.Http
                 if (!queryStringDic.TryAdd(kvp.Key, kvp.Value))
                 {
 #else
-                if (!headersDic.ContainsKey(key))
+                if (!queryStringDic.ContainsKey(kvp.Key))
                 {
-                    headersDic.Add(key, request.Headers[key]);
+                    queryStringDic.Add(kvp.Key, kvp.Value);
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -29,10 +29,18 @@ namespace Datadog.Trace.Util.Http
                 }
             }
 
-            var cookiesDic = new Dictionary<string, string>(request.Cookies.Keys.Count);
-            foreach (var k in request.Cookies.Keys)
+            var cookiesDic = new Dictionary<string, List<string>>(request.Cookies.Keys.Count);
+            foreach (var k in request.Cookies)
             {
-                cookiesDic.Add(k, request.Cookies[k]);
+                var keyExists = cookiesDic.TryGetValue(k.Key, out var value);
+                if (keyExists)
+                {
+                    value.Add(k.Value);
+                }
+                else
+                {
+                    cookiesDic.Add(k.Key, new List<string> { k.Value ?? string.Empty });
+                }
             }
 
             var queryStringDic = new Dictionary<string, List<string>>(request.Query.Count);

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -27,12 +27,17 @@ namespace Datadog.Trace.Util.Http
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
                     var key = k.ToLowerInvariant();
+#if NETCOREAPP
+                    if (!headersDic.TryAdd(key, request.Headers[key]))
+                    {
+#else
                     if (!headersDic.ContainsKey(key))
                     {
                         headersDic.Add(key, request.Headers[key]);
                     }
                     else
                     {
+#endif
                         Log.Warning("Header {key} couldn't be added as argument to the waf", key);
                     }
                 }
@@ -56,12 +61,17 @@ namespace Datadog.Trace.Util.Http
             var queryStringDic = new Dictionary<string, string[]>(request.Query.Count);
             foreach (var kvp in request.Query)
             {
-                if (!queryStringDic.ContainsKey(kvp.Key))
+#if NETCOREAPP
+                if (!queryStringDic.TryAdd(kvp.Key, kvp.Value))
                 {
-                    queryStringDic.Add(kvp.Key, kvp.Value);
+#else
+                if (!headersDic.ContainsKey(key))
+                {
+                    headersDic.Add(key, request.Headers[key]);
                 }
                 else
                 {
+#endif
                     Log.Warning("Query string with {key} couldn't be added as argument to the waf", kvp.Key);
                 }
             }

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Util.Http
         internal static Dictionary<string, object> PrepareArgsForWaf(this HttpRequest request, RouteData routeDatas = null)
         {
             var url = GetUrl(request);
-            var headersDic = new Dictionary<string, string>(request.Headers.Keys.Count);
+            var headersDic = new Dictionary<string, string[]>(request.Headers.Keys.Count);
             foreach (var k in request.Headers.Keys)
             {
                 if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Util.Http
                     var key = k.ToLowerInvariant();
                     if (!headersDic.ContainsKey(key))
                     {
-                        headersDic.Add(key, request.Headers[k]);
+                        headersDic.Add(key, request.Headers[key]);
                     }
                     else
                     {
@@ -53,12 +53,12 @@ namespace Datadog.Trace.Util.Http
                 }
             }
 
-            var queryStringDic = new Dictionary<string, List<string>>(request.Query.Count);
+            var queryStringDic = new Dictionary<string, string[]>(request.Query.Count);
             foreach (var kvp in request.Query)
             {
                 if (!queryStringDic.ContainsKey(kvp.Key))
                 {
-                    queryStringDic.Add(kvp.Key, kvp.Value.ToList());
+                    queryStringDic.Add(kvp.Key, kvp.Value);
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -42,13 +42,13 @@ namespace Datadog.Trace.Util.Http
             foreach (var k in request.Cookies)
             {
                 var keyExists = cookiesDic.TryGetValue(k.Key, out var value);
-                if (keyExists)
+                if (!keyExists)
                 {
-                    value.Add(k.Value);
+                    cookiesDic.Add(k.Key, new List<string> { k.Value ?? string.Empty });
                 }
                 else
                 {
-                    cookiesDic.Add(k.Key, new List<string> { k.Value ?? string.Empty });
+                    value.Add(k.Value);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -39,16 +39,17 @@ namespace Datadog.Trace.Util.Http
             }
 
             var cookiesDic = new Dictionary<string, List<string>>(request.Cookies.Keys.Count);
-            foreach (var k in request.Cookies)
+            for (var i = 0; i < request.Cookies.Count; i++)
             {
-                var keyExists = cookiesDic.TryGetValue(k.Key, out var value);
+                var cookie = request.Cookies.ElementAt(i);
+                var keyExists = cookiesDic.TryGetValue(cookie.Key, out var value);
                 if (!keyExists)
                 {
-                    cookiesDic.Add(k.Key, new List<string> { k.Value ?? string.Empty });
+                    cookiesDic.Add(cookie.Key, new List<string> { cookie.Value ?? string.Empty });
                 }
                 else
                 {
-                    value.Add(k.Value);
+                    value.Add(cookie.Value);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -27,10 +27,19 @@ namespace Datadog.Trace.Util.Http
                 }
             }
 
-            var cookiesDic = new Dictionary<string, string>(request.Cookies.AllKeys.Length);
-            foreach (var k in request.Cookies.AllKeys)
+            var cookiesDic = new Dictionary<string, List<string>>(request.Cookies.AllKeys.Length);
+            for (var i = 0; i < request.Cookies.Count; i++)
             {
-                cookiesDic.Add(k, request.Cookies[k].Value);
+                var cookie = request.Cookies[i];
+                var keyExists = cookiesDic.TryGetValue(cookie.Name, out var value);
+                if (keyExists)
+                {
+                    value.Add(cookie.Value);
+                }
+                else
+                {
+                    cookiesDic.Add(cookie.Name, new List<string> { cookie.Value ?? string.Empty });
+                }
             }
 
             var queryDic = new Dictionary<string, string>(request.QueryString.AllKeys.Length);
@@ -42,11 +51,21 @@ namespace Datadog.Trace.Util.Http
 
             var dict = new Dictionary<string, object>
             {
-                { AddressesConstants.RequestMethod, request.HttpMethod },
-                { AddressesConstants.RequestUriRaw, request.Url.AbsoluteUri },
-                { AddressesConstants.RequestQuery, queryDic },
-                { AddressesConstants.RequestHeaderNoCookies, headersDic },
-                { AddressesConstants.RequestCookies, cookiesDic },
+                {
+                    AddressesConstants.RequestMethod, request.HttpMethod
+                },
+                {
+                    AddressesConstants.RequestUriRaw, request.Url.AbsoluteUri
+                },
+                {
+                    AddressesConstants.RequestQuery, queryDic
+                },
+                {
+                    AddressesConstants.RequestHeaderNoCookies, headersDic
+                },
+                {
+                    AddressesConstants.RequestCookies, cookiesDic
+                },
             };
 
             if (routeDatas != null && routeDatas.Values.Any())

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Util.Http
 
         internal static Dictionary<string, object> PrepareArgsForWaf(this HttpRequest request, RouteData routeDatas = null)
         {
-            var headersDic = new Dictionary<string, string>(request.Headers.Keys.Count);
+            var headersDic = new Dictionary<string, string[]>(request.Headers.Keys.Count);
             var headerKeys = request.Headers.Keys;
             foreach (string k in headerKeys)
             {
@@ -28,7 +28,7 @@ namespace Datadog.Trace.Util.Http
                     var key = k.ToLowerInvariant();
                     if (!headersDic.ContainsKey(key))
                     {
-                        headersDic.Add(key, request.Headers[k]);
+                        headersDic.Add(key, request.Headers.GetValues(key));
                     }
                     else
                     {
@@ -52,10 +52,10 @@ namespace Datadog.Trace.Util.Http
                 }
             }
 
-            var queryDic = new Dictionary<string, string>(request.QueryString.AllKeys.Length);
+            var queryDic = new Dictionary<string, string[]>(request.QueryString.AllKeys.Length);
             foreach (var k in request.QueryString.AllKeys)
             {
-                var values = request.QueryString[k];
+                var values = request.QueryString.GetValues(k);
                 if (!queryDic.ContainsKey(k))
                 {
                     queryDic.Add(k, values);

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -42,13 +42,13 @@ namespace Datadog.Trace.Util.Http
             {
                 var cookie = request.Cookies[i];
                 var keyExists = cookiesDic.TryGetValue(cookie.Name, out var value);
-                if (keyExists)
+                if (!keyExists)
                 {
-                    value.Add(cookie.Value);
+                    cookiesDic.Add(cookie.Name, new List<string> { cookie.Value ?? string.Empty });
                 }
                 else
                 {
-                    cookiesDic.Add(cookie.Name, new List<string> { cookie.Value ?? string.Empty });
+                    value.Add(cookie.Value);
                 }
             }
 
@@ -56,13 +56,13 @@ namespace Datadog.Trace.Util.Http
             foreach (var k in request.QueryString.AllKeys)
             {
                 var values = request.QueryString[k];
-                if (queryDic.ContainsKey(k))
+                if (!queryDic.ContainsKey(k))
                 {
                     queryDic.Add(k, values);
                 }
                 else
                 {
-                    Log.Warning("Header {key} couldn't be added as argument to the waf", k);
+                    Log.Warning("Query string {key} couldn't be added as argument to the waf", k);
                 }
             }
 


### PR DESCRIPTION
Fixes:
- On IIS, if you curl for example:
Curl -v --get --cookie "value=something;value=something2" "http://localhost/AspNetmvc5/"
You get 2 cookies with the same key, so adding them to a dictionary crashes. 
- To be safe, check for the other dictionaries and log if the same key reappears



@DataDog/apm-dotnet