### PR TITLE
CallTarget ByRef: Fix ByRef Generics arguments

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -132,10 +132,10 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                         callGenericTypes.Add(parameterProxyType);
                     }
                 }
-                else if (targetParameterType.IsByRef && targetParameterType.GetElementType().IsGenericParameter)
+                else if (targetParameterType.IsByRef && targetParameterType.GetElementType() is { IsGenericParameter: true } elementType)
                 {
                     // ByRef generic parameters needs to be unwrapped before accessing the `IsGenericParameter` property.
-                    var genTargetParameterType = genericArgumentsTypes[targetParameterType.GetElementType().GenericParameterPosition];
+                    var genTargetParameterType = genericArgumentsTypes[elementType.GenericParameterPosition];
                     targetParameterTypeConstraint = genTargetParameterType.GetGenericParameterConstraints().FirstOrDefault(pType => pType != typeof(IDuckType));
                     if (targetParameterTypeConstraint is null)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -123,13 +123,27 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                     targetParameterTypeConstraint = targetParameterType.GetGenericParameterConstraints().FirstOrDefault(pType => pType != typeof(IDuckType));
                     if (targetParameterTypeConstraint is null)
                     {
-                        callGenericTypes.Add(targetParameterType.IsByRef ? sourceParameterType : sourceParameterType.GetElementType());
+                        callGenericTypes.Add(sourceParameterType.GetElementType());
                     }
                     else
                     {
                         var result = DuckType.GetOrCreateProxyType(targetParameterTypeConstraint, sourceParameterType.GetElementType());
                         parameterProxyType = result.ProxyType;
                         callGenericTypes.Add(parameterProxyType);
+                    }
+                }
+                else if (targetParameterType.IsByRef && targetParameterType.GetElementType().IsGenericParameter)
+                {
+                    // ByRef generic parameters needs to be unwrapped before accessing the `IsGenericParameter` property.
+                    var genTargetParameterType = genericArgumentsTypes[targetParameterType.GetElementType().GenericParameterPosition];
+                    targetParameterTypeConstraint = genTargetParameterType.GetGenericParameterConstraints().FirstOrDefault(pType => pType != typeof(IDuckType));
+                    if (targetParameterTypeConstraint is null)
+                    {
+                        callGenericTypes.Add(sourceParameterType.GetElementType());
+                    }
+                    else
+                    {
+                        throw new InvalidCastException($"DuckType constraints cannot be used in ByRef arguments. ({targetParameterTypeConstraint})");
                     }
                 }
                 else

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -88,8 +88,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (new MockTracerAgent(agentPort))
             using (var processResult = RunSampleAndWaitForExit(agentPort, arguments: "withref"))
             {
-                string beginMethodString = $"ProfilerOK: BeginMethod\\({2}\\)";
-                int beginMethodCount = Regex.Matches(processResult.StandardOutput, beginMethodString).Count;
+                int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
+                int begin2MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({2}\\)").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
 
                 string[] typeNames = new string[]
@@ -99,7 +99,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 };
 
                 Assert.Equal(2, beginMethodCount);
-                Assert.Equal(2, endMethodCount);
+                Assert.Equal(2, begin2MethodCount);
+                Assert.Equal(4, endMethodCount);
 
                 foreach (var typeName in typeNames)
                 {
@@ -116,8 +117,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (new MockTracerAgent(agentPort))
             using (var processResult = RunSampleAndWaitForExit(agentPort, arguments: "without"))
             {
-                string beginMethodString = $"ProfilerOK: BeginMethod\\({2}\\)";
-                int beginMethodCount = Regex.Matches(processResult.StandardOutput, beginMethodString).Count;
+                int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
+                int begin2MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({2}\\)").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
 
                 string[] typeNames = new string[]
@@ -126,7 +127,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 };
 
                 Assert.Equal(1, beginMethodCount);
-                Assert.Equal(1, endMethodCount);
+                Assert.Equal(1, begin2MethodCount);
+                Assert.Equal(2, endMethodCount);
 
                 foreach (var typeName in typeNames)
                 {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericOutModificationVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericOutModificationVoidIntegration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace CallTargetNativeTest.NoOp
+{
+    public static class GenericOutModificationVoidIntegration
+    {
+        public static CallTargetState OnMethodBegin<TTarget, TArg1>(TTarget instance, out TArg1 arg01)
+        {
+            arg01 = default;
+            CallTargetState returnValue = CallTargetState.GetDefault();
+            Console.WriteLine($"ProfilerOK: BeginMethod(1)<{typeof(GenericOutModificationVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}>({instance}, {arg01})");
+            return returnValue;
+        }
+
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            CallTargetReturn returnValue = CallTargetReturn.GetDefault();
+            Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(GenericOutModificationVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            return returnValue;
+        }
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericRefModificationVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/GenericRefModificationVoidIntegration.cs
@@ -1,0 +1,22 @@
+using System;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace CallTargetNativeTest.NoOp
+{
+    public static class GenericRefModificationVoidIntegration
+    {
+        public static CallTargetState OnMethodBegin<TTarget, TArg1>(TTarget instance, ref TArg1 arg01)
+        {
+            CallTargetState returnValue = CallTargetState.GetDefault();
+            Console.WriteLine($"ProfilerOK: BeginMethod(1)<{typeof(GenericRefModificationVoidIntegration)}, {typeof(TTarget)}, {typeof(TArg1)}>({instance}, {arg01})");
+            return returnValue;
+        }
+
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, CallTargetState state)
+        {
+            CallTargetReturn returnValue = CallTargetReturn.GetDefault();
+            Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(GenericRefModificationVoidIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            return returnValue;
+        }
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -56,8 +56,12 @@ namespace CallTargetNativeTest
             // Add By Ref integrations
             definitionsList.Add(new(TargetAssembly, typeof(WithRefArguments).FullName, "VoidMethod", new[] { "_", "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(StringAndIntRefModificationVoidIntegration).FullName));
             definitionsList.Add(new(TargetAssembly, typeof(WithRefArguments).FullName, "VoidRefMethod", new[] { "_", "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(StringAndIntRefModificationVoidIntegration).FullName));
+            definitionsList.Add(new(TargetAssembly, typeof(WithRefArguments).FullName, "VoidMethod", new[] { "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(GenericRefModificationVoidIntegration).FullName));
+            definitionsList.Add(new(TargetAssembly, typeof(WithRefArguments).FullName, "VoidRefMethod", new[] { "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(GenericRefModificationVoidIntegration).FullName));
 
+            // Add Out integrations
             definitionsList.Add(new(TargetAssembly, typeof(WithOutArguments).FullName, "VoidMethod", new[] { "_", "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(StringAndIntOutVoidIntegration).FullName));
+            definitionsList.Add(new(TargetAssembly, typeof(WithOutArguments).FullName, "VoidMethod", new[] { "_", "_" }, 0, 0, 0, 1, 1, 1, integrationAssembly, typeof(GenericOutModificationVoidIntegration).FullName));
 
             NativeMethods.InitializeProfiler(Guid.NewGuid().ToString("N"), definitionsList.ToArray());
         }
@@ -159,6 +163,11 @@ namespace CallTargetNativeTest
             Console.WriteLine($"{typeof(WithRefArguments).FullName}.VoidMethod");
             RunMethod(() =>
             {
+                wRefArg.VoidMethod("MyString");
+            });
+
+            RunMethod(() =>
+            {
                 wRefArg.VoidMethod("MyString", 15);
 
                 if (wRefArg.StringValue != "MyString (Modified)")
@@ -173,6 +182,16 @@ namespace CallTargetNativeTest
             });
 
             Console.WriteLine($"{typeof(WithRefArguments).FullName}.VoidRefMethod");
+            RunMethod(() =>
+            {
+                string strVal = "MyString";
+                wRefArg.VoidRefMethod(ref strVal);
+
+                if (strVal != "Hello world")
+                {
+                    throw new Exception("Error modifying string value.");
+                }
+            });
             RunMethod(() =>
             {
                 string strVal = "MyString";
@@ -196,6 +215,16 @@ namespace CallTargetNativeTest
         {
             var wOutArg = new WithOutArguments();
             Console.WriteLine($"{typeof(WithOutArguments).FullName}.VoidMethod");
+            RunMethod(() =>
+            {
+                string strValue;
+                wOutArg.VoidMethod(out strValue);
+
+                if (strValue != "Arg01")
+                {
+                    throw new Exception("Error modifying string value.");
+                }
+            });
             RunMethod(() =>
             {
                 string strValue;

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithOutArguments.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithOutArguments.cs
@@ -1,7 +1,12 @@
-﻿namespace CallTargetNativeTest
+namespace CallTargetNativeTest
 {
     internal class WithOutArguments
     {
+        public void VoidMethod(out string arg1)
+        {
+            arg1 = "Arg01";
+        }
+
         public void VoidMethod(out string arg1, out int arg2)
         {
             arg1 = "Arg01";

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefArguments.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefArguments.cs
@@ -22,5 +22,15 @@ namespace CallTargetNativeTest
             StringValue = arg1;
             IntValue = arg2;
         }
+
+
+        public void VoidMethod(string arg1)
+        {
+        }
+
+        public void VoidRefMethod(ref string arg1)
+        {
+            arg1 = "Hello world";
+        }
     }
 }


### PR DESCRIPTION
This PR fixes an issue on byref generic arguments. 



@DataDog/apm-dotnet