### PR TITLE
add initial support for `x-datadog-tags` propagation header (horizontal propagation)

### DIFF
--- a/tracer/src/Datadog.Trace/HttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/HttpHeaderNames.cs
@@ -37,8 +37,15 @@ namespace Datadog.Trace
         public const string Origin = "x-datadog-origin";
 
         /// <summary>
-        /// Origin of the distributed trace.
+        /// The user agent that originated an http request.
         /// </summary>
         public const string UserAgent = "User-Agent";
+
+        /// <summary>
+        /// Internal Datadog tags.
+        /// A collection of internal Datadog tags. Only tags with names that
+        /// begin with "_dd.p.*" will be propagated using this header.
+        /// </summary>
+        public const string DatadogTags = "x-datadog-tags";
     }
 }

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -14,7 +14,14 @@ namespace Datadog.Trace
     /// </summary>
     public class SpanContext : ISpanContext, IReadOnlyDictionary<string, string>
     {
-        private static readonly string[] KeyNames = { HttpHeaderNames.TraceId, HttpHeaderNames.ParentId, HttpHeaderNames.SamplingPriority, HttpHeaderNames.Origin };
+        private static readonly string[] KeyNames =
+        {
+            HttpHeaderNames.TraceId,
+            HttpHeaderNames.ParentId,
+            HttpHeaderNames.SamplingPriority,
+            HttpHeaderNames.Origin,
+            HttpHeaderNames.DatadogTags,
+        };
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SpanContext"/> class
@@ -109,6 +116,16 @@ namespace Datadog.Trace
         /// Gets or sets the origin of the trace
         /// </summary>
         internal string Origin { get; set; }
+
+        /// <summary>
+        /// Gets or sets a collection of propagated internal Datadog tags,
+        /// formatted as "key1=value1,key2=value2".
+        /// </summary>
+        /// <remarks>
+        /// We're keeping this as the string representation to avoid having to parse.
+        /// For now, it's relatively easy to append new values when needed.
+        /// </remarks>
+        internal string DatadogTags { get; set; }
 
         /// <summary>
         /// Gets the trace context.
@@ -208,10 +225,15 @@ namespace Datadog.Trace
                 case HttpHeaderNames.Origin:
                     value = Origin;
                     return true;
-            }
 
-            value = null;
-            return false;
+                case HttpHeaderNames.DatadogTags:
+                    value = DatadogTags;
+                    return true;
+
+                default:
+                    value = null;
+                    return false;
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -77,6 +77,13 @@ namespace Datadog.Trace
             {
                 setter(carrier, HttpHeaderNames.SamplingPriority, samplingPriority.Value.ToString(_invariantCulture));
             }
+
+            var datadogTags = context.TraceContext?.DatadogTags ?? context.DatadogTags;
+
+            if (datadogTags != null)
+            {
+                setter(carrier, HttpHeaderNames.DatadogTags, datadogTags);
+            }
         }
 
         /// <summary>
@@ -114,8 +121,12 @@ namespace Datadog.Trace
             var parentId = ParseUInt64(carrier, getter, HttpHeaderNames.ParentId) ?? 0;
             var samplingPriority = (SamplingPriority?)ParseInt32(carrier, getter, HttpHeaderNames.SamplingPriority);
             var origin = ParseString(carrier, getter, HttpHeaderNames.Origin);
+            var datadogTags = ParseString(carrier, getter, HttpHeaderNames.DatadogTags);
 
-            return new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin);
+            return new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin)
+                   {
+                       DatadogTags = datadogTags
+                   };
         }
 
         public IEnumerable<KeyValuePair<string, string?>> ExtractHeaderTags<T>(T headers, IEnumerable<KeyValuePair<string, string?>> headerToTagMap, string defaultTagPrefix)

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -124,9 +124,9 @@ namespace Datadog.Trace
             var datadogTags = ParseString(carrier, getter, HttpHeaderNames.DatadogTags);
 
             return new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin)
-                   {
-                       DatadogTags = datadogTags
-                   };
+            {
+                DatadogTags = datadogTags
+            };
         }
 
         public IEnumerable<KeyValuePair<string, string?>> ExtractHeaderTags<T>(T headers, IEnumerable<KeyValuePair<string, string?>> headerToTagMap, string defaultTagPrefix)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -49,6 +49,16 @@ namespace Datadog.Trace
 
         private TimeSpan Elapsed => StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp);
 
+        /// <summary>
+        /// Gets or sets a collection of propagated internal Datadog tags,
+        /// formatted as "key1=value1,key2=value2".
+        /// </summary>
+        /// <remarks>
+        /// We're keeping this as the string representation to avoid having to parse.
+        /// For now, it's relatively easy to append new values when needed.
+        /// </remarks>
+        public string DatadogTags { get; set; }
+
         public void AddSpan(Span span)
         {
             lock (this)

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -179,6 +179,7 @@ namespace Datadog.Trace
     }
     public static class HttpHeaderNames
     {
+        public const string DatadogTags = "x-datadog-tags";
         public const string Origin = "x-datadog-origin";
         public const string ParentId = "x-datadog-parent-id";
         public const string SamplingPriority = "x-datadog-sampling-priority";

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.Tests
         private const ulong SpanId = 2;
         private const SamplingPriority SamplingPriority = Trace.SamplingPriority.UserReject;
         private const string Origin = "origin";
+        private const string DatadogTags = "key1=value1;key2=value2";
 
         private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
 
@@ -28,6 +29,7 @@ namespace Datadog.Trace.Tests
             new(HttpHeaderNames.ParentId, SpanId.ToString(InvariantCulture)),
             new(HttpHeaderNames.SamplingPriority, ((int)SamplingPriority).ToString(InvariantCulture)),
             new(HttpHeaderNames.Origin, Origin),
+            new(HttpHeaderNames.DatadogTags, DatadogTags)
         };
 
         public static TheoryData<string> GetInvalidIds() => new()
@@ -42,7 +44,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void Inject_IHeadersCollection()
         {
-            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin);
+            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { DatadogTags = DatadogTags };
             var headers = new Mock<IHeadersCollection>();
 
             SpanContextPropagator.Instance.Inject(context, headers.Object);
@@ -53,7 +55,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void Inject_CarrierAndDelegate()
         {
-            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin);
+            var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin) { DatadogTags = DatadogTags };
 
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = new Mock<IHeadersCollection>();

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
@@ -22,6 +22,14 @@ namespace Datadog.Trace.Tests
 
         private static readonly CultureInfo InvariantCulture = CultureInfo.InvariantCulture;
 
+        private static readonly KeyValuePair<string, string>[] DefaultHeaderValues =
+        {
+            new(HttpHeaderNames.TraceId, TraceId.ToString(InvariantCulture)),
+            new(HttpHeaderNames.ParentId, SpanId.ToString(InvariantCulture)),
+            new(HttpHeaderNames.SamplingPriority, ((int)SamplingPriority).ToString(InvariantCulture)),
+            new(HttpHeaderNames.Origin, Origin),
+        };
+
         public static TheoryData<string> GetInvalidIds() => new()
         {
             null,
@@ -249,10 +257,10 @@ namespace Datadog.Trace.Tests
         {
             var headers = new Mock<IHeadersCollection>(MockBehavior.Strict);
 
-            headers.Setup(h => h.GetValues(HttpHeaderNames.TraceId)).Returns(new[] { TraceId.ToString(InvariantCulture) });
-            headers.Setup(h => h.GetValues(HttpHeaderNames.ParentId)).Returns(new[] { SpanId.ToString(InvariantCulture) });
-            headers.Setup(h => h.GetValues(HttpHeaderNames.SamplingPriority)).Returns(new[] { ((int)SamplingPriority).ToString(InvariantCulture) });
-            headers.Setup(h => h.GetValues(HttpHeaderNames.Origin)).Returns(new[] { Origin });
+            foreach (var pair in DefaultHeaderValues)
+            {
+                headers.Setup(h => h.GetValues(pair.Key)).Returns(new[] { pair.Value });
+            }
 
             return headers;
         }
@@ -261,17 +269,11 @@ namespace Datadog.Trace.Tests
         {
             var headers = new Mock<IReadOnlyDictionary<string, string>>();
 
-            var traceId = TraceId.ToString(InvariantCulture);
-            headers.Setup(h => h.TryGetValue(HttpHeaderNames.TraceId, out traceId)).Returns(true);
-
-            var spanId = SpanId.ToString(InvariantCulture);
-            headers.Setup(h => h.TryGetValue(HttpHeaderNames.ParentId, out spanId)).Returns(true);
-
-            var samplingPriority = ((int)SamplingPriority).ToString(InvariantCulture);
-            headers.Setup(h => h.TryGetValue(HttpHeaderNames.SamplingPriority, out samplingPriority)).Returns(true);
-
-            var origin = Origin;
-            headers.Setup(h => h.TryGetValue(HttpHeaderNames.Origin, out origin)).Returns(true);
+            foreach (var pair in DefaultHeaderValues)
+            {
+                var value = pair.Value;
+                headers.Setup(h => h.TryGetValue(pair.Key, out value)).Returns(true);
+            }
 
             return headers;
         }
@@ -280,10 +282,11 @@ namespace Datadog.Trace.Tests
         {
             var once = Times.Once();
 
-            headers.Verify(h => h.Set(HttpHeaderNames.TraceId, TraceId.ToString(InvariantCulture)), once);
-            headers.Verify(h => h.Set(HttpHeaderNames.ParentId, SpanId.ToString(InvariantCulture)), once);
-            headers.Verify(h => h.Set(HttpHeaderNames.SamplingPriority, ((int)SamplingPriority).ToString(InvariantCulture)), once);
-            headers.Verify(h => h.Set(HttpHeaderNames.Origin, Origin), once);
+            foreach (var pair in DefaultHeaderValues)
+            {
+                headers.Verify(h => h.Set(pair.Key, pair.Value), once);
+            }
+
             headers.VerifyNoOtherCalls();
         }
 
@@ -291,10 +294,11 @@ namespace Datadog.Trace.Tests
         {
             var once = Times.Once();
 
-            headers.Verify(h => h.GetValues(HttpHeaderNames.TraceId), once);
-            headers.Verify(h => h.GetValues(HttpHeaderNames.ParentId), once);
-            headers.Verify(h => h.GetValues(HttpHeaderNames.SamplingPriority), once);
-            headers.Verify(h => h.GetValues(HttpHeaderNames.Origin), once);
+            foreach (var pair in DefaultHeaderValues)
+            {
+                headers.Verify(h => h.GetValues(pair.Key), once);
+            }
+
             headers.VerifyNoOtherCalls();
         }
 
@@ -303,10 +307,11 @@ namespace Datadog.Trace.Tests
             var once = Times.Once();
             string value;
 
-            headers.Verify(h => h.TryGetValue(HttpHeaderNames.TraceId, out value), once);
-            headers.Verify(h => h.TryGetValue(HttpHeaderNames.ParentId, out value), once);
-            headers.Verify(h => h.TryGetValue(HttpHeaderNames.SamplingPriority, out value), once);
-            headers.Verify(h => h.TryGetValue(HttpHeaderNames.Origin, out value), once);
+            foreach (var pair in DefaultHeaderValues)
+            {
+                headers.Verify(h => h.TryGetValue(pair.Key, out value), once);
+            }
+
             headers.VerifyNoOtherCalls();
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
@@ -6,7 +6,6 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
-using System.Linq;
 using Datadog.Trace.Headers;
 using FluentAssertions;
 using Moq;
@@ -26,13 +25,11 @@ namespace Datadog.Trace.Tests
 
         private static readonly KeyValuePair<string, string>[] DefaultHeaderValues =
         {
-            // order is not important, expect we need these two first than the rest for some tests
             new(HttpHeaderNames.TraceId, TraceId.ToString(InvariantCulture)),
             new(HttpHeaderNames.ParentId, SpanId.ToString(InvariantCulture)),
-
             new(HttpHeaderNames.SamplingPriority, ((int)SamplingPriority).ToString(InvariantCulture)),
             new(HttpHeaderNames.Origin, Origin),
-            new(HttpHeaderNames.DatadogTags, DatadogTags)
+            new(HttpHeaderNames.DatadogTags, DatadogTags),
         };
 
         public static TheoryData<string> GetInvalidIds() => new()
@@ -77,11 +74,8 @@ namespace Datadog.Trace.Tests
             SpanContextPropagator.Instance.Inject(context, headers.Object);
 
             // null values are not set, so only traceId and spanId (the first two in the list) should be set
-            foreach (var pair in DefaultHeaderValues.Take(2))
-            {
-                headers.Verify(h => h.Set(pair.Key, pair.Value), Times.Once());
-            }
-
+            headers.Verify(h => h.Set(HttpHeaderNames.TraceId, TraceId.ToString(InvariantCulture)), Times.Once());
+            headers.Verify(h => h.Set(HttpHeaderNames.ParentId, SpanId.ToString(InvariantCulture)), Times.Once());
             headers.VerifyNoOtherCalls();
         }
 


### PR DESCRIPTION
This PR adds minimal support for the new `x-datadog-tags` propagation header. It reads the heading from incoming service calls and injects the same header back into outgoing service calls. This PR does not add support for any specific tags, so we do _not_ modify the contents of the header in any way or include it as span tags. I will add support for the first tag (`_dd.p.upstream_services`) in a separate PR (#2224).

- add new constant `HttpHeaderNames.DatadogTags = "x-datadog-tags"`
- add `SpanContext.DatadogTags` (used for propagation only) and `TraceContext.DatadogTags` (the in-memory object model)[^1]
- update `SpanContextPropagator` to inject and extract the new header
- add `SpanContextPropagator` tests that inject and extract the new header

[^1]: We currently mix some concerns between `SpanContext` (using it both for propagation, which was its original goal in [OpenTracing](https://github.com/opentracing/opentracing-csharp/blob/master/src/OpenTracing/ISpanContext.cs) and as an in-memory model) and `TraceContext`. I have a branch (`lpimentel/refactor-core-object-models`) with some refactoring to try to improve this.