### PR TITLE
Improve performance of AutomaticTracer

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -36,6 +36,7 @@ namespace Datadog.Trace.ClrProfiler
 
         void IDistributedTracer.SetSpanContext(SpanContext value)
         {
+            // This is a performance optimization. See comment in GetDistributedTrace() about potential race condition
             if (_child != null)
             {
                 DistributedTrace.Value = value;


### PR DESCRIPTION
- Remove an asynclocal read in `GetSpanContext`
- Remove the asynclocal write in `IDistributedTracer.SetSpanContext` when there is no manual tracer
