### PR TITLE
[2.0] Simplify Tracer.StartActive overloads to match ITracer.StartActive overloads

### DIFF
--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -232,13 +232,28 @@ namespace Datadog.Trace
         }
 
         /// <inheritdoc cref="ITracer" />
-        IScope ITracer.StartActive(string operationName)
+        IScope ITracer.StartActive(string operationName) => StartActive(operationName);
+
+        /// <inheritdoc cref="ITracer" />
+        IScope ITracer.StartActive(string operationName, SpanCreationSettings settings) => StartActive(operationName, settings);
+
+        /// <summary>
+        /// This creates a new span with the given parameters and makes it active.
+        /// </summary>
+        /// <param name="operationName">The span's operation name</param>
+        /// <returns>A scope wrapping the newly created span</returns>
+        public IScope StartActive(string operationName)
         {
             return StartActive(operationName, parent: null, serviceName: null, startTime: null, ignoreActiveScope: false, finishOnClose: true);
         }
 
-        /// <inheritdoc cref="ITracer" />
-        IScope ITracer.StartActive(string operationName, SpanCreationSettings settings)
+        /// <summary>
+        /// This creates a new span with the given parameters and makes it active.
+        /// </summary>
+        /// <param name="operationName">The span's operation name</param>
+        /// <param name="settings">Settings for the new <see cref="IScope"/></param>
+        /// <returns>A scope wrapping the newly created span</returns>
+        public IScope StartActive(string operationName, SpanCreationSettings settings)
         {
             return StartActive(operationName, settings.Parent, serviceName: null, settings.StartTime, ignoreActiveScope: false, finishOnClose: settings.FinishOnClose ?? true);
         }
@@ -253,7 +268,7 @@ namespace Datadog.Trace
         /// <param name="ignoreActiveScope">If set the span will not be a child of the currently active span</param>
         /// <param name="finishOnClose">If set to false, closing the returned scope will not close the enclosed span </param>
         /// <returns>A scope wrapping the newly created span</returns>
-        public IScope StartActive(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool ignoreActiveScope = false, bool finishOnClose = true)
+        internal Scope StartActive(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool ignoreActiveScope = false, bool finishOnClose = true)
         {
             var span = StartSpan(operationName, parent: parent, serviceName: serviceName, startTime: startTime, ignoreActiveScope: ignoreActiveScope);
             return TracerManager.ScopeManager.Activate(span, finishOnClose);

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -354,7 +354,7 @@ namespace Datadog.Trace
                 traceContext = new TraceContext(this) { SamplingPriority = DistributedTracer.Instance.GetSamplingPriority() };
             }
 
-            var finalServiceName = serviceName ?? parent?.ServiceName ?? DefaultServiceName;
+            var finalServiceName = serviceName ?? DefaultServiceName;
             var spanContext = new SpanContext(parent, traceContext, finalServiceName, traceId: traceId, spanId: spanId);
 
             return spanContext;

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanBuilderTests.cs
@@ -137,7 +137,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         }
 
         [Fact]
-        public void Start_SettingServiceInParent_ImplicitChildInheritServiceName()
+        public void Start_SettingServiceInParent_ChildDoesNotInheritServiceName()
         {
             var root = _tracer.BuildSpan(null)
                                  .WithTag(DatadogTags.ServiceName, "MyService")
@@ -146,11 +146,12 @@ namespace Datadog.Trace.OpenTracing.Tests
                                   .StartActive(finishSpanOnDispose: true);
 
             Assert.Equal("MyService", ((OpenTracingSpan)root.Span).Span.ServiceName);
-            Assert.Equal("MyService", ((OpenTracingSpan)child.Span).Span.ServiceName);
+            Assert.NotEqual("MyService", ((OpenTracingSpan)child.Span).Span.ServiceName);
+            Assert.Equal(DefaultServiceName, ((OpenTracingSpan)child.Span).Span.ServiceName);
         }
 
         [Fact]
-        public void Start_SettingServiceInParent_ExplicitChildInheritServiceName()
+        public void Start_SettingServiceInParent_ExplicitChildDoesNotInheritServiceName()
         {
             var root = _tracer.BuildSpan(null)
                                  .WithTag(DatadogTags.ServiceName, "MyService")
@@ -160,7 +161,8 @@ namespace Datadog.Trace.OpenTracing.Tests
                                   .StartActive(finishSpanOnDispose: true);
 
             Assert.Equal("MyService", ((OpenTracingSpan)root.Span).Span.ServiceName);
-            Assert.Equal("MyService", ((OpenTracingSpan)child.Span).Span.ServiceName);
+            Assert.NotEqual("MyService", ((OpenTracingSpan)child.Span).Span.ServiceName);
+            Assert.Equal(DefaultServiceName, ((OpenTracingSpan)child.Span).Span.ServiceName);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingTracerTests.cs
@@ -303,7 +303,7 @@ namespace Datadog.Trace.OpenTracing.Tests
         }
 
         [Fact]
-        public void InheritParentServiceName_WithTag()
+        public void DoesNotInheritParentServiceName_WithTag()
         {
             var parentScope = _tracer.BuildSpan("ParentOperation")
                                      .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
@@ -313,14 +313,13 @@ namespace Datadog.Trace.OpenTracing.Tests
                                     .AsChildOf(parentScope.Span)
                                     .StartActive();
 
-            var otSpan = (OpenTracingSpan)childScope.Span;
-            var ddSpan = otSpan.Span;
-
-            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+            Assert.Equal("MyAwesomeService", ((OpenTracingSpan)parentScope.Span).Span.ServiceName);
+            Assert.NotEqual("MyAwesomeService", ((OpenTracingSpan)childScope.Span).Span.ServiceName);
+            Assert.Equal(_tracer.DefaultServiceName, ((OpenTracingSpan)childScope.Span).Span.ServiceName);
         }
 
         [Fact]
-        public void InheritParentServiceName_SetTag()
+        public void DoesNotInheritParentServiceName_SetTag()
         {
             var parentScope = _tracer.BuildSpan("ParentOperation")
                                      .StartActive();
@@ -331,16 +330,16 @@ namespace Datadog.Trace.OpenTracing.Tests
                                     .AsChildOf(parentScope.Span)
                                     .StartActive();
 
-            var otSpan = (OpenTracingSpan)childScope.Span;
-            var ddSpan = otSpan.Span;
-
-            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+            Assert.Equal("MyAwesomeService", ((OpenTracingSpan)parentScope.Span).Span.ServiceName);
+            Assert.NotEqual("MyAwesomeService", ((OpenTracingSpan)childScope.Span).Span.ServiceName);
+            Assert.Equal(_tracer.DefaultServiceName, ((OpenTracingSpan)childScope.Span).Span.ServiceName);
         }
 
         [Fact]
         public void Parent_OverrideDefaultServiceName_WithTag()
         {
-            var tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
+            const string defaultServiceName = "DefaultServiceName";
+            var tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: defaultServiceName);
 
             var parentScope = tracer.BuildSpan("ParentOperation")
                                     .WithTag(DatadogTags.ServiceName, "MyAwesomeService")
@@ -350,16 +349,16 @@ namespace Datadog.Trace.OpenTracing.Tests
                                    .AsChildOf(parentScope.Span)
                                    .StartActive();
 
-            var otSpan = (OpenTracingSpan)childScope.Span;
-            var ddSpan = otSpan.Span;
-
-            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+            Assert.Equal("MyAwesomeService", ((OpenTracingSpan)parentScope.Span).Span.ServiceName);
+            Assert.NotEqual("MyAwesomeService", ((OpenTracingSpan)childScope.Span).Span.ServiceName);
+            Assert.Equal(defaultServiceName, ((OpenTracingSpan)childScope.Span).Span.ServiceName);
         }
 
         [Fact]
         public void Parent_OverrideDefaultServiceName_SetTag()
         {
-            var tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: "DefaultServiceName");
+            const string defaultServiceName = "DefaultServiceName";
+            var tracer = OpenTracingTracerFactory.CreateTracer(defaultServiceName: defaultServiceName);
 
             var parentScope = tracer.BuildSpan("ParentOperation")
                                     .StartActive();
@@ -370,10 +369,9 @@ namespace Datadog.Trace.OpenTracing.Tests
                                    .AsChildOf(parentScope.Span)
                                    .StartActive();
 
-            var otSpan = (OpenTracingSpan)childScope.Span;
-            var ddSpan = otSpan.Span;
-
-            Assert.Equal("MyAwesomeService", ddSpan.ServiceName);
+            Assert.Equal("MyAwesomeService", ((OpenTracingSpan)parentScope.Span).Span.ServiceName);
+            Assert.NotEqual("MyAwesomeService", ((OpenTracingSpan)childScope.Span).Span.ServiceName);
+            Assert.Equal(defaultServiceName, ((OpenTracingSpan)childScope.Span).Span.ServiceName);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -376,7 +376,8 @@ namespace Datadog.Trace
         public static Datadog.Trace.Tracer Instance { get; set; }
         protected override void Finalize() { }
         public System.Threading.Tasks.Task ForceFlushAsync() { }
-        public Datadog.Trace.IScope StartActive(string operationName, Datadog.Trace.ISpanContext parent = null, string serviceName = null, System.DateTimeOffset? startTime = default, bool ignoreActiveScope = false, bool finishOnClose = true) { }
+        public Datadog.Trace.IScope StartActive(string operationName) { }
+        public Datadog.Trace.IScope StartActive(string operationName, Datadog.Trace.SpanCreationSettings settings) { }
         public static void Configure(Datadog.Trace.Configuration.TracerSettings settings) { }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -171,12 +171,13 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void StartActive_SetParentServiceName_ChildServiceNameIsSet()
+        public void StartActive_SetParentServiceName_ChildServiceNameIsDefaultServiceName()
         {
             var parent = _tracer.StartActive("Parent", serviceName: "MyAwesomeService");
             var child = _tracer.StartActive("Child");
 
-            Assert.Equal("MyAwesomeService", child.Span.ServiceName);
+            Assert.NotEqual("MyAwesomeService", child.Span.ServiceName);
+            Assert.Equal(_tracer.DefaultServiceName, child.Span.ServiceName);
         }
 
         [Fact]

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
@@ -138,14 +138,8 @@ namespace Samples.AspNet.VersionConflict.Controllers
             object instance = instanceGetMethod.Invoke(null, new object[] {});
 
             // Invoke 'public Scope StartActive(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool ignoreActiveScope = false, bool finishOnClose = true)'
-            var startActive = tracerType.GetMethod("StartActive");
-            object parent = null;
-            string serviceName = null;
-            DateTimeOffset? startTime = null;
-            bool ignoreActiveScope = false;
-            bool finishOnClose = true;
-
-            return (IDisposable)startActive.Invoke(instance, new[] { operationName, parent, serviceName, startTime, ignoreActiveScope, finishOnClose });
+            var startActive = tracerType.GetMethod("StartActive", new Type[] { typeof(string) });
+            return (IDisposable)startActive.Invoke(instance, new[] { operationName });
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.MongoDB/Program.cs
@@ -38,7 +38,7 @@ namespace Samples.MongoDB
             };
 
 
-            using (var mainScope = Tracer.Instance.StartActive("Main()", serviceName: "Samples.MongoDB"))
+            using (var mainScope = Tracer.Instance.StartActive("Main()"))
             {
                 var connectionString = $"mongodb://{Host()}:27017";
                 var client = new MongoClient(connectionString);
@@ -59,7 +59,7 @@ namespace Samples.MongoDB
         {
             var allFilter = new BsonDocument();
 
-            using (var syncScope = Tracer.Instance.StartActive("sync-calls", serviceName: "Samples.MongoDB"))
+            using (var syncScope = Tracer.Instance.StartActive("sync-calls"))
             {
 #if MONGODB_2_2
                 collection.DeleteMany(allFilter);
@@ -100,7 +100,7 @@ namespace Samples.MongoDB
         {
             var allFilter = new BsonDocument();
 
-            using (var asyncScope = Tracer.Instance.StartActive("async-calls", serviceName: "Samples.MongoDB"))
+            using (var asyncScope = Tracer.Instance.StartActive("async-calls"))
             {
                 await collection.DeleteManyAsync(allFilter);
                 await collection.InsertOneAsync(newDocument);
@@ -122,14 +122,14 @@ namespace Samples.MongoDB
 
         public static void WireProtocolExecuteIntegrationTest(MongoClient client)
         {
-            using (var syncScope = Tracer.Instance.StartActive("sync-calls-execute", serviceName: "Samples.MongoDB"))
+            using (var syncScope = Tracer.Instance.StartActive("sync-calls-execute"))
             {
                 var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
                 var channel = server.GetChannel(CancellationToken.None);
                 channel.KillCursors(new long[] { 0, 1, 2 }, new global::MongoDB.Driver.Core.WireProtocol.Messages.Encoders.MessageEncoderSettings(), CancellationToken.None);
             }
 
-            using (var asyncScope = Tracer.Instance.StartActive("async-calls-execute", serviceName: "Samples.MongoDB"))
+            using (var asyncScope = Tracer.Instance.StartActive("async-calls-execute"))
             {
                 var server = client.Cluster.SelectServer(new ServerSelector(), CancellationToken.None);
                 var channel = server.GetChannel(CancellationToken.None);

--- a/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RabbitMQ/Program.cs
@@ -191,7 +191,7 @@ namespace Samples.RabbitMQ
                 var consumer = new EventingBasicConsumer(channel);
                 consumer.Received += (model, ea) =>
                 {
-                    using (Tracer.Instance.StartActive("consumer.Received event", serviceName: "Samples.RabbitMQ"))
+                    using (Tracer.Instance.StartActive("consumer.Received event"))
                     {
 #if RABBITMQ_6_0
                         var body = ea.Body.ToArray();

--- a/tracer/test/test-applications/integrations/Samples.RateLimiter/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RateLimiter/Program.cs
@@ -25,6 +25,10 @@ namespace Samples.RateLimiter
             Console.WriteLine($"Ready to run for {numberOfSeconds} seconds.");
             Console.WriteLine($"Configured rate limit of {configuredLimitPerSecond}");
 
+            var settings = TracerSettings.FromDefaultSources();
+            settings.ServiceName = ServiceDogWalker;
+            Tracer.Configure(settings);
+
             PrepKeys(ServiceDogWalker, RootWalkOperation, configuredLimitPerSecond * numberOfSeconds);
 
             var timer = new Stopwatch();
@@ -68,11 +72,11 @@ namespace Samples.RateLimiter
 
             IScope root;
 
-            using (root = Tracer.Instance.StartActive(operationName: operationName, serviceName: serviceName))
+            using (root = Tracer.Instance.StartActive(operationName: operationName))
             {
                 Thread.Sleep(3);
 
-                using (var sub = Tracer.Instance.StartActive(operationName: "sub", serviceName: serviceName))
+                using (var sub = Tracer.Instance.StartActive(operationName: "sub"))
                 {
                     Thread.Sleep(2);
                 }

--- a/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using Datadog.Trace;
+using Datadog.Trace.Configuration;
 
 namespace Samples.TracingWithoutLimits
 {
@@ -102,24 +103,28 @@ namespace Samples.TracingWithoutLimits
 
         private static void RunStuff(string serviceName, string operationName)
         {
+            var settings = TracerSettings.FromDefaultSources();
+            settings.ServiceName = serviceName;
+            Tracer.Configure(settings);
+
             Counts[Key(serviceName, operationName)]++;
 
             IScope root;
 
-            using (root = Tracer.Instance.StartActive(operationName: operationName, serviceName: serviceName))
+            using (root = Tracer.Instance.StartActive(operationName: operationName))
             {
                 Thread.Sleep(3);
 
-                using (var sub = Tracer.Instance.StartActive(operationName: SubOperation, serviceName: serviceName))
+                using (var sub = Tracer.Instance.StartActive(operationName: SubOperation))
                 {
                     Thread.Sleep(2);
 
-                    using (var open = Tracer.Instance.StartActive(operationName: OpenOperation, serviceName: serviceName))
+                    using (var open = Tracer.Instance.StartActive(operationName: OpenOperation))
                     {
                         Thread.Sleep(2);
                     }
 
-                    using (var close = Tracer.Instance.StartActive(operationName: CloseOperation, serviceName: serviceName))
+                    using (var close = Tracer.Instance.StartActive(operationName: CloseOperation))
                     {
                         Thread.Sleep(1);
                     }

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/TracerUtils.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper.VersionConflict/TracerUtils.cs
@@ -61,14 +61,8 @@ namespace LogsInjectionHelper.VersionConflict
             object instance = instanceGetMethod.Invoke(null, new object[] {});
 
             // Invoke 'public Scope StartActive(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool ignoreActiveScope = false, bool finishOnClose = true)'
-            var startActive = tracerType.GetMethod("StartActive");
-            object parent = null;
-            string serviceName = null;
-            DateTimeOffset? startTime = null;
-            bool ignoreActiveScope = false;
-            bool finishOnClose = true;
-
-            return (IDisposable)startActive.Invoke(instance, new[] { operationName, parent, serviceName, startTime, ignoreActiveScope, finishOnClose });
+            var startActive = tracerType.GetMethod("StartActive", new Type[] { typeof(string) });
+            return (IDisposable)startActive.Invoke(instance, new[] { operationName });
         }
     }
 }


### PR DESCRIPTION
### Breaking changes
- Add StartActive(string) and StartActive(string, SpanCreationSettings) to Tracer public API
- When creating a span, set the ServiceName to the DefaultServiceName instead of the parent's ServiceName
  - This is a breaking change and is being considered for 2.x feature development so now is the appropriate time to take the change, if approved.
  - If a user still prefers the new span to have the parent span's ServiceName, this can be fixed locally by updating the `ISpan.ServiceName` property or this can be fixed globally by updating the `TracerSettings.ServiceName` and running `Tracer.Configure(settings)`

### Other changes
- Separate ITracer implementation and Tracer implementation of public methods (we're doing this for ISpan and IScope so I followed convention)
- Modify `Tracer.StartActive(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool ignoreActiveScope = false, bool finishOnClose = true)` API to be internal
- Fix samples that were using the service name parameter previously exposed by the `StartActive` API

### Changes in public API
```diff
    public class Tracer : Datadog.Trace.ITracer
    {
        [System.Obsolete("This API is deprecated. Use Tracer.Instance to obtain a Tracer instance to create" +
            " spans.")]
        public Tracer() { }
        [System.Obsolete(@"This API is deprecated, as it replaces the global settings for all Tracer instances in the application. If you were using this API to configure the global Tracer.Instance in code, use the static Tracer.Configure() to replace the global Tracer settings for the application")]
        public Tracer(Datadog.Trace.Configuration.TracerSettings settings) { }
        public Datadog.Trace.IScope ActiveScope { get; }
        public string DefaultServiceName { get; }
        public Datadog.Trace.Configuration.ImmutableTracerSettings Settings { get; }
        [set: System.Obsolete("Use Tracer.Configure to configure the global Tracer instance in code.")]
        public static Datadog.Trace.Tracer Instance { get; set; }
        protected override void Finalize() { }
        public System.Threading.Tasks.Task ForceFlushAsync() { }
-       public Datadog.Trace.IScope StartActive(string operationName, Datadog.Trace.ISpanContext parent = null, string serviceName = null, System.DateTimeOffset? startTime = default, bool ignoreActiveScope = false, bool finishOnClose = true) { }
+       public Datadog.Trace.IScope StartActive(string operationName) { }
+       public Datadog.Trace.IScope StartActive(string operationName, Datadog.Trace.SpanCreationSettings settings) { }
        public static void Configure(Datadog.Trace.Configuration.TracerSettings settings) { }
    }
```