### PR TITLE
Fix benchmarks comparison

### DIFF
--- a/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
@@ -73,7 +73,7 @@ namespace BenchmarkComparison
                        var baseSummariesByName = baseSummary.Results
                                                            .ToDictionary(b => $"{b.Method}-{b.Toolchain}", x => x);
 
-                       var diffSummariesByName = baseSummary.Results
+                       var diffSummariesByName = diffSummary.Results
                                                            .ToDictionary(b => $"{b.Method}-{b.Toolchain}", x => x);
                        var summaryKeys = baseSummariesByName.Keys.Concat(diffSummariesByName.Keys).Distinct();
 
@@ -143,7 +143,7 @@ namespace BenchmarkComparison
                 }
 
                 var zero = ByteSize.FromBytes(0);
-                var difference = baseBytes - diffBytes;
+                var difference = diffBytes - baseBytes;
                 // handle divide by zero
                 var percentageDifference = difference == zero ? 0 : baseBytes.Bytes / difference.Bytes;
 

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkMarkdownGenerator.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkMarkdownGenerator.cs
@@ -213,8 +213,8 @@ Allocation changes below **{BenchmarkComparer.AllocationThresholdPercent:N1}%** 
                                    Id = result.Id,
                                    BaseAllocation = result.BaseResult.Allocated,
                                    DiffAllocation = result.DiffResult.Allocated,
-                                   Change = (baseSize - diffSize).ToString(),
-                                   PercentChange = (baseSize - diffSize).Bytes / baseSize.Bytes,
+                                   Change = (diffSize - baseSize).ToString(),
+                                   PercentChange = (diffSize - baseSize).Bytes / baseSize.Bytes,
                                };
                            })
                       .OrderByDescending(result => result.PercentChange)


### PR DESCRIPTION
Due to a copy-pasta problem, we weren't actually comparing allocations properly

@DataDog/apm-dotnet 
