### PR TITLE
Revert "Disable version conflict fix (#2155)"

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
@@ -88,7 +88,7 @@ bool IsAzureFunctionsEnabled()
 
 bool IsVersionCompatibilityEnabled()
 {
-    ToBooleanWithDefault(GetEnvironmentValue(environment::internal_version_compatibility), false);
+    ToBooleanWithDefault(GetEnvironmentValue(environment::internal_version_compatibility), true);
 }
 
 } // namespace trace

--- a/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
@@ -21,7 +21,6 @@ namespace Datadog.Trace.ClrProfiler
 
         static DistributedTracer()
         {
-            /*
             try
             {
                 var parent = GetDistributedTracer();
@@ -45,42 +44,23 @@ namespace Datadog.Trace.ClrProfiler
                 Log.Error(ex, "Error while building the tracer, falling back to automatic");
                 Instance = new AutomaticTracer();
             }
-            */
-
-            Instance = new DummyInstance();
         }
 
         internal static IDistributedTracer Instance { get; private set; }
 
+        /// <summary>
+        /// Get the instance of IDistributedTracer. This method will be rewritten by the profiler.
+        /// </summary>
+        /// <remarks>Don't ever change the return type of this method,
+        /// as this would require special handling by the profiler.</remarks>
+        /// <returns>The instance of IDistributedTracer</returns>
+        [Browsable(false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static object GetDistributedTracer() => Instance;
+
         internal static void SetInstanceOnlyForTests(IDistributedTracer instance)
         {
             Instance = instance;
-        }
-
-        private class DummyInstance : IDistributedTracer
-        {
-            public SpanContext GetSpanContext()
-            {
-                return null;
-            }
-
-            public IScope GetActiveScope()
-            {
-                return null;
-            }
-
-            public void SetSpanContext(SpanContext value)
-            {
-            }
-
-            public void LockSamplingPriority()
-            {
-            }
-
-            public SamplingPriority? TrySetSamplingPriority(SamplingPriority? samplingPriority)
-            {
-                return samplingPriority;
-            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             _iisFixture.TryStartIis(this, IisAppType.AspNetClassic);
         }
 
-        [SkippableFact(Skip = "Version conflict temporarily disabled")]
+        [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             httpSpan.Name.Should().Be("http.request");
         }
 
-        [SkippableTheory(Skip = "Version conflict temporarily disabled")]
+        [SkippableTheory]
         [InlineData(true)]
         [InlineData(false)]
         [Trait("Category", "EndToEnd")]
@@ -153,7 +153,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             spans.Should().OnlyContain(s => VerifySpan(s, parentTrace));
         }
 
-        [SkippableFact(Skip = "Version conflict temporarily disabled")]
+        [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
         }
 
-        [Fact(Skip = "Version conflict temporarily disabled")]
+        [Fact]
         public void SubmitTraces()
         {
             // 1 manual span + 1 http span

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         {
         }
 
-        [Fact(Skip = "Version conflict temporarily disabled")]
+        [Fact]
         public void SubmitTraces()
         {
             // 1 manual span + 2 http spans


### PR DESCRIPTION
This reverts commit 60075b6ce8e1f638b0d5bea2df1ae013041d088b.

This also fixes a build break from the merging of the AsyncLocal fix without adding an implementation of `IDistributedTracer.GetSpanContextRaw()` on type `DistributedTracer.DummyInstance`

@DataDog/apm-dotnet