### PR TITLE
Use PathBase.ToUriComponent in AspNetCoreDiagnosticObserver

### DIFF
--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -511,7 +511,7 @@ namespace Datadog.Trace.DiagnosticListeners
                         controllerName: controllerName,
                         actionName: actionName);
 
-                    resourceName = $"{parentTags.HttpMethod} {request.PathBase.Value}{resourcePathName}";
+                    resourceName = $"{parentTags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
                     aspNetRoute = routeTemplate?.TemplateText.ToLowerInvariant();
                 }
             }
@@ -675,7 +675,7 @@ namespace Datadog.Trace.DiagnosticListeners
                     controllerName: controllerName,
                     actionName: actionName);
 
-                var resourceName = $"{tags.HttpMethod} {request.PathBase}{resourcePathName}";
+                var resourceName = $"{tags.HttpMethod} {request.PathBase.ToUriComponent()}{resourcePathName}";
 
                 // NOTE: We could set the controller/action/area tags on the parent span
                 // But instead we re-extract them in the MVC endpoint as these are MVC


### PR DESCRIPTION
- In `OnRoutingEndpointMatched`, use `PathBase.ToUriComponent` instead of just `PathBase`. This allows all arguments to be string, and the compiler rewrites the statement using `string.Concat` instead of `string.Format`
- In `StartMvcCoreSpan`, use `PathBase.ToUriComponent` instead of `PathBase.Value`. The code was originally using `PathBase.ToString` which internally call `PathBase.ToUriComponent`, but it was changed to Value (thus affecting the behavior) when attempting a similar optimization in https://github.com/DataDog/dd-trace-dotnet/pull/2024