### PR TITLE
Log additional information about the AssemblyLoadContext

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -88,7 +88,7 @@ namespace Datadog.Trace.Logging
                     loggerConfiguration.Enrich.WithProperty("Process", $"[{domainMetadata.ProcessId} {domainMetadata.ProcessName}]");
                     loggerConfiguration.Enrich.WithProperty("AppDomain", $"[{domainMetadata.AppDomainId} {domainMetadata.AppDomainName}]");
 #if NETCOREAPP
-                    loggerConfiguration.Enrich.WithProperty("AssemblyLoadContext", System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(DatadogLogging).Assembly).Name);
+                    loggerConfiguration.Enrich.WithProperty("AssemblyLoadContext", System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(typeof(DatadogLogging).Assembly)?.ToString());
 #endif
                     loggerConfiguration.Enrich.WithProperty("TracerVersion", TracerConstants.AssemblyVersion);
                 }


### PR DESCRIPTION
Most custom ALCs don't have a name, and we can't set the name of our own ALC in the loader because it doesn't have a netcoreapp3.x target.

Instead, we can use `.ToString()`, which includes the name as well as additional information (the type of ALC and its id).