### PR TITLE
code clean up in `SpanContextPropagator`

### DIFF
--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -63,7 +63,6 @@ namespace Datadog.Trace
             setter(carrier, HttpHeaderNames.TraceId, context.TraceId.ToString(_invariantCulture));
             setter(carrier, HttpHeaderNames.ParentId, context.SpanId.ToString(_invariantCulture));
 
-            // avoid writing origin header if not set, keeping the previous behavior.
             if (context.Origin != null)
             {
                 setter(carrier, HttpHeaderNames.Origin, context.Origin);

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace
         /// <param name="carrier">The headers to add to.</param>
         /// <param name="setter">The action that can set a header in the carrier.</param>
         /// <typeparam name="TCarrier">Type of header collection</typeparam>
-        public void Inject<TCarrier>(SpanContext context, TCarrier carrier, Action<TCarrier, string, string?> setter)
+        public void Inject<TCarrier>(SpanContext context, TCarrier carrier, Action<TCarrier, string, string> setter)
         {
             if (context == null) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
@@ -73,7 +73,7 @@ namespace Datadog.Trace
 
             if (samplingPriority != null)
             {
-                setter(carrier, HttpHeaderNames.SamplingPriority, samplingPriority?.ToString(_invariantCulture));
+                setter(carrier, HttpHeaderNames.SamplingPriority, samplingPriority.Value.ToString(_invariantCulture));
             }
         }
 

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -119,10 +119,10 @@ namespace Datadog.Trace
             }
 
             var parentId = ParseUInt64(headers, HttpHeaderNames.ParentId);
-            var samplingPriority = ParseSamplingPriority(headers, HttpHeaderNames.SamplingPriority);
+            var samplingPriority = ParseInt32(headers, HttpHeaderNames.SamplingPriority);
             var origin = ParseString(headers, HttpHeaderNames.Origin);
 
-            return new SpanContext(traceId, parentId, samplingPriority, null, origin);
+            return new SpanContext(traceId, parentId, (SamplingPriority?)samplingPriority, null, origin);
         }
 
         /// <summary>
@@ -146,10 +146,10 @@ namespace Datadog.Trace
             }
 
             var parentId = ParseUInt64(carrier, getter, HttpHeaderNames.ParentId);
-            var samplingPriority = ParseSamplingPriority(carrier, getter, HttpHeaderNames.SamplingPriority);
+            var samplingPriority = ParseInt32(carrier, getter, HttpHeaderNames.SamplingPriority);
             var origin = ParseString(carrier, getter, HttpHeaderNames.Origin);
 
-            return new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin);
+            return new SpanContext(traceId, parentId, (SamplingPriority?)samplingPriority, serviceName: null, origin);
         }
 
         public IEnumerable<KeyValuePair<string, string?>> ExtractHeaderTags<T>(T headers, IEnumerable<KeyValuePair<string, string?>> headerToTagMap, string defaultTagPrefix)
@@ -302,7 +302,7 @@ namespace Datadog.Trace
             return 0;
         }
 
-        private SamplingPriority? ParseSamplingPriority<T>(T headers, string headerName)
+        private int? ParseInt32<T>(T headers, string headerName)
             where T : IHeadersCollection
         {
             var headerValues = headers.GetValues(headerName);
@@ -315,7 +315,7 @@ namespace Datadog.Trace
                     // note this int value may not be defined in the enum,
                     // but we should pass it along without validation
                     // for forward compatibility
-                    return (SamplingPriority)result;
+                    return result;
                 }
 
                 hasValue = true;
@@ -332,7 +332,7 @@ namespace Datadog.Trace
             return default;
         }
 
-        private SamplingPriority? ParseSamplingPriority<T>(T carrier, Func<T, string, IEnumerable<string?>> getter, string headerName)
+        private int? ParseInt32<T>(T carrier, Func<T, string, IEnumerable<string?>> getter, string headerName)
         {
             var headerValues = getter(carrier, headerName);
             bool hasValue = false;
@@ -344,7 +344,7 @@ namespace Datadog.Trace
                     // note this int value may not be defined in the enum,
                     // but we should pass it along without validation
                     // for forward compatibility
-                    return (SamplingPriority)result;
+                    return result;
                 }
 
                 hasValue = true;

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -240,7 +240,7 @@ namespace Datadog.Trace
             return null;
         }
 
-        private int? ParseInt32<TTCarrier>(TTCarrier carrier, Func<TTCarrier, string, IEnumerable<string?>> getter, string headerName)
+        private int? ParseInt32<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string headerName)
         {
             var headerValues = getter(carrier, headerName);
             bool hasValue = false;

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -39,11 +39,11 @@ namespace Datadog.Trace
         /// </summary>
         /// <param name="context">A <see cref="SpanContext"/> value that will be propagated into <paramref name="headers"/>.</param>
         /// <param name="headers">A <see cref="IHeadersCollection"/> to add new headers to.</param>
-        /// <typeparam name="T">Type of header collection</typeparam>
-        public void Inject<T>(SpanContext context, T headers)
-            where T : IHeadersCollection
+        /// <typeparam name="TCarrier">Type of header collection</typeparam>
+        public void Inject<TCarrier>(SpanContext context, TCarrier headers)
+            where TCarrier : IHeadersCollection
         {
-            Inject(context, headers, DelegateCache<T>.Setter);
+            Inject(context, headers, DelegateCache<TCarrier>.Setter);
         }
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace Datadog.Trace
         /// <param name="context">A <see cref="SpanContext"/> value that will be propagated into <paramref name="carrier"/>.</param>
         /// <param name="carrier">The headers to add to.</param>
         /// <param name="setter">The action that can set a header in the carrier.</param>
-        /// <typeparam name="T">Type of header collection</typeparam>
-        public void Inject<T>(SpanContext context, T carrier, Action<T, string, string?> setter)
+        /// <typeparam name="TCarrier">Type of header collection</typeparam>
+        public void Inject<TCarrier>(SpanContext context, TCarrier carrier, Action<TCarrier, string, string?> setter)
         {
             if (context == null) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
@@ -81,12 +81,12 @@ namespace Datadog.Trace
         /// Extracts a <see cref="SpanContext"/> from the values found in the specified headers.
         /// </summary>
         /// <param name="headers">The headers that contain the values to be extracted.</param>
-        /// <typeparam name="T">Type of header collection</typeparam>
+        /// <typeparam name="TCarrier">Type of header collection</typeparam>
         /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="headers"/>.</returns>
-        public SpanContext? Extract<T>(T headers)
-            where T : IHeadersCollection
+        public SpanContext? Extract<TCarrier>(TCarrier headers)
+            where TCarrier : IHeadersCollection
         {
-            return Extract(headers, DelegateCache<T>.Getter);
+            return Extract(headers, DelegateCache<TCarrier>.Getter);
         }
 
         /// <summary>
@@ -94,9 +94,9 @@ namespace Datadog.Trace
         /// </summary>
         /// <param name="carrier">The headers that contain the values to be extracted.</param>
         /// <param name="getter">The function that can extract a list of values for a given header name.</param>
-        /// <typeparam name="T">Type of header collection</typeparam>
+        /// <typeparam name="TCarrier">Type of header collection</typeparam>
         /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="carrier"/>.</returns>
-        public SpanContext? Extract<T>(T carrier, Func<T, string, IEnumerable<string?>> getter)
+        public SpanContext? Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
         {
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
             if (getter == null) { ThrowHelper.ThrowArgumentNullException(nameof(getter)); }
@@ -218,7 +218,7 @@ namespace Datadog.Trace
             return new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin);
         }
 
-        private ulong? ParseUInt64<T>(T carrier, Func<T, string, IEnumerable<string?>> getter, string headerName)
+        private ulong? ParseUInt64<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string headerName)
         {
             var headerValues = getter(carrier, headerName);
             bool hasValue = false;
@@ -241,7 +241,7 @@ namespace Datadog.Trace
             return null;
         }
 
-        private int? ParseInt32<T>(T carrier, Func<T, string, IEnumerable<string?>> getter, string headerName)
+        private int? ParseInt32<TTCarrier>(TTCarrier carrier, Func<TTCarrier, string, IEnumerable<string?>> getter, string headerName)
         {
             var headerValues = getter(carrier, headerName);
             bool hasValue = false;
@@ -270,8 +270,8 @@ namespace Datadog.Trace
             return null;
         }
 
-        private string? ParseString<T>(T headers, string headerName)
-            where T : IHeadersCollection
+        private string? ParseString<TCarrier>(TCarrier headers, string headerName)
+            where TCarrier : IHeadersCollection
         {
             var headerValues = headers.GetValues(headerName);
 
@@ -286,7 +286,7 @@ namespace Datadog.Trace
             return null;
         }
 
-        private string? ParseString<T>(T carrier, Func<T, string, IEnumerable<string?>> getter, string headerName)
+        private string? ParseString<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter, string headerName)
         {
             var headerValues = getter(carrier, headerName);
 

--- a/tracer/src/Datadog.Trace/SpanTypes.cs
+++ b/tracer/src/Datadog.Trace/SpanTypes.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace
         public const string Custom = "custom";
 
         /// <summary>
-        /// The span type for a Test instegration.
+        /// The span type for a Test integration.
         /// </summary>
         public const string Test = "test";
 


### PR DESCRIPTION
Refactor `SpanContextPropagator` to reduce code duplication before we add more propagation headers. There were also some opportunities for general code clean up.

Main changes
- reimplement `Inject<TCarrier>(SpanContext, TCarrier)` as a call to `Inject<TCarrier>(SpanContext, TCarrier, setter)`
- reimplement `Extract<TCarrier>(TCarrier)` as a call to `Extract<TCarrier>(TCarrier, getter)`
- add `DelegateCache<TCarrier>` to cache getters and setters used above (avoid allocating new ones on each call)
- remove `ParseFoo()` overloads that are not used anymore after the changes above

Misc clean up
- rename all `T` type parameters to `TCarrier`
- return `int?` from `ParseSamplingPriority()` and rename it to `ParseInt32()` (trying to move away from using the `SamplingPriority` enum where possible)
- return nullable `long?` from `ParseUInt64()` for consistency with all the other `Parse{Type}()` methods
- replace static fields with instance fields (statics are slower in shared assemblies, which applies to  most .NET Framework apps in IIS, and `SpanContextPropagator` is a singleton so there are no other instances to share the fields with, anyway)
- enable nullable annotations and warnings in file