### PR TITLE
[2.0] replace manual keep/drop API

### DIFF
--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExporter.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.BenchmarkDotNet
                     Span span = tracer.StartSpan("benchmarkdotnet.test", startTime: startTime);
                     double durationNanoseconds = 0;
 
-                    span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+                    span.SetTraceSamplingPriority(SamplingPriority.AutoKeep, lockSampling: false);
                     span.Type = SpanTypes.Test;
                     span.ResourceName = $"{report.BenchmarkCase.Descriptor.Type.FullName}.{report.BenchmarkCase.Descriptor.WorkloadMethod.Name}";
                     CIEnvironmentValues.DecorateSpan(span);

--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -102,7 +102,7 @@ namespace Datadog.Trace.MSBuild
 
                 _buildSpan = _tracer.StartSpan(BuildTags.BuildOperationName);
                 _buildSpan.SetMetric(Tags.Analytics, 1.0d);
-                _buildSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+                _buildSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep, lockSampling: false);
 
                 _buildSpan.Type = SpanTypes.Build;
                 _buildSpan.SetTag(BuildTags.BuildName, e.SenderName);
@@ -175,7 +175,7 @@ namespace Datadog.Trace.MSBuild
 
                 Span projectSpan = _tracer.StartSpan(BuildTags.BuildOperationName, parent: parentSpan.Context, serviceName: projectName);
                 projectSpan.ResourceName = projectName;
-                projectSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+                projectSpan.SetTraceSamplingPriority(SamplingPriority.AutoKeep, lockSampling: false);
                 projectSpan.Type = SpanTypes.Build;
 
                 foreach (KeyValuePair<string, string> prop in e.GlobalProperties)

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -209,7 +209,7 @@ namespace Datadog.Trace.AppSec
         private void Report(ITransport transport, Span span, WafMatch[] results, bool blocked)
         {
             span.SetTag(Tags.AppSecEvent, "true");
-            span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+            span.SetTraceSamplingPriority(SamplingPriority.UserKeep, lockSampling: false);
 
             LogMatchesIfDebugEnabled(results, blocked);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -77,8 +77,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority)
                         {
-                            scope.Span.SetTraceSamplingPriority(existingSpanContext.SamplingPriority.Value);
-                            scope.Span.Context.TraceContext.LockSamplingPriority();
+                            scope.Span.SetTraceSamplingPriority(existingSpanContext.SamplingPriority.Value, lockSampling: true);
                         }
 
                         if (returnValue is HttpWebResponse response)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -54,8 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     {
                         if (setSamplingPriority)
                         {
-                            scope.Span.SetTraceSamplingPriority(spanContext.SamplingPriority.Value);
-                            scope.Span.Context.TraceContext.LockSamplingPriority();
+                            scope.Span.SetTraceSamplingPriority(spanContext.SamplingPriority.Value, lockSampling: true);
                         }
 
                         // add distributed tracing headers to the HTTP request

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;
-            span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+            span.SetTraceSamplingPriority(SamplingPriority.AutoKeep, lockSampling: false);
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;
-            span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+            span.SetTraceSamplingPriority(SamplingPriority.AutoKeep, lockSampling: false);
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;
-            span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
+            span.SetTraceSamplingPriority(SamplingPriority.AutoKeep, lockSampling: false);
             span.ResourceName = $"{testSuite}.{testName}";
             span.SetTag(Tags.Origin, TestTags.CIAppTestOriginName);
             span.SetTag(TestTags.Suite, testSuite);

--- a/tracer/src/Datadog.Trace/SamplingPriority.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriority.cs
@@ -24,27 +24,29 @@ namespace Datadog.Trace
     {
         /// <summary>
         /// Trace should be dropped (not sampled).
-        /// Sampling decision made explicitly by user through
-        /// code or configuration (e.g. the rules sampler).
+        /// User changed the sampling priority directly through code
+        /// or via configuration (sampling rates, sampling rules).
         /// </summary>
         UserReject = -1,
 
         /// <summary>
         /// Trace should be dropped (not sampled).
-        /// Sampling decision made by the built-in sampler.
+        /// Sampling decision made automatically
+        /// without user input or configuration.
         /// </summary>
         AutoReject = 0,
 
         /// <summary>
         /// Trace should be kept (sampled).
-        /// Sampling decision made by the built-in sampler.
+        /// Sampling decision made automatically
+        /// without user input or configuration.
         /// </summary>
         AutoKeep = 1,
 
         /// <summary>
         /// Trace should be kept (sampled).
-        /// Sampling decision made explicitly by user through
-        /// code or configuration (e.g. the rules sampler).
+        /// User changed the sampling priority directly through code
+        /// or via configuration (sampling rates, sampling rules).
         /// </summary>
         UserKeep = 2,
     }


### PR DESCRIPTION
To try avoid exposing `SamplingPriority` publicly, replace extension method `Span.SetTraceSamplingPriority(SamplingPriority)` with `KeepTrace()` and `DropTrace()`. This is similar to setting the `manual.keep` and `manual.drop` span tags supported across all language tracers instead of the `sampling.priority` tag.

This is a breaking change for users of this public API, so it should be included in release 2.0. Note that we already made a (binary) breaking change here in 2.0 by changing the signature of `SetTraceSamplingPriority()` from taking `Span` to `ISpan`.