### PR TITLE
Stop using benchmark csv and support params

### DIFF
--- a/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BenchmarkComparer.cs" company="Datadog">
+// <copyright file="BenchmarkComparer.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -75,9 +75,20 @@ namespace BenchmarkComparison
                    })
                   .ToList();
 
-            static string GetName(Benchmark benchmark) => benchmark.DisplayInfo.Contains("Toolchain=net472")
-                                                       ? $"{benchmark.FullName}-net472"
-                                                       : $"{benchmark.FullName}-netcoreapp3.1";
+
+            static string GetName(Benchmark benchmark)
+            {
+                var name = benchmark.FullName;
+
+                if (!string.IsNullOrEmpty(benchmark.Parameters))
+                {
+                    name += $"-{benchmark.Parameters}";
+                }
+
+                name += $"-{(benchmark.DisplayInfo.Contains("Toolchain=net472") ? "net472" : "netcoreapp3.1")}";
+
+                return name;
+            }
 
             static T GetValueOrDefault<T>(Dictionary<string, T> dict, string key)
                 => dict.TryGetValue(key, out var value) ? value : default;

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
@@ -117,8 +117,8 @@ namespace BenchmarkComparison
         {
             foreach (var result in results)
             {
-                var baseBytes = result.BaseResult.Memory?.BytesAllocatedPerOperation;
-                var diffBytes = result.DiffResult.Memory?.BytesAllocatedPerOperation;
+                var baseBytes = result.BaseResult?.Memory.BytesAllocatedPerOperation;
+                var diffBytes = result.DiffResult?.Memory.BytesAllocatedPerOperation;
                 if (baseBytes is null || diffBytes is null)
                 {
                     yield return result with { Conclusion = AllocationConclusion.Unknown };

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
@@ -1,4 +1,4 @@
-// <copyright file="BenchmarkComparer.cs" company="Datadog">
+﻿// <copyright file="BenchmarkComparer.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -75,20 +75,9 @@ namespace BenchmarkComparison
                    })
                   .ToList();
 
-
-            static string GetName(Benchmark benchmark)
-            {
-                var name = benchmark.FullName;
-
-                if (!string.IsNullOrEmpty(benchmark.Parameters))
-                {
-                    name += $"-{benchmark.Parameters}";
-                }
-
-                name += $"-{(benchmark.DisplayInfo.Contains("Toolchain=net472") ? "net472" : "netcoreapp3.1")}";
-
-                return name;
-            }
+            static string GetName(Benchmark benchmark) => benchmark.DisplayInfo.Contains("Toolchain=net472")
+                                                       ? $"{benchmark.FullName}-net472"
+                                                       : $"{benchmark.FullName}-netcoreapp3.1";
 
             static T GetValueOrDefault<T>(Dictionary<string, T> dict, string key)
                 => dict.TryGetValue(key, out var value) ? value : default;

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkComparer.cs
@@ -18,7 +18,7 @@ namespace BenchmarkComparison
     {
         public static readonly Threshold SignificantResultThreshold = Threshold.Create(ThresholdUnit.Ratio, 0.10);
         public static readonly Threshold NoiseThreshold = Threshold.Create(ThresholdUnit.Nanoseconds, 0.3);
-        public static readonly decimal AllocationThresholdPercent = new(value: 0.5);//%
+        public static readonly decimal AllocationThresholdPercent = 0.5M; //%
 
         public static List<MatchedSummary> MatchAndCompareResults(
             IEnumerable<BdnResult> baseResults,

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkMarkdownGenerator.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkMarkdownGenerator.cs
@@ -94,7 +94,9 @@ Benchmarks for {newBranchMarkdown} compared to {oldBranchMarkdown}:
                     var stdError = FormatNanoSeconds(run.Statistics.StandardError);
                     var toolchainMatch = Regex.Match(run.DisplayInfo, ".*Toolchain=(.+?),.*");
                     var toolchain = toolchainMatch.Success ? toolchainMatch.Groups[1].Value : "Unknown";
-                    sb1.AppendLine($@"|{branchMarkdown}|`{run.Method}`|{toolchain}|{NoBr(mean)}|{NoBr(stdError)}|{NoBr(stdDev)}|{gen0}| {gen1}|{gen2}|{NoBr(allocated)}|");
+
+                    var name = string.IsNullOrEmpty(run.Parameters) ? run.Method : $"{run.Method}({run.Parameters})";
+                    sb1.AppendLine($@"|{branchMarkdown}|`{name}`|{toolchain}|{NoBr(mean)}|{NoBr(stdError)}|{NoBr(stdDev)}|{gen0:G3}| {gen1:G3}|{gen2:G3}|{NoBr(allocated)}|");
                 }
             }
 
@@ -224,10 +226,10 @@ Allocation changes below **{BenchmarkComparer.AllocationThresholdPercent:N1}%** 
                                return new
                                {
                                    Id = result.Id,
-                                   BaseAllocation = ByteSize.FromBytes(baseSize),
-                                   DiffAllocation = ByteSize.FromBytes(diffSize),
-                                   Change = (diffSize - baseSize).ToString(),
-                                   PercentChange = (diffSize - baseSize) / baseSize,
+                                   BaseAllocation = ByteSize.FromBytes(baseSize).ToString(),
+                                   DiffAllocation = ByteSize.FromBytes(diffSize).ToString(),
+                                   Change = ByteSize.FromBytes(diffSize - baseSize).ToString(),
+                                   PercentChange = (diffSize - baseSize) / (double)baseSize,
                                };
                            })
                       .OrderByDescending(result => result.PercentChange)

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkParser.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkParser.cs
@@ -6,11 +6,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using CsvHelper;
-using CsvHelper.Configuration;
 using Newtonsoft.Json;
 using Nuke.Common;
 
@@ -19,13 +16,6 @@ namespace BenchmarkComparison
     public static class BenchmarkParser
     {
         private const string FullBdnJsonFileExtension = "full-compressed.json";
-        private const string BdnCsvFileExtension = ".csv";
-
-        public static List<BdnRunSummary> ReadCsvResults(string path)
-        {
-            var files = GetFilesToParse(path, BdnCsvFileExtension);
-            return files.Select(ReadFromCsvFile).ToList();
-        }
 
         public static List<BdnResult> ReadJsonResults(string path)
         {
@@ -44,27 +34,6 @@ namespace BenchmarkComparison
             catch (Exception ex)
             {
                 Logger.Error($"Exception reading benchmarkdotnet json results '{resultFilePath}': {ex}");
-                throw;
-            }
-        }
-
-        private static BdnRunSummary ReadFromCsvFile(string resultFilePath)
-        {
-            try
-            {
-                var config = new CsvConfiguration(CultureInfo.InvariantCulture)
-                {
-                    HasHeaderRecord = true,
-                };
-                using var reader = new StreamReader(resultFilePath);
-                using var csv = new CsvReader(reader, config);
-                var summaries = csv.GetRecords<BdnBenchmarkSummary>().ToList();
-                var name = Path.GetFileName(resultFilePath).Replace("-report.csv", "");
-                return new BdnRunSummary(name, summaries);
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"Exception reading benchmarkdotnet csv results '{resultFilePath}': {ex}");
                 throw;
             }
         }

--- a/tracer/build/_build/BenchmarkComparison/CompareBenchmarks.cs
+++ b/tracer/build/_build/BenchmarkComparison/CompareBenchmarks.cs
@@ -16,10 +16,7 @@ namespace BenchmarkComparison
             var baseJsonResults = BenchmarkParser.ReadJsonResults(masterDir);
             var prJsonResults = BenchmarkParser.ReadJsonResults(prDir);
 
-            var baseCsvResults = BenchmarkParser.ReadCsvResults(masterDir);
-            var prCsvResults = BenchmarkParser.ReadCsvResults(prDir);
-
-            var comparison = BenchmarkComparer.MatchAndCompareResults(baseJsonResults, prJsonResults, baseCsvResults, prCsvResults);
+            var comparison = BenchmarkComparer.MatchAndCompareResults(baseJsonResults, prJsonResults);
 
             return BenchmarkMarkdownGenerator.GetMarkdown(comparison, oldBranchMarkdown, newBranchMarkdown);
         }

--- a/tracer/build/_build/BenchmarkComparison/Data.cs
+++ b/tracer/build/_build/BenchmarkComparison/Data.cs
@@ -136,8 +136,8 @@ namespace BenchmarkComparison
 
     public record MatchedSummary(
         string BenchmarkName,
-        List<BdnBenchmarkSummary> BaseSummary,
-        List<BdnBenchmarkSummary> DiffSummary,
+        List<Benchmark> BaseResults,
+        List<Benchmark> DiffResults,
         List<BenchmarkComparison> Comparisons,
         List<AllocationComparison> AllocationComparisons)
     {
@@ -196,35 +196,9 @@ namespace BenchmarkComparison
 
     public record AllocationComparison(
         string Id,
-        BdnBenchmarkSummary BaseResult,
-        BdnBenchmarkSummary DiffResult,
+        Benchmark BaseResult,
+        Benchmark DiffResult,
         AllocationConclusion Conclusion);
-
-    public record BdnRunSummary(string FileName, List<BdnBenchmarkSummary> Results);
-
-    public class BdnBenchmarkSummary
-    {
-        public string Method { get; set; }
-        public string Job { get; set; }
-        public string Runtime { get; set; }
-        public string Toolchain { get; set; }
-        public string IterationTime { get; set; }
-        public string Mean { get; set; }
-        public string Error { get; set; }
-        public string StdDev { get; set; }
-        public string Ratio { get; set; }
-
-        [Name("Gen 0")]
-        public string Gen0 { get; set; }
-
-        [Name("Gen 1")]
-        public string Gen1 { get; set; }
-
-        [Name("Gen 2")]
-        public string Gen2 { get; set; }
-
-        public string Allocated { get; set; }
-    }
 
     public enum AllocationConclusion
     {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -710,7 +710,7 @@ partial class Build
 
         var zipPath = outputDirectory / $"{artifact.Name}.zip";
 
-        Console.WriteLine($"Found artifacts. Downloading to {zipPath}...");
+        Console.WriteLine($"Found artifacts. Downloading from {artifact.Resource.DownloadUrl} to {zipPath}...");
 
         // buildHttpClient.GetArtifactContentZipAsync doesn't seem to work
         var temporary = new HttpClient();


### PR DESCRIPTION
I was previously using the CSV file in addition to the JSON file for convenience reasons, because it summarises some things nicely, and includes the Error (half of the 99.9% margin) which we can't derive from the JSON results. But using both introduces extra complexity, and generally shouldn't be required.

This PR also cherry-pick's Kevin's change in #2197 for simplicity

@DataDog/apm-dotnet