### PR TITLE
Reset the AsyncLocal DistributedValue when starting an automatic instrumentation continuation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -17,6 +17,18 @@ namespace Datadog.Trace.ClrProfiler
 
         private ICommonTracer _child;
 
+        IReadOnlyDictionary<string, string> IDistributedTracer.GetSpanContextRaw()
+        {
+            if (_child is null)
+            {
+                return null;
+            }
+            else
+            {
+                return DistributedTrace.Value;
+            }
+        }
+
         IScope IDistributedTracer.GetActiveScope()
         {
             // The automatic tracer doesn't need to get the manual active trace
@@ -38,6 +50,15 @@ namespace Datadog.Trace.ClrProfiler
             }
 
             return SpanContextPropagator.Instance.Extract(value);
+        }
+
+        void IDistributedTracer.SetSpanContextRaw(IReadOnlyDictionary<string, string> value)
+        {
+            // This is a performance optimization. See comment in GetDistributedTrace() about potential race condition
+            if (_child != null)
+            {
+                DistributedTrace.Value = value;
+            }
         }
 
         void IDistributedTracer.SetSpanContext(SpanContext value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -52,16 +52,7 @@ namespace Datadog.Trace.ClrProfiler
             return SpanContextPropagator.Instance.Extract(value);
         }
 
-        void IDistributedTracer.SetSpanContextRaw(IReadOnlyDictionary<string, string> value)
-        {
-            // This is a performance optimization. See comment in GetDistributedTrace() about potential race condition
-            if (_child != null)
-            {
-                DistributedTrace.Value = value;
-            }
-        }
-
-        void IDistributedTracer.SetSpanContext(SpanContext value)
+        void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)
         {
             // This is a performance optimization. See comment in GetDistributedTrace() about potential race condition
             if (_child != null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetState.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetState.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
@@ -21,6 +22,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         private readonly object _state;
         private readonly DateTimeOffset? _startTime;
 
+        private readonly IReadOnlyDictionary<string, string> _previousDistributedSpanContext;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CallTargetState"/> struct.
         /// </summary>
@@ -31,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _scope = scope;
             _state = null;
             _startTime = null;
+            _previousDistributedSpanContext = null;
         }
 
         /// <summary>
@@ -44,6 +48,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _scope = scope;
             _state = state;
             _startTime = null;
+            _previousDistributedSpanContext = null;
         }
 
         /// <summary>
@@ -58,14 +63,16 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
             _scope = scope;
             _state = state;
             _startTime = startTime;
+            _previousDistributedSpanContext = null;
         }
 
-        internal CallTargetState(Scope previousScope, CallTargetState state)
+        internal CallTargetState(Scope previousScope, IReadOnlyDictionary<string, string> previousDistributedSpanContext, CallTargetState state)
         {
             _previousScope = previousScope;
             _scope = state._scope;
             _state = state._state;
             _startTime = state._startTime;
+            _previousDistributedSpanContext = previousDistributedSpanContext;
         }
 
         /// <summary>
@@ -84,6 +91,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget
         public DateTimeOffset? StartTime => _startTime;
 
         internal Scope PreviousScope => _previousScope;
+
+        internal IReadOnlyDictionary<string, string> PreviousDistributedSpanContext => _previousDistributedSpanContext;
 
         /// <summary>
         /// Gets the default call target state (used by the native side to initialize the locals)

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, object[] arguments)
         {
-            return new CallTargetState(Tracer.Instance.InternalActiveScope, _invokeDelegate(instance, arguments));
+            return new CallTargetState(Tracer.Instance.InternalActiveScope, Tracer.Instance.DistributedSpanContext, _invokeDelegate(instance, arguments));
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -80,6 +80,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 if (Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
                 {
                     rawAccess.Active = state.PreviousScope;
+                    // Also set the distributed span context
+                    DistributedTracer.Instance.SetSpanContextRaw(state.PreviousDistributedSpanContext);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -75,12 +75,11 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
             {
                 returnValue = _continuationGenerator.SetContinuation(instance, returnValue, exception, state);
 
-                // Restore previous scope if there is a continuation
+                // Restore previous scope and the previous DistributedTrace if there is a continuation
                 // This is used to mimic the ExecutionContext copy from the StateMachine
                 if (Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
                 {
                     rawAccess.Active = state.PreviousScope;
-                    // Also set the distributed span context
                     DistributedTracer.Instance.SetSpanContextRaw(state.PreviousDistributedSpanContext);
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 if (Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
                 {
                     rawAccess.Active = state.PreviousScope;
-                    DistributedTracer.Instance.SetSpanContextRaw(state.PreviousDistributedSpanContext);
+                    DistributedTracer.Instance.SetSpanContext(state.PreviousDistributedSpanContext);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
@@ -15,9 +15,7 @@ namespace Datadog.Trace.ClrProfiler
 
         IScope GetActiveScope();
 
-        void SetSpanContextRaw(IReadOnlyDictionary<string, string> value);
-
-        void SetSpanContext(SpanContext value);
+        void SetSpanContext(IReadOnlyDictionary<string, string> value);
 
         void LockSamplingPriority();
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
@@ -3,13 +3,19 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
+
 namespace Datadog.Trace.ClrProfiler
 {
     internal interface IDistributedTracer
     {
+        IReadOnlyDictionary<string, string> GetSpanContextRaw();
+
         SpanContext GetSpanContext();
 
         IScope GetActiveScope();
+
+        void SetSpanContextRaw(IReadOnlyDictionary<string, string> value);
 
         void SetSpanContext(SpanContext value);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -66,12 +66,7 @@ namespace Datadog.Trace.ClrProfiler
             }
         }
 
-        void IDistributedTracer.SetSpanContextRaw(IReadOnlyDictionary<string, string> value)
-        {
-            _parent.SetDistributedTrace(value);
-        }
-
-        void IDistributedTracer.SetSpanContext(SpanContext value)
+        void IDistributedTracer.SetSpanContext(IReadOnlyDictionary<string, string> value)
         {
             _parent.SetDistributedTrace(value);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
 
@@ -50,6 +51,8 @@ namespace Datadog.Trace.ClrProfiler
             }
         }
 
+        IReadOnlyDictionary<string, string> IDistributedTracer.GetSpanContextRaw() => _parent.GetDistributedTrace();
+
         SpanContext IDistributedTracer.GetSpanContext()
         {
             var values = _parent.GetDistributedTrace();
@@ -61,6 +64,11 @@ namespace Datadog.Trace.ClrProfiler
             {
                 return SpanContextPropagator.Instance.Extract(values);
             }
+        }
+
+        void IDistributedTracer.SetSpanContextRaw(IReadOnlyDictionary<string, string> value)
+        {
+            _parent.SetDistributedTrace(value);
         }
 
         void IDistributedTracer.SetSpanContext(SpanContext value)

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
@@ -157,6 +158,11 @@ namespace Datadog.Trace
                 return DistributedTracer.Instance.GetActiveScope() ?? InternalActiveScope;
             }
         }
+
+        /// <summary>
+        /// Gets the active span context dictionary by consulting DistributedTracer.Instance
+        /// </summary>
+        internal IReadOnlyDictionary<string, string> DistributedSpanContext => DistributedTracer.Instance.GetSpanContextRaw() ?? InternalActiveScope?.Span?.Context;
 
         /// <summary>
         /// Gets the active scope

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -27,8 +27,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Datadog.Trace, Version=2.255.249.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.249\lib\net461\Datadog.Trace.dll</HintPath>
+    <Reference Include="Datadog.Trace, Version=2.255.248.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.248\lib\net461\Datadog.Trace.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Datadog.Trace" version="2.255.249" targetFramework="net461" />
+  <package id="Datadog.Trace" version="2.255.248" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
@@ -2,7 +2,7 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.255.249" />
+    <PackageReference Include="Datadog.Trace" Version="2.255.248" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
This behavior is similar to resetting the AsyncLocal Active scope. Without this fix, when an async automatic instrumentation method is run, it will update the AsyncLocal DistributedValue to the newly created span and subsequent spans will have the incorrect parent. This can be seen in Samples.AspNet.VersionConflict.Controllers.HomeController:

### Code
```csharp
    using (var scope = Tracer.Instance.StartActive("Manual"))
    {
        scope.Span.SetTag(Tags.SamplingPriority, "UserKeep");
    
        using (var client = new HttpClient())
        {
            var target = Url.Action("Index", "Home", null, "http");
    
            _ = client.GetStringAsync(target).Result;
    
            // This should be ignored because the sampling priority has been locked
            scope.Span.SetTag(Tags.SamplingPriority, "UserReject");
    
            _ = client.GetStringAsync(target).Result;
    
            Tracer.Instance.StartActive("Child").Dispose();
        }
    }
```

### Previous Result
```
manual
┣ http.request
  ┣ http.request
    ┣ Child
```

### New Result
```
manual
┣ http.request
┣ http.request
┣ Child
```

@DataDog/apm-dotnet