### PR TITLE
improve the `ThrowArgumentNullException` helper

### DIFF
--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -52,10 +52,7 @@ namespace Datadog.Trace.AspNet
         /// <param name="operationName">The operation name to be used for the trace/span data generated</param>
         public TracingHttpModule(string operationName)
         {
-            if (operationName is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(operationName));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(operationName);
 
             _requestOperationName = operationName;
             _httpContextScopeKey = string.Concat("__Datadog.Trace.AspNet.TracingHttpModule-", _requestOperationName);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/HttpHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/HttpHeadersCollection.cs
@@ -17,10 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         public HttpHeadersCollection(IRequestHeaders headers)
         {
-            if (headers is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(headers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             _headers = headers;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpHeadersCollection.cs
@@ -16,10 +16,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
 
         public HttpHeadersCollection(IRequestHeaders headers)
         {
-            if (headers is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(headers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             _headers = headers;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/Emit/ObjectExtensions.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Emit/ObjectExtensions.cs
@@ -293,15 +293,8 @@ namespace Datadog.Trace.ClrProfiler.Emit
 
             public PropertyFetcherCacheKey(Type type1, Type type2, Type type3, string name)
             {
-                if (type1 is null)
-                {
-                    ThrowHelper.ThrowArgumentNullException(nameof(type1));
-                }
-
-                if (name is null)
-                {
-                    ThrowHelper.ThrowArgumentNullException(nameof(name));
-                }
+                ThrowHelper.ThrowArgumentNullExceptionIfNull(type1);
+                ThrowHelper.ThrowArgumentNullExceptionIfNull(name);
 
                 Type1 = type1;
                 Type2 = type2;

--- a/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ManualTracer.cs
@@ -19,10 +19,7 @@ namespace Datadog.Trace.ClrProfiler
 
         internal ManualTracer(IAutomaticTracer parent)
         {
-            if (parent is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(parent));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(parent);
 
             _parent = parent;
             _parent.Register(this);

--- a/tracer/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/CompositeConfigurationSource.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The configuration source to add.</param>
         public void Add(IConfigurationSource source)
         {
-            if (source == null) { ThrowHelper.ThrowArgumentNullException(nameof(source)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(source);
 
             _sources.Add(source);
         }
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="item">The configuration source to insert.</param>
         public void Insert(int index, IConfigurationSource item)
         {
-            if (item == null) { ThrowHelper.ThrowArgumentNullException(nameof(item)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(item);
 
             _sources.Insert(index, item);
         }

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -20,10 +20,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         public IntegrationSettings(string integrationName, IConfigurationSource source)
         {
-            if (integrationName is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(integrationName));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(integrationName);
 
             IntegrationName = integrationName;
 

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
@@ -24,10 +24,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         public DiagnosticManager(IEnumerable<DiagnosticObserver> diagnosticSubscribers)
         {
-            if (diagnosticSubscribers == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(diagnosticSubscribers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(diagnosticSubscribers);
 
             _diagnosticObservers = diagnosticSubscribers.Where(x => x.IsSubscriberEnabled());
         }

--- a/tracer/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
@@ -15,10 +15,7 @@ namespace Datadog.Trace.ExtensionMethods
     {
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
         {
-            if (dictionary == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(dictionary));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(dictionary);
 
             return dictionary.TryGetValue(key, out var value)
                        ? value
@@ -27,10 +24,7 @@ namespace Datadog.Trace.ExtensionMethods
 
         public static TValue GetValueOrDefault<TValue>(this IDictionary dictionary, object key)
         {
-            if (dictionary == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(dictionary));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(dictionary);
 
             return dictionary.TryGetValue(key, out TValue value)
                        ? value
@@ -39,10 +33,7 @@ namespace Datadog.Trace.ExtensionMethods
 
         public static bool TryGetValue<TValue>(this IDictionary dictionary, object key, out TValue value)
         {
-            if (dictionary == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(dictionary));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(dictionary);
 
             object valueObj;
 

--- a/tracer/src/Datadog.Trace/ExtensionMethods/NameValueCollectionExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/NameValueCollectionExtensions.cs
@@ -22,10 +22,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// <returns>An object that implements <see cref="IHeadersCollection"/>.</returns>
         public static NameValueHeadersCollection Wrap(this NameValueCollection collection)
         {
-            if (collection == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(collection));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(collection);
 
             return new NameValueHeadersCollection(collection);
         }

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// <param name="samplingPriority">The new sampling priority for the trace.</param>
         public static void SetTraceSamplingPriority(this ISpan span, SamplingPriority samplingPriority)
         {
-            if (span == null) { ThrowHelper.ThrowArgumentNullException(nameof(span)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(span);
 
             if (span.Context is SpanContext spanContext && spanContext.TraceContext != null)
             {

--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// <returns>A new string with <paramref name="suffix"/> removed from the end, if found. Otherwise, <paramref name="value"/>.</returns>
         public static string TrimEnd(this string value, string suffix, StringComparison comparisonType)
         {
-            if (value == null) { ThrowHelper.ThrowArgumentNullException(nameof(value)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(value);
 
             return !string.IsNullOrEmpty(suffix) && value.EndsWith(suffix, comparisonType)
                        ? value.Substring(0, value.Length - suffix.Length)
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// <returns><c>true</c> or <c>false</c> if <paramref name="value"/> is one of the accepted values; <c>null</c> otherwise.</returns>
         public static bool? ToBoolean(this string value)
         {
-            if (value == null) { ThrowHelper.ThrowArgumentNullException(nameof(value)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(value);
 
             if (value.Length == 0)
             {

--- a/tracer/src/Datadog.Trace/ExtensionMethods/WebHeadersExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/WebHeadersExtensions.cs
@@ -24,10 +24,7 @@ namespace Datadog.Trace.ExtensionMethods
         /// <returns>An object that implements <see cref="IHeadersCollection"/>.</returns>
         public static WebHeadersCollection Wrap(this WebHeaderCollection headers)
         {
-            if (headers == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(headers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             return new WebHeadersCollection(headers);
         }

--- a/tracer/src/Datadog.Trace/Headers/NameValueHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/Headers/NameValueHeadersCollection.cs
@@ -17,10 +17,7 @@ namespace Datadog.Trace.Headers
 
         public NameValueHeadersCollection(NameValueCollection headers)
         {
-            if (headers is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(headers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             _headers = headers;
         }

--- a/tracer/src/Datadog.Trace/Headers/WebHeadersCollection.cs
+++ b/tracer/src/Datadog.Trace/Headers/WebHeadersCollection.cs
@@ -19,10 +19,7 @@ namespace Datadog.Trace.Headers
 
         public WebHeadersCollection(WebHeaderCollection headers)
         {
-            if (headers is null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(headers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             _headers = headers;
         }

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -41,9 +41,8 @@ namespace Datadog.Trace
         public void Inject<T>(SpanContext context, T headers)
             where T : IHeadersCollection
         {
-            if (context == null) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
-
-            if (headers == null) { ThrowHelper.ThrowArgumentNullException(nameof(headers)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(context);
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             headers.Set(HttpHeaderNames.TraceId, context.TraceId.ToString(InvariantCulture));
             headers.Set(HttpHeaderNames.ParentId, context.SpanId.ToString(InvariantCulture));
@@ -74,11 +73,9 @@ namespace Datadog.Trace
         /// <typeparam name="T">Type of header collection</typeparam>
         public void Inject<T>(SpanContext context, T carrier, Action<T, string, string> setter)
         {
-            if (context == null) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
-
-            if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
-
-            if (setter == null) { ThrowHelper.ThrowArgumentNullException(nameof(setter)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(context);
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(carrier);
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(setter);
 
             setter(carrier, HttpHeaderNames.TraceId, context.TraceId.ToString(InvariantCulture));
             setter(carrier, HttpHeaderNames.ParentId, context.SpanId.ToString(InvariantCulture));
@@ -106,10 +103,7 @@ namespace Datadog.Trace
         public SpanContext Extract<T>(T headers)
             where T : IHeadersCollection
         {
-            if (headers == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(headers));
-            }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(headers);
 
             var traceId = ParseUInt64(headers, HttpHeaderNames.TraceId);
 
@@ -135,9 +129,8 @@ namespace Datadog.Trace
         /// <returns>A new <see cref="SpanContext"/> that contains the values obtained from <paramref name="carrier"/>.</returns>
         public SpanContext Extract<T>(T carrier, Func<T, string, IEnumerable<string>> getter)
         {
-            if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
-
-            if (getter == null) { ThrowHelper.ThrowArgumentNullException(nameof(getter)); }
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(carrier);
+            ThrowHelper.ThrowArgumentNullExceptionIfNull(getter);
 
             var traceId = ParseUInt64(carrier, getter, HttpHeaderNames.TraceId);
 

--- a/tracer/src/Datadog.Trace/Util/System.Runtime.CompilerServices.Attributes.cs
+++ b/tracer/src/Datadog.Trace/Util/System.Runtime.CompilerServices.Attributes.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="System.Runtime.CompilerServices.Attributes.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This file contains attributes from the System.Diagnostics.CompilerServices namespace
+// used by the compiler. We define them here for older .NET runtimes.
+
+#pragma warning disable SA1649 // file name should match first type name
+#pragma warning disable SA1402 // file may only contain a single type
+
+#if !NETCOREAPP3_0_OR_GREATER
+
+// ReSharper disable once CheckNamespace
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class CallerArgumentExpressionAttribute : Attribute
+    {
+        public CallerArgumentExpressionAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}
+
+#endif
+
+#pragma warning restore SA1402
+#pragma warning restore SA1649

--- a/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -16,12 +18,12 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowArgumentNullException(string paramName) => throw new ArgumentNullException(paramName);
+        internal static void ThrowArgumentNullException(string? paramName) => throw new ArgumentNullException(paramName);
 
         /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
         /// <param name="argument">The reference type argument to validate as non-null.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
-        public static void ThrowArgumentNullExceptionIfNull<T>(T argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        public static void ThrowArgumentNullExceptionIfNull<T>(T? argument, [CallerArgumentExpression("argument")] string? paramName = null)
         {
             if (argument is null)
             {
@@ -32,51 +34,51 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowArgumentOutOfRangeException(string paramName) => throw new ArgumentOutOfRangeException(paramName);
+        internal static void ThrowArgumentOutOfRangeException(string? paramName) => throw new ArgumentOutOfRangeException(paramName);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowArgumentOutOfRangeException(string paramName, string message) => throw new ArgumentOutOfRangeException(paramName, message);
+        internal static void ThrowArgumentOutOfRangeException(string? paramName, string? message) => throw new ArgumentOutOfRangeException(paramName, message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowArgumentOutOfRangeException(string paramName, object actualValue, string message) => throw new ArgumentOutOfRangeException(paramName, actualValue, message);
+        internal static void ThrowArgumentOutOfRangeException(string? paramName, object? actualValue, string? message) => throw new ArgumentOutOfRangeException(paramName, actualValue, message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowArgumentException(string message) => throw new ArgumentException(message);
+        internal static void ThrowArgumentException(string? message) => throw new ArgumentException(message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowArgumentException(string message, string paramName) => throw new ArgumentException(message, paramName);
+        internal static void ThrowArgumentException(string? message, string? paramName) => throw new ArgumentException(message, paramName);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowInvalidOperationException(string message) => throw new InvalidOperationException(message);
+        internal static void ThrowInvalidOperationException(string? message) => throw new InvalidOperationException(message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowException(string message) => throw new Exception(message);
+        internal static void ThrowException(string? message) => throw new Exception(message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowInvalidCastException(string message) => throw new InvalidCastException(message);
+        internal static void ThrowInvalidCastException(string? message) => throw new InvalidCastException(message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowNotSupportedException(string message) => throw new NotSupportedException(message);
+        internal static void ThrowNotSupportedException(string? message) => throw new NotSupportedException(message);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]
-        internal static void ThrowKeyNotFoundException(string message) => throw new KeyNotFoundException(message);
+        internal static void ThrowKeyNotFoundException(string? message) => throw new KeyNotFoundException(message);
     }
 }

--- a/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Util
         /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
         /// <param name="argument">The reference type argument to validate as non-null.</param>
         /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
-        public static void ThrowArgumentNullExceptionIfNull<T>(T? argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        public static void ThrowArgumentNullExceptionIfNull(object? argument, [CallerArgumentExpression("argument")] string? paramName = null)
         {
             if (argument is null)
             {

--- a/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
+++ b/tracer/src/Datadog.Trace/Util/ThrowHelper.cs
@@ -18,6 +18,17 @@ namespace Datadog.Trace.Util
         [DoesNotReturn]
         internal static void ThrowArgumentNullException(string paramName) => throw new ArgumentNullException(paramName);
 
+        /// <summary>Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is null.</summary>
+        /// <param name="argument">The reference type argument to validate as non-null.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        public static void ThrowArgumentNullExceptionIfNull<T>(T argument, [CallerArgumentExpression("argument")] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                ThrowArgumentNullException(paramName);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         [DebuggerHidden]
         [DoesNotReturn]


### PR DESCRIPTION
Add `[CallerArgumentExpression]` and `ThrowHelper.ThrowArgumentNullExceptionIfNull()` so we can use:

```csharp
Foo(object arg)
{
    ThrowHelper.ThrowArgumentNullExceptionIfNull(arg);

    // ...
}
```

instead of

```csharp
Foo(object arg)
{
    if(arg is null)
    {
        ThrowHelper.ThrowArgumentNullException(nameof(arg))
    };

    // ...
}
```

Similar to `ArgumentNullException.ThrowIfNull()` added in .NET 6. I'm open to different naming ideas, like `ArgumentNullExceptionHelper.ThrowIfNull()`.