### PR TITLE
Synchronize runtime id across versions of the tracer

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal interface IAutomaticTracer : ICommonTracer
     {
+        string GetAutomaticRuntimeId();
+
         object GetAutomaticActiveScope();
 
         IReadOnlyDictionary<string, string> GetDistributedTrace();

--- a/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/IDistributedTracer.cs
@@ -9,6 +9,8 @@ namespace Datadog.Trace.ClrProfiler
 {
     internal interface IDistributedTracer
     {
+        bool IsChildTracer { get; }
+
         IReadOnlyDictionary<string, string> GetSpanContextRaw();
 
         SpanContext GetSpanContext();
@@ -20,5 +22,7 @@ namespace Datadog.Trace.ClrProfiler
         SamplingPriority? GetSamplingPriority();
 
         void SetSamplingPriority(SamplingPriority? samplingPriority);
+
+        string GetRuntimeId();
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -22,6 +22,8 @@ namespace Datadog.Trace.ClrProfiler
             _parent.Register(this);
         }
 
+        bool IDistributedTracer.IsChildTracer => true;
+
         IScope IDistributedTracer.GetActiveScope()
         {
             var activeTrace = _parent.GetDistributedTrace();
@@ -81,5 +83,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             _parent.SetSamplingPriority((int?)samplingPriority);
         }
+
+        string IDistributedTracer.GetRuntimeId() => _parent.GetAutomaticRuntimeId();
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -202,12 +202,6 @@ namespace Datadog.Trace.Configuration
         public bool TracerMetricsEnabled { get; }
 
         /// <summary>
-        /// Gets a value indicating whether runtime metrics
-        /// are enabled and sent to DogStatsd.
-        /// </summary>
-        public bool RuntimeMetricsEnabled { get; }
-
-        /// <summary>
         /// Gets a value indicating whether partial flush is enabled
         /// </summary>
         public bool PartialFlushEnabled { get; }
@@ -228,6 +222,12 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the diagnostic log at startup is enabled
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether runtime metrics
+        /// are enabled and sent to DogStatsd.
+        /// </summary>
+        internal bool RuntimeMetricsEnabled { get; }
 
         /// <summary>
         /// Gets the comma separated list of url patterns to skip tracing.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -349,12 +349,6 @@ namespace Datadog.Trace.Configuration
         public bool TracerMetricsEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether runtime metrics
-        /// are enabled and sent to DogStatsd.
-        /// </summary>
-        public bool RuntimeMetricsEnabled { get; set; }
-
-        /// <summary>
         /// Gets or sets a value indicating whether the use
         /// of System.Diagnostics.DiagnosticSource is enabled.
         /// Default is <c>true</c>.
@@ -409,6 +403,12 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets a value indicating whether the diagnostic log at startup is enabled
         /// </summary>
         public bool StartupDiagnosticLogEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether runtime metrics
+        /// are enabled and sent to DogStatsd.
+        /// </summary>
+        internal bool RuntimeMetricsEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets the comma separated list of url patterns to skip tracing.

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -24,8 +24,6 @@ namespace Datadog.Trace
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Tracer));
 
-        private static string _runtimeId;
-
         /// <summary>
         /// The number of Tracer instances that have been created and not yet destroyed.
         /// This is used in the heartbeat metrics to estimate the number of
@@ -202,7 +200,7 @@ namespace Datadog.Trace
         /// </summary>
         ISampler IDatadogTracer.Sampler => TracerManager.Sampler;
 
-        internal static string RuntimeId => LazyInitializer.EnsureInitialized(ref _runtimeId, () => Guid.NewGuid().ToString());
+        internal static string RuntimeId => DistributedTracer.Instance.GetRuntimeId();
 
         internal static int LiveTracerCount => _liveTracerCount;
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerManagerFactory.cs" company="Datadog">
+// <copyright file="TracerManagerFactory.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Datadog.Trace.Agent;
+using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
@@ -68,7 +69,7 @@ namespace Datadog.Trace
             agentWriter ??= GetAgentWriter(settings, statsd, sampler);
             scopeManager ??= new AsyncLocalScopeManager();
 
-            if (settings.RuntimeMetricsEnabled)
+            if (settings.RuntimeMetricsEnabled && !DistributedTracer.Instance.IsChildTracer)
             {
                 runtimeMetrics ??= new RuntimeMetricsWriter(statsd ?? CreateDogStatsdClient(settings, defaultServiceName, settings.DogStatsdPort), TimeSpan.FromSeconds(10));
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -59,6 +59,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             var rootSpan = spans.Single(s => s.ParentId == null);
 
             rootSpan.Name.Should().Be("aspnet.request");
+            rootSpan.Tags.Should().ContainKey(Tags.RuntimeId);
+
+            var runtimeId = rootSpan.Tags[Tags.RuntimeId];
+            Guid.TryParse(runtimeId, out _).Should().BeTrue();
+
+            spans.Where(s => s.Name == "aspnet.request")
+                 .Should()
+                 .OnlyContain(s => s.Tags[Tags.RuntimeId] == runtimeId);
 
             var mvcSpan = spans.Single(s => s.ParentId == rootSpan.SpanId);
 
@@ -79,11 +87,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             automaticOuterSpan.TraceId.Should().Be(rootSpan.TraceId);
             automaticOuterSpan.Name.Should().Be("Automatic-Outer");
+            automaticOuterSpan.Tags[Tags.RuntimeId].Should().Be(runtimeId);
 
             var httpSpan = spans.Single(s => s.ParentId == automaticOuterSpan.SpanId);
 
             httpSpan.TraceId.Should().Be(rootSpan.TraceId);
             httpSpan.Name.Should().Be("http.request");
+            httpSpan.Tags[Tags.RuntimeId].Should().Be(runtimeId);
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -82,6 +82,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
                 outputLines[0].Should().Be($"{firstHttpSpan.TraceId}/{firstHttpSpan.SpanId}/2");
                 outputLines[1].Should().Be($"{secondHttpSpan.TraceId}/{secondHttpSpan.SpanId}/-1");
+
+                rootSpan.Tags.Should().ContainKey(Tags.RuntimeId);
+
+                var runtimeId = rootSpan.Tags[Tags.RuntimeId];
+                Guid.TryParse(runtimeId, out _).Should().BeTrue();
+
+                httpSpans.Should().OnlyContain(
+                    s => s.Tags[Tags.RuntimeId] == runtimeId,
+                    "runtime id should be synchronized across versions of the tracer");
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -95,6 +96,20 @@ namespace Datadog.Trace.Tests.DistributedTracer
             }
 
             automaticTracer.GetDistributedTrace().Should().BeNull();
+        }
+
+        [Fact]
+        public void RuntimeId()
+        {
+            var automaticTracer = new AutomaticTracer();
+
+            var runtimeId = automaticTracer.GetAutomaticRuntimeId();
+
+            Guid.TryParse(runtimeId, out _).Should().BeTrue();
+
+            automaticTracer.GetAutomaticRuntimeId().Should().Be(runtimeId, "runtime id should remain the same");
+
+            ((IDistributedTracer)automaticTracer).GetRuntimeId().Should().Be(runtimeId, "distributed tracer API should return the same runtime id");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/AutomaticTracerTests.cs
@@ -111,5 +111,12 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             ((IDistributedTracer)automaticTracer).GetRuntimeId().Should().Be(runtimeId, "distributed tracer API should return the same runtime id");
         }
+
+        [Fact]
+        public void IsChildTracer()
+        {
+            var automaticTracer = new AutomaticTracer();
+            ((IDistributedTracer)automaticTracer).IsChildTracer.Should().BeFalse();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/ManualTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/ManualTracerTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.ClrProfiler;
 using FluentAssertions;
 using Moq;
@@ -50,6 +51,26 @@ namespace Datadog.Trace.Tests.DistributedTracer
             ((IDistributedTracer)manualTracer).SetSamplingPriority(SamplingPriority.UserKeep);
 
             automaticTracer.Verify(t => t.SetSamplingPriority((int?)SamplingPriority.UserKeep), Times.Once());
+        }
+
+        [Fact]
+        public void RuntimeId()
+        {
+            var expectedRuntimeId = Guid.NewGuid().ToString();
+
+            var automaticTracer = new Mock<IAutomaticTracer>();
+            automaticTracer.Setup(t => t.GetAutomaticRuntimeId()).Returns(expectedRuntimeId);
+
+            var manualTracer = new ManualTracer(automaticTracer.Object);
+
+            ((IDistributedTracer)manualTracer).GetRuntimeId().Should().Be(expectedRuntimeId);
+        }
+
+        [Fact]
+        public void IsChildTracer()
+        {
+            var manualTracer = new ManualTracer(Mock.Of<IAutomaticTracer>());
+            ((IDistributedTracer)manualTracer).IsChildTracer.Should().BeTrue();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -134,7 +134,6 @@ namespace Datadog.Trace.Configuration
         public string MetricsPipeName { get; }
         public bool PartialFlushEnabled { get; }
         public int PartialFlushMinSpans { get; }
-        public bool RuntimeMetricsEnabled { get; }
         public string ServiceName { get; }
         public string ServiceVersion { get; }
         public bool StartupDiagnosticLogEnabled { get; }
@@ -208,7 +207,6 @@ namespace Datadog.Trace.Configuration
         public string MetricsPipeName { get; set; }
         public bool PartialFlushEnabled { get; set; }
         public int PartialFlushMinSpans { get; set; }
-        public bool RuntimeMetricsEnabled { get; set; }
         public string ServiceName { get; set; }
         public string ServiceVersion { get; set; }
         public bool StartupDiagnosticLogEnabled { get; set; }

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -27,8 +27,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Datadog.Trace, Version=2.255.247.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.247\lib\net461\Datadog.Trace.dll</HintPath>
+    <Reference Include="Datadog.Trace, Version=2.255.246.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.246\lib\net461\Datadog.Trace.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Datadog.Trace" version="2.255.247" targetFramework="net461" />
+  <package id="Datadog.Trace" version="2.255.246" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />

--- a/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
+++ b/tracer/test/test-applications/integrations/Samples.VersionConflict.2x/Samples.VersionConflict.2x.csproj
@@ -2,7 +2,7 @@
 
   
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace" Version="2.255.247" />
+    <PackageReference Include="Datadog.Trace" Version="2.255.246" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
- Add a distributed tracer API to synchronize the runtime id across versions of the tracer
- When multiple versions of the tracer are loaded, only enable runtime metrics in the automatic one
- Remove the possibility to disable runtime metrics from code, as synchronizing that state across versions would greatly increase the complexity of the change

Changes in public API:

```diff
    public class TracerSettings
    {
        public const string DefaultAgentHost = "localhost";
        public const int DefaultAgentPort = 8126;
        public TracerSettings() { }
        public TracerSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
        public System.Uri AgentUri { get; set; }
        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
        public bool AnalyticsEnabled { get; set; }
        public string CustomSamplingRules { get; set; }
        public bool DiagnosticSourceEnabled { get; set; }
        public System.Collections.Generic.HashSet<string> DisabledIntegrationNames { get; set; }
        public int DogStatsdPort { get; set; }
        public string Environment { get; set; }
        public double? GlobalSamplingRate { get; set; }
        public System.Collections.Generic.IDictionary<string, string> GlobalTags { get; set; }
        public System.Collections.Generic.IDictionary<string, string> HeaderTags { get; set; }
        public Datadog.Trace.Configuration.IntegrationSettingsCollection Integrations { get; }
        public bool KafkaCreateConsumerScopeEnabled { get; set; }
        public bool LogsInjectionEnabled { get; set; }
        public int MaxTracesSubmittedPerSecond { get; set; }
        public string MetricsPipeName { get; set; }
        public bool PartialFlushEnabled { get; set; }
        public int PartialFlushMinSpans { get; set; }
-       public bool RuntimeMetricsEnabled { get; set; }
        public string ServiceName { get; set; }
        public string ServiceVersion { get; set; }
        public bool StartupDiagnosticLogEnabled { get; set; }
        public bool TraceEnabled { get; set; }
        public bool TracerMetricsEnabled { get; set; }
        public string TracesPipeName { get; set; }
        public int TracesPipeTimeoutMs { get; set; }
        public string TracesTransport { get; set; }
        public Datadog.Trace.Configuration.ImmutableTracerSettings Build() { }
        public void SetHttpClientErrorStatusCodes(System.Collections.Generic.IEnumerable<int> statusCodes) { }
        public void SetHttpServerErrorStatusCodes(System.Collections.Generic.IEnumerable<int> statusCodes) { }
        public void SetServiceNameMappings(System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> mappings) { }
        public static Datadog.Trace.Configuration.CompositeConfigurationSource CreateDefaultConfigurationSource() { }
        public static Datadog.Trace.Configuration.TracerSettings FromDefaultSources() { }
    }

    public class ImmutableTracerSettings
    {
        public ImmutableTracerSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
        public ImmutableTracerSettings(Datadog.Trace.Configuration.TracerSettings settings) { }
        public System.Uri AgentUri { get; }
        [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
            "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
        public bool AnalyticsEnabled { get; }
        public string CustomSamplingRules { get; }
        public int DogStatsdPort { get; }
        public string Environment { get; }
        public double? GlobalSamplingRate { get; }
        public System.Collections.Generic.IReadOnlyDictionary<string, string> GlobalTags { get; }
        public System.Collections.Generic.IReadOnlyDictionary<string, string> HeaderTags { get; }
        public Datadog.Trace.Configuration.ImmutableIntegrationSettingsCollection Integrations { get; }
        public bool KafkaCreateConsumerScopeEnabled { get; }
        public bool LogsInjectionEnabled { get; }
        public int MaxTracesSubmittedPerSecond { get; }
        public string MetricsPipeName { get; }
        public bool PartialFlushEnabled { get; }
        public int PartialFlushMinSpans { get; }
-       public bool RuntimeMetricsEnabled { get; }
        public string ServiceName { get; }
        public string ServiceVersion { get; }
        public bool StartupDiagnosticLogEnabled { get; }
        public bool TraceEnabled { get; }
        public bool TracerMetricsEnabled { get; }
        public string TracesPipeName { get; }
        public int TracesPipeTimeoutMs { get; }
        public string TracesTransport { get; }
        public static Datadog.Trace.Configuration.ImmutableTracerSettings FromDefaultSources() { }
    }
```