### PR TITLE
Fix flaky test in unit tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
@@ -19,6 +19,8 @@ namespace Datadog.Trace.Tests.PlatformHelpers
     [AzureAppServicesRestorer]
     public class AzureAppServicesMetadataTests
     {
+        internal static readonly string DeploymentId = "AzureExampleSiteName";
+
         private const string AppServiceKind = "app";
         private const string AppServiceType = "app";
         private const string FunctionKind = "functionapp";
@@ -34,7 +36,6 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 
         private static readonly string SubscriptionId = "8c500027-5f00-400e-8f00-60000000000f";
         private static readonly string PlanResourceGroup = "apm-dotnet";
-        private static readonly string DeploymentId = "AzureExampleSiteName";
         private static readonly string SiteResourceGroup = "apm-dotnet-site-resource-group";
         private static readonly string ExpectedResourceId =
             $"/subscriptions/{SubscriptionId}/resourcegroups/{SiteResourceGroup}/providers/microsoft.web/sites/{DeploymentId}".ToLowerInvariant();

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tests.PlatformHelpers;
 using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
 using Moq;
@@ -310,7 +311,10 @@ namespace Datadog.Trace.Tests
 
             if (expectedServiceName == null)
             {
-                Assert.Contains(span.ServiceName, TestRunners.ValidNames);
+                // due to the service name fallback, if this runs at the same time as AzureAppServicesMetadataTests,
+                // then AzureAppServices.IsRelevant returns true, and we may pull the service name from the AAS env vars
+                var expectedServiceNames = TestRunners.ValidNames.Concat(new[] { AzureAppServicesMetadataTests.DeploymentId });
+                Assert.Contains(span.ServiceName, expectedServiceNames);
             }
             else
             {


### PR DESCRIPTION
Due to the way we calculate service name, if service name tests run at the same time as AzureAppServicesMetadataTests, then AzureAppServices.IsRelevant returns true, and we may unexpectedly pull the service name from the AAS env vars. This change handles that scenario.

> [See this build for an example failure](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=82641&view=logs&j=61ef1a4a-6239-5ffb-3d52-8f25bbbf347b&t=c641a42e-b4ea-56b0-462d-84f194465978)

@DataDog/apm-dotnet 