### PR TITLE
Avoid potential exception in Security constructor

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.AppSec
             }
             catch (Exception ex)
             {
-                _settings.Enabled = false;
+                _settings = new(source: null) { Enabled = false };
                 Log.Error(ex, "AppSec could not start because of an unexpected error. No security activities will be collected. Please contact support at https://docs.datadoghq.com/help/ for help.");
             }
         }


### PR DESCRIPTION
Very niche and unlikely, but if `SecuritySettings.FromDefaultSources()` throws, then `_settings` will be null. The exception would be caught, but there would be a null ref exception here. Given that this can happen in very early code paths in the app, this could cause a fatal error.

Safe(r) to create a new object instead. Explicitly setting `Enabled = false` in case the default changes at some point.

@DataDog/apm-dotnet