### PR TITLE
DBScopeFactory improvements.

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -168,9 +168,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     }
 
                     // We create or replace the cache with the new service name
-                    _tracerDefaultServiceName = tracer.DefaultServiceName;
-                    serviceName = $"{_tracerDefaultServiceName}-{dbTypeName}";
+                    var defaultServiceName = tracer.DefaultServiceName;
+                    serviceName = $"{defaultServiceName}-{dbTypeName}";
                     _serviceName = serviceName;
+                    _tracerDefaultServiceName = defaultServiceName;
                 }
 
                 return serviceName;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -157,7 +157,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     if (DbTypeName != dbTypeName)
                     {
                         // We cannot cache in the base class
-                        return $"{_tracerDefaultServiceName}-{dbTypeName}";
+                        return $"{tracer.DefaultServiceName}-{dbTypeName}";
                     }
 
                     // If not a base class

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -4,8 +4,10 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
@@ -18,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DbScopeFactory));
 
-        private static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command, IntegrationId integrationId, string dbType, string operationName, string serviceName)
+        private static Scope CreateDbCommandScope(Tracer tracer, IDbCommand command, IntegrationId integrationId, string dbType, string operationName, string serviceName, ref DbCommandCache.TagsCacheItem tagsFromConnectionString)
         {
             if (!tracer.Settings.IsIntegrationEnabled(integrationId))
             {
@@ -46,14 +48,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                            {
                                DbType = dbType,
                                InstrumentationName = IntegrationRegistry.GetName(integrationId),
+                               DbName = tagsFromConnectionString.DbName,
+                               DbUser = tagsFromConnectionString.DbUser,
+                               OutHost = tagsFromConnectionString.OutHost,
                            };
 
                 tags.SetAnalyticsSampleRate(integrationId, tracer.Settings, enabledWithGlobalSetting: false);
-
-                var cachedTags = DbCommandCache.GetTagsFromDbCommand(command);
-                tags.DbName = cachedTags.DbName;
-                tags.DbUser = cachedTags.DbUser;
-                tags.OutHost = cachedTags.OutHost;
 
                 scope = tracer.StartActiveInternal(operationName, tags: tags, serviceName: serviceName);
                 scope.Span.ResourceName = command.CommandText;
@@ -111,8 +111,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
             private static readonly string DbTypeName;
             private static readonly string OperationName;
             private static readonly IntegrationId IntegrationId;
-            private static string _tracerDefaultServiceName;
-            private static string _serviceName;
+
+            // ServiceName cache
+            private static KeyValuePair<string, string> _serviceNameCache;
+
+            // ConnectionString tags cache
+            private static KeyValuePair<string, DbCommandCache.TagsCacheItem> _tagsByConnectionStringCache;
             // ReSharper restore StaticMemberInGenericType
 
             static Cache()
@@ -136,7 +140,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                 if (commandType == CommandType)
                 {
                     // use the cached values if command.GetType() == typeof(TCommand)
-                    return DbScopeFactory.CreateDbCommandScope(tracer, command, IntegrationId, DbTypeName, OperationName, GetServiceName(tracer, DbTypeName));
+                    var tagsFromConnectionString = GetTagsFromConnectionString(command);
+                    return DbScopeFactory.CreateDbCommandScope(
+                        tracer: tracer,
+                        command: command,
+                        integrationId: IntegrationId,
+                        dbType: DbTypeName,
+                        operationName: OperationName,
+                        serviceName: GetServiceName(tracer, DbTypeName),
+                        tagsFromConnectionString: ref tagsFromConnectionString);
                 }
 
                 // if command.GetType() != typeof(TCommand), we are probably instrumenting a method
@@ -144,7 +156,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                 if (TryGetIntegrationDetails(commandType.FullName, out var integrationId, out var dbTypeName))
                 {
                     var operationName = $"{dbTypeName}.query";
-                    return DbScopeFactory.CreateDbCommandScope(tracer, command, integrationId.Value, dbTypeName, operationName, GetServiceName(tracer, dbTypeName));
+                    var tagsFromConnectionString = GetTagsFromConnectionString(command);
+                    return DbScopeFactory.CreateDbCommandScope(
+                        tracer: tracer,
+                        command: command,
+                        integrationId: integrationId.Value,
+                        dbType: dbTypeName,
+                        operationName: operationName,
+                        serviceName: GetServiceName(tracer, dbTypeName),
+                        tagsFromConnectionString: ref tagsFromConnectionString);
                 }
 
                 return null;
@@ -160,21 +180,43 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                         return $"{tracer.DefaultServiceName}-{dbTypeName}";
                     }
 
+                    var serviceNameCache = _serviceNameCache;
+
                     // If not a base class
-                    if (_tracerDefaultServiceName == tracer.DefaultServiceName)
+                    if (serviceNameCache.Key == tracer.DefaultServiceName)
                     {
                         // Service has not changed
-                        return _serviceName;
+                        // Fastpath
+                        return serviceNameCache.Value;
                     }
 
                     // We create or replace the cache with the new service name
+                    // Slowpath
                     var defaultServiceName = tracer.DefaultServiceName;
                     serviceName = $"{defaultServiceName}-{dbTypeName}";
-                    _serviceName = serviceName;
-                    _tracerDefaultServiceName = defaultServiceName;
+                    _serviceNameCache = new KeyValuePair<string, string>(defaultServiceName, serviceName);
                 }
 
                 return serviceName;
+            }
+
+            private static DbCommandCache.TagsCacheItem GetTagsFromConnectionString(IDbCommand command)
+            {
+                var connectionString = command.Connection?.ConnectionString;
+
+                // Check if the connection string is the one in the cache
+                var tagsByConnectionString = _tagsByConnectionStringCache;
+                if (tagsByConnectionString.Key == connectionString)
+                {
+                    // Fastpath
+                    return tagsByConnectionString.Value;
+                }
+
+                // Cache the new tags by connection string
+                // Slowpath
+                var tags = DbCommandCache.GetTagsFromDbCommand(command);
+                _tagsByConnectionStringCache = new KeyValuePair<string, DbCommandCache.TagsCacheItem>(connectionString, tags);
+                return tags;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ImmutableTracerSettings.cs" company="Datadog">
+// <copyright file="ImmutableTracerSettings.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -323,6 +323,11 @@ namespace Datadog.Trace.Configuration
         internal string GetServiceName(Tracer tracer, string serviceName)
         {
             return ServiceNameMappings.GetServiceName(tracer.DefaultServiceName, serviceName);
+        }
+
+        internal bool TryGetServiceName(string key, out string serviceName)
+        {
+            return ServiceNameMappings.TryGetServiceName(key, out serviceName);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ServiceNames.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ServiceNames.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -31,6 +32,17 @@ namespace Datadog.Trace.Configuration
             {
                 return $"{applicationName}-{key}";
             }
+        }
+
+        public bool TryGetServiceName(string key, out string name)
+        {
+            if (_mappings is not null && _mappings.TryGetValue(key, out name))
+            {
+                return true;
+            }
+
+            name = null;
+            return false;
         }
 
         public void SetServiceNameMappings(IEnumerable<KeyValuePair<string, string>> mappings)

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -21,24 +21,6 @@ namespace Datadog.Trace.ExtensionMethods
     public static class SpanExtensions
     {
         /// <summary>
-        /// Adds standard tags to a span with values taken from the specified <see cref="DbCommand"/>.
-        /// </summary>
-        /// <param name="span">The span to add the tags to.</param>
-        /// <param name="command">The db command to get tags values from.</param>
-        public static void AddTagsFromDbCommand(this ISpan span, IDbCommand command)
-        {
-            span.ResourceName = command.CommandText;
-            span.Type = SpanTypes.Sql;
-
-            var tags = DbCommandCache.GetTagsFromDbCommand(command);
-
-            foreach (var pair in tags)
-            {
-                span.SetTag(pair.Key, pair.Value);
-            }
-        }
-
-        /// <summary>
         /// Sets the sampling priority for the trace that contains the specified <see cref="ISpan"/>.
         /// </summary>
         /// <param name="span">A span that belongs to the trace.</param>

--- a/tracer/src/Datadog.Trace/Tagging/SqlTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/SqlTags.cs
@@ -5,9 +5,8 @@
 
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
-using Datadog.Trace.Tagging;
 
-namespace Datadog.Trace.ClrProfiler
+namespace Datadog.Trace.Tagging
 {
     internal class SqlTags : InstrumentationTags
     {

--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -37,13 +37,13 @@ namespace Datadog.Trace.Util
             }
         }
 
-        public static TagsCacheItem? GetTagsFromDbCommand(IDbCommand command)
+        public static TagsCacheItem GetTagsFromDbCommand(IDbCommand command)
         {
             var connectionString = command.Connection?.ConnectionString;
 
             if (connectionString is null)
             {
-                return null;
+                return default;
             }
 
             var cache = _cache;
@@ -82,9 +82,9 @@ namespace Datadog.Trace.Util
             var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
 
             return new TagsCacheItem(
-                GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog"),
-                GetConnectionStringValue(builder, "User ID", "UserID"),
-                GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"));
+                dbName: GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog"),
+                dbUser: GetConnectionStringValue(builder, "User ID", "UserID"),
+                outHost: GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"));
         }
 
         private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)

--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -19,12 +19,12 @@ namespace Datadog.Trace.Util
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DbCommandCache));
 
-        private static ConcurrentDictionary<string, KeyValuePair<string, string>[]> _cache = new();
+        private static ConcurrentDictionary<string, TagsCacheItem> _cache = new();
 
         /// <summary>
         /// Gets or sets the underlying cache, to be used for unit tests
         /// </summary>
-        internal static ConcurrentDictionary<string, KeyValuePair<string, string>[]> Cache
+        internal static ConcurrentDictionary<string, TagsCacheItem> Cache
         {
             get
             {
@@ -37,13 +37,13 @@ namespace Datadog.Trace.Util
             }
         }
 
-        public static KeyValuePair<string, string>[] GetTagsFromDbCommand(IDbCommand command)
+        public static TagsCacheItem? GetTagsFromDbCommand(IDbCommand command)
         {
             var connectionString = command.Connection?.ConnectionString;
 
             if (connectionString is null)
             {
-                return Array.Empty<KeyValuePair<string, string>>();
+                return null;
             }
 
             var cache = _cache;
@@ -76,25 +76,15 @@ namespace Datadog.Trace.Util
             return ExtractTagsFromConnectionString(connectionString);
         }
 
-        private static KeyValuePair<string, string>[] ExtractTagsFromConnectionString(string connectionString)
+        private static TagsCacheItem ExtractTagsFromConnectionString(string connectionString)
         {
             // Parse the connection string
             var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
 
-            return new[]
-            {
-                new KeyValuePair<string, string>(
-                    Tags.DbName,
-                    GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog")),
-
-                new KeyValuePair<string, string>(
-                    Tags.DbUser,
-                    GetConnectionStringValue(builder, "User ID", "UserID")),
-
-                new KeyValuePair<string, string>(
-                    Tags.OutHost,
-                    GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"))
-            };
+            return new TagsCacheItem(
+                GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog"),
+                GetConnectionStringValue(builder, "User ID", "UserID"),
+                GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"));
         }
 
         private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)
@@ -109,6 +99,20 @@ namespace Datadog.Trace.Util
             }
 
             return null;
+        }
+
+        internal readonly struct TagsCacheItem
+        {
+            public readonly string DbName;
+            public readonly string DbUser;
+            public readonly string OutHost;
+
+            public TagsCacheItem(string dbName, string dbUser, string outHost)
+            {
+                DbName = dbName;
+                DbUser = dbUser;
+                OutHost = outHost;
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -35,13 +35,9 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             var span = new Span(spanContext, null);
 
             var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
-
-            if (commandTags != null)
-            {
-                Assert.Equal(expectedDbName, commandTags.Value.DbName);
-                Assert.Equal(expectedUserId, commandTags.Value.DbUser);
-                Assert.Equal(expectedHost, commandTags.Value.OutHost);
-            }
+            Assert.Equal(expectedDbName, commandTags.DbName);
+            Assert.Equal(expectedUserId, commandTags.DbUser);
+            Assert.Equal(expectedHost, commandTags.OutHost);
         }
 
         [Fact]
@@ -60,7 +56,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
                 var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
                 Assert.NotNull(DbCommandCache.Cache);
-                Assert.Equal("myServerName" + i, commandTags.Value.OutHost);
+                Assert.Equal("myServerName" + i, commandTags.OutHost);
             }
 
             // Test the logic with cache disabled
@@ -71,7 +67,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
                 var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
                 Assert.Null(DbCommandCache.Cache);
-                Assert.Equal("myServerName" + "NoCache" + i, commandTags.Value.OutHost);
+                Assert.Equal("myServerName" + "NoCache" + i, commandTags.OutHost);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/SpanExtensionsTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         public SpanExtensionsTests()
         {
             // Reset the cache
-            DbCommandCache.Cache = new ConcurrentDictionary<string, KeyValuePair<string, string>[]>();
+            DbCommandCache.Cache = new();
         }
 
         [Theory]
@@ -34,26 +34,14 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             var spanContext = new SpanContext(Mock.Of<ISpanContext>(), Mock.Of<ITraceContext>(), "test");
             var span = new Span(spanContext, null);
 
-            span.AddTagsFromDbCommand(CreateDbCommand(connectionString));
+            var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
-            Assert.Equal(expectedDbName, span.GetTag(Tags.DbName));
-            Assert.Equal(expectedUserId, span.GetTag(Tags.DbUser));
-            Assert.Equal(expectedHost, span.GetTag(Tags.OutHost));
-        }
-
-        [Fact]
-        public void SetSpanTypeToSql()
-        {
-            const string connectionString = "Server=myServerName;Database=myDataBase;User Id=myUsername;Password=myPassword;";
-            const string commandText = "SELECT * FROM Table ORDER BY id";
-
-            var spanContext = new SpanContext(Mock.Of<ISpanContext>(), Mock.Of<ITraceContext>(), "test");
-            var span = new Span(spanContext, null);
-
-            span.AddTagsFromDbCommand(CreateDbCommand(connectionString, commandText));
-
-            Assert.Equal(SpanTypes.Sql, span.Type);
-            Assert.Equal(commandText, span.ResourceName);
+            if (commandTags != null)
+            {
+                Assert.Equal(expectedDbName, commandTags.Value.DbName);
+                Assert.Equal(expectedUserId, commandTags.Value.DbUser);
+                Assert.Equal(expectedHost, commandTags.Value.OutHost);
+            }
         }
 
         [Fact]
@@ -69,10 +57,10 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             {
                 var connectionString = string.Format(connectionStringTemplate, i);
 
-                span.AddTagsFromDbCommand(CreateDbCommand(connectionString));
+                var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
                 Assert.NotNull(DbCommandCache.Cache);
-                Assert.Equal("myServerName" + i, span.GetTag(Tags.OutHost));
+                Assert.Equal("myServerName" + i, commandTags.Value.OutHost);
             }
 
             // Test the logic with cache disabled
@@ -80,10 +68,10 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             {
                 var connectionString = string.Format(connectionStringTemplate, "NoCache" + i);
 
-                span.AddTagsFromDbCommand(CreateDbCommand(connectionString));
+                var commandTags = DbCommandCache.GetTagsFromDbCommand(CreateDbCommand(connectionString));
 
                 Assert.Null(DbCommandCache.Cache);
-                Assert.Equal("myServerName" + "NoCache" + i, span.GetTag(Tags.OutHost));
+                Assert.Equal("myServerName" + "NoCache" + i, commandTags.Value.OutHost);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -378,7 +378,6 @@ namespace Datadog.Trace.ExtensionMethods
 {
     public static class SpanExtensions
     {
-        public static void AddTagsFromDbCommand(this Datadog.Trace.ISpan span, System.Data.IDbCommand command) { }
         public static void SetTraceSamplingPriority(this Datadog.Trace.ISpan span, Datadog.Trace.SamplingPriority samplingPriority) { }
     }
 }


### PR DESCRIPTION
Change `DBScopeFactory` implementation to reduce allocations and use `SqlTags` directly.


@DataDog/apm-dotnet