### PR TITLE
Fix host metadata kernel information

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/HostMetadata.cs
@@ -114,6 +114,7 @@ namespace Datadog.Trace.PlatformHelpers
                     var fullVersion = File.ReadAllText("/proc/version");
 
                     ParseKernel(fullVersion, out kernel, out kernelRelease, out kernelVersion);
+                    return;
                 }
             }
             catch

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/HostMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/HostMetadataTests.cs
@@ -50,6 +50,17 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             version.Should().Be(expectedVersion);
         }
 
+        [Fact]
+        public void CanRetrieveKernelInfo()
+        {
+            if (FrameworkDescription.Instance.OSPlatform == OSPlatform.Linux)
+            {
+                HostMetadata.Instance.KernelName.Should().NotBeNullOrEmpty();
+                HostMetadata.Instance.KernelRelease.Should().NotBeNullOrEmpty();
+                HostMetadata.Instance.KernelVersion.Should().NotBeNullOrEmpty();
+            }
+        }
+
         public static class TestData
         {
             /// <summary>


### PR DESCRIPTION
#2097 Added the `HostMetadata` class, but [as pointed out by Zach](https://github.com/DataDog/dd-trace-dotnet/pull/2097/files/ba46d397484b7c73e2461971c73fcb9b1adc71bb#r759588263) there was a bug in the `TryGetKernalInformation` implementation where it would never get the values

@DataDog/apm-dotnet