### PR TITLE
Small pipeline reliability updates

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -35,6 +35,7 @@ steps:
         --env DiffEngine_Disabled=true \
         --env TestAllPackageVersions=$(TestAllPackageVersions) \
         --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
+        --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
         dd-trace-dotnet/${{ parameters.baseImage }}-${{ parameters.target }} \
         dotnet /build/bin/Debug/_build.dll ${{ parameters.command }}
   displayName: Run '${{ parameters.command }}' in Docker

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -84,6 +84,7 @@ variables:
   Verify_DisableClipboard: true
   DiffEngine_Disabled: true
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])]
+  NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY: true
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -598,26 +598,15 @@ stages:
         $Iterations = 5
         do {
             Try{
-              docker-compose pull --include-deps IntegrationTests.IIS
+              docker-compose build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS
+              docker-compose up -d IntegrationTests.IIS
               $Iterations = 0
           } catch { 
             echo "Retrying... "
             Start-Sleep -s 1
             $Iterations = $Iterations - 1 }
         } while ($Iterations -gt 0)
-      displayName: docker-compose pull IntegrationTests.IIS
-
-    - task: DockerCompose@0
-      displayName: docker-compose build IIS containers
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: build --build-arg dotnet_tracer_msi=.$(relativeMsiOutputDirectory)/*.msi --build-arg ENABLE_32_BIT=$(enable32bit) IntegrationTests.IIS
-
-    - task: DockerCompose@0
-      displayName: docker-compose start IIS containers
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: up -d IntegrationTests.IIS
+      displayName: docker-compose start IntegrationTests.IIS
 
     - script: tracer\build.cmd RunWindowsIisIntegrationTests -Framework $(framework) --code-coverage
       displayName: RunWindowsIisIntegrationTests
@@ -718,26 +707,14 @@ stages:
     - script: |
         # retry up to 5 times to pull the docker images
         for i in 1 2 3 4 5; do 
-          docker-compose pull --include-deps IntegrationTests && break || sleep 5; 
+          docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests && \
+          docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies && \
+          break || sleep 5; 
         done
       env:
         baseImage: $(baseImage)
         framework: $(publishTargetFramework)
-      displayName: docker-compose pull IntegrationTests
-
-    - task: DockerCompose@0
-      displayName: docker-compose build IntegrationTests
-      env:
-        baseImage: $(baseImage)
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests
-
-    - task: DockerCompose@0
-      displayName: docker-compose start dependencies
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: run --rm StartDependencies
+      displayName: docker-compose build IntegrationTests and run StartDependencies
 
     - task: DockerCompose@0
       displayName: docker-compose run IntegrationTests
@@ -747,6 +724,7 @@ stages:
           baseImage=$(baseImage)
           framework=$(publishTargetFramework)
         dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) IntegrationTests
+        projectName: ddtrace_$(Build.BuildNumber)
 
     - task: DockerCompose@0
       displayName: docker-compose stop services
@@ -819,26 +797,14 @@ stages:
         - script: |
             # retry up to 5 times to pull the docker images
             for i in 1 2 3 4 5; do 
-              docker-compose pull --include-deps IntegrationTests.ARM64 && break || sleep 5; 
+              docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64 && \
+              docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64 && \
+              break || sleep 1; 
             done
           env:
             baseImage: $(baseImage)
             framework: $(publishTargetFramework)
-          displayName: docker-compose pull IntegrationTests
-
-        - task: DockerCompose@0
-          displayName: docker-compose build IntegrationTests
-          inputs:
-            containerregistrytype: Container Registry
-            dockerComposeCommand: build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests.ARM64
-            projectName: ddtrace_$(Build.BuildNumber)
-
-        - task: DockerCompose@0
-          displayName: docker-compose start dependencies
-          inputs:
-            containerregistrytype: Container Registry
-            dockerComposeCommand: run --rm StartDependencies.ARM64
-            projectName: ddtrace_$(Build.BuildNumber)
+          displayName: docker-compose build IntegrationTests and run StartDependencies
 
         - task: DockerCompose@0
           displayName: docker-compose run IntegrationTests

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -594,6 +594,19 @@ stages:
     - script: tracer\build.cmd BuildWindowsIntegrationTests -Framework $(framework)
       displayName: BuildWindowsIntegrationTests
 
+    - powershell: |
+        $Iterations = 5
+        do {
+            Try{
+              docker-compose pull --include-deps IntegrationTests.IIS
+              $Iterations = 0
+          } catch { 
+            echo "Retrying... "
+            Start-Sleep -s 1
+            $Iterations = $Iterations - 1 }
+        } while ($Iterations -gt 0)
+      displayName: docker-compose pull IntegrationTests.IIS
+
     - task: DockerCompose@0
       displayName: docker-compose build IIS containers
       inputs:
@@ -702,6 +715,16 @@ stages:
         baseImage: $(baseImage)
         command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
 
+    - script: |
+        # retry up to 5 times to pull the docker images
+        for i in 1 2 3 4 5; do 
+          docker-compose pull --include-deps IntegrationTests && break || sleep 5; 
+        done
+      env:
+        baseImage: $(baseImage)
+        framework: $(publishTargetFramework)
+      displayName: docker-compose pull IntegrationTests
+
     - task: DockerCompose@0
       displayName: docker-compose build IntegrationTests
       env:
@@ -792,6 +815,16 @@ stages:
             build: true
             baseImage: $(baseImage)
             command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
+
+        - script: |
+            # retry up to 5 times to pull the docker images
+            for i in 1 2 3 4 5; do 
+              docker-compose pull --include-deps IntegrationTests.ARM64 && break || sleep 5; 
+            done
+          env:
+            baseImage: $(baseImage)
+            framework: $(publishTargetFramework)
+          displayName: docker-compose pull IntegrationTests
 
         - task: DockerCompose@0
           displayName: docker-compose build IntegrationTests


### PR DESCRIPTION
* Add some retries to the nuget restore step using the new .NET 6 feature
* Add retries to the docker pull/build/start dependencies step, by using a script instead of the built-in task. This is a frequent source of transient CI failures, and there's no way to tell AzDo "Retry this step if it fails", so falling back to this hacky mess.

@DataDog/apm-dotnet