### PR TITLE
Properly disable parallelization in AzureAppServicesMetadataTests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesMetadataTests.cs
@@ -16,6 +16,7 @@ using Xunit.Sdk;
 namespace Datadog.Trace.Tests.PlatformHelpers
 {
     [CollectionDefinition(nameof(AzureAppServicesMetadataTests), DisableParallelization = true)]
+    [Collection(nameof(AzureAppServicesMetadataTests))]
     [AzureAppServicesRestorer]
     public class AzureAppServicesMetadataTests
     {


### PR DESCRIPTION
The default collection name of the tests is the full type name (in this case, `Datadog.Trace.Tests.PlatformHelpers.AzureAppServicesMetadataTests`). If we disable parallelization for the collection `nameof(AzureAppServicesMetadataTests)`, we also need to make sure to rename the collection for the test.

This caused a failure in https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=83895&view=results when the test ran concurrently with `TracerTests.StartActive_NoServiceName_DefaultServiceName`.