### PR TITLE
Remove params from Serilog benchmark

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
@@ -22,9 +22,6 @@ namespace Benchmarks.Trace
         private static readonly Logger Logger;
         private static readonly Tracer LogInjectionTracer;
 
-        [Params(1, 10, 100)]
-        public static int N { get; set; }
-
         static SerilogBenchmark()
         {
             LogProvider.SetCurrentLogProvider(new NoOpSerilogLogProvider());
@@ -56,7 +53,7 @@ namespace Benchmarks.Trace
             {
                 using (LogInjectionTracer.StartActive("Child"))
                 {
-                    for (int i = 0; i < N; i++)
+                    for (int i = 0; i < 10; i++)
                     {
                         var logEvent = new LogEvent(
                             DateTimeOffset.Now,


### PR DESCRIPTION
Remove the parameters from the Serilog benchmark until the report generator is fixed.