### PR TITLE
add GitHub action to close stale PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'There has not been activity on this issue for 60 days. It will be closed automatically in 7 days.'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,28 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '21 9 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'There has not been activity on this issue for 60 days. It will be closed automatically in 7 days.'
+        stale-pr-message: 'There has not been activity on this pull request for 60 days. It will be closed automatically in 7 days.'
+        stale-issue-label: 'no-activity'
+        stale-pr-label: 'no-activity'
+        debug-only: true


### PR DESCRIPTION
> Warns and then closes issues and PRs that have had no activity for a specified amount of time.

https://github.com/actions/stale#close-stale-issues-and-prs