### PR TITLE
[AppSec] Handle null keys when reading headers, cookies and query strings

### DIFF
--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Core.cs
@@ -24,21 +24,22 @@ namespace Datadog.Trace.Util.Http
             var headersDic = new Dictionary<string, string[]>(request.Headers.Keys.Count);
             foreach (var k in request.Headers.Keys)
             {
-                if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
+                var currentKey = k ?? string.Empty;
+                if (!currentKey.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    var key = k.ToLowerInvariant();
+                    currentKey = currentKey.ToLowerInvariant();
 #if NETCOREAPP
-                    if (!headersDic.TryAdd(key, request.Headers[key]))
+                    if (!headersDic.TryAdd(currentKey, request.Headers[currentKey]))
                     {
 #else
-                    if (!headersDic.ContainsKey(key))
+                    if (!headersDic.ContainsKey(currentKey))
                     {
-                        headersDic.Add(key, request.Headers[key]);
+                        headersDic.Add(currentKey, request.Headers[currentKey]);
                     }
                     else
                     {
 #endif
-                        Log.Warning("Header {key} couldn't be added as argument to the waf", key);
+                        Log.Warning("Header {key} couldn't be added as argument to the waf", currentKey);
                     }
                 }
             }
@@ -47,10 +48,11 @@ namespace Datadog.Trace.Util.Http
             for (var i = 0; i < request.Cookies.Count; i++)
             {
                 var cookie = request.Cookies.ElementAt(i);
-                var keyExists = cookiesDic.TryGetValue(cookie.Key, out var value);
+                var currentKey = cookie.Key ?? string.Empty;
+                var keyExists = cookiesDic.TryGetValue(currentKey, out var value);
                 if (!keyExists)
                 {
-                    cookiesDic.Add(cookie.Key, new List<string> { cookie.Value ?? string.Empty });
+                    cookiesDic.Add(currentKey, new List<string> { cookie.Value ?? string.Empty });
                 }
                 else
                 {
@@ -61,18 +63,20 @@ namespace Datadog.Trace.Util.Http
             var queryStringDic = new Dictionary<string, string[]>(request.Query.Count);
             foreach (var kvp in request.Query)
             {
+                var currentKey = kvp.Key ?? string.Empty;
+
 #if NETCOREAPP
-                if (!queryStringDic.TryAdd(kvp.Key, kvp.Value))
+                if (!queryStringDic.TryAdd(currentKey, kvp.Value))
                 {
 #else
-                if (!queryStringDic.ContainsKey(kvp.Key))
+                if (!queryStringDic.ContainsKey(currentKey))
                 {
-                    queryStringDic.Add(kvp.Key, kvp.Value);
+                    queryStringDic.Add(currentKey, kvp.Value);
                 }
                 else
                 {
 #endif
-                    Log.Warning("Query string with {key} couldn't be added as argument to the waf", kvp.Key);
+                    Log.Warning("Query string with {key} couldn't be added as argument to the waf", currentKey);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -23,16 +23,17 @@ namespace Datadog.Trace.Util.Http
             var headerKeys = request.Headers.Keys;
             foreach (string k in headerKeys)
             {
-                if (!k.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
+                var currentKey = k ?? string.Empty;
+                if (!currentKey.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    var key = k.ToLowerInvariant();
-                    if (!headersDic.ContainsKey(key))
+                    currentKey = currentKey.ToLowerInvariant();
+                    if (!headersDic.ContainsKey(currentKey))
                     {
-                        headersDic.Add(key, request.Headers.GetValues(key));
+                        headersDic.Add(currentKey, request.Headers.GetValues(currentKey));
                     }
                     else
                     {
-                        Log.Warning("Header {key} couldn't be added as argument to the waf", key);
+                        Log.Warning("Header {key} couldn't be added as argument to the waf", currentKey);
                     }
                 }
             }
@@ -55,14 +56,15 @@ namespace Datadog.Trace.Util.Http
             var queryDic = new Dictionary<string, string[]>(request.QueryString.AllKeys.Length);
             foreach (var k in request.QueryString.AllKeys)
             {
-                var values = request.QueryString.GetValues(k);
-                if (!queryDic.ContainsKey(k))
+                var currentKey = k ?? string.Empty;
+                var values = request.QueryString.GetValues(currentKey);
+                if (!queryDic.ContainsKey(currentKey))
                 {
-                    queryDic.Add(k, values);
+                    queryDic.Add(currentKey, values);
                 }
                 else
                 {
-                    Log.Warning("Query string {key} couldn't be added as argument to the waf", k);
+                    Log.Warning("Query string {key} couldn't be added as argument to the waf", currentKey);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/HttpRequestExtensions.Framework.cs
@@ -21,19 +21,19 @@ namespace Datadog.Trace.Util.Http
         {
             var headersDic = new Dictionary<string, string[]>(request.Headers.Keys.Count);
             var headerKeys = request.Headers.Keys;
-            foreach (string k in headerKeys)
+            foreach (string originalKey in headerKeys)
             {
-                var currentKey = k ?? string.Empty;
-                if (!currentKey.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
+                var keyForDictionary = originalKey ?? string.Empty;
+                if (!keyForDictionary.Equals("cookie", System.StringComparison.OrdinalIgnoreCase))
                 {
-                    currentKey = currentKey.ToLowerInvariant();
-                    if (!headersDic.ContainsKey(currentKey))
+                    keyForDictionary = keyForDictionary.ToLowerInvariant();
+                    if (!headersDic.ContainsKey(keyForDictionary))
                     {
-                        headersDic.Add(currentKey, request.Headers.GetValues(currentKey));
+                        headersDic.Add(keyForDictionary, request.Headers.GetValues(originalKey));
                     }
                     else
                     {
-                        Log.Warning("Header {key} couldn't be added as argument to the waf", currentKey);
+                        Log.Warning("Header {key} couldn't be added as argument to the waf", keyForDictionary);
                     }
                 }
             }
@@ -42,6 +42,7 @@ namespace Datadog.Trace.Util.Http
             for (var i = 0; i < request.Cookies.Count; i++)
             {
                 var cookie = request.Cookies[i];
+                var keyForDictionary = cookie.Name ?? string.Empty;
                 var keyExists = cookiesDic.TryGetValue(cookie.Name, out var value);
                 if (!keyExists)
                 {
@@ -54,21 +55,21 @@ namespace Datadog.Trace.Util.Http
             }
 
             var queryDic = new Dictionary<string, string[]>(request.QueryString.AllKeys.Length);
-            foreach (var k in request.QueryString.AllKeys)
+            foreach (var originalKey in request.QueryString.AllKeys)
             {
-                var currentKey = k ?? string.Empty;
-                var values = request.QueryString.GetValues(currentKey);
-                if (!queryDic.ContainsKey(currentKey))
+                var values = request.QueryString.GetValues(originalKey);
+                var keyForDictionary = originalKey ?? string.Empty;
+                if (!queryDic.ContainsKey(keyForDictionary))
                 {
-                    queryDic.Add(currentKey, values);
+                    queryDic.Add(keyForDictionary, values);
                 }
                 else
                 {
-                    Log.Warning("Query string {key} couldn't be added as argument to the waf", currentKey);
+                    Log.Warning("Query string {key} couldn't be added as argument to the waf", keyForDictionary);
                 }
             }
 
-            var dict = new Dictionary<string, object>
+            var dict = new Dictionary<string, object>(capacity: 5)
             {
                 {
                     AddressesConstants.RequestMethod, request.HttpMethod

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var resultRequests = await Task.WhenAll(attack(), attack(), attack(), attack(), attack());
             agent.SpanFilters.Add(s => s.Tags.ContainsKey("http.url") && s.Tags["http.url"].IndexOf("Health", StringComparison.InvariantCultureIgnoreCase) > 0);
             var spans = agent.WaitForSpans(expectedSpans);
-            Assert.Equal(expectedSpans, spans.Count());
+            Assert.Equal(expectedSpans, spans.Count);
 
             var expectedAppSecEvents = enableSecurity ? 5 : 0;
             var actualAppSecEvents = 0;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -81,9 +81,9 @@ namespace Datadog.Trace.Security.IntegrationTests
             _agent?.Dispose();
         }
 
-        public async Task TestBlockedRequestAsync(MockTracerAgent agent, bool enableSecurity, HttpStatusCode expectedStatusCode, int expectedSpans, IEnumerable<Action<MockTracerAgent.Span>> assertOnSpans)
+        public async Task TestBlockedRequestAsync(MockTracerAgent agent, bool enableSecurity, HttpStatusCode expectedStatusCode, int expectedSpans, IEnumerable<Action<MockTracerAgent.Span>> assertOnSpans, string url = "/Health/?arg=[$slice]")
         {
-            Func<Task<(HttpStatusCode StatusCode, string ResponseText)>> attack = () => SubmitRequest("/Health/?arg=[$slice]");
+            Func<Task<(HttpStatusCode StatusCode, string ResponseText)>> attack = () => SubmitRequest(url);
             var resultRequests = await Task.WhenAll(attack(), attack(), attack(), attack(), attack());
             agent.SpanFilters.Add(s => s.Tags.ContainsKey("http.url") && s.Tags["http.url"].IndexOf("Health", StringComparison.InvariantCultureIgnoreCase) > 0);
             var spans = agent.WaitForSpans(expectedSpans);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private int _httpPort;
         private Process _process;
         private MockTracerAgent _agent;
+        protected const string DefaultAttackUrl = "/Health/?arg=[$slice]";
 
         public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null)
             : base(sampleName, samplesDir ?? "test/test-applications/security", outputHelper)
@@ -81,7 +82,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             _agent?.Dispose();
         }
 
-        public async Task TestBlockedRequestAsync(MockTracerAgent agent, bool enableSecurity, HttpStatusCode expectedStatusCode, int expectedSpans, IEnumerable<Action<MockTracerAgent.Span>> assertOnSpans, string url = "/Health/?arg=[$slice]")
+        public async Task TestBlockedRequestAsync(MockTracerAgent agent, bool enableSecurity, HttpStatusCode expectedStatusCode, int expectedSpans, IEnumerable<Action<MockTracerAgent.Span>> assertOnSpans, string url)
         {
             Func<Task<(HttpStatusCode StatusCode, string ResponseText)>> attack = () => SubmitRequest(url);
             var resultRequests = await Task.WhenAll(attack(), attack(), attack(), attack(), attack());

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -22,12 +22,12 @@ namespace Datadog.Trace.Security.IntegrationTests
 {
     public class AspNetBase : TestHelper
     {
+        protected const string DefaultAttackUrl = "/Health/?arg=[$slice]";
         private readonly HttpClient _httpClient;
         private readonly string _shutdownPath;
         private int _httpPort;
         private Process _process;
         private MockTracerAgent _agent;
-        protected const string DefaultAttackUrl = "/Health/?arg=[$slice]";
 
         public AspNetBase(string sampleName, ITestOutputHelper outputHelper, string shutdownPath, string samplesDir = null)
             : base(sampleName, samplesDir ?? "test/test-applications/security", outputHelper)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -27,19 +27,20 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK)]
         [InlineData(false, true, HttpStatusCode.OK)]
         [InlineData(false, false, HttpStatusCode.OK)]
+        [InlineData(true, false, HttpStatusCode.OK, "?test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode)
+        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = null)
         {
             var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
-            await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, new Action<TestHelpers.MockTracerAgent.Span>[]
+            await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, expectedSpans: 5, url: url, assertOnSpans: new Action<TestHelpers.MockTracerAgent.Span>[]
             {
                  s => Assert.Equal("aspnet_core.request", s.Name),
                  s  => Assert.Equal("Samples.AspNetCore2", s.Service),
                  s  =>  Assert.Equal("web", s.Type),
                  s =>
                  {
-                    var securityTags = new Dictionary<string, string>()
+                    var securityTags = new Dictionary<string, string>
                     {
                         { "network.client.ip", "127.0.0.1" },
                         { "http.response.headers.content-type", "text/plain; charset=utf-8" },

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK, "?test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = null)
+        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
             var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
             await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, expectedSpans: 5, url: url, assertOnSpans: new Action<TestHelpers.MockTracerAgent.Span>[]

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK)]
         [InlineData(false, true, HttpStatusCode.OK)]
         [InlineData(false, false, HttpStatusCode.OK)]
-        [InlineData(true, false, HttpStatusCode.OK, "?test&[$slice]")]
+        [InlineData(true, false, HttpStatusCode.OK, "/Health/test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
         public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK)]
         [InlineData(false, true, HttpStatusCode.OK)]
         [InlineData(false, false, HttpStatusCode.OK)]
-        [InlineData(true, false, HttpStatusCode.OK, "/Health/test&[$slice]")]
+        [InlineData(true, false, HttpStatusCode.OK, "/Health/?test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
         public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK)]
         [InlineData(false, true, HttpStatusCode.OK)]
         [InlineData(false, false, HttpStatusCode.OK)]
-        [InlineData(true, false, HttpStatusCode.OK, "/Health/test&[$slice]")]
+        [InlineData(true, false, HttpStatusCode.OK, "/Health/?test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
         public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK)]
         [InlineData(false, true, HttpStatusCode.OK)]
         [InlineData(false, false, HttpStatusCode.OK)]
-        [InlineData(true, false, HttpStatusCode.OK, "?test&[$slice]")]
+        [InlineData(true, false, HttpStatusCode.OK, "/Health/test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
         public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK, "?test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = null)
+        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
             var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
             await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, new Action<TestHelpers.MockTracerAgent.Span>[]
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                         Assert.Equal(kvp.Value, tagValue);
                     }
                  },
-            });
+            }, url);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = DefaultAttackUrl)
         {
             var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
-            await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, new Action<TestHelpers.MockTracerAgent.Span>[]
+            await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, url: url, assertOnSpans: new Action<TestHelpers.MockTracerAgent.Span>[]
             {
                  s => Assert.Equal("aspnet_core.request", s.Name),
                  s  => Assert.Equal("Samples.AspNetCore5", s.Service),
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                         Assert.Equal(kvp.Value, tagValue);
                     }
                  },
-            }, url);
+            });
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -30,9 +30,10 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(true, false, HttpStatusCode.OK)]
         [InlineData(false, true, HttpStatusCode.OK)]
         [InlineData(false, false, HttpStatusCode.OK)]
+        [InlineData(true, false, HttpStatusCode.OK, "?test&[$slice]")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode)
+        public async Task TestSecurity(bool enableSecurity, bool enableBlocking, HttpStatusCode expectedStatusCode, string url = null)
         {
             var agent = await RunOnSelfHosted(enableSecurity, enableBlocking);
             await TestBlockedRequestAsync(agent, enableSecurity, expectedStatusCode, 5, new Action<TestHelpers.MockTracerAgent.Span>[]
@@ -42,7 +43,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                  s  =>  Assert.Equal("web", s.Type),
                  s =>
                  {
-                    var securityTags = new Dictionary<string, string>()
+                    var securityTags = new Dictionary<string, string>
                     {
                         { "network.client.ip", "127.0.0.1" },
                         { "http.response.headers.content-type", "text/plain; charset=utf-8" },

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -6,9 +6,7 @@
 #if NET461
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
@@ -99,7 +97,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [Theory]
-        [InlineData("/Health/test&[$slice]")]
+        [InlineData("/Health/?test&[$slice]")]
         [InlineData]
         public Task TestSecurity(string url = DefaultAttackUrl)
         {

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
         [Theory]
-        [InlineData("?test&[$slice]")]
+        [InlineData("/Health/test&[$slice]")]
         public Task TestSecurity(string url = DefaultAttackUrl)
         {
             // if blocking is enabled, request stops before reaching asp net mvc integrations intercepting before action methods, so no more spans are generated

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("LoadFromGAC", "True")]
         [Theory]
         [InlineData("?test&[$slice]")]
-        public Task TestSecurity(string url = null)
+        public Task TestSecurity(string url = DefaultAttackUrl)
         {
             // if blocking is enabled, request stops before reaching asp net mvc integrations intercepting before action methods, so no more spans are generated
             // NOTE: by integrating the latest version of the WAF, blocking was disabled, as it does not support blocking yet

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -100,6 +100,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("LoadFromGAC", "True")]
         [Theory]
         [InlineData("/Health/test&[$slice]")]
+        [InlineData]
         public Task TestSecurity(string url = DefaultAttackUrl)
         {
             // if blocking is enabled, request stops before reaching asp net mvc integrations intercepting before action methods, so no more spans are generated

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -98,12 +98,13 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
-        [Fact]
-        public Task TestSecurity()
+        [Theory]
+        [InlineData("?test&[$slice]")]
+        public Task TestSecurity(string url = null)
         {
             // if blocking is enabled, request stops before reaching asp net mvc integrations intercepting before action methods, so no more spans are generated
             // NOTE: by integrating the latest version of the WAF, blocking was disabled, as it does not support blocking yet
-            return TestBlockedRequestAsync(_iisFixture.Agent, _enableSecurity, _enableSecurity && _blockingEnabled ? HttpStatusCode.OK : HttpStatusCode.OK, _enableSecurity && _blockingEnabled ? 10 : 10, new Action<TestHelpers.MockTracerAgent.Span>[]
+            return TestBlockedRequestAsync(_iisFixture.Agent, _enableSecurity, _enableSecurity && _blockingEnabled ? HttpStatusCode.OK : HttpStatusCode.OK, _enableSecurity && _blockingEnabled ? 10 : 10, url: url, assertOnSpans: new Action<TestHelpers.MockTracerAgent.Span>[]
              {
                  s => Assert.Matches("aspnet(-mvc)?.request", s.Name),
                  s => Assert.Equal("sample", s.Service),


### PR DESCRIPTION
# Problem
When we have an url like http://localhost/AspNetmvc5/?t=[$slice]&t=2**&test** the query string key pushed by IIS is null, so it would crash. 
We got this stack trace for example:
```
2021-12-14 11:01:33.957 +01:00 [ERR] AppSec Error.
System.ArgumentNullException: Value cannot be null.
Parameter name: key
   at System.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Collections.Generic.Dictionary`2.FindEntry(TKey key)
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at Datadog.Trace.Util.Http.HttpRequestExtensions.PrepareArgsForWaf(HttpRequest request, RouteData routeDatas)
   at Datadog.Trace.AppSec.InstrumentationGateway.RaiseEvent(HttpContext context, HttpRequest request, Span relatedSpan, RouteData routeData)
{ MachineName: ".", Process: "[11344 w3wp]", AppDomain: "[2 /LM/W3SVC/2/ROOT/scriptaspx/Economy/Accounting/Registration-1-132839138925700128]", TracerVersion: "1.31.0.0" }
```
# Changes proposed in this pull request:

A query string without equal signs and just values is treated differently by IIS / Core. With IIS we received a key of "" and values of [$slice] and test (following example above) and with core [$slice] and test are actually keys of the query string object. 
We iron out differences by putting everything like IIS, in values. The advantage of considering query strings members without equal signs as values is that the WAF will currently analyze them, indeed the WAF is not analyzing query string keys at the moment.
So implementation might seem a bit awkward here, but it's just to put all keys without values into one key string.empty and those keys in actual values for the Core implementation,

Replace all null keys with empty strings when building dictionary. 


@DataDog/apm-dotnet