### PR TITLE
Cherry pick "Remove dependency from the shared project to main project (#2043)"

### DIFF
--- a/shared/src/native-src/loader.cpp
+++ b/shared/src/native-src/loader.cpp
@@ -1,7 +1,9 @@
 #include "loader.h"
 
 #ifdef _WIN32
-#include "DllMain.h"
+#include <windows.h>
+EXTERN_C IMAGE_DOS_HEADER __ImageBase;
+#define HINST_THISCOMPONENT ((HINSTANCE)&__ImageBase)
 #endif
 
 #include "il_rewriter_wrapper.h"
@@ -1746,7 +1748,7 @@ namespace shared
         _loadersLoadedSet.insert(appDomainId);
 
 #ifdef _WIN32
-        HINSTANCE hInstance = DllHandle;
+        HINSTANCE hInstance = HINST_THISCOMPONENT;
         LPCWSTR dllLpName;
         LPCWSTR symbolsLpName;
 


### PR DESCRIPTION
By including the dllmain.h file, we add a dependency between
the shared project that contains the loader and the main project
(today, the profiler C++ project)

__ImageBase is a linker (Windows) trick that allows us to get
the HINSTANCE and to remove the dependency


@DataDog/apm-dotnet