### PR TITLE
Fix warnings in Nuke

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -264,13 +265,21 @@ partial class Build
     Target DownloadLibDdwaf => _ => _
         .Unlisted()
         .After(CreateRequiredDirectories)
-        .Executes(() =>
+        .Executes(async () =>
         {
-            var wc = new WebClient();
             var libDdwafUri = new Uri($"https://www.nuget.org/api/v2/package/libddwaf/{LibDdwafVersion}");
             var libDdwafZip = TempDirectory / "libddwaf.zip";
 
-            wc.DownloadFile(libDdwafUri, libDdwafZip);
+            using (var client = new HttpClient())
+            {
+                var response = await client.GetAsync(libDdwafUri);
+
+                response.EnsureSuccessStatusCode();
+
+                await using var file = File.Create(libDdwafZip);
+                await using var stream = await response.Content.ReadAsStreamAsync();
+                await stream.CopyToAsync(file);
+            }
 
             Console.WriteLine($"{libDdwafZip} downloaded. Extracting to {LibDdwafDirectory}...");
 

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -189,7 +189,7 @@ partial class Build
     Target UpdateIntegrationDefinitions => _ => _
        .Description("Update the integration definitions file")
        .DependsOn(Clean, Restore, CreateRequiredDirectories, CompileManagedSrc, PublishManagedProfiler) // We load the dlls from the output, so need to do a clean build
-       .Executes(async () =>
+       .Executes(() =>
         {
             var assemblies = TracerHomeDirectory
                             .GlobFiles("**/Datadog.Trace.dll")


### PR DESCRIPTION
Fixes two warnings in the Nuke pipeline:

 - Build.Steps.cs(269,22): warning SYSLIB0014: 'WebClient.WebClient()' is obsolete: 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.' 

 - Build.Utilities.cs(192,27): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. 