### PR TITLE
Do not normalize periods in header tags if specified by the customer

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -349,6 +349,13 @@ namespace Datadog.Trace.Configuration
             /// </summary>
             /// <seealso cref="TracerSettings.DelayWcfInstrumentationEnabled"/>
             public const string DelayWcfInstrumentationEnabled = "DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED";
+
+            /// <summary>
+            /// Enables a fix around header tags normalization:
+            /// We used to normalize periods even if a tag was provided for a header, whereas we should not.
+            /// This flag defaults to false and is here for retrocompatibility only
+            /// </summary>
+            public const string ReplacePeriodsInHeaderTags = "DD_TRACE_REPLACE_HEADER_TAG_PERIODS_ENABLED";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -351,11 +351,11 @@ namespace Datadog.Trace.Configuration
             public const string DelayWcfInstrumentationEnabled = "DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED";
 
             /// <summary>
-            /// Enables a fix around header tags normalization:
+            /// Enables a fix around header tags normalization.
             /// We used to normalize periods even if a tag was provided for a header, whereas we should not.
-            /// This flag defaults to false and is here for retrocompatibility only
+            /// This flag defaults to true and is here in case customers need retrocompatibility only
             /// </summary>
-            public const string ReplacePeriodsInHeaderTags = "DD_TRACE_REPLACE_HEADER_TAG_PERIODS_ENABLED";
+            public const string HeaderTagsNormalizationFixEnabled = "DD_TRACE_HEADER_TAG_NORMALIZATION_FIX_ENABLED";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -387,15 +387,24 @@ namespace Datadog.Trace.Configuration
         {
             var headerTags = new Dictionary<string, string>();
 
-            foreach (KeyValuePair<string, string> kvp in configurationDictionary)
+            foreach (var kvp in configurationDictionary)
             {
-                if (!string.IsNullOrWhiteSpace(kvp.Key) && string.IsNullOrWhiteSpace(kvp.Value))
+                var headerName = kvp.Key;
+                var providedTagName = kvp.Value;
+                if (string.IsNullOrWhiteSpace(headerName))
                 {
-                    headerTags.Add(kvp.Key.Trim(), string.Empty);
+                    continue;
                 }
-                else if (!string.IsNullOrWhiteSpace(kvp.Key) && kvp.Value.TryConvertToNormalizedHeaderTagName(out string result))
+
+                // The user has not provided a tag name. The normalization will happen later, when adding the prefix.
+                if (string.IsNullOrEmpty(providedTagName))
                 {
-                    headerTags.Add(kvp.Key.Trim(), result);
+                    headerTags.Add(headerName.Trim(), string.Empty);
+                }
+                else if (providedTagName.TryConvertToNormalizedTagName(normalizePeriods: false, out var normalizedTagName))
+                {
+                    // If the user has provided a tag name, then we don't normalize periods in the provided tag name
+                    headerTags.Add(headerName.Trim(), normalizedTagName);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -18,7 +18,8 @@ namespace Datadog.Trace.Tests.Configuration
     {
         private static readonly Dictionary<string, string> TagsK1V1K2V2 = new Dictionary<string, string> { { "k1", "v1" }, { "k2", "v2" } };
         private static readonly Dictionary<string, string> TagsK2V2 = new Dictionary<string, string> { { "k2", "v2" } };
-        private static readonly Dictionary<string, string> HeaderTagsWithOptionalMappings = new Dictionary<string, string> { { "header1", "tag1" }, { "header2", "content-type" }, { "header3", "content-type" }, { "header4", "c___ont_____ent----typ_/_e" }, { "header5", "some_header" }, { "validheaderonly", string.Empty }, { "validheaderwithoutcolon", string.Empty } };
+        private static readonly Dictionary<string, string> HeaderTagsWithOptionalMappings = new Dictionary<string, string> { { "header1", "tag1" }, { "header2", "content-type" }, { "header3", "content-type" }, { "header4", "c___ont_____ent----typ_/_e" }, { "validheaderonly", string.Empty }, { "validheaderwithoutcolon", string.Empty } };
+        private static readonly Dictionary<string, string> HeaderTagsWithDots = new Dictionary<string, string> { { "header3", "my.header.with.dot" }, { "my.new.header.with.dot", string.Empty } };
         private static readonly Dictionary<string, string> HeaderTagsSameTag = new Dictionary<string, string> { { "header1", "tag1" }, { "header2", "tag1" } };
 
         public static IEnumerable<object[]> GetGlobalDefaultTestData()
@@ -94,9 +95,10 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { ConfigurationKeys.GlobalAnalyticsEnabled, "false", CreateFunc(s => s.AnalyticsEnabled), false };
 #pragma warning restore 618
 
-            yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:Content-Type,header3: Content-Type ,header4:C!!!ont_____ent----tYp!/!e,header5:Some.Header,header6:9invalidtagname,:invalidtagonly,validheaderonly:,validheaderwithoutcolon,:", CreateFunc(s => s.HeaderTags), HeaderTagsWithOptionalMappings };
+            yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:Content-Type,header3: Content-Type ,header4:C!!!ont_____ent----tYp!/!e,header6:9invalidtagname,:invalidtagonly,validheaderonly:,validheaderwithoutcolon,:", CreateFunc(s => s.HeaderTags), HeaderTagsWithOptionalMappings };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header2:tag1", CreateFunc(s => s.HeaderTags), HeaderTagsSameTag };
             yield return new object[] { ConfigurationKeys.HeaderTags, "header1:tag1,header1:tag2", CreateFunc(s => s.HeaderTags.Count), 1 };
+            yield return new object[] { ConfigurationKeys.HeaderTags, "header3:my.header.with.dot,my.new.header.with.dot", CreateFunc(s => s.HeaderTags), HeaderTagsWithDots };
         }
 
         // JsonConfigurationSource needs to be tested with JSON data, which cannot be used with the other IConfigurationSource implementations.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -318,5 +318,23 @@ namespace Datadog.Trace.Tests.Configuration
             var actualValue = settingGetter(settings);
             Assert.Equal(expectedValue, actualValue);
         }
+
+        [Theory]
+        [InlineData(true, "tag_1")]
+        [InlineData(false, "tag.1")]
+        public void TestHeaderTagsNormalization(bool replacePeriodsInHeaderTags, string expectedHeader)
+        {
+            var expectedValue = new Dictionary<string, string> { { "header", expectedHeader } };
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.FeatureFlags.ReplacePeriodsInHeaderTags, replacePeriodsInHeaderTags.ToString() },
+                { ConfigurationKeys.HeaderTags, "header:tag.1" },
+            };
+
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var settings = new TracerSettings(source);
+
+            Assert.Equal(expectedValue, settings.HeaderTags);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -320,14 +320,14 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData(true, "tag_1")]
-        [InlineData(false, "tag.1")]
-        public void TestHeaderTagsNormalization(bool replacePeriodsInHeaderTags, string expectedHeader)
+        [InlineData(false, "tag_1")]
+        [InlineData(true, "tag.1")]
+        public void TestHeaderTagsNormalization(bool headerTagsNormalizationFixEnabled, string expectedHeader)
         {
             var expectedValue = new Dictionary<string, string> { { "header", expectedHeader } };
             var collection = new NameValueCollection
             {
-                { ConfigurationKeys.FeatureFlags.ReplacePeriodsInHeaderTags, replacePeriodsInHeaderTags.ToString() },
+                { ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, headerTagsNormalizationFixEnabled.ToString() },
                 { ConfigurationKeys.HeaderTags, "header:tag.1" },
             };
 

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         [InlineData(" original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________", true, "original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________")]
         public void TryConvertToNormalizedTagName(string input, bool expectedConversionSuccess, string expectedTagName)
         {
-            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(out string actualTagName);
+            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(normalizePeriods: false, out string actualTagName);
             Assert.Equal(expectedConversionSuccess, actualConversionSuccess);
 
             if (actualConversionSuccess)
@@ -52,14 +52,14 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         [InlineData("Content-Type", true, "content-type")]
         [InlineData(" Content-Type ", true, "content-type")]
         [InlineData("C!!!ont_____ent----tYp!/!e", true, "c___ont_____ent----typ_/_e")]
-        [InlineData("Some.Header", true, "some_header")] // Note: Differs from TryConvertToNormalizedTagName because '.' characters are replaced with '_'
+        [InlineData("Some.Header", true, "some_header")]
         [InlineData("9invalidtagname", false, null)]
         [InlineData("invalid_length_201_______________________________________________________________________________________________________________________________________________________________________________________", false, null)]
         [InlineData("valid_length_200________________________________________________________________________________________________________________________________________________________________________________________", true, "valid_length_200________________________________________________________________________________________________________________________________________________________________________________________")]
         [InlineData(" original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________", true, "original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________")]
         public void TryConvertToNormalizedHeaderTagName(string input, bool expectedConversionSuccess, string expectedTagName)
         {
-            bool actualConversionSuccess = input.TryConvertToNormalizedHeaderTagName(out string actualTagName);
+            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(normalizePeriods: true, out string actualTagName);
             Assert.Equal(expectedConversionSuccess, actualConversionSuccess);
 
             if (actualConversionSuccess)


### PR DESCRIPTION
Currently, when we normalize header tags, we replace dots by underscores even in the case where the user has provided a target tag. This shouldn't be the case. Indeed, we should not to normalize dots when a header tag is provided in the `DD_TRACE_HEADER_TAGS` variable. 
So the following should apply:
- `this.header:http.request.headers.this.header` should propagate the tag `http.request.headers.this.header`
- `this.header:whatever.the.  user.--wants.this**.header!`should propagate the tag `whatever.the.user.__wants.this__.header_`

This fix is set behind a feature flag activated by default

[Link to internal documentation](https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2302444638/DD+TRACE+HEADER+TAGS)
Fixes [APMS-6268](https://datadoghq.atlassian.net/browse/APMS-6268)





@DataDog/apm-dotnet