### PR TITLE
Fix flaky test in AspNetVersionConflictTests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -136,25 +136,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             manualSpan.TraceId.Should().Be(secondTraceId);
             manualSpan.Name.Should().Be("Manual");
 
-            var nestedSpans = spans.Where(s => s.ParentId == manualSpan.SpanId).OrderBy(s => s.Start).ToArray();
-            nestedSpans.Should().HaveCount(3);
+            var nestedSpans = spans.Where(s => s.ParentId == manualSpan.SpanId).ToArray();
+            nestedSpans.Should()
+                       .HaveCount(3)
+                       .And.OnlyContain(s => s.TraceId == secondTraceId);
 
-            // Validate the first http request and its subspans
-            var firstHttpSpan = nestedSpans[0];
-
-            firstHttpSpan.TraceId.Should().Be(secondTraceId);
-            firstHttpSpan.Name.Should().Be("http.request");
-
-            // Validate the second http request and its subspans
-            var secondHttpSpan = nestedSpans[1];
-
-            secondHttpSpan.TraceId.Should().Be(secondTraceId);
-            secondHttpSpan.Name.Should().Be("http.request");
-
-            var manualInnerSpan = nestedSpans[2];
-
-            manualInnerSpan.TraceId.Should().Be(secondTraceId);
-            manualInnerSpan.Name.Should().Be("Child");
+            nestedSpans.Where(s => s.Name == "http.request").Should().HaveCount(2);
+            nestedSpans.Where(s => s.Name == "Child").Should().HaveCount(1);
 
             // Make sure there is no extra root span
             var rootTraces = spans.Where(s => s.ParentId == null).ToList();


### PR DESCRIPTION
The assertion rely on the order of the spans, but it's not deterministic because manual and automatic spans are pushed by different tracers. Spans are sorted by start time but it doesn't seem to be enough, I'm assuming they're all started within 15 ms and so the clock resolution is not low enough.