### PR TITLE
Add a big fat warning in NativeCallTargetDefinition file

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/NativeCallTargetDefinition.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/NativeCallTargetDefinition.cs
@@ -31,6 +31,7 @@ namespace Datadog.Trace.ClrProfiler
  //
  // If you happen to change the layout of this structure,
  // this will lead to an AccessViolationException in netCore when using a more recent version of the nuget.
+ // If you need to modify the definition, create a new interface NativeCallTargetDefinition# that will be consumed by the native layer
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct NativeCallTargetDefinition

--- a/tracer/src/Datadog.Trace/ClrProfiler/NativeCallTargetDefinition.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/NativeCallTargetDefinition.cs
@@ -8,6 +8,30 @@ using System.Runtime.InteropServices;
 
 namespace Datadog.Trace.ClrProfiler
 {
+ // !                                         ██
+ //                                         ██░░██
+ //                                       ██░░░░░░██
+ //                                     ██░░░░░░░░░░██
+ //                                     ██░░░░░░░░░░██
+ //                                   ██░░░░░░░░░░░░░░██
+ //                                 ██░░░░░░██████░░░░░░██
+ //                                 ██░░░░░░██████░░░░░░██
+ //                               ██░░░░░░░░██████░░░░░░░░██
+ //                               ██░░░░░░░░██████░░░░░░░░██
+ //                             ██░░░░░░░░░░██████░░░░░░░░░░██
+ //                           ██░░░░░░░░░░░░██████░░░░░░░░░░░░██
+ //                           ██░░░░░░░░░░░░██████░░░░░░░░░░░░██
+ //                         ██░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░██
+ //                         ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██
+ //                       ██░░░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░░░██
+ //                       ██░░░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░░░██
+ //                     ██░░░░░░░░░░░░░░░░░░██████░░░░░░░░░░░░░░░░░░██
+ //                     ██░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██
+ //                       ██████████████████████████████████████████
+ //
+ // If you happen to change the layout of this structure,
+ // this will lead to an AccessViolationException in netCore when using a more recent version of the nuget.
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct NativeCallTargetDefinition
     {


### PR DESCRIPTION
As discussed when we discussed the possible crash introduced in 1.30.0




@DataDog/apm-dotnet