### PR TITLE
Explicitly state contentType when calling IApiRequest.PostAsync()

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -165,7 +165,7 @@ namespace Datadog.Trace.Agent
                 try
                 {
                     _statsd?.Increment(TracerMetricNames.Api.Requests);
-                    response = await request.PostAsync(traces).ConfigureAwait(false);
+                    response = await request.PostAsync(traces, "application/msgpack").ConfigureAwait(false);
                 }
                 catch
                 {

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -165,7 +165,7 @@ namespace Datadog.Trace.Agent
                 try
                 {
                     _statsd?.Increment(TracerMetricNames.Api.Requests);
-                    response = await request.PostAsync(traces, "application/msgpack").ConfigureAwait(false);
+                    response = await request.PostAsync(traces, MimeTypes.MsgPack).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Agent
     {
         void AddHeader(string name, string value);
 
-        Task<IApiResponse> PostAsync(ArraySegment<byte> traces);
+        Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType);
 
         Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer);
     }

--- a/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
@@ -14,7 +14,7 @@ namespace Datadog.Trace.Agent
     {
         void AddHeader(string name, string value);
 
-        Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType);
+        Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType);
 
         Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer);
     }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Agent.Transports
         public async Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
         {
             _request.Method = "POST";
-            _request.ContentType = "application/json";
+            _request.ContentType = MimeTypes.Json;
 
             using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
             {

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -36,10 +36,10 @@ namespace Datadog.Trace.Agent.Transports
             _request.Headers.Add(name, value);
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
         {
             _request.Method = "POST";
-            _request.ContentType = "application/msgpack";
+            _request.ContentType = contentType;
             using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
             {
                 await requestStream.WriteAsync(traces.Array, traces.Offset, traces.Count).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -36,13 +36,13 @@ namespace Datadog.Trace.Agent.Transports
             _request.Headers.Add(name, value);
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
         {
             _request.Method = "POST";
             _request.ContentType = contentType;
             using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
             {
-                await requestStream.WriteAsync(traces.Array, traces.Offset, traces.Count).ConfigureAwait(false);
+                await requestStream.WriteAsync(bytes.Array, bytes.Offset, bytes.Count).ConfigureAwait(false);
             }
 
             try

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Agent.Transports
                 using (JsonWriter writer = new JsonTextWriter(sw) { CloseOutput = true })
                 {
                     serializer.Serialize(writer, events);
-                    content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                    content.Headers.ContentType = new MediaTypeHeaderValue(MimeTypes.Json);
                     _request.Content = content;
                     await writer.FlushAsync().ConfigureAwait(false);
                     memoryStream.Seek(0, SeekOrigin.Begin);

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -63,10 +63,10 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
         {
             // re-create HttpContent on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
-            using (var content = new ByteArrayContent(traces.Array, traces.Offset, traces.Count))
+            using (var content = new ByteArrayContent(bytes.Array, bytes.Offset, bytes.Count))
             {
                 content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
                 _request.Content = content;

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
@@ -5,7 +5,6 @@
 
 #if NETCOREAPP
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -64,12 +63,12 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
         {
             // re-create HttpContent on every retry because some versions of HttpClient always dispose of it, so we can't reuse.
             using (var content = new ByteArrayContent(traces.Array, traces.Offset, traces.Count))
             {
-                content.Headers.ContentType = new MediaTypeHeaderValue("application/msgpack");
+                content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
                 _request.Content = content;
 
                 var response = await _client.SendAsync(_request).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType) => (await PostSegmentAsync(traces, contentType).ConfigureAwait(false)).Item1;
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType) => (await PostSegmentAsync(bytes, contentType).ConfigureAwait(false)).Item1;
 
         private async Task<Tuple<IApiResponse, HttpRequest>> PostSegmentAsync(ArraySegment<byte> segment, string contentType)
         {

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Agent.Transports
                 await memoryStream.FlushAsync().ConfigureAwait(false);
                 memoryStream.Seek(0, SeekOrigin.Begin);
                 var buffer = memoryStream.GetBuffer();
-                var result = await PostSegmentAsync(new ArraySegment<byte>(buffer, 0, (int)memoryStream.Length), "application/json").ConfigureAwait(false);
+                var result = await PostSegmentAsync(new ArraySegment<byte>(buffer, 0, (int)memoryStream.Length), MimeTypes.Json).ConfigureAwait(false);
                 var response = result.Item1;
                 var request = result.Item2;
                 if (response.StatusCode != 200 && response.StatusCode != 202)

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -55,8 +55,7 @@ namespace Datadog.Trace.Agent.Transports
                 await memoryStream.FlushAsync().ConfigureAwait(false);
                 memoryStream.Seek(0, SeekOrigin.Begin);
                 var buffer = memoryStream.GetBuffer();
-                _headers.Add("Content-Type", "application/json");
-                var result = await PostSegmentAsync(new ArraySegment<byte>(buffer, 0, (int)memoryStream.Length)).ConfigureAwait(false);
+                var result = await PostSegmentAsync(new ArraySegment<byte>(buffer, 0, (int)memoryStream.Length), "application/json").ConfigureAwait(false);
                 var response = result.Item1;
                 var request = result.Item2;
                 if (response.StatusCode != 200 && response.StatusCode != 202)
@@ -73,13 +72,14 @@ namespace Datadog.Trace.Agent.Transports
             }
         }
 
-        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces) => (await PostSegmentAsync(traces).ConfigureAwait(false)).Item1;
+        public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType) => (await PostSegmentAsync(traces, contentType).ConfigureAwait(false)).Item1;
 
-        private async Task<Tuple<IApiResponse, HttpRequest>> PostSegmentAsync(ArraySegment<byte> segment)
+        private async Task<Tuple<IApiResponse, HttpRequest>> PostSegmentAsync(ArraySegment<byte> segment, string contentType)
         {
             using (var bidirectionalStream = _streamFactory.GetBidirectionalStream())
             {
                 var content = new BufferContent(segment);
+                _headers.Add("Content-Type", contentType);
                 var request = new HttpRequest("POST", _uri.Host, _uri.PathAndQuery, _headers, content);
                 // send request, get response
                 var response = await _client.SendAsync(request, bidirectionalStream, bidirectionalStream).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Agent/Transports/MimeTypes.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/MimeTypes.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="MimeTypes.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Agent.Transports
+{
+    internal static class MimeTypes
+    {
+        public const string MsgPack = "application/msgpack";
+        public const string Json = "application/json";
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.StatusCode).Returns(200);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>())).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack")).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
-            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>()), Times.Once());
+            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack"), Times.Once());
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.StatusCode).Returns(500);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>())).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack")).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
@@ -53,7 +53,7 @@ namespace Datadog.Trace.Tests
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
-            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>()), Times.Exactly(5));
+            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack"), Times.Exactly(5));
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.GetHeader(AgentHttpHeaderNames.AgentVersion)).Returns(agentVersion);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>())).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack")).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.ContentLength).Returns(serializedResponse.Length);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>())).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<string>())).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);

--- a/tracer/test/Datadog.Trace.Tests/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -25,7 +26,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.StatusCode).Returns(200);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack")).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack)).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
@@ -34,7 +35,7 @@ namespace Datadog.Trace.Tests
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
-            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack"), Times.Once());
+            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
         }
 
         [Fact]
@@ -44,7 +45,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.StatusCode).Returns(500);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack")).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack)).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);
@@ -53,7 +54,7 @@ namespace Datadog.Trace.Tests
 
             await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1);
 
-            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack"), Times.Exactly(5));
+            requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Exactly(5));
         }
 
         [Fact]
@@ -66,7 +67,7 @@ namespace Datadog.Trace.Tests
             responseMock.Setup(x => x.GetHeader(AgentHttpHeaderNames.AgentVersion)).Returns(agentVersion);
 
             var requestMock = new Mock<IApiRequest>();
-            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), "application/msgpack")).ReturnsAsync(responseMock.Object);
+            requestMock.Setup(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack)).ReturnsAsync(responseMock.Object);
 
             var factoryMock = new Mock<IApiRequestFactory>();
             factoryMock.Setup(x => x.Create(It.IsAny<Uri>())).Returns(requestMock.Object);

--- a/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Agent.Transports;
 using Xunit;
 
@@ -27,7 +26,7 @@ namespace Datadog.Trace.Tests
 
             request.AddHeader("Hello", "World");
 
-            await request.PostAsync(ArraySegment<byte>.Empty, "application/msgpack");
+            await request.PostAsync(ArraySegment<byte>.Empty, MimeTypes.MsgPack);
 
             var message = handler.Message;
 
@@ -46,7 +45,7 @@ namespace Datadog.Trace.Tests
             var factory = new HttpClientRequestFactory(handler);
             var request = factory.Create(new Uri("http://localhost/"));
 
-            await request.PostAsync(ArraySegment<byte>.Empty, "application/msgpack");
+            await request.PostAsync(ArraySegment<byte>.Empty, MimeTypes.MsgPack);
 
             var message = handler.Message;
 

--- a/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.Tests
 
             request.AddHeader("Hello", "World");
 
-            await request.PostAsync(ArraySegment<byte>.Empty);
+            await request.PostAsync(ArraySegment<byte>.Empty, "application/msgpack");
 
             var message = handler.Message;
 
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests
             var factory = new HttpClientRequestFactory(handler);
             var request = factory.Create(new Uri("http://localhost/"));
 
-            await request.PostAsync(ArraySegment<byte>.Empty);
+            await request.PostAsync(ArraySegment<byte>.Empty, "application/msgpack");
 
             var message = handler.Message;
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -103,7 +103,7 @@ namespace Benchmarks.Trace
                 return Task.FromResult<IApiResponse>(new FakeApiResponse());
             }
 
-            public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces)
+            public async Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
             {
                 using (var requestStream = Stream.Null)
                 {


### PR DESCRIPTION
Previously we were silently setting the content-type to msgpack, now we _explicitly_ set it in the method
Also, we we previously _weren't_ setting the contentType in `HttpStreamRequest`, now we do

> This commit was originally part of #1945 (and is required by that PR). Moving it out in an attempt to make that PR more approachable!


@DataDog/apm-dotnet