### PR TITLE
Disable version conflict fix

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
@@ -88,7 +88,7 @@ bool IsAzureFunctionsEnabled()
 
 bool IsVersionCompatibilityEnabled()
 {
-    ToBooleanWithDefault(GetEnvironmentValue(environment::internal_version_compatibility), true);
+    ToBooleanWithDefault(GetEnvironmentValue(environment::internal_version_compatibility), false);
 }
 
 } // namespace trace

--- a/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.ClrProfiler
 
         static DistributedTracer()
         {
+            /*
             try
             {
                 var parent = GetDistributedTracer();
@@ -44,6 +45,9 @@ namespace Datadog.Trace.ClrProfiler
                 Log.Error(ex, "Error while building the tracer, falling back to automatic");
                 Instance = new AutomaticTracer();
             }
+            */
+
+            Instance = new DummyInstance();
         }
 
         internal static IDistributedTracer Instance { get; private set; }
@@ -61,6 +65,32 @@ namespace Datadog.Trace.ClrProfiler
         internal static void SetInstanceOnlyForTests(IDistributedTracer instance)
         {
             Instance = instance;
+        }
+
+        private class DummyInstance : IDistributedTracer
+        {
+            public SpanContext GetSpanContext()
+            {
+                return null;
+            }
+
+            public IScope GetActiveScope()
+            {
+                return null;
+            }
+
+            public void SetSpanContext(SpanContext value)
+            {
+            }
+
+            public void LockSamplingPriority()
+            {
+            }
+
+            public SamplingPriority? TrySetSamplingPriority(SamplingPriority? samplingPriority)
+            {
+                return samplingPriority;
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
@@ -52,16 +52,6 @@ namespace Datadog.Trace.ClrProfiler
 
         internal static IDistributedTracer Instance { get; private set; }
 
-        /// <summary>
-        /// Get the instance of IDistributedTracer. This method will be rewritten by the profiler.
-        /// </summary>
-        /// <remarks>Don't ever change the return type of this method,
-        /// as this would require special handling by the profiler.</remarks>
-        /// <returns>The instance of IDistributedTracer</returns>
-        [Browsable(false)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static object GetDistributedTracer() => Instance;
-
         internal static void SetInstanceOnlyForTests(IDistributedTracer instance)
         {
             Instance = instance;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             _iisFixture.TryStartIis(this, IisAppType.AspNetClassic);
         }
 
-        [SkippableFact]
+        [SkippableFact(Skip = "Version conflict temporarily disabled")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             httpSpan.Name.Should().Be("http.request");
         }
 
-        [SkippableTheory]
+        [SkippableTheory(Skip = "Version conflict temporarily disabled")]
         [InlineData(true)]
         [InlineData(false)]
         [Trait("Category", "EndToEnd")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -119,7 +119,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             spans.Should().OnlyContain(s => VerifySpan(s, parentTrace));
         }
 
-        [SkippableFact]
+        [SkippableFact(Skip = "Version conflict temporarily disabled")]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
         }
 
-        [Fact]
+        [Fact(Skip = "Version conflict temporarily disabled")]
         public void SubmitTraces()
         {
             // 1 manual span + 1 http span

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
         }
 
-        [Fact]
+        [Fact(Skip = "Version conflict temporarily disabled")]
         public void SubmitTraces()
         {
             // 1 manual span + 2 http spans


### PR DESCRIPTION
Temporarily disable the version conflict fix to unblock the release of 2.0.