### PR TITLE
[2.0] - Skip loader injection on profiler managed loader

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/dd_profiler_constants.h
@@ -72,6 +72,7 @@ const WSTRING skip_assemblies[]{WStr("mscorlib"),
                                 WStr("Microsoft.AspNetCore.Razor.Language"),
                                 WStr("Microsoft.AspNetCore.Mvc.RazorPages"),
                                 WStr("Anonymously Hosted DynamicMethods Assembly"),
+                                WStr("Datadog.AutoInstrumentation.ManagedLoader"),
                                 WStr("ISymWrapper")};
 
 const WSTRING mscorlib_assemblyName = WStr("mscorlib");


### PR DESCRIPTION
This PR fix a crash in WCF applications when using the Tracer and Profiler together by skipping the tracer loader injection in the profiler loader.

@DataDog/apm-dotnet