### PR TITLE
Remove LockSamplingPriority

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -78,7 +78,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         if (setSamplingPriority)
                         {
                             scope.Span.SetTraceSamplingPriority(existingSpanContext.SamplingPriority.Value);
-                            scope.Span.Context.TraceContext.LockSamplingPriority();
                         }
 
                         if (returnValue is HttpWebResponse response)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -55,7 +55,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         if (setSamplingPriority)
                         {
                             scope.Span.SetTraceSamplingPriority(spanContext.SamplingPriority.Value);
-                            scope.Span.Context.TraceContext.LockSamplingPriority();
                         }
 
                         // add distributed tracing headers to the HTTP request

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -61,19 +61,9 @@ namespace Datadog.Trace.ClrProfiler
             }
         }
 
-        void IDistributedTracer.LockSamplingPriority()
+        void IDistributedTracer.SetSamplingPriority(SamplingPriority? samplingPriority)
         {
-            _child?.LockSamplingPriority();
-        }
-
-        SamplingPriority? IDistributedTracer.TrySetSamplingPriority(SamplingPriority? samplingPriority)
-        {
-            if (_child == null)
-            {
-                return samplingPriority;
-            }
-
-            return (SamplingPriority?)_child.TrySetSamplingPriority((int?)samplingPriority);
+            _child?.SetSamplingPriority((int?)samplingPriority);
         }
 
         public object GetAutomaticActiveScope()

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.DuckTyping;
@@ -59,6 +60,11 @@ namespace Datadog.Trace.ClrProfiler
             {
                 DistributedTrace.Value = value;
             }
+        }
+
+        SamplingPriority? IDistributedTracer.GetSamplingPriority()
+        {
+            return (SamplingPriority?)_child?.GetSamplingPriority();
         }
 
         void IDistributedTracer.SetSamplingPriority(SamplingPriority? samplingPriority)

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using Datadog.Trace.Logging;
-
 namespace Datadog.Trace.ClrProfiler
 {
     /// <summary>
@@ -13,6 +11,11 @@ namespace Datadog.Trace.ClrProfiler
     /// </summary>
     internal abstract class CommonTracer : ICommonTracer
     {
+        public int? GetSamplingPriority()
+        {
+            return (int?)Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext?.SamplingPriority;
+        }
+
         public void SetSamplingPriority(int? samplingPriority)
         {
             var traceContext = Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext;

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -13,44 +13,14 @@ namespace Datadog.Trace.ClrProfiler
     /// </summary>
     internal abstract class CommonTracer : ICommonTracer
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(CommonTracer));
-
-        public void LockSamplingPriority()
+        public void SetSamplingPriority(int? samplingPriority)
         {
             var traceContext = Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext;
 
             if (traceContext != null)
             {
-                traceContext.LockSamplingPriority(notifyDistributedTracer: false);
+                traceContext.SetSamplingPriority((SamplingPriority?)samplingPriority, notifyDistributedTracer: false);
             }
-        }
-
-        public int? TrySetSamplingPriority(int? samplingPriority)
-        {
-            var traceContext = Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext;
-
-            // If there is no trace context, when a new span is propagated the sampling priority will automatically be locked
-            // because it will be considered as a distributed trace
-            if (traceContext != null)
-            {
-                if (traceContext.IsSamplingPriorityLocked())
-                {
-                    var currentSamplingPriority = traceContext.SamplingPriority;
-
-                    if (currentSamplingPriority != null)
-                    {
-                        return (int)currentSamplingPriority.Value;
-                    }
-
-                    Log.Warning("SamplingPriority is locked without value");
-                }
-                else
-                {
-                    traceContext.SetSamplingPriority((SamplingPriority?)samplingPriority, notifyDistributedTracer: false);
-                }
-            }
-
-            return samplingPriority;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ICommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ICommonTracer.cs
@@ -7,8 +7,6 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal interface ICommonTracer
     {
-        void LockSamplingPriority();
-
-        int? TrySetSamplingPriority(int? samplingPriority);
+        void SetSamplingPriority(int? samplingPriority);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ICommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ICommonTracer.cs
@@ -7,6 +7,8 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal interface ICommonTracer
     {
+        int? GetSamplingPriority();
+
         void SetSamplingPriority(int? samplingPriority);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
@@ -17,8 +17,6 @@ namespace Datadog.Trace.ClrProfiler
 
         void SetSpanContext(IReadOnlyDictionary<string, string> value);
 
-        void LockSamplingPriority();
-
-        SamplingPriority? TrySetSamplingPriority(SamplingPriority? samplingPriority);
+        void SetSamplingPriority(SamplingPriority? samplingPriority);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
@@ -17,6 +17,8 @@ namespace Datadog.Trace.ClrProfiler
 
         void SetSpanContext(IReadOnlyDictionary<string, string> value);
 
+        SamplingPriority? GetSamplingPriority();
+
         void SetSamplingPriority(SamplingPriority? samplingPriority);
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -71,14 +71,9 @@ namespace Datadog.Trace.ClrProfiler
             _parent.SetDistributedTrace(value);
         }
 
-        void IDistributedTracer.LockSamplingPriority()
+        void IDistributedTracer.SetSamplingPriority(SamplingPriority? samplingPriority)
         {
-            _parent.LockSamplingPriority();
-        }
-
-        SamplingPriority? IDistributedTracer.TrySetSamplingPriority(SamplingPriority? samplingPriority)
-        {
-            return (SamplingPriority?)_parent.TrySetSamplingPriority((int?)samplingPriority);
+            _parent.SetSamplingPriority((int?)samplingPriority);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -56,6 +56,7 @@ namespace Datadog.Trace.ClrProfiler
         SpanContext IDistributedTracer.GetSpanContext()
         {
             var values = _parent.GetDistributedTrace();
+
             if (values is SpanContext spanContext)
             {
                 return spanContext;
@@ -69,6 +70,11 @@ namespace Datadog.Trace.ClrProfiler
         void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)
         {
             _parent.SetDistributedTrace(value);
+        }
+
+        SamplingPriority? IDistributedTracer.GetSamplingPriority()
+        {
+            return (SamplingPriority?)_parent.GetSamplingPriority();
         }
 
         void IDistributedTracer.SetSamplingPriority(SamplingPriority? samplingPriority)

--- a/tracer/src/Datadog.Trace/ITraceContext.cs
+++ b/tracer/src/Datadog.Trace/ITraceContext.cs
@@ -19,11 +19,7 @@ namespace Datadog.Trace
 
         void CloseSpan(Span span);
 
-        void LockSamplingPriority(bool notifyDistributedTracer = true);
-
         void SetSamplingPriority(SamplingPriority? samplingPriority, bool notifyDistributedTracer = true);
-
-        bool IsSamplingPriorityLocked();
 
         TimeSpan ElapsedSince(DateTimeOffset date);
     }

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -199,7 +199,7 @@ namespace Datadog.Trace
                     return true;
 
                 case HttpHeaderNames.SamplingPriority:
-                    var samplingPriority = SamplingPriority ?? TraceContext?.SamplingPriority;
+                    var samplingPriority = SamplingPriority;
 
                     value = samplingPriority != null ? ((int)samplingPriority.Value).ToString() : null;
                     return true;

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -44,9 +44,6 @@ namespace Datadog.Trace
 
             if (headers == null) { throw new ArgumentNullException(nameof(headers)); }
 
-            // lock sampling priority when span propagates.
-            context.TraceContext?.LockSamplingPriority();
-
             headers.Set(HttpHeaderNames.TraceId, context.TraceId.ToString(InvariantCulture));
             headers.Set(HttpHeaderNames.ParentId, context.SpanId.ToString(InvariantCulture));
 
@@ -81,9 +78,6 @@ namespace Datadog.Trace
             if (carrier == null) { throw new ArgumentNullException(nameof(carrier)); }
 
             if (setter == null) { throw new ArgumentNullException(nameof(setter)); }
-
-            // lock sampling priority when span propagates.
-            context.TraceContext?.LockSamplingPriority();
 
             setter(carrier, HttpHeaderNames.TraceId, context.TraceId.ToString(InvariantCulture));
             setter(carrier, HttpHeaderNames.ParentId, context.SpanId.ToString(InvariantCulture));

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -21,6 +22,8 @@ namespace Datadog.Trace
     /// </summary>
     public class Tracer : ITracer, IDatadogTracer, IDatadogOpenTracingTracer
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Tracer));
+
         private static string _runtimeId;
 
         /// <summary>
@@ -330,12 +333,12 @@ namespace Datadog.Trace
             // otherwise start a new trace context
             if (parent is SpanContext parentSpanContext)
             {
-                traceContext = parentSpanContext.TraceContext ??
-                    new TraceContext(this) { SamplingPriority = parentSpanContext.SamplingPriority };
+                traceContext = parentSpanContext.TraceContext
+                    ?? new TraceContext(this) { SamplingPriority = parentSpanContext.SamplingPriority ?? DistributedTracer.Instance.GetSamplingPriority() };
             }
             else
             {
-                traceContext = new TraceContext(this);
+                traceContext = new TraceContext(this) { SamplingPriority = DistributedTracer.Instance.GetSamplingPriority() };
             }
 
             var finalServiceName = serviceName ?? parent?.ServiceName ?? DefaultServiceName;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -36,13 +36,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
                 rootSpan.Name.Should().Be("Manual");
                 rootSpan.Metrics.Should().ContainKey(Metrics.SamplingPriority);
-                rootSpan.Metrics[Metrics.SamplingPriority].Should().Be((double)SamplingPriority.UserKeep);
+                rootSpan.Metrics[Metrics.SamplingPriority].Should().Be((double)SamplingPriority.UserReject);
 
                 var httpSpans = spans.Where(s => s.Name == "http.request").ToList();
 
-                httpSpans.Should().HaveCount(2);
-                httpSpans.Should().OnlyContain(
-                    s => !s.Metrics.ContainsKey(Metrics.SamplingPriority) || s.Metrics[Metrics.SamplingPriority] == (double)SamplingPriority.UserKeep);
+                httpSpans.Should()
+                    .HaveCount(2)
+                    .And.OnlyContain(s => s.ParentId == rootSpan.SpanId && s.TraceId == rootSpan.TraceId)
+                    .And.ContainSingle(s => s.Metrics[Metrics.SamplingPriority] == (double)SamplingPriority.UserKeep)
+                    .And.ContainSingle(s => s.Metrics[Metrics.SamplingPriority] == (double)SamplingPriority.UserReject);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -29,6 +30,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             {
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
+                foreach (var span in spans)
+                {
+                    var samplingPriority = string.Empty;
+
+                    if (span.Metrics.ContainsKey(Metrics.SamplingPriority))
+                    {
+                        samplingPriority = span.Metrics[Metrics.SamplingPriority].ToString();
+                    }
+
+                    Output.WriteLine($"{span.Name} - {span.TraceId} - {span.SpanId} - {span.ParentId} - {span.Resource} - {samplingPriority}");
+                }
+
                 spans.Should().HaveCount(expectedSpanCount);
 
                 // Check that no trace is orphaned
@@ -40,11 +53,35 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
                 var httpSpans = spans.Where(s => s.Name == "http.request").ToList();
 
+                // There is a difference in behavior between .NET Framework and .NET Core
+                // This happens because the version of the nuget is higher than the version of the automatic tracer
+                // When that's the case, only the nuget tracer is loaded, and we're not actually in a version conflict situation.
+                // When version 2.1 of the tracer ships, we can go back to the test and add a case using nuget 2.0,
+                // which will actually test the version conflict behavior.
+
+#if NETCOREAPP
+                httpSpans.Should()
+                    .HaveCount(2)
+                    .And.OnlyContain(s => s.ParentId == rootSpan.SpanId && s.TraceId == rootSpan.TraceId)
+                    .And.OnlyContain(s => !s.Metrics.ContainsKey(Metrics.SamplingPriority));
+#else
                 httpSpans.Should()
                     .HaveCount(2)
                     .And.OnlyContain(s => s.ParentId == rootSpan.SpanId && s.TraceId == rootSpan.TraceId)
                     .And.ContainSingle(s => s.Metrics[Metrics.SamplingPriority] == (double)SamplingPriority.UserKeep)
                     .And.ContainSingle(s => s.Metrics[Metrics.SamplingPriority] == (double)SamplingPriority.UserReject);
+#endif
+
+                // Check the headers of the outbound http requests
+                var outputLines = processResult.StandardOutput.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+                outputLines.Should().HaveCount(2);
+
+                var firstHttpSpan = httpSpans.Single(s => s.Resource.EndsWith("/a"));
+                var secondHttpSpan = httpSpans.Single(s => s.Resource.EndsWith("/b"));
+
+                outputLines[0].Should().Be($"{firstHttpSpan.TraceId}/{firstHttpSpan.SpanId}/2");
+                outputLines[1].Should().Be($"{secondHttpSpan.TraceId}/{secondHttpSpan.SpanId}/-1");
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
@@ -58,40 +58,24 @@ namespace Datadog.Trace.Tests.DistributedTracer
         }
 
         [Fact]
-        public void LockSamplingPriority()
+        public void SetSamplingPriority_NoChild()
+        {
+            var automaticTracer = new AutomaticTracer();
+
+            ((IDistributedTracer)automaticTracer).SetSamplingPriority(SamplingPriority.UserKeep);
+        }
+
+        [Fact]
+        public void SetSamplingPriority()
         {
             var manualTracer = new Mock<ICommonTracer>();
 
             var automaticTracer = new AutomaticTracer();
             automaticTracer.Register(manualTracer.Object);
 
-            ((IDistributedTracer)automaticTracer).LockSamplingPriority();
+            ((IDistributedTracer)automaticTracer).SetSamplingPriority(SamplingPriority.UserKeep);
 
-            manualTracer.Verify(t => t.LockSamplingPriority(), Times.Once);
-        }
-
-        [Fact]
-        public void TrySetSamplingPriority_NoChild()
-        {
-            var automaticTracer = new AutomaticTracer();
-
-            var samplingPriority = ((IDistributedTracer)automaticTracer).TrySetSamplingPriority(SamplingPriority.UserKeep);
-
-            samplingPriority.Should().Be(SamplingPriority.UserKeep, "TrySetSamplingPriority should be pass-through when there is no child");
-        }
-
-        [Fact]
-        public void TrySetSamplingPriority()
-        {
-            var manualTracer = new Mock<ICommonTracer>();
-            manualTracer.Setup(t => t.TrySetSamplingPriority(It.IsAny<int?>())).Returns((int?)SamplingPriority.UserReject);
-
-            var automaticTracer = new AutomaticTracer();
-            automaticTracer.Register(manualTracer.Object);
-
-            var samplingPriority = ((IDistributedTracer)automaticTracer).TrySetSamplingPriority(SamplingPriority.UserKeep);
-
-            samplingPriority.Should().Be(SamplingPriority.UserReject, "TrySetSamplingPriority should return the value given by the child");
+            manualTracer.Verify(t => t.SetSamplingPriority((int?)SamplingPriority.UserKeep), Times.Once);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
@@ -15,59 +15,7 @@ namespace Datadog.Trace.Tests.DistributedTracer
     public class CommonTracerTests
     {
         [Fact]
-        public void LockSamplingPriority()
-        {
-            var commonTracer = new CommonTracerImpl();
-
-            using (var scope = (Scope)Tracer.Instance.StartActive("Test"))
-            {
-                scope.Span.Context.TraceContext.IsSamplingPriorityLocked().Should().BeFalse();
-
-                commonTracer.LockSamplingPriority();
-
-                scope.Span.Context.TraceContext.IsSamplingPriorityLocked().Should().BeTrue();
-            }
-        }
-
-        [Fact]
-        public void LockSamplingPriority_NoActiveTrace()
-        {
-            var commonTracer = new CommonTracerImpl();
-
-            // Just making sure that it doesn't throw when there is no active trace
-            commonTracer.LockSamplingPriority();
-        }
-
-        [Fact]
-        public void TrySetSamplingPriority_NoTrace()
-        {
-            var commonTracer = new CommonTracerImpl();
-
-            var expectedSamplingPriority = (int?)SamplingPriority.UserKeep;
-
-            var actualSamplingPriority = commonTracer.TrySetSamplingPriority(expectedSamplingPriority);
-
-            actualSamplingPriority.Should().Be(expectedSamplingPriority, "TrySetSamplingPriority should be pass-through when there is no active trace");
-        }
-
-        [Fact]
-        public void TrySetSamplingPriority_LockedPriority()
-        {
-            var commonTracer = new CommonTracerImpl();
-
-            var expectedSamplingPriority = SamplingPriority.UserKeep;
-
-            using var scope = (Scope)Tracer.Instance.StartActive("Test");
-            scope.Span.Context.TraceContext.SetSamplingPriority(expectedSamplingPriority);
-            scope.Span.Context.TraceContext.LockSamplingPriority();
-
-            var actualSamplingPriority = (SamplingPriority?)commonTracer.TrySetSamplingPriority((int?)SamplingPriority.UserReject);
-
-            actualSamplingPriority.Should().Be(expectedSamplingPriority, "TrySetSamplingPriority should return the current sampling priority when locked");
-        }
-
-        [Fact]
-        public void TrySetSamplingPriority()
+        public void SetSamplingPriority()
         {
             var commonTracer = new CommonTracerImpl();
 
@@ -75,10 +23,9 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             using var scope = (Scope)Tracer.Instance.StartActive("Test");
 
-            var actualSamplingPriority = (SamplingPriority?)commonTracer.TrySetSamplingPriority((int?)expectedSamplingPriority);
+            commonTracer.SetSamplingPriority((int?)expectedSamplingPriority);
 
-            actualSamplingPriority.Should().Be(expectedSamplingPriority);
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(expectedSamplingPriority, "TrySetSamplingPriority should have successfully set the active trace sampling priority");
+            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(expectedSamplingPriority, "SetSamplingPriority should have successfully set the active trace sampling priority");
         }
 
         private class CommonTracerImpl : CommonTracer

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/DistributedTracerTests.cs
@@ -17,24 +17,6 @@ namespace Datadog.Trace.Tests.DistributedTracer
     [TracerRestorer]
     public class DistributedTracerTests
     {
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void LockSamplingPriority(bool notifyDistributedTracer)
-        {
-            var distributedTracer = new Mock<IDistributedTracer>();
-
-            ClrProfiler.DistributedTracer.SetInstanceOnlyForTests(distributedTracer.Object);
-
-            using var scope = (Scope)Tracer.Instance.StartActive("Test");
-
-            scope.Span.Context.TraceContext.LockSamplingPriority(notifyDistributedTracer);
-
-            Func<Times> expectedInvocations = notifyDistributedTracer ? Times.Once : Times.Never;
-
-            distributedTracer.Verify(t => t.LockSamplingPriority(), expectedInvocations);
-        }
-
         [Fact]
         public void GetSpanContext()
         {

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/ManualTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/ManualTracerTests.cs
@@ -41,27 +41,15 @@ namespace Datadog.Trace.Tests.DistributedTracer
         }
 
         [Fact]
-        public void LockSamplingPriority()
+        public void SetSamplingPriority()
         {
             var automaticTracer = new Mock<IAutomaticTracer>();
-            var manualTracer = new ManualTracer(automaticTracer.Object);
-
-            ((IDistributedTracer)manualTracer).LockSamplingPriority();
-
-            automaticTracer.Verify(t => t.LockSamplingPriority(), Times.Once);
-        }
-
-        [Fact]
-        public void TrySetSamplingPriority()
-        {
-            var automaticTracer = new Mock<IAutomaticTracer>();
-            automaticTracer.Setup(t => t.TrySetSamplingPriority(It.IsAny<int?>())).Returns((int?)SamplingPriority.UserReject);
 
             var manualTracer = new ManualTracer(automaticTracer.Object);
 
-            var samplingPriority = ((IDistributedTracer)manualTracer).TrySetSamplingPriority(SamplingPriority.UserKeep);
+            ((IDistributedTracer)manualTracer).SetSamplingPriority(SamplingPriority.UserKeep);
 
-            samplingPriority.Should().Be(SamplingPriority.UserReject, "TrySetSamplingPriority should return the value given by the parent");
+            automaticTracer.Verify(t => t.SetSamplingPriority((int?)SamplingPriority.UserKeep), Times.Once());
         }
     }
 }

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -27,8 +27,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Datadog.Trace, Version=2.255.248.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.248\lib\net461\Datadog.Trace.dll</HintPath>
+    <Reference Include="Datadog.Trace, Version=2.255.247.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.247\lib\net461\Datadog.Trace.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Datadog.Trace" version="2.255.248" targetFramework="net461" />
+  <package id="Datadog.Trace" version="2.255.247" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace;
 
@@ -9,27 +10,42 @@ namespace Samples.VersionConflict_2x
     {
         static async Task Main()
         {
-            using (WebServer.Start(out var url))
+            using var server = WebServer.Start(out var url);
+            
+            server.RequestHandler = context =>
             {
-                // Attempt to access the ActiveScope while the automatic ActiveScope is null
-                var activeScope = Tracer.Instance.ActiveScope;
-                if (activeScope is null)
+                var traceId = context.Request.Headers[HttpHeaderNames.TraceId];
+                var spanId = context.Request.Headers[HttpHeaderNames.ParentId];
+                var samplingPriority = context.Request.Headers[HttpHeaderNames.SamplingPriority];
+
+                Console.WriteLine($"{traceId}/{spanId}/{samplingPriority}");
+
+                var payload = Encoding.UTF8.GetBytes("OK");
+
+                context.Response.ContentEncoding = Encoding.UTF8;
+                context.Response.ContentLength64 = payload.Length;
+                context.Response.OutputStream.Write(payload, 0, payload.Length);
+                context.Response.Close();
+            };
+
+            // Attempt to access the ActiveScope while the automatic ActiveScope is null
+            var activeScope = Tracer.Instance.ActiveScope;
+            if (activeScope is not null)
+            {
+                throw new InvalidOperationException("Tracer.Instance.ActiveScope should be null");
+            }
+
+            using (var scope = Tracer.Instance.StartActive("Manual"))
+            {
+                scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");
+
+                using (var client = new HttpClient())
                 {
-                    Console.WriteLine("As expected, initial Tracer.Instance.ActiveScope == null");
-                }
+                    _ = await client.GetStringAsync(url + "/a");
 
-                using (var scope = Tracer.Instance.StartActive("Manual"))
-                {
-                    scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");
+                    scope.Span.SetTag(Tags.SamplingPriority, "UserReject");
 
-                    using (var client = new HttpClient())
-                    {
-                        _ = await client.GetStringAsync(url);
-
-                        scope.Span.SetTag(Tags.SamplingPriority, "UserReject");
-
-                        _ = await client.GetStringAsync(url);
-                    }
+                    _ = await client.GetStringAsync(url + "/b");
                 }
             }
         }

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
@@ -2,7 +2,7 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.255.248" />
+    <PackageReference Include="Datadog.Trace" Version="2.255.247" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
This change allows the sampling priority of a trace to be changed midway. 