### PR TITLE
Add space before exception message

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Logging
                        .MinimumLevel.ControlledBy(LoggingLevelSwitch)
                        .WriteTo.File(
                             managedLogPath,
-                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{Exception} {Properties}{NewLine}",
+                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception} {Properties}{NewLine}",
                             rollingInterval: RollingInterval.Day,
                             rollOnFileSizeLimit: true,
                             fileSizeLimitBytes: MaxLogFileSize,


### PR DESCRIPTION
@pierotibou was right in #2094, we needed an extra space, otherwise message runs together with the log message:

```
2021-12-06 14:59:27.722 +02:00 [ERR] An error occurred while sending 0 traces to the agent at http://127.0.0.1:8126/v0.4/tracesSystem.Net.WebException: No connection could be made because the target machine actively refused it
```


@DataDog/apm-dotnet