### PR TITLE
[Redo] Fix logs injection to work correctly when there's a version mismatch

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -446,6 +446,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog20.Versio
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog10.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog10.VersionConflict.2x\LogsInjection.NLog10.VersionConflict.2x.csproj", "{D00DDBDA-66F5-490D-8C1C-16CC5E142170}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.ILogger.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.ILogger.VersionConflict.2x\LogsInjection.ILogger.VersionConflict.2x.csproj", "{238F67DB-1E48-447C-B1B8-BDC692103791}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{24d3e547-8897-4111-baa2-b92f50cc13d4}*SharedItemsImports = 5
@@ -1984,6 +1986,18 @@ Global
 		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x64.Build.0 = Release|x64
 		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x86.ActiveCfg = Release|x86
 		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x86.Build.0 = Release|x86
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|Any CPU.Build.0 = Debug|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|x64.ActiveCfg = Debug|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|x64.Build.0 = Debug|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|x86.ActiveCfg = Debug|x86
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Debug|x86.Build.0 = Debug|x86
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|Any CPU.ActiveCfg = Release|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|Any CPU.Build.0 = Release|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|x64.ActiveCfg = Release|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|x64.Build.0 = Release|x64
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|x86.ActiveCfg = Release|x86
+		{238F67DB-1E48-447C-B1B8-BDC692103791}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2143,6 +2157,7 @@ Global
 		{F19B5109-36AC-4A64-AFE6-FAF9E831C528} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{0980BCDD-A231-42D1-B689-41A41BBA161A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{D00DDBDA-66F5-490D-8C1C-16CC5E142170} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{238F67DB-1E48-447C-B1B8-BDC692103791} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -418,19 +418,21 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.N
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.MySqlConnector", "tracer\test\test-applications\integrations\Samples.MySqlConnector\Samples.MySqlConnector.csproj", "{73252693-2563-4B20-A2F5-F8DB37B91DBE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Couchbase", "tracer\test\test-applications\integrations\Samples.Couchbase\Samples.Couchbase.csproj", "{6F38B456-1D16-4842-AEE5-E74564FB506A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Couchbase", "tracer\test\test-applications\integrations\Samples.Couchbase\Samples.Couchbase.csproj", "{6F38B456-1D16-4842-AEE5-E74564FB506A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Couchbase3", "tracer\test\test-applications\integrations\Samples.Couchbase3\Samples.Couchbase3.csproj", "{65A66859-2735-4DD6-A927-B416B7A62D0F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Couchbase3", "tracer\test\test-applications\integrations\Samples.Couchbase3\Samples.Couchbase3.csproj", "{65A66859-2735-4DD6-A927-B416B7A62D0F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNetCoreMinimalApis", "tracer\test\test-applications\integrations\Samples.AspNetCoreMinimalApis\Samples.AspNetCoreMinimalApis.csproj", "{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AspNetCoreMinimalApis", "tracer\test\test-applications\integrations\Samples.AspNetCoreMinimalApis\Samples.AspNetCoreMinimalApis.csproj", "{2A6D3042-C675-4EA3-A8E7-5BDD3C5758EA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspNetCoreSmokeTest", "tracer\test\test-applications\regression\AspNetCoreSmokeTest\AspNetCoreSmokeTest.csproj", "{BED94A61-6FD9-4103-BD35-70B4798C301C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspNetCoreSmokeTest", "tracer\test\test-applications\regression\AspNetCoreSmokeTest\AspNetCoreSmokeTest.csproj", "{BED94A61-6FD9-4103-BD35-70B4798C301C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AspNet.VersionConflict", "tracer\test\test-applications\aspnet\Samples.AspNet.VersionConflict\Samples.AspNet.VersionConflict.csproj", "{FAB2B108-E5BE-4647-869B-1DC5D362252E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.1x", "tracer\test\test-applications\integrations\Samples.VersionConflict.1x\Samples.VersionConflict.1x.csproj", "{6F8B63EA-98D6-4909-BE9E-F39029C29C4F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.2x", "tracer\test\test-applications\integrations\Samples.VersionConflict.2x\Samples.VersionConflict.2x.csproj", "{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjectionHelper.VersionConflict", "tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj", "{E9D55D41-B161-492F-9EC7-FF2F2231A587}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -1886,6 +1888,18 @@ Global
 		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Release|x64.Build.0 = Release|x64
 		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Release|x86.ActiveCfg = Release|x86
 		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}.Release|x86.Build.0 = Release|x86
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Debug|x86.Build.0 = Debug|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x64.Build.0 = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2038,6 +2052,7 @@ Global
 		{FAB2B108-E5BE-4647-869B-1DC5D362252E} = {AFA0AB23-64F0-4AC1-9050-6CE8FE06F580}
 		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{E9D55D41-B161-492F-9EC7-FF2F2231A587} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -434,6 +434,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.2x"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjectionHelper.VersionConflict", "tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj", "{E9D55D41-B161-492F-9EC7-FF2F2231A587}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Serilog.VersionConflict.2x\LogsInjection.Serilog.VersionConflict.2x.csproj", "{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog14.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Serilog14.VersionConflict.2x\LogsInjection.Serilog14.VersionConflict.2x.csproj", "{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{24d3e547-8897-4111-baa2-b92f50cc13d4}*SharedItemsImports = 5
@@ -1900,6 +1904,30 @@ Global
 		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x64.Build.0 = Release|Any CPU
 		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x86.ActiveCfg = Release|Any CPU
 		{E9D55D41-B161-492F-9EC7-FF2F2231A587}.Release|x86.Build.0 = Release|Any CPU
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|Any CPU.Build.0 = Debug|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|x64.ActiveCfg = Debug|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|x64.Build.0 = Debug|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|x86.ActiveCfg = Debug|x86
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Debug|x86.Build.0 = Debug|x86
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|Any CPU.ActiveCfg = Release|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|Any CPU.Build.0 = Release|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|x64.ActiveCfg = Release|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|x64.Build.0 = Release|x64
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|x86.ActiveCfg = Release|x86
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73}.Release|x86.Build.0 = Release|x86
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|Any CPU.Build.0 = Debug|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|x64.ActiveCfg = Debug|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|x64.Build.0 = Debug|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|x86.ActiveCfg = Debug|x86
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Debug|x86.Build.0 = Debug|x86
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|Any CPU.ActiveCfg = Release|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|Any CPU.Build.0 = Release|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x64.ActiveCfg = Release|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x64.Build.0 = Release|x64
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x86.ActiveCfg = Release|x86
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2053,6 +2081,8 @@ Global
 		{6F8B63EA-98D6-4909-BE9E-F39029C29C4F} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{E9D55D41-B161-492F-9EC7-FF2F2231A587} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
+		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -440,6 +440,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog14.Ver
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Log4Net.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Log4Net.VersionConflict.2x\LogsInjection.Log4Net.VersionConflict.2x.csproj", "{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog.VersionConflict.2x\LogsInjection.NLog.VersionConflict.2x.csproj", "{F19B5109-36AC-4A64-AFE6-FAF9E831C528}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog20.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog20.VersionConflict.2x\LogsInjection.NLog20.VersionConflict.2x.csproj", "{0980BCDD-A231-42D1-B689-41A41BBA161A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.NLog10.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.NLog10.VersionConflict.2x\LogsInjection.NLog10.VersionConflict.2x.csproj", "{D00DDBDA-66F5-490D-8C1C-16CC5E142170}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{24d3e547-8897-4111-baa2-b92f50cc13d4}*SharedItemsImports = 5
@@ -1942,6 +1948,42 @@ Global
 		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x64.Build.0 = Release|x64
 		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x86.ActiveCfg = Release|x86
 		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x86.Build.0 = Release|x86
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|Any CPU.Build.0 = Debug|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|x64.ActiveCfg = Debug|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|x64.Build.0 = Debug|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|x86.ActiveCfg = Debug|x86
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Debug|x86.Build.0 = Debug|x86
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|Any CPU.ActiveCfg = Release|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|Any CPU.Build.0 = Release|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|x64.ActiveCfg = Release|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|x64.Build.0 = Release|x64
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|x86.ActiveCfg = Release|x86
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528}.Release|x86.Build.0 = Release|x86
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|Any CPU.Build.0 = Debug|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|x64.ActiveCfg = Debug|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|x64.Build.0 = Debug|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|x86.ActiveCfg = Debug|x86
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Debug|x86.Build.0 = Debug|x86
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|Any CPU.ActiveCfg = Release|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|Any CPU.Build.0 = Release|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|x64.ActiveCfg = Release|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|x64.Build.0 = Release|x64
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|x86.ActiveCfg = Release|x86
+		{0980BCDD-A231-42D1-B689-41A41BBA161A}.Release|x86.Build.0 = Release|x86
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|Any CPU.Build.0 = Debug|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|x64.ActiveCfg = Debug|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|x64.Build.0 = Debug|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|x86.ActiveCfg = Debug|x86
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Debug|x86.Build.0 = Debug|x86
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|Any CPU.ActiveCfg = Release|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|Any CPU.Build.0 = Release|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x64.ActiveCfg = Release|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x64.Build.0 = Release|x64
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x86.ActiveCfg = Release|x86
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2098,6 +2140,9 @@ Global
 		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{F19B5109-36AC-4A64-AFE6-FAF9E831C528} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{0980BCDD-A231-42D1-B689-41A41BBA161A} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{D00DDBDA-66F5-490D-8C1C-16CC5E142170} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -438,6 +438,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog.Versi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Serilog14.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Serilog14.VersionConflict.2x\LogsInjection.Serilog14.VersionConflict.2x.csproj", "{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.Log4Net.VersionConflict.2x", "tracer\test\test-applications\integrations\LogsInjection.Log4Net.VersionConflict.2x\LogsInjection.Log4Net.VersionConflict.2x.csproj", "{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{24d3e547-8897-4111-baa2-b92f50cc13d4}*SharedItemsImports = 5
@@ -1928,6 +1930,18 @@ Global
 		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x64.Build.0 = Release|x64
 		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x86.ActiveCfg = Release|x86
 		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3}.Release|x86.Build.0 = Release|x86
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|Any CPU.Build.0 = Debug|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|x64.ActiveCfg = Debug|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|x64.Build.0 = Debug|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|x86.ActiveCfg = Debug|x86
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Debug|x86.Build.0 = Debug|x86
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|Any CPU.ActiveCfg = Release|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|Any CPU.Build.0 = Release|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x64.ActiveCfg = Release|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x64.Build.0 = Release|x64
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x86.ActiveCfg = Release|x86
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2083,6 +2097,7 @@ Global
 		{E9D55D41-B161-492F-9EC7-FF2F2231A587} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 		{268B6D05-B6D5-4D20-B2B1-0B9422A92D73} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{3C78C521-6507-4D3A-B92E-BC41CEE9D9F3} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{25B7D571-C385-4CA6-9B6A-573D3E3FF3C9} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1122,6 +1122,12 @@ partial class Build
                     var project = Solution.GetProject(path);
                     return project?.Name switch
                     {
+                        "LogsInjection.Log4Net.VersionConflict.2x" => Framework != TargetFramework.NETCOREAPP2_1,
+                        "LogsInjection.NLog.VersionConflict.2x" => Framework != TargetFramework.NETCOREAPP2_1,
+                        "LogsInjection.NLog10.VersionConflict.2x" => Framework == TargetFramework.NET461,
+                        "LogsInjection.NLog20.VersionConflict.2x" => Framework == TargetFramework.NET461,
+                        "LogsInjection.Serilog.VersionConflict.2x" => Framework != TargetFramework.NETCOREAPP2_1,
+                        "LogsInjection.Serilog14.VersionConflict.2x" => Framework == TargetFramework.NET461,
                         "Samples.AspNetCoreMvc21" => Framework == TargetFramework.NETCOREAPP2_1,
                         "Samples.AspNetCoreMvc30" => Framework == TargetFramework.NETCOREAPP3_0,
                         "Samples.AspNetCoreMvc31" => Framework == TargetFramework.NETCOREAPP3_1,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DatadogLoggingScope.cs
@@ -48,8 +48,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
                     0 => new KeyValuePair<string, object>("dd_service", _service),
                     1 => new KeyValuePair<string, object>("dd_env", _env),
                     2 => new KeyValuePair<string, object>("dd_version", _version),
-                    3 => new KeyValuePair<string, object>("dd_trace_id", (_tracer.ActiveScope?.Span.TraceId ?? 0).ToString()),
-                    4 => new KeyValuePair<string, object>("dd_span_id", (_tracer.ActiveScope?.Span.SpanId ?? 0).ToString()),
+                    3 => new KeyValuePair<string, object>("dd_trace_id", _tracer.DistributedSpanContext?[HttpHeaderNames.TraceId] ?? "0"),
+                    4 => new KeyValuePair<string, object>("dd_span_id", _tracer.DistributedSpanContext?[HttpHeaderNames.ParentId] ?? "0"),
                     _ => throw new ArgumentOutOfRangeException(nameof(index))
                 };
             }
@@ -57,8 +57,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 
         public override string ToString()
         {
-            var span = _tracer.ActiveScope?.Span;
-            if (span is null)
+            var spanContext = _tracer.DistributedSpanContext;
+            if (spanContext is null)
             {
                 return _cachedFormat;
             }
@@ -67,21 +67,21 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
                 CultureInfo.InvariantCulture,
                 "{0}, dd_trace_id:\"{1}\", dd_span_id:\"{2}\"",
                 _cachedFormat,
-                span.TraceId,
-                span.SpanId);
+                spanContext[HttpHeaderNames.TraceId],
+                spanContext[HttpHeaderNames.ParentId]);
         }
 
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
-            var span = _tracer.ActiveScope?.Span;
+            var spanContext = _tracer.DistributedSpanContext;
             yield return new KeyValuePair<string, object>("dd_service", _service);
             yield return new KeyValuePair<string, object>("dd_env", _env);
             yield return new KeyValuePair<string, object>("dd_version", _version);
 
-            if (span is not null)
+            if (spanContext is not null)
             {
-                yield return new KeyValuePair<string, object>("dd_trace_id", span.TraceId.ToString());
-                yield return new KeyValuePair<string, object>("dd_span_id", span.SpanId.ToString());
+                yield return new KeyValuePair<string, object>("dd_trace_id", spanContext[HttpHeaderNames.TraceId]);
+                yield return new KeyValuePair<string, object>("dd_span_id", spanContext[HttpHeaderNames.ParentId]);
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/AppenderAttachedImplIntegration.cs
@@ -46,10 +46,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
                 loggingEvent.Properties[CorrelationIdentifier.EnvKey] = tracer.Settings.Environment ?? string.Empty;
 
                 var spanContext = tracer.DistributedSpanContext;
-                if (spanContext is not null)
+                if (spanContext is not null
+                    && spanContext.TryGetValue(HttpHeaderNames.TraceId, out string traceId)
+                    && spanContext.TryGetValue(HttpHeaderNames.ParentId, out string spanId))
                 {
-                    loggingEvent.Properties[CorrelationIdentifier.TraceIdKey] = spanContext[HttpHeaderNames.TraceId];
-                    loggingEvent.Properties[CorrelationIdentifier.SpanIdKey] = spanContext[HttpHeaderNames.ParentId];
+                    loggingEvent.Properties[CorrelationIdentifier.TraceIdKey] = traceId;
+                    loggingEvent.Properties[CorrelationIdentifier.SpanIdKey] = spanId;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/AppenderAttachedImplIntegration.cs
@@ -45,11 +45,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
                 loggingEvent.Properties[CorrelationIdentifier.VersionKey] = tracer.Settings.ServiceVersion ?? string.Empty;
                 loggingEvent.Properties[CorrelationIdentifier.EnvKey] = tracer.Settings.Environment ?? string.Empty;
 
-                var span = tracer.ActiveScope?.Span;
-                if (span is not null)
+                var spanContext = tracer.DistributedSpanContext;
+                if (spanContext is not null)
                 {
-                    loggingEvent.Properties[CorrelationIdentifier.TraceIdKey] = span.TraceId;
-                    loggingEvent.Properties[CorrelationIdentifier.SpanIdKey] = span.SpanId;
+                    loggingEvent.Properties[CorrelationIdentifier.TraceIdKey] = spanContext[HttpHeaderNames.TraceId];
+                    loggingEvent.Properties[CorrelationIdentifier.SpanIdKey] = spanContext[HttpHeaderNames.ParentId];
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/DiagnosticContextHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/DiagnosticContextHelper.cs
@@ -7,11 +7,14 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjection
 {
     internal static class DiagnosticContextHelper
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DiagnosticContextHelper));
+
         public static MappedDiagnosticsLogicalContextSetterProxy GetMdlcProxy(Assembly nlogAssembly)
         {
             var mdlcType = nlogAssembly.GetType("NLog.MappedDiagnosticsLogicalContext");
@@ -126,6 +129,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
                 }
 
                 // Something is very awry, but don't throw, just don't inject logs
+                Log.Warning("Failed to create proxies for both MDLC and MDC using TMarker={TMarker}, TMarker.Assembly={Assembly}. No automatic logs injection will occur for this assembly.", typeof(TMarker), nlogAssembly);
             }
 
             public static MappedDiagnosticsLogicalContextSetterProxy Mdlc { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegration.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
         MethodName = "Write",
         ReturnTypeName = ClrNames.Void,
         ParameterTypeNames = new[] { ClrNames.Type, "NLog.Internal.TargetWithFilterChain", "NLog.LogEventInfo", "NLog.LogFactory" },
-        MinimumVersion = "2.1.0",
+        MinimumVersion = "1.0.0.505",
         MaximumVersion = "4.*.*",
         IntegrationName = "NLog")]
     [Browsable(false)]

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
@@ -57,10 +57,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInje
                 AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogEnvKey, tracer.Settings.Environment);
 
                 var spanContext = tracer.DistributedSpanContext;
-                if (spanContext is not null)
+                if (spanContext is not null
+                    && spanContext.TryGetValue(HttpHeaderNames.TraceId, out string traceId)
+                    && spanContext.TryGetValue(HttpHeaderNames.ParentId, out string spanId))
                 {
-                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogTraceIdKey, spanContext[HttpHeaderNames.TraceId]);
-                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogSpanIdKey, spanContext[HttpHeaderNames.ParentId]);
+                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogTraceIdKey, traceId);
+                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogSpanIdKey, spanId);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
@@ -56,11 +56,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInje
                 AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogVersionKey, tracer.Settings.ServiceVersion);
                 AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogEnvKey, tracer.Settings.Environment);
 
-                var span = tracer.ActiveScope?.Span;
-                if (span is not null)
+                var spanContext = tracer.DistributedSpanContext;
+                if (spanContext is not null)
                 {
-                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogTraceIdKey, span.TraceId.ToString());
-                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogSpanIdKey, span.SpanId.ToString());
+                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogTraceIdKey, spanContext[HttpHeaderNames.TraceId]);
+                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogSpanIdKey, spanContext[HttpHeaderNames.ParentId]);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/SerilogLogPropertyHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/SerilogLogPropertyHelper.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInje
             var scalarValueConstructor = scalarValueType.GetConstructor(new[] { typeof(object) });
 
             DynamicMethod createLogEventPropertyMethod = new DynamicMethod(
-                $"SerilogLogPropertyHelper",
+                "SerilogLogPropertyHelper",
                 returnType: scalarValueType,
                 parameterTypes: new Type[] { typeof(string) },
                 typeof(DuckType).Module,

--- a/tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs
@@ -192,7 +192,7 @@ namespace Datadog.Trace.ClrProfiler
                 new("MySqlConnector", "MySqlConnector.MySqlCommand", "ExecuteScalarAsync",  new[] { "System.Threading.Tasks.Task`1<System.Object>", "System.Threading.CancellationToken" }, 1, 0, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteScalarAsyncIntegration"),
 
                 // NLog
-                new("NLog", "NLog.LoggerImpl", "Write",  new[] { "System.Void", "System.Type", "NLog.Internal.TargetWithFilterChain", "NLog.LogEventInfo", "NLog.LogFactory" }, 2, 1, 0, 4, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjection.LoggerImplWriteIntegration"),
+                new("NLog", "NLog.LoggerImpl", "Write",  new[] { "System.Void", "System.Type", "NLog.Internal.TargetWithFilterChain", "NLog.LogEventInfo", "NLog.LogFactory" }, 1, 0, 0, 4, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjection.LoggerImplWriteIntegration"),
 
                 // Npgsql
                 new("Npgsql", "Npgsql.NpgsqlCommand", "ExecuteDbDataReader",  new[] { "System.Data.Common.DbDataReader", "System.Data.CommandBehavior" }, 4, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteReaderWithBehaviorIntegration"),

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -36,13 +36,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void InjectsLogs()
         {
+#if NETFRAMEWORK
+            var expectedTraceCount = 3;
+#else
+            var expectedTraceCount = 2;
+#endif
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, aspNetCorePort: 0))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 spans.Should().HaveCountGreaterOrEqualTo(1);
 
-                ValidateLogCorrelation(spans, _logFiles);
+                ValidateLogCorrelation(spans, _logFiles, expectedTraceCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -36,6 +36,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void InjectsLogs()
         {
+            // One of the traces starts by manual opening a span when the background service starts,
+            // and then it sends a HTTP request to the server.
+            // On .NET Framework, we do not yet automatically instrument AspNetCore so instead of
+            // having one distributed trace, the result is two separate traces. So expect one more trace
+            // when running on .NET Framework
 #if NETFRAMEWORK
             var expectedTraceCount = 3;
 #else

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -41,18 +41,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // On .NET Framework, we do not yet automatically instrument AspNetCore so instead of
             // having one distributed trace, the result is two separate traces. So expect one more trace
             // when running on .NET Framework
+
+            // We also log inside of the web server handling, so in .NET Core expect one more log line
 #if NETFRAMEWORK
-            var expectedTraceCount = 3;
+            var expectedCorrelatedTraceCount = 3;
+            var expectedCorrelatedSpanCount = 3;
 #else
-            var expectedTraceCount = 2;
+            var expectedCorrelatedTraceCount = 2;
+            var expectedCorrelatedSpanCount = 4;
 #endif
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, aspNetCorePort: 0))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 spans.Should().HaveCountGreaterOrEqualTo(1);
 
-                ValidateLogCorrelation(spans, _logFiles, expectedTraceCount);
+                ValidateLogCorrelation(spans, _logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -66,15 +66,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #if NETFRAMEWORK
                 if (!string.IsNullOrWhiteSpace(packageVersion) && new Version(packageVersion) >= new Version("2.0.5"))
                 {
-                    ValidateLogCorrelation(spans, _nlog205LogFileTests, packageVersion);
+                    ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedTraceCount: 1, packageVersion);
                 }
                 else
                 {
-                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, packageVersion);
+                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 1, packageVersion);
                 }
 #else
                 // Regardless of package version, for .NET Core just assert against raw log lines
-                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, packageVersion);
+                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 1, packageVersion);
 #endif
             }
         }
@@ -96,15 +96,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #if NETFRAMEWORK
                 if (!string.IsNullOrWhiteSpace(packageVersion) && new Version(packageVersion) >= new Version("2.0.5"))
                 {
-                    ValidateLogCorrelation(spans, _nlog205LogFileTests, packageVersion, disableLogCorrelation: true);
+                    ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
                 }
                 else
                 {
-                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, packageVersion, disableLogCorrelation: true);
+                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
                 }
 #else
                 // Regardless of package version, for .NET Core just assert against raw log lines
-                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, packageVersion, disableLogCorrelation: true);
+                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -57,6 +57,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 1;
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
@@ -66,15 +69,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #if NETFRAMEWORK
                 if (!string.IsNullOrWhiteSpace(packageVersion) && new Version(packageVersion) >= new Version("2.0.5"))
                 {
-                    ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedTraceCount: 1, packageVersion);
+                    ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion);
                 }
                 else
                 {
-                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 1, packageVersion);
+                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion);
                 }
 #else
                 // Regardless of package version, for .NET Core just assert against raw log lines
-                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 1, packageVersion);
+                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion);
 #endif
             }
         }
@@ -87,6 +90,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
 
+            var expectedCorrelatedTraceCount = 0;
+            var expectedCorrelatedSpanCount = 0;
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
@@ -96,15 +102,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 #if NETFRAMEWORK
                 if (!string.IsNullOrWhiteSpace(packageVersion) && new Version(packageVersion) >= new Version("2.0.5"))
                 {
-                    ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
+                    ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion, disableLogCorrelation: true);
                 }
                 else
                 {
-                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
+                    ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion, disableLogCorrelation: true);
                 }
 #else
                 // Regardless of package version, for .NET Core just assert against raw log lines
-                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
+                ValidateLogCorrelation(spans, _nlogPre205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion, disableLogCorrelation: true);
 #endif
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -35,6 +35,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 1;
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
@@ -42,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var testFiles = GetTestFiles(packageVersion);
-                ValidateLogCorrelation(spans, testFiles, expectedTraceCount: 1, packageVersion);
+                ValidateLogCorrelation(spans, testFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion);
             }
         }
 
@@ -54,6 +57,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
 
+            var expectedCorrelatedTraceCount = 0;
+            var expectedCorrelatedSpanCount = 0;
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
@@ -61,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var testFiles = GetTestFiles(packageVersion, logsInjectionEnabled: false);
-                ValidateLogCorrelation(spans, testFiles, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
+                ValidateLogCorrelation(spans, testFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion, disableLogCorrelation: true);
             }
         }
 
@@ -70,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (packageVersion is null or "")
             {
 #if NETFRAMEWORK
-                packageVersion = "4.1.2";
+                packageVersion = "1.0.0.505";
 #else
                 packageVersion = "4.5.0";
 #endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var testFiles = GetTestFiles(packageVersion);
-                ValidateLogCorrelation(spans, testFiles, packageVersion);
+                ValidateLogCorrelation(spans, testFiles, expectedTraceCount: 1, packageVersion);
             }
         }
 
@@ -61,7 +61,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var testFiles = GetTestFiles(packageVersion, logsInjectionEnabled: false);
-                ValidateLogCorrelation(spans, testFiles, packageVersion, disableLogCorrelation: true);
+                ValidateLogCorrelation(spans, testFiles, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: true);
-                ValidateLogCorrelation(spans, logFiles, packageVersion);
+                ValidateLogCorrelation(spans, logFiles, expectedTraceCount: 1, packageVersion);
             }
         }
 
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: false);
-                ValidateLogCorrelation(spans, logFiles, packageVersion, disableLogCorrelation: true);
+                ValidateLogCorrelation(spans, logFiles, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -27,7 +27,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             : base(output, "LogsInjection.Serilog")
         {
             SetServiceVersion("1.0.0");
-            EnableDebugMode();
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -37,6 +37,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 1;
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
@@ -44,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: true);
-                ValidateLogCorrelation(spans, logFiles, expectedTraceCount: 1, packageVersion);
+                ValidateLogCorrelation(spans, logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion);
             }
         }
 
@@ -56,6 +59,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
 
+            var expectedCorrelatedTraceCount = 0;
+            var expectedCorrelatedSpanCount = 0;
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion))
             {
@@ -63,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: false);
-                ValidateLogCorrelation(spans, logFiles, expectedTraceCount: 0, packageVersion, disableLogCorrelation: true);
+                ValidateLogCorrelation(spans, logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion, disableLogCorrelation: true);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
@@ -1,0 +1,54 @@
+// <copyright file="ILoggerVersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    // ReSharper disable once InconsistentNaming
+    public class ILoggerVersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _logFiles =
+        {
+            new LogFileTest
+            {
+                FileName = "simple.log",
+                RegexFormat = @"""{0}"":{1}",
+                UnTracedLogTypes = UnTracedLogTypes.EnvServiceTracingPropertiesOnly,
+                PropertiesUseSerilogNaming = true
+            },
+        };
+
+        public ILoggerVersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.ILogger.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogs()
+        {
+#if NETFRAMEWORK
+            var expectedTraceCount = 3;
+#else
+            var expectedTraceCount = 2;
+#endif
+            using (var agent = EnvironmentHelper.GetMockAgent())
+            using (RunSampleAndWaitForExit(agent.Port, aspNetCorePort: 0))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                spans.Should().HaveCountGreaterOrEqualTo(1);
+
+                ValidateLogCorrelation(spans, _logFiles, expectedTraceCount);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
@@ -36,18 +36,28 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [Trait("RunOnWindows", "True")]
         public void InjectsLogs()
         {
+            // One of the traces starts by manual opening a span when the background service starts,
+            // and then it sends a HTTP request to the server.
+            // On .NET Framework, we do not yet automatically instrument AspNetCore so instead of
+            // having one distributed trace, the result is two separate traces. So expect one more trace
+            // when running on .NET Framework
+
+            // We also log inside of the web server handling, so in .NET Core expect one more log line
 #if NETFRAMEWORK
-            var expectedTraceCount = 3;
+            var expectedCorrelatedTraceCount = 3;
+            var expectedCorrelatedSpanCount = 3;
 #else
-            var expectedTraceCount = 2;
+            var expectedCorrelatedTraceCount = 2;
+            var expectedCorrelatedSpanCount = 4;
 #endif
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, aspNetCorePort: 0))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 spans.Should().HaveCountGreaterOrEqualTo(1);
 
-                ValidateLogCorrelation(spans, _logFiles, expectedTraceCount);
+                ValidateLogCorrelation(spans, _logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -1,0 +1,58 @@
+// <copyright file="Log4NetVersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETCOREAPP2_1
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    public class Log4NetVersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _nlog205LogFileTests =
+            {
+                new LogFileTest()
+                {
+                    FileName = "log-textFile.log",
+                    RegexFormat = @"{0}: {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EmptyProperties,
+                    PropertiesUseSerilogNaming = false
+                },
+                new LogFileTest()
+                {
+                    FileName = "log-jsonFile.log",
+                    RegexFormat = @"""{0}"":{1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EnvServiceTracingPropertiesOnly,
+                    PropertiesUseSerilogNaming = false
+                }
+            };
+
+        public Log4NetVersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.Log4Net.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogsWhenEnabled()
+        {
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            using (var agent = new MockTracerAgent(agentPort))
+            using (RunSampleAndWaitForExit(agent.Port))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
+
+                ValidateLogCorrelation(spans, _nlog205LogFileTests);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -43,6 +43,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 8;
+
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))
             using (RunSampleAndWaitForExit(agent.Port))
@@ -50,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedTraceCount: 1);
+                ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlog205LogFileTests);
+                ValidateLogCorrelation(spans, _nlog205LogFileTests, expectedTraceCount: 1);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 8;
+
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))
             using (RunSampleAndWaitForExit(agent.Port))
@@ -43,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedTraceCount: 1);
+                ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -1,0 +1,51 @@
+// <copyright file="NLog10VersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    public class NLog10VersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _nlogPre40LogFileTests =
+            {
+                new LogFileTest()
+                {
+                    FileName = "log-textFile.log",
+                    RegexFormat = @"{0}: {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EmptyProperties,
+                    PropertiesUseSerilogNaming = false
+                }
+            };
+
+        public NLog10VersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.NLog10.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogsWhenEnabled()
+        {
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            using (var agent = new MockTracerAgent(agentPort))
+            using (RunSampleAndWaitForExit(agent.Port))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
+
+                ValidateLogCorrelation(spans, _nlogPre40LogFileTests);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlogPre40LogFileTests);
+                ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedTraceCount: 1);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 8;
+
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))
             using (RunSampleAndWaitForExit(agent.Port))
@@ -43,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedTraceCount: 1);
+                ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -1,0 +1,51 @@
+// <copyright file="NLog20VersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    public class NLog20VersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _nlogPre40LogFileTests =
+            {
+                new LogFileTest()
+                {
+                    FileName = "log-textFile.log",
+                    RegexFormat = @"{0}: {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EmptyProperties,
+                    PropertiesUseSerilogNaming = false
+                }
+            };
+
+        public NLog20VersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.NLog20.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogsWhenEnabled()
+        {
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            using (var agent = new MockTracerAgent(agentPort))
+            using (RunSampleAndWaitForExit(agent.Port))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
+
+                ValidateLogCorrelation(spans, _nlogPre40LogFileTests);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlogPre40LogFileTests);
+                ValidateLogCorrelation(spans, _nlogPre40LogFileTests, expectedTraceCount: 1);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -1,0 +1,58 @@
+// <copyright file="NLogVersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETCOREAPP2_1
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    public class NLogVersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _nlog40LogFileTests =
+            {
+                new LogFileTest()
+                {
+                    FileName = "log-textFile.log",
+                    RegexFormat = @"{0}: {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EmptyProperties,
+                    PropertiesUseSerilogNaming = false
+                },
+                new LogFileTest()
+                {
+                    FileName = "log-jsonFile.log",
+                    RegexFormat = @"""{0}"": {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EnvServiceTracingPropertiesOnly,
+                    PropertiesUseSerilogNaming = false
+                }
+            };
+
+        public NLogVersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.NLog.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogsWhenEnabled()
+        {
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            using (var agent = new MockTracerAgent(agentPort))
+            using (RunSampleAndWaitForExit(agent.Port))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
+
+                ValidateLogCorrelation(spans, _nlog40LogFileTests);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -43,6 +43,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 8;
+
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))
             using (RunSampleAndWaitForExit(agent.Port))
@@ -50,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlog40LogFileTests, expectedTraceCount: 1);
+                ValidateLogCorrelation(spans, _nlog40LogFileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _nlog40LogFileTests);
+                ValidateLogCorrelation(spans, _nlog40LogFileTests, expectedTraceCount: 1);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -36,6 +36,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 8;
+
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))
             using (RunSampleAndWaitForExit(agent.Port))
@@ -43,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _log200FileTests, expectedTraceCount: 1);
+                ValidateLogCorrelation(spans, _log200FileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -1,0 +1,51 @@
+// <copyright file="Serilog14VersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    public class Serilog14VersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _log200FileTests =
+            {
+                new LogFileTest()
+                {
+                    FileName = "log-textFile.log",
+                    RegexFormat = @"{0}: {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EmptyProperties,
+                    PropertiesUseSerilogNaming = true
+                }
+            };
+
+        public Serilog14VersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.Serilog14.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogsWhenEnabled()
+        {
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            using (var agent = new MockTracerAgent(agentPort))
+            using (RunSampleAndWaitForExit(agent.Port))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
+
+                ValidateLogCorrelation(spans, _log200FileTests);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _log200FileTests);
+                ValidateLogCorrelation(spans, _log200FileTests, expectedTraceCount: 1);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -1,0 +1,58 @@
+// <copyright file="SerilogVersionConflict2xTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETCOREAPP2_1
+using Datadog.Trace.TestHelpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
+{
+    public class SerilogVersionConflict2xTests : LogsInjectionTestBase
+    {
+        private readonly LogFileTest[] _log200FileTests =
+            {
+                new LogFileTest()
+                {
+                    FileName = "log-textFile.log",
+                    RegexFormat = @"{0}: {1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EmptyProperties,
+                    PropertiesUseSerilogNaming = true
+                },
+                new LogFileTest()
+                {
+                    FileName = "log-jsonFile.log",
+                    RegexFormat = @"""{0}"":{1}",
+                    UnTracedLogTypes = UnTracedLogTypes.EnvServiceTracingPropertiesOnly,
+                    PropertiesUseSerilogNaming = true
+                }
+            };
+
+        public SerilogVersionConflict2xTests(ITestOutputHelper output)
+            : base(output, "LogsInjection.Serilog.VersionConflict.2x")
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void InjectsLogsWhenEnabled()
+        {
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+
+            int agentPort = TcpPortProvider.GetOpenPort();
+            using (var agent = new MockTracerAgent(agentPort))
+            using (RunSampleAndWaitForExit(agent.Port))
+            {
+                var spans = agent.WaitForSpans(1, 2500);
+                Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
+
+                ValidateLogCorrelation(spans, _log200FileTests);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -43,6 +43,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
+            var expectedCorrelatedTraceCount = 1;
+            var expectedCorrelatedSpanCount = 8;
+
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = new MockTracerAgent(agentPort))
             using (RunSampleAndWaitForExit(agent.Port))
@@ -50,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _log200FileTests, expectedTraceCount: 1);
+                ValidateLogCorrelation(spans, _log200FileTests, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
 
-                ValidateLogCorrelation(spans, _log200FileTests);
+                ValidateLogCorrelation(spans, _log200FileTests, expectedTraceCount: 1);
             }
         }
     }

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -37,7 +37,7 @@ namespace Samples
 
         public static void RunShutDownTasks(object caller)
         {
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
 
             foreach (var assembly in assemblies)
             {

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/LogHelper.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/LogHelper.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Serialization;
+#endif
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace LogsInjection.ILogger.VersionConflict_2x
+{
+    public static class LogHelper
+    {
+        public const string ExcludeMessagePrefix = "[ExcludeMessage]";
+
+        public static void UninjectedLog(this Microsoft.Extensions.Logging.ILogger logger, string message)
+        {
+            logger.LogInformation($"{ExcludeMessagePrefix}{message}");
+        }
+
+        public static void ConditionalLog(this Microsoft.Extensions.Logging.ILogger logger, string message)
+        {
+#if NETCOREAPP
+                logger.LogInformation(message);
+#else
+                // We don't instrument on .NET Framework, so we don't expect this to be log injected
+                logger.UninjectedLog(message);
+#endif
+        }
+
+        public static void ConfigureCustomLogging(WebHostBuilderContext ctx, ILoggingBuilder logging)
+        {
+            // delete existing log file
+            var logFile = Path.Combine(ctx.HostingEnvironment.ContentRootPath, "simple.log");
+            if (File.Exists(logFile))
+            {
+                try
+                {
+                    File.Delete(logFile);
+                }
+                catch
+                {
+                    // Don't throw if something's amiss
+                }
+            }
+
+            logging.AddProvider(new SimpleLogProvider(logFile));
+        }
+
+        public class SimpleLogProvider : ILoggerProvider, ISupportExternalScope
+        {
+            private readonly string _logPath;
+
+            public SimpleLogProvider(string logPath)
+            {
+                _logPath = logPath;
+            }
+
+            internal IExternalScopeProvider ScopeProvider { get; private set; }
+
+            public Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName) => new SimpleLogger(this, categoryName, _logPath);
+
+            public void Dispose()
+            {
+            }
+
+            void ISupportExternalScope.SetScopeProvider(IExternalScopeProvider scopeProvider)
+            {
+                ScopeProvider = scopeProvider;
+            }
+
+            public class SimpleLogger : Microsoft.Extensions.Logging.ILogger
+            {
+                private readonly SimpleLogProvider _provider;
+                private readonly string _logPath;
+                private readonly string _category;
+
+                public SimpleLogger(SimpleLogProvider loggerProvider, string categoryName, string logPath)
+                {
+                    _provider = loggerProvider;
+                    _category = categoryName;
+                    _logPath = logPath;
+                }
+
+                public IDisposable BeginScope<TState>(TState state)
+                {
+                    return _provider.ScopeProvider?.Push(state);
+                }
+
+                public bool IsEnabled(LogLevel logLevel)
+                {
+                    return true;
+                }
+
+                public void Log<TState>(DateTimeOffset timestamp, LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                    if (!IsEnabled(logLevel))
+                    {
+                        return;
+                    }
+
+                    var scopes = new Dictionary<string, object>();
+                    var scopeProvider = _provider.ScopeProvider;
+                    if (scopeProvider != null)
+                    {
+                        scopeProvider.ForEachScope(
+                            (scope, builder) =>
+                            {
+                                if (scope is IEnumerable<KeyValuePair<string, object>> pairs)
+                                {
+                                    foreach (var kvp in pairs)
+                                    {
+                                        builder[kvp.Key] = kvp.Value;
+                                    }
+                                }
+                                else
+                                {
+                                    var temp = builder.TryGetValue("scopes", out var rawScope)
+                                                   ? (List<object>)rawScope
+                                                   : new List<object>();
+                                    temp.Add(scope);
+                                    builder["scopes"] = temp;
+                                }
+                            },
+                            scopes);
+                    }
+#if NETCOREAPP2_1 || !NETCOREAPP
+                    var log = Newtonsoft.Json.JsonConvert.SerializeObject(
+                        new
+                        {
+                            timestamp = timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
+                            category = _category,
+                            scopes = scopes,
+                            message = formatter(state, exception),
+                            exception = exception?.Message
+                        }, Newtonsoft.Json.Formatting.None);
+#else
+                    var log = System.Text.Json.JsonSerializer.Serialize(
+                        new
+                        {
+                            timestamp = timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff zzz"),
+                            category = _category,
+                            scopes = scopes,
+                            message = formatter(state, exception),
+                            exception = exception?.Message
+                        }, new System.Text.Json.JsonSerializerOptions()
+                        {
+                            WriteIndented = false,
+#if NET6_0_OR_GREATER
+                            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+#else
+                            IgnoreNullValues = true,
+#endif
+                        });
+#endif
+
+
+                    File.AppendAllText(_logPath, log + Environment.NewLine);
+                }
+
+                public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                {
+                    Log(DateTimeOffset.UtcNow, logLevel, eventId, state, exception, formatter);
+                }
+            }
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/LogsInjection.ILogger.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/LogsInjection.ILogger.VersionConflict.2x.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Program.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace LogsInjection.ILogger.VersionConflict_2x
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                   .UseContentRoot(AppContext.BaseDirectory)
+                   .UseSetting(WebHostDefaults.SuppressStatusMessagesKey, "True")
+                   .ConfigureLogging(LogHelper.ConfigureCustomLogging)
+                   .UseStartup<Startup>();
+
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,24 @@
+﻿{
+  "profiles": {
+    "LogsInjection.ILogger.VersionConflict.2x": {
+      "commandName": "Project",
+      "dotnetRunMessages": "false",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "http://127.0.0.1:0",
+
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+        "DD_LOGS_INJECTION": "1"
+      }
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Startup.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Startup.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using Datadog.Trace;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace LogsInjection.ILogger.VersionConflict_2x
+{
+    public class Startup
+    {
+        public static volatile bool AppListening = false;
+        public static volatile string ServerAddress = null;
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHostedService<Worker>();
+            services.AddHttpClient();
+        }
+
+#pragma warning disable 618 // ignore obsolete IApplicationLifetime
+        public void Configure(IApplicationBuilder app, IApplicationLifetime lifetime, ILogger<Startup> logger)
+#pragma warning restore 618
+        {
+            // Not injected as we won't have a traceId
+            logger.UninjectedLog("Building pipeline");
+            using (var scope = Tracer.Instance.StartActive("pipeline build"))
+            {
+                logger.LogInformation("Still building pipeline...");
+            }
+
+            // Register a callback to run after the app is fully configured
+            lifetime.ApplicationStarted.Register(() =>
+            {
+                ServerAddress = app.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First();
+                AppListening = true;
+            });
+
+            app.Use((httpContext, next) =>
+            {
+                logger.ConditionalLog($"Visited {httpContext.Request.Path}");
+                return next();
+            });
+
+            app.Run(context =>
+            {
+                logger.ConditionalLog("Received request, echoing");
+
+                using var scope = Tracer.Instance.StartActive("middleware execution");
+                logger.LogInformation("Sending response");
+                return context.Response.WriteAsync("PONG");
+            });
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Worker.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/Worker.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace LogsInjection.ILogger.VersionConflict_2x
+{
+    public class Worker : BackgroundService
+    {
+        private readonly ILogger<Worker> _logger;
+        private readonly IServiceProvider _serviceProvider;
+#pragma warning disable 618 // ignore obsolete IApplicationLifetime
+        private readonly IApplicationLifetime _lifetime;
+
+        public Worker(ILogger<Worker> logger, IApplicationLifetime lifetime, IServiceProvider serviceProvider)
+#pragma warning restore 618
+        {
+            _logger = logger;
+            _lifetime = lifetime;
+            _serviceProvider = serviceProvider;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!Startup.AppListening && !stoppingToken.IsCancellationRequested)
+            {
+                _logger.UninjectedLog("Waiting for app started handling requests");
+                await Task.Delay(100, stoppingToken);
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                _logger.UninjectedLog("Cancellation requested.");
+                return;
+            }
+
+            using (var scope = Datadog.Trace.Tracer.Instance.StartActive("worker request"))
+            {
+                try
+                {
+                    using var serviceScope = _serviceProvider.CreateScope();
+                    var httpClientFactory = serviceScope.ServiceProvider.GetRequiredService<IHttpClientFactory>();
+                    var client = httpClientFactory.CreateClient();
+
+                    _logger.LogInformation("Sending request to self");
+                    var response = await client.GetAsync(Startup.ServerAddress, stoppingToken);
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        _logger.LogError("Error sending request, status code did not indicate success");
+                        response.EnsureSuccessStatusCode();
+                    }
+
+                    _logger.LogInformation("Request sent successfully");
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error sending request");
+                }
+            }
+
+            _logger.UninjectedLog("Stopping application");
+
+            // trigger app shutdown
+            _lifetime.StopApplication();
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/appsettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.ILogger.VersionConflict.2x/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/AppDirFileAppender.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/AppDirFileAppender.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using log4net.Appender;
+
+namespace LogsInjection.Log4Net.VersionConflict_2x
+{
+    /// <summary>
+    /// See the following StackOverflow link for overwriting built-in appenders: https://stackoverflow.com/questions/1922430/how-do-you-make-log4net-output-to-current-working-directory
+    /// </summary>
+    public class AppDirFileAppender : FileAppender
+    {
+        public override string File
+        {
+            set
+            {
+                var directory = Directory.GetParent(typeof(AppDirFileAppender).Assembly.Location).FullName;
+                base.File = Path.Combine(directory, value);
+            }
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/LogsInjection.Log4Net.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/LogsInjection.Log4Net.VersionConflict.2x.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Exclude .NET Core 2.1 because it doesn't have the AssemblyLoadContext.All API-->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="log4net.Ext.Json" Version="2.0.10.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="log4net.205.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/Program.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using log4net;
+using log4net.Config;
+using LogsInjectionHelper.VersionConflict;
+
+namespace LogsInjection.Log4Net.VersionConflict_2x
+{
+    public class Program
+    {
+        private static readonly ILog log = LogManager.GetLogger(typeof(Program));
+
+        public static int Main(string[] args)
+        {
+            var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
+            var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
+            var jsonFilePath = Path.Combine(appDirectory, "log-jsonFile.log");
+
+            File.Delete(textFilePath);
+            File.Delete(jsonFilePath);
+
+            // Initialize log4net
+            var logRepository = LogManager.GetRepository(typeof(Program).Assembly);
+            XmlConfigurator.Configure(logRepository, new FileInfo(Path.Combine(appDirectory, "log4net.205.config")));
+
+            return LoggingMethods.RunLoggingProcedure(log.Info);
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "LogsInjection.Log4Net.VersionConflict.2x": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/log4net.205.config
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net.VersionConflict.2x/log4net.205.config
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <configSections>
+        <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net" />
+    </configSections>
+    <log4net>
+        <appender name="BasicForwardingAppender" type="log4net.Appender.ForwardingAppender" >
+            <threshold value="ALL"/>
+            <appender-ref ref="jsonfile" />
+            <appender-ref ref="textfile" />
+        </appender>
+
+        <appender name="jsonfile" type="LogsInjection.Log4Net.VersionConflict_2x.AppDirFileAppender, LogsInjection.Log4Net.VersionConflict.2x" >
+            <file value="log-jsonFile.log" />
+            <!-- Set up SerializedLayout as defined here: https://github.com/BrightOpen/log4net.Ext.Json#json-stuff -->
+            <layout type='log4net.Layout.SerializedLayout, log4net.Ext.Json'>
+              <decorator type='log4net.Layout.Decorators.StandardTypesDecorator, log4net.Ext.Json' />
+              <default />
+              <!--explicit default members-->
+              <remove value='message' />
+              <!--remove the default preformatted message member-->
+              <member value='message:messageobject' />
+              <!--add raw message-->
+
+              <!-- Manual changes: start -->
+              <member value='dd.env' />
+              <member value='dd.service' />
+              <member value='dd.version' />
+              <member value='dd.trace_id' />
+              <member value='dd.span_id' />
+              <!-- Manual changes: end -->
+            </layout>
+        </appender>
+
+        <appender name="textfile" type="LogsInjection.Log4Net.VersionConflict_2x.AppDirFileAppender, LogsInjection.Log4Net.VersionConflict.2x">
+            <file value="log-textFile.log" />
+            <layout type="log4net.Layout.PatternLayout">
+                <conversionPattern value="%date [%thread] %level %logger {dd.env: &quot;%property{dd.env}&quot;, dd.service: &quot;%property{dd.service}&quot;, dd.version: &quot;%property{dd.version}&quot;, dd.trace_id: &quot;%property{dd.trace_id}&quot;, dd.span_id: &quot;%property{dd.span_id}&quot;} - %message%newline" />
+            </layout>
+        </appender>
+
+        <root>
+            <level value="INFO" />
+          <appender-ref ref="BasicForwardingAppender" />
+        </root>
+    </log4net>
+</configuration>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/LogsInjection.NLog.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/LogsInjection.NLog.VersionConflict.2x.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Exclude .NET Core 2.1 because it doesn't have the AssemblyLoadContext.All API-->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.7.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="NLog.46.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/NLog.46.config
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/NLog.46.config
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <targets>
+        <target name="jsonFile" xsi:type="File" fileName="${basedir}\log-jsonFile.log">
+            <layout xsi:type="JsonLayout" includeMdlc="true">
+                <attribute name="time" layout="${longdate}" />
+                <attribute name="level" layout="${level:upperCase=true}"/>
+                <attribute name="message" layout="${message}" />
+                <attribute name="exception" layout="${exception:format=ToString}" />
+            </layout>
+        </target>
+
+        <target name="textFile" xsi:type="File" fileName="${basedir}\log-textFile.log"
+                layout="${longdate}|${uppercase:${level}}|${logger}|{dd.env: &quot;${mdlc:item=dd.env}&quot;,dd.service: &quot;${mdlc:item=dd.service}&quot;,dd.version: &quot;${mdlc:item=dd.version}&quot;,dd.trace_id: &quot;${mdlc:item=dd.trace_id}&quot;,dd.span_id: &quot;${mdlc:item=dd.span_id}&quot;}|${message}" />
+    </targets>
+
+    <!-- rules to map from logger name to target -->
+    <rules>
+        <logger name="*" minlevel="Trace" writeTo="jsonFile,textFile" />
+    </rules>
+</nlog>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/Program.cs
@@ -1,7 +1,9 @@
 using System.IO;
+using System.Runtime.InteropServices;
 using LogsInjectionHelper.VersionConflict;
 using NLog;
 using NLog.Config;
+using NLog.Targets;
 
 namespace LogsInjection.NLog.VersionConflict_2x
 {
@@ -18,8 +20,26 @@ namespace LogsInjection.NLog.VersionConflict_2x
 
             // Initialize NLog
             LogManager.Configuration = new XmlLoggingConfiguration(Path.Combine(appDirectory, "NLog.46.config"));
-            Logger logger = LogManager.GetCurrentClassLogger();
+#if NETCOREAPP
+            // Hacks for the fact the NLog on Linux just can't do anything right
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var target = (FileTarget)LogManager.Configuration.FindTargetByName("textFile");
+                if (target is not null)
+                {
+                    target.FileName = Path.Combine(appDirectory, "log-textFile.log");
+                }
 
+                target = (FileTarget)LogManager.Configuration.FindTargetByName("jsonFile");
+                if (target is not null)
+                {
+                    target.FileName = Path.Combine(appDirectory, "log-jsonFile.log");
+                }
+                LogManager.ReconfigExistingLoggers();
+            }
+#endif
+
+            Logger logger = LogManager.GetCurrentClassLogger();
             return LoggingMethods.RunLoggingProcedure(logger.Info);
         }
     }

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/Program.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using LogsInjectionHelper.VersionConflict;
+using NLog;
+using NLog.Config;
+
+namespace LogsInjection.NLog.VersionConflict_2x
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
+            var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
+            var jsonFilePath = Path.Combine(appDirectory, "log-jsonFile.log");
+
+            File.Delete(textFilePath);
+            File.Delete(jsonFilePath);
+
+            // Initialize NLog
+            LogManager.Configuration = new XmlLoggingConfiguration(Path.Combine(appDirectory, "NLog.46.config"));
+            Logger logger = LogManager.GetCurrentClassLogger();
+
+            return LoggingMethods.RunLoggingProcedure(logger.Info);
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "LogsInjection.NLog.VersionConflict.2x": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">4.1.2</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">1.0.0.505</ApiVersion>
     <ApiVersion Condition="'$(ApiVersion)' == '' AND !$(TargetFramework.StartsWith('net4')) ">4.5.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='4.0.0'">$(DefineConstants);NLOG_4_0</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='4.6.0'">$(DefineConstants);NLOG_4_6</DefineConstants>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/Properties/launchSettings.json
@@ -3,7 +3,17 @@
     "LogsInjection.NLog": {
       "commandName": "Project",
       "environmentVariables": {
-        "DD_LOGS_INJECTION": "true"
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+        "DD_LOGS_INJECTION": "1"
       }
     }
   }

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/LogsInjection.NLog10.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/LogsInjection.NLog10.VersionConflict.2x.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Older versions of NLog are built for .NET Framework -->
+    <TargetFrameworks>net461</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="1.0.0.505" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="NLog.Pre40.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/NLog.Pre40.config
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/NLog.Pre40.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <targets>
+        <target name="textFile" xsi:type="File" fileName="${basedir}\log-textFile.log"
+                layout="${longdate}|${uppercase:${level}}|${logger}|{dd.env: &quot;${mdc:item=dd.env}&quot;,dd.service: &quot;${mdc:item=dd.service}&quot;,dd.version: &quot;${mdc:item=dd.version}&quot;,dd.trace_id: &quot;${mdc:item=dd.trace_id}&quot;,dd.span_id: &quot;${mdc:item=dd.span_id}&quot;}|${message}" />
+    </targets>
+
+    <!-- rules to map from logger name to target -->
+    <rules>
+        <logger name="*" minlevel="Trace" writeTo="textFile" />
+    </rules>
+</nlog>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/Program.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using LogsInjectionHelper.VersionConflict;
+using NLog;
+using NLog.Config;
+
+namespace LogsInjection.NLog10.VersionConflict_2x
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
+            var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
+
+            File.Delete(textFilePath);
+
+            // Initialize NLog
+            LogManager.Configuration = new XmlLoggingConfiguration(Path.Combine(appDirectory, "NLog.Pre40.config"));
+            Logger logger = LogManager.GetCurrentClassLogger();
+
+            return LoggingMethods.RunLoggingProcedure(logger.Info);
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog10.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "LogsInjection.NLog10.VersionConflict.2x": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/LogsInjection.NLog20.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/LogsInjection.NLog20.VersionConflict.2x.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Older versions of NLog are built for .NET Framework -->
+    <TargetFrameworks>net461</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="2.0.0.2000" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="NLog.Pre40.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/NLog.Pre40.config
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/NLog.Pre40.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <targets>
+        <target name="textFile" xsi:type="File" fileName="${basedir}\log-textFile.log"
+                layout="${longdate}|${uppercase:${level}}|${logger}|{dd.env: &quot;${mdc:item=dd.env}&quot;,dd.service: &quot;${mdc:item=dd.service}&quot;,dd.version: &quot;${mdc:item=dd.version}&quot;,dd.trace_id: &quot;${mdc:item=dd.trace_id}&quot;,dd.span_id: &quot;${mdc:item=dd.span_id}&quot;}|${message}" />
+    </targets>
+
+    <!-- rules to map from logger name to target -->
+    <rules>
+        <logger name="*" minlevel="Trace" writeTo="textFile" />
+    </rules>
+</nlog>

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/Program.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using LogsInjectionHelper.VersionConflict;
+using NLog;
+using NLog.Config;
+
+namespace LogsInjection.NLog20.VersionConflict_2x
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
+            var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
+
+            File.Delete(textFilePath);
+
+            // Initialize NLog
+            LogManager.Configuration = new XmlLoggingConfiguration(Path.Combine(appDirectory, "NLog.Pre40.config"));
+            Logger logger = LogManager.GetCurrentClassLogger();
+
+            return LoggingMethods.RunLoggingProcedure(logger.Info);
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog20.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "LogsInjection.NLog20.VersionConflict.2x": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/LogsInjection.Serilog.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/LogsInjection.Serilog.VersionConflict.2x.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Exclude .NET Core 2.1 because it doesn't have the AssemblyLoadContext.All API-->
+    <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net461;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/Program.cs
@@ -1,0 +1,36 @@
+
+using System.IO;
+using LogsInjectionHelper.VersionConflict;
+using Serilog;
+using Serilog.Formatting.Json;
+using LogEventLevel = Serilog.Events.LogEventLevel;
+
+namespace LogsInjection.Serilog.VersionConflict_2x
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Initialize Serilog
+            var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
+            var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
+            var jsonFilePath = Path.Combine(appDirectory, "log-jsonFile.log");
+
+            File.Delete(textFilePath);
+            File.Delete(jsonFilePath);
+
+            var log = new LoggerConfiguration()
+                                        .Enrich.FromLogContext()
+                                        .MinimumLevel.Is(LogEventLevel.Information)
+                                        .WriteTo.File(
+                                            textFilePath,
+                                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {{ dd_service: \"{dd_service}\", dd_version: \"{dd_version}\", dd_env: \"{dd_env}\", dd_trace_id: \"{dd_trace_id}\", dd_span_id: \"{dd_span_id}\" }} {Message:lj} {NewLine}{Exception}")
+                                        .WriteTo.File(
+                                            new JsonFormatter(),
+                                            jsonFilePath)
+                                        .CreateLogger();
+
+            return LoggingMethods.RunLoggingProcedure(log.Information);
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "LogsInjection.Serilog.VersionConflict.2x": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/LogsInjection.Serilog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">1.5.14</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">1.4.16</ApiVersion>
     <ApiVersion Condition="'$(ApiVersion)' == '' AND !$(TargetFramework.StartsWith('net4')) ">2.0.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='2.0.0'">$(DefineConstants);SERILOG_2_0</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='1.4.152' and '$(ApiVersion)'&lt;'2.0.0'">$(DefineConstants);SERILOG_LOG_OPTIN_CROSS_APPDOMAIN</DefineConstants>

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog/Properties/launchSettings.json
@@ -3,7 +3,17 @@
     "LogsInjection.Serilog": {
       "commandName": "Project",
       "environmentVariables": {
-        "DD_LOGS_INJECTION": "true"
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+        "DD_LOGS_INJECTION": "1"
       }
     }
   }

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog14.VersionConflict.2x/LogsInjection.Serilog14.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog14.VersionConflict.2x/LogsInjection.Serilog14.VersionConflict.2x.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Older versions of NLog are built for .NET Framework -->
+    <TargetFrameworks>net461</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="1.4.16" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog14.VersionConflict.2x/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog14.VersionConflict.2x/Program.cs
@@ -1,0 +1,38 @@
+
+using System;
+using System.IO;
+using LogsInjectionHelper.VersionConflict;
+using Serilog;
+using LogEventLevel = Serilog.Events.LogEventLevel;
+
+namespace LogsInjection.Serilog14.VersionConflict_2x
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Initialize Serilog
+            var appDirectory = Directory.GetParent(typeof(Program).Assembly.Location).FullName;
+            var textFilePath = Path.Combine(appDirectory, "log-textFile.log");
+            var jsonFilePath = Path.Combine(appDirectory, "log-jsonFile.log");
+
+            File.Delete(textFilePath);
+            File.Delete(jsonFilePath);
+
+            var log = new LoggerConfiguration()
+                                        .Enrich.FromLogContext()
+                                        .MinimumLevel.Is(LogEventLevel.Information)
+                                        .WriteTo.File(
+                                            textFilePath,
+                                            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {{ dd_service: \"{dd_service}\", dd_version: \"{dd_version}\", dd_env: \"{dd_env}\", dd_trace_id: \"{dd_trace_id}\", dd_span_id: \"{dd_span_id}\" }} {Message:lj} {NewLine}{Exception}")
+                                        .CreateLogger();
+
+            return LoggingMethods.RunLoggingProcedure(LogWrapper(log));
+        }
+
+        public static Action<string> LogWrapper(ILogger log)
+        {
+            return (string message) => log.Information(message);
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/LogsInjection.Serilog14.VersionConflict.2x/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/LogsInjection.Serilog14.VersionConflict.2x/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "LogsInjection.Serilog14.VersionConflict.2x": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LoggingMethods.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Datadog.Trace;
+
+namespace LogsInjectionHelper.VersionConflict
+{
+    public static class LoggingMethods
+    {
+        /// <summary>
+        /// Prepend a string to log lines that should not be validated for logs injection.
+        /// In other words, they're not written within a Datadog scope 
+        /// </summary>
+        private static readonly string ExcludeMessagePrefix = "[ExcludeMessage]";
+
+        public static int RunLoggingProcedure(Action<string> logAction)
+        {
+            try
+            {
+                logAction($"{ExcludeMessagePrefix}Starting manual1 Datadog scope.");
+                using (Tracer.Instance.StartActive("manual1"))
+                {
+                    logAction($"Trace: manual1");
+                    using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic2"))
+                    {
+                        logAction($"Trace: manual1-automatic2");
+                        using (Tracer.Instance.StartActive("manual3"))
+                        {
+                            logAction($"Trace: manual1-automatic2-manual3");
+                            using (Tracer.Instance.StartActive("manual4"))
+                            {
+                                logAction($"Trace: manual1-automatic2-manual3-manual4");
+
+                                using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic5"))
+                                {
+                                    logAction($"Trace: manual1-automatic2-manual3-manual4-automatic5");
+                                }
+
+                                logAction($"Trace: manual1-automatic2-manual3-manual4");
+                            }
+
+                            logAction($"Trace: manual1-automatic2-manual3");
+
+                            using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic4"))
+                            {
+                                logAction($"Trace: manual1-automatic2-manual3-automatic4");
+                                using (TracerUtils.StartAutomaticTraceHigherAssemblyVersion("automatic5"))
+                                {
+                                    logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5");
+                                    using (Tracer.Instance.StartActive("manual6"))
+                                    {
+                                        logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5-manual6");
+                                    }
+
+                                    logAction($"Trace: manual1-automatic2-manual3-automatic4-automatic5");
+                                }
+
+                                logAction($"Trace: manual1-automatic2-manual3-automatic4");
+                            }
+
+                            logAction($"Trace: manual1-automatic2-manual3");
+                        }
+                        logAction($"Trace: manual1-automatic2");
+                    }
+
+                    logAction($"Trace: manual1");
+                }
+
+                logAction($"{ExcludeMessagePrefix}Exited manual1 Datadog scope.");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                return (int)ExitCode.UnknownError;
+            }
+
+#if NETCOREAPP2_1
+            // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+            // This would cause a segmentation fault on .net core 2.x
+            System.Threading.Thread.Sleep(5000);
+#endif
+
+            return (int)ExitCode.Success;
+        }
+
+        enum ExitCode : int
+        {
+            Success = 0,
+            UnknownError = -10
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LogsInjectionHelper.VersionConflict.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LogsInjectionHelper.VersionConflict.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Datadog.Trace" Version="2.0.0-dev1.29.0-build10-nomanuallogsinjection" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LogsInjectionHelper.VersionConflict.csproj
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/LogsInjectionHelper.VersionConflict.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.0.0-dev1.29.0-build10-nomanuallogsinjection" />
+    <PackageReference Include="Datadog.Trace" Version="2.0.0-dev1.29.0-build11-nomanuallogsinjection" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/TracerUtils.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/TracerUtils.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Datadog.Trace;
+
+namespace LogsInjectionHelper.VersionConflict
+{
+    public class TracerUtils
+    {
+        private static readonly Version _manualTracingVersion = typeof(Tracer).Assembly.GetName().Version;
+        private static Assembly _automaticAssembly;
+
+        private static bool VersionIsLowerThanManualTracingVersion(Version version)
+        {
+#if NETFRAMEWORK
+            return version < _manualTracingVersion;
+#else
+            return version == _manualTracingVersion;
+#endif
+        }
+
+        private static bool VersionIsHigherThanManualTracingVersion(Version version)
+        {
+            return version > _manualTracingVersion;
+        }
+
+
+        public static IDisposable StartAutomaticTraceLowerAssemblyVersion(string operationName)
+        {
+            return StartAutomaticTrace(operationName, VersionIsLowerThanManualTracingVersion);
+        }
+
+        public static IDisposable StartAutomaticTraceHigherAssemblyVersion(string operationName)
+        {
+            return StartAutomaticTrace(operationName, VersionIsHigherThanManualTracingVersion);
+        }
+
+        private static IDisposable StartAutomaticTrace(string operationName, Func<Version, bool> versionComparisonFunc)
+        {
+            if (_automaticAssembly is null)
+            {
+                // Get the Datadog.Trace.Tracer type from the automatic instrumentation assembly
+#if NETFRAMEWORK
+                _automaticAssembly = System.AppDomain.CurrentDomain.GetAssemblies().Single(asm => asm.GetName().Name.Equals("Datadog.Trace") && versionComparisonFunc(asm.GetName().Version));
+#elif !NETCOREAPP2_1
+                foreach (var alc in System.Runtime.Loader.AssemblyLoadContext.All)
+                {
+                    _automaticAssembly = alc.Assemblies.SingleOrDefault(asm => asm.GetName().Name.Equals("Datadog.Trace") && versionComparisonFunc(asm.GetName().Version));
+                    if (_automaticAssembly != null)
+                    {
+                        break;
+                    }
+                }
+#endif
+            }
+
+            Type tracerType = _automaticAssembly.GetType("Datadog.Trace.Tracer");
+
+            // Invoke 'Tracer.Instance'
+            var instanceGetMethod = tracerType.GetProperty("Instance", BindingFlags.Static | BindingFlags.Public).GetGetMethod();
+            object instance = instanceGetMethod.Invoke(null, new object[] {});
+
+            // Invoke 'public Scope StartActive(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool ignoreActiveScope = false, bool finishOnClose = true)'
+            var startActive = tracerType.GetMethod("StartActive");
+            object parent = null;
+            string serviceName = null;
+            DateTimeOffset? startTime = null;
+            bool ignoreActiveScope = false;
+            bool finishOnClose = true;
+
+            return (IDisposable)startActive.Invoke(instance, new[] { operationName, parent, serviceName, startTime, ignoreActiveScope, finishOnClose });
+        }
+    }
+}

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -55,7 +55,6 @@ namespace PluginApplication
 #if NETFRAMEWORK
                     logAction("Calling the PluginApplication.Program in a separate AppDomain");
                     AppDomainProxy.Call(applicationAppDomain, "PluginApplication", "PluginApplication.Program", "Invoke", null);
-                    logAction("Returned from the PluginApplication.Program call");
 #else
                     logAction("Skipping the cross-AppDomain call on .NET Core");
 #endif


### PR DESCRIPTION
## Changes
- Enables logs injection to work with the new DistributedTracer when version conflicts occur by using the `IReadOnlyDictionary<string, string> IDistributedTracer.GetSpanContext()` API to get the active TraceId / SpanId instead of the local active scope. We only need to fetch the TraceId and SpanId, so we access the dictionary with the appropriate keys.
- Lowers the minimum assembly version for NLog from 2.1.0 to 1.0.0.505, which passes both the DistributedTrace case and the cross-AppDomain scenarios
- Note: This is rebased on top of https://github.com/DataDog/dd-trace-dotnet/pull/2152 and https://github.com/DataDog/dd-trace-dotnet/pull/2096 which has the automatic instrumentation changes. This will be rebased on master once those are merged.

## Testing
- Add sample applications with a version mismatch for the following libraries:
  - Serilog: v1.4.16 and v2.0
  - NLog: v1.0, v2.0, and v4.6
  - log4net
  - ILogger