### PR TITLE
Reinstate Integration.AdoNet integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetClientInstrumentMethodAttribute.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetClientInstrumentMethodAttribute.cs
@@ -19,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
             MinimumVersion = AdoNetClientData.MinimumVersion;
             MaximumVersion = AdoNetClientData.MaximumVersion;
 
-            // Not used for ADO.NET integration.
+            // Informational only.
             // Integration name is determined by type of DbCommand in DbScopeFactory
-            IntegrationName = null;
+            IntegrationName = AdoNetClientData.IntegrationName;
         }
 
         protected IAdoNetClientData AdoNetClientData { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/AdoNetConstants.cs
@@ -3,14 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.Configuration;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 {
     internal static class AdoNetConstants
     {
         internal struct SystemDataClientData : IAdoNetClientData
         {
-            // note: not a real integration id, cannot be used for configuration
-            public string IntegrationName => "AdoNet";
+            // note: not a real integration id, cannot currently be used for configuration
+            public string IntegrationName => nameof(IntegrationId.AdoNet);
 
             public string AssemblyName => "System.Data";
 
@@ -27,8 +29,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
         internal struct SystemDataCommonClientData : IAdoNetClientData
         {
-            // note: not a real integration id, cannot be used for configuration
-            public string IntegrationName => "AdoNet";
+            // note: not a real integration id, cannot currently be used for configuration
+            public string IntegrationName => nameof(IntegrationId.AdoNet);
 
             public string AssemblyName => "System.Data.Common";
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
 
         private static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command, IntegrationId integrationId, string dbType, string operationName)
         {
-            if (!tracer.Settings.IsIntegrationEnabled(integrationId))
+            if (!tracer.Settings.IsIntegrationEnabled(integrationId) || !tracer.Settings.IsIntegrationEnabled(IntegrationId.AdoNet))
             {
                 // integration disabled, don't create a scope, skip this span
                 return null;

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
@@ -12,6 +12,7 @@ namespace Datadog.Trace.Configuration
         WinHttpHandler,
         CurlHandler,
         AspNetCore,
+        AdoNet,
         AspNet,
         AspNetMvc,
         AspNetWebApi2,

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -57,6 +57,23 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbCommands))]
+        public void CreateDbCommandScope_ReturnNullForAdoNetDisabledIntegration(IDbCommand command, string integrationName, string dbType)
+        {
+            // HACK: avoid analyzer warning about not using arguments
+            _ = dbType;
+
+            var tracerSettings = new TracerSettings();
+            tracerSettings.Integrations[integrationName].Enabled = true;
+            tracerSettings.Integrations[nameof(IntegrationId.AdoNet)].Enabled = false;
+            var tracer = TracerHelper.Create(tracerSettings);
+
+            // Create scope
+            using var scope = CreateDbCommandScope(tracer, command);
+            Assert.Null(scope);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDbCommands))]
         public void CreateDbCommandScope_UsesReplacementServiceNameWhenProvided(IDbCommand command, string integrationName, string dbType)
         {
             // HACK: avoid analyzer warning about not using arguments


### PR DESCRIPTION
In #2008 we removed `IntegrationId.AdoNet` and replaced it with individual IDs for the individual integration types. This was a breaking change. In #2120 we are going to add `AdoNet` back as we can instrument the base type, which would be another breaking change. 

This PR reinstates `IntegrationId.AdoNet` now, before we make the break. If a user disables `AdoNet` then _all_ ADO.NET integrations will be disabled. This keeps the existing pre-2.0 behaviour, while still allowing users to disable specific integrations.

@DataDog/apm-dotnet