### PR TITLE
[AppSec] Conform to new standard logs docs and remove some spammy logs

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
+++ b/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.AppSec
             {
                 foreach (var key in args.Keys)
                 {
-                    Log.Debug("Pushing address {Key} to the Instrumentation Gateway.", key);
+                    Log.Debug("DDAS-0009-00: Pushing address {Key} to the Instrumentation Gateway.", key);
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "AppSec Error.");
+                Log.Error(ex, "DDAS-0004-00: AppSec failed to process request.");
             }
         }
     }

--- a/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
+++ b/tracer/src/Datadog.Trace/AppSec/InstrumentationGateway.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.AppSec
             {
                 foreach (var key in args.Keys)
                 {
-                    Log.Debug("DDAS-0009-00: Pushing address {Key} to the Instrumentation Gateway.", key);
+                    Log.Debug("DDAS-0008-00: Pushing address {Key} to the Instrumentation Gateway.", key);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -113,7 +113,7 @@ namespace Datadog.Trace.AppSec
             catch (Exception ex)
             {
                 _settings = new(source: null) { Enabled = false };
-                Log.Error(ex, "AppSec could not start because of an unexpected error. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.");
+                Log.Error(ex, "DDAS-0001-01: AppSec could not start because of an unexpected error. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.");
             }
         }
 
@@ -173,7 +173,7 @@ namespace Datadog.Trace.AppSec
                 for (var i = 0; i < results.Length; i++)
                 {
                     var match = results[i];
-                    Log.Debug(blocked ? "Blocking current transaction (rule: {RuleId})" : "Detecting an attack from rule {RuleId}", match.Rule);
+                    Log.Debug(blocked ? "DDAS-0012-02: Blocking current transaction (rule: {RuleId})" : "DDAS-0012-01: Detecting an attack from rule {RuleId}", match.Rule);
                 }
             }
         }
@@ -223,7 +223,7 @@ namespace Datadog.Trace.AppSec
             if (!osSupported || !archSupported)
             {
                 Log.Error(
-                    "AppSec could not start because the current environment is not supported. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help. Host information: operating_system: {{ {OSPlatform} }}, arch: {{ {ProcessArchitecture} }}, runtime_infos: {{ {ProductVersion} }}",
+                    "DDAS-0001-02: AppSec could not start because the current environment is not supported. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help. Host information: operating_system: {{ {OSPlatform} }}, arch: {{ {ProcessArchitecture} }}, runtime_infos: {{ {ProductVersion} }}",
                     frameworkDescription.OSPlatform,
                     frameworkDescription.ProcessArchitecture,
                     frameworkDescription.ProductVersion);

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.Waf
@@ -35,13 +34,12 @@ namespace Datadog.Trace.AppSec.Waf
 
         public IResult Run(IDictionary<string, object> args)
         {
-            LogParametersIfDebugEnabled(args);
-
             var pwArgs = encoder.Encode(args, argCache);
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
-                Log.Debug("Executing AppSec In-App WAF");
+                var parameters = Encoder.FormatArgs(args);
+                Log.Debug("DDAS-0010-00: Executing AppSec In-App WAF with parameters: {Parameters}", parameters);
             }
 
             var rawAgs = pwArgs.RawPtr;
@@ -54,30 +52,13 @@ namespace Datadog.Trace.AppSec.Waf
             if (Log.IsEnabled(LogEventLevel.Debug))
             {
                 Log.Debug<ReturnCode, string>(
-                    @"AppSec In-App WAF returned: {ReturnCode} {Data} Took {PerfTotalRuntime} ms",
+                    "DDAS-0011-00: AppSec In-App WAF returned: {ReturnCode} {Data} Took {PerfTotalRuntime} ms",
                     ret.ReturnCode,
                     ret.Data,
                     retNative.PerfTotalRuntime);
             }
 
             return ret;
-        }
-
-        private static void LogParametersIfDebugEnabled(IDictionary<string, object> args)
-        {
-            if (Log.IsEnabled(LogEventLevel.Debug))
-            {
-                var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-
-                foreach (var kvp in args)
-                {
-                    sb.Append(kvp.Key);
-                    sb.Append(": ");
-                    sb.AppendLine(kvp.Value.ToString());
-                }
-
-                Log.Debug("Executing AppSec In-App WAF with parameters: {Parameters}", sb.ToString());
-            }
         }
 
         public void Dispose(bool disposing)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -63,8 +63,6 @@ namespace Datadog.Trace.AppSec.Waf
 
         private Obj EncodeInternal(object o, List<Obj> argCache, int remainingDepth)
         {
-            Log.Debug("Encoding type: {Type}", o?.GetType());
-
             var value =
                 o switch
                 {
@@ -93,8 +91,6 @@ namespace Datadog.Trace.AppSec.Waf
 
         private Obj EncodeList(IEnumerable<object> objEnumerator, List<Obj> argCache, int remainingDepth)
         {
-            Log.Debug("Encoding list: {Type}", objEnumerator?.GetType());
-
             var arrNat = _wafNative.ObjectArray();
 
             if (remainingDepth-- <= 0)
@@ -121,8 +117,6 @@ namespace Datadog.Trace.AppSec.Waf
 
         private Obj EncodeDictionary(IEnumerable<KeyValuePair<string, object>> objDictEnumerator, List<Obj> argCache, int remainingDepth)
         {
-            Log.Debug("Encoding dictionary: {Type}", objDictEnumerator?.GetType());
-
             var mapNat = _wafNative.ObjectMap();
 
             if (remainingDepth-- <= 0)

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -31,6 +31,11 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             {
                 DdwafConfigStruct args = default;
                 var ruleHandle = wafNative.Init(configObj.RawPtr, ref args);
+                if (ruleHandle == IntPtr.Zero)
+                {
+                    Log.Warning("DDAS-0005-00: WAF initialization failed.");
+                }
+
                 return ruleHandle;
             }
             finally
@@ -66,11 +71,11 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             {
                 if (rulesFile != null)
                 {
-                    Log.Error(ex, "AppSec could not read the rule file \"{RulesFile}\" as it was invalid. AppSec will not run any protections in this application.", rulesFile);
+                    Log.Error(ex, "DDAS-0003-02: AppSec could not read the rule file \"{RulesFile}\". Reason: Invalid file format. AppSec will not run any protections in this application.", rulesFile);
                 }
                 else
                 {
-                    Log.Error(ex, "AppSec could not read the rule file embedded in the manifest as it was invalid. AppSec will not run any protections in this application.");
+                    Log.Error(ex, "DDAS-0003-02: AppSec could not read the rule file embedded in the manifest. Reason: Invalid file format. AppSec will not run any protections in this application.");
                 }
 
                 return null;
@@ -92,7 +97,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                         var idProp = ev.Value<JValue>("id");
                         var nameProp = ev.Value<JValue>("name");
                         var addresses = ev.Value<JArray>("conditions").SelectMany(x => x.Value<JObject>("parameters").Value<JArray>("inputs"));
-                        Log.Debug("Loaded rule: {id} - {name} on addresses: {addresses}", idProp.Value, nameProp.Value, string.Join(", ", addresses));
+                        Log.Debug("DDAS-0007-00: Loaded rule: {id} - {name} on addresses: {addresses}", idProp.Value, nameProp.Value, string.Join(", ", addresses));
                     }
                 }
                 catch (Exception ex)
@@ -116,7 +121,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
         {
             if (!File.Exists(rulesFile))
             {
-                Log.Error("AppSec could not find the rules file in path \"{RulesFile}\". AppSec will not run any protections in this application.", rulesFile);
+                Log.Error("DDAS-0003-01: AppSec could not read the rule file \"{RulesFile}\". Reason: File not found. AppSec will not run any protections in this application.", rulesFile);
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -4,20 +4,16 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Datadog.Trace.AppSec.Waf.Initialization;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
-using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.Waf
 {
     internal class Waf : IWaf
     {
+        private const string InitContextError = "WAF ddwaf_init_context failed.";
+
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Waf));
 
         private readonly IntPtr ruleHandle;
@@ -71,8 +67,8 @@ namespace Datadog.Trace.AppSec.Waf
 
             if (handle == IntPtr.Zero)
             {
-                Log.Error("WAF initialization failed.");
-                throw new Exception("WAF initialization failed.");
+                Log.Error(InitContextError);
+                throw new Exception(InitContextError);
             }
 
             return new Context(handle, wafNative, encoder);


### PR DESCRIPTION
Fixes #

Changes proposed in this pull request:




@DataDog/apm-dotnet