### PR TITLE
Direct log submission

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -5,7 +5,7 @@
 
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -14,8 +14,8 @@ namespace Datadog.Trace.Ci
 {
     internal class CITracerManager : TracerManager, ILockedTracer
     {
-        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, string defaultServiceName)
-            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, defaultServiceName)
+        public CITracerManager(ImmutableTracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd, RuntimeMetricsWriter runtimeMetricsWriter, DirectLogSubmissionManager logSubmissionManager, string defaultServiceName)
+            : base(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetricsWriter, logSubmissionManager, defaultServiceName)
         {
         }
     }

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -8,6 +8,7 @@ using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -23,9 +24,10 @@ namespace Datadog.Trace.Ci
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetrics,
+            DirectLogSubmissionManager logSubmissionManager,
             string defaultServiceName)
         {
-            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, defaultServiceName);
+            return new CITracerManager(settings, agentWriter, sampler, scopeManager, statsd, runtimeMetrics, logSubmissionManager, defaultServiceName);
         }
 
         protected override ISampler GetSampler(ImmutableTracerSettings settings)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLogger.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLogger.cs
@@ -1,0 +1,105 @@
+﻿// <copyright file="DirectSubmissionLogger.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.Formatting;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    /// <summary>
+    /// An implementation of ILogger for use with direct log submission
+    /// </summary>
+    internal class DirectSubmissionLogger
+    {
+        private readonly string _name;
+        private readonly IExternalScopeProvider? _scopeProvider;
+        private readonly IDatadogSink _sink;
+        private readonly LogFormatter? _logFormatter;
+        private readonly int _minimumLogLevel;
+
+        internal DirectSubmissionLogger(
+            string name,
+            IExternalScopeProvider? scopeProvider,
+            IDatadogSink sink,
+            LogFormatter? logFormatter,
+            DirectSubmissionLogLevel minimumLogLevel)
+        {
+            _name = name;
+            _scopeProvider = scopeProvider;
+            _sink = sink;
+            _logFormatter = logFormatter;
+            _minimumLogLevel = (int)minimumLogLevel;
+        }
+
+        /// <summary>
+        /// Writes a log entry.
+        /// </summary>
+        /// <param name="logLevel">Entry will be written on this level.</param>
+        /// <param name="eventId">Id of the event.</param>
+        /// <param name="state">The entry to be written. Can be also an object.</param>
+        /// <param name="exception">The exception related to this entry.</param>
+        /// <param name="formatter">Function to create a <see cref="string"/> message of the <paramref name="state"/> and <paramref name="exception"/>.</param>
+        /// <typeparam name="TState">The type of the object to be written.</typeparam>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "Microsoft.Extensions.Logging.LogLevel", "Microsoft.Extensions.Logging.EventId", "TState", "System.Exception", "Func`3" })]
+        public void Log<TState>(int logLevel, object eventId, TState state, Exception exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            // We render the event to a string immediately as we need to capture the properties
+            // This is more expensive from a CPU perspective, but saves having to persist the
+            // properties to a dictionary and rendering later
+
+            var logEntry = new LogEntry<TState>(
+                DateTime.UtcNow,
+                logLevel,
+                _name,
+                eventId.GetHashCode(),
+                state,
+                exception,
+                formatter,
+                _scopeProvider);
+            var logFormatter = _logFormatter ?? TracerManager.Instance.DirectLogSubmission.Formatter;
+            var serializedLog = LoggerLogFormatter.FormatLogEvent(logFormatter, logEntry);
+
+            var log = new LoggerDatadogLogEvent(serializedLog);
+
+            _sink.EnqueueLog(log);
+        }
+
+        /// <summary>
+        /// Checks if the given <paramref name="logLevel"/> is enabled.
+        /// </summary>
+        /// <param name="logLevel">Level to be checked.</param>
+        /// <returns><c>true</c> if enabled.</returns>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.Abstractions" })]
+        public bool IsEnabled(int logLevel) => logLevel >= _minimumLogLevel;
+
+        /// <summary>
+        /// Begins a logical operation scope.
+        /// </summary>
+        /// <param name="state">The identifier for the scope.</param>
+        /// <typeparam name="TState">The type of the state to begin scope for.</typeparam>
+        /// <returns>An <see cref="IDisposable"/> that ends the logical operation scope on dispose.</returns>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "TState" })]
+        public IDisposable BeginScope<TState>(TState state) => _scopeProvider?.Push(state) ?? NullDisposable.Instance;
+
+        private class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="DirectSubmissionLoggerProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for ILoggerProvider
+    /// </summary>
+    internal class DirectSubmissionLoggerProvider
+    {
+        private readonly ConcurrentDictionary<string, DirectSubmissionLogger> _loggers = new();
+        private readonly IDatadogSink _sink;
+        private readonly LogFormatter? _formatter;
+        private readonly DirectSubmissionLogLevel _minimumLogLevel;
+        private IExternalScopeProvider? _scopeProvider;
+
+        internal DirectSubmissionLoggerProvider(IDatadogSink sink, DirectSubmissionLogLevel minimumLogLevel)
+            : this(sink, formatter: null, minimumLogLevel)
+        {
+        }
+
+        // used for testing
+        internal DirectSubmissionLoggerProvider(
+            IDatadogSink sink,
+            LogFormatter? formatter,
+            DirectSubmissionLogLevel minimumLogLevel)
+        {
+            _sink = sink;
+            _formatter = formatter;
+            _minimumLogLevel = minimumLogLevel;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ILogger"/> instance.
+        /// </summary>
+        /// <param name="categoryName">The category name for messages produced by the logger.</param>
+        /// <returns>The instance of <see cref="ILogger"/> that was created.</returns>
+        [DuckReverseMethod]
+        public DirectSubmissionLogger CreateLogger(string categoryName)
+        {
+            return _loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
+        }
+
+        private DirectSubmissionLogger CreateLoggerImplementation(string name)
+        {
+            return new DirectSubmissionLogger(name, _scopeProvider, _sink, _formatter, _minimumLogLevel);
+        }
+
+        /// <inheritdoc cref="IDisposable.Dispose"/>
+        [DuckReverseMethod]
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// Method for ISupportExternalScope
+        /// </summary>
+        /// <param name="scopeProvider">The provider of scope data</param>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "Microsoft.Extensions.Logging.IExternalScopeProvider, Microsoft.Extensions.Logging.Abstractions" })]
+        public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+        {
+            _scopeProvider = scopeProvider;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
     /// </summary>
     internal class DirectSubmissionLoggerProvider
     {
+        private readonly Func<string, DirectSubmissionLogger> _createLoggerFunc;
         private readonly ConcurrentDictionary<string, DirectSubmissionLogger> _loggers = new();
         private readonly IDatadogSink _sink;
         private readonly LogFormatter? _formatter;
@@ -39,6 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
             _sink = sink;
             _formatter = formatter;
             _minimumLogLevel = minimumLogLevel;
+            _createLoggerFunc = CreateLoggerImplementation;
         }
 
         /// <summary>
@@ -49,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
         [DuckReverseMethod]
         public DirectSubmissionLogger CreateLogger(string categoryName)
         {
-            return _loggers.GetOrAdd(categoryName, x => CreateLoggerImplementation(x));
+            return _loggers.GetOrAdd(categoryName, _createLoggerFunc);
         }
 
         private DirectSubmissionLogger CreateLoggerImplementation(string name)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
         [DuckReverseMethod]
         public DirectSubmissionLogger CreateLogger(string categoryName)
         {
-            return _loggers.GetOrAdd(categoryName, CreateLoggerImplementation);
+            return _loggers.GetOrAdd(categoryName, x => CreateLoggerImplementation(x));
         }
 
         private DirectSubmissionLogger CreateLoggerImplementation(string name)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LogEntry.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LogEntry.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="LogEntry.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.Formatting
+{
+    internal readonly struct LogEntry<TState>
+    {
+        public LogEntry(
+            DateTime timestamp,
+            int logLevel,
+            string category,
+            int eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter,
+            IExternalScopeProvider? scopeProvider)
+        {
+            Timestamp = timestamp;
+            LogLevel = logLevel;
+            Category = category;
+            EventId = eventId;
+            State = state;
+            Exception = exception;
+            Formatter = formatter;
+            ScopeProvider = scopeProvider;
+        }
+
+        public DateTime Timestamp { get; }
+
+        public int LogLevel { get; }
+
+        public string Category { get; }
+
+        public int EventId { get; }
+
+        public TState State { get; }
+
+        public Exception? Exception { get; }
+
+        public Func<TState, Exception?, string> Formatter { get; }
+
+        public IExternalScopeProvider? ScopeProvider { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                 logEntry.EventId == 0 ? null : logEntry.EventId,
                 GetLogLevelString(logEntry.LogLevel),
                 logEntry.Exception,
-                RenderProperties);
+                (JsonTextWriter w, in LogEntry<T> e) => RenderProperties(w, e));
 
             return StringBuilderCache.GetStringAndRelease(sb);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
@@ -116,14 +116,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                     },
                     writerWrapper);
 
-                if (writerWrapper.Values.Count > 0)
+                if (writerWrapper.HasValues && writerWrapper.Values.Count > 0)
                 {
                     writer.WritePropertyName("Scopes", escape: false);
                     writer.WriteStartArray();
 
-                    for (var i = 0; i < writerWrapper.Values.Count; i++)
+                    var values = writerWrapper.Values;
+                    for (var i = 0; i < values.Count; i++)
                     {
-                        LogFormatter.WriteValue(writer, writerWrapper.Values[i]);
+                        LogFormatter.WriteValue(writer, values[i]);
                     }
 
                     writer.WriteEndArray();
@@ -152,16 +153,23 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                 _ => DirectSubmissionLogLevelExtensions.Unknown,
             };
 
-        private readonly struct WriterWrapper
+        private class WriterWrapper
         {
-            public readonly JsonWriter Writer;
-            public readonly List<object> Values;
+            private List<object>? _values;
 
             public WriterWrapper(JsonWriter writer)
             {
                 Writer = writer;
-                Values = new List<object>();
             }
+
+            public JsonWriter Writer { get; }
+
+            public List<object> Values
+            {
+                get => _values ??= new List<object>();
+            }
+
+            public bool HasValues => _values is not null;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
@@ -130,7 +130,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                 }
             }
 
-            return new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate);
+            return new LogPropertyRenderingDetails(
+                hasRenderedSource: haveSource,
+                hasRenderedService: haveService,
+                hasRenderedHost: haveHost,
+                hasRenderedTags: haveTags,
+                hasRenderedEnv: haveEnv,
+                hasRenderedVersion: haveVersion,
+                messageTemplate: messageTemplate);
         }
 
         private static string GetLogLevelString(int logLevel) =>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/Formatting/LoggerLogFormatter.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="LoggerLogFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Collections.Generic;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.Formatting
+{
+    internal class LoggerLogFormatter
+    {
+        private const string MessageTemplateKey = "{OriginalFormat}";
+
+        public static string? FormatLogEvent<T>(LogFormatter logFormatter, in LogEntry<T> logEntry)
+        {
+            var message = logEntry.Formatter(logEntry.State, logEntry.Exception);
+            if (logEntry.Exception == null && message == null)
+            {
+                // No message! weird...
+                return null;
+            }
+
+            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+
+            logFormatter.FormatLog(
+                sb,
+                logEntry,
+                logEntry.Timestamp,
+                message,
+                logEntry.EventId == 0 ? null : logEntry.EventId,
+                GetLogLevelString(logEntry.LogLevel),
+                logEntry.Exception,
+                RenderProperties);
+
+            return StringBuilderCache.GetStringAndRelease(sb);
+        }
+
+        private static LogPropertyRenderingDetails RenderProperties<T>(JsonTextWriter writer, in LogEntry<T> logEntry)
+        {
+            var haveSource = false;
+            var haveService = false;
+            var haveHost = false;
+            var haveTags = false;
+            var haveVersion = false;
+            var haveEnv = false;
+            string? messageTemplate = null;
+
+            if (logEntry.State is { } state)
+            {
+                if (state is IEnumerable<KeyValuePair<string, object>> stateProperties)
+                {
+                    foreach (var item in stateProperties)
+                    {
+                        // we don't need to write the message template
+                        // (but should we) ?
+                        var key = item.Key;
+                        if (key != MessageTemplateKey)
+                        {
+                            haveSource |= LogFormatter.IsSourceProperty(key);
+                            haveService |= LogFormatter.IsServiceProperty(key);
+                            haveHost |= LogFormatter.IsHostProperty(key);
+                            haveTags |= LogFormatter.IsTagsProperty(key);
+                            haveEnv |= LogFormatter.IsEnvProperty(key);
+                            haveVersion |= LogFormatter.IsVersionProperty(key);
+
+                            LogFormatter.WritePropertyName(writer, key);
+                            LogFormatter.WriteValue(writer, item.Value);
+                        }
+                        else if (item.Value is string stringValue)
+                        {
+                            messageTemplate = stringValue;
+                        }
+                    }
+                }
+                else
+                {
+                    writer.WritePropertyName("@s", escape: false);
+                    LogFormatter.WriteValue(writer, state);
+                }
+            }
+
+            if (logEntry.ScopeProvider is { } scopeProvider)
+            {
+                var writerWrapper = new WriterWrapper(writer);
+                scopeProvider.ForEachScope(
+                    (scope, wrapper) =>
+                    {
+                        // Add dictionary scopes to a properties object
+                        // Theoretically we _should_ handle "duplicate" values, where the property has been added as state,
+                        // And then we try and add it again, but the backend seems to handle this ok
+                        if (scope is IEnumerable<KeyValuePair<string, object>> scopeItems)
+                        {
+                            foreach (var item in scopeItems)
+                            {
+                                var key = item.Key;
+                                haveSource |= LogFormatter.IsSourceProperty(key);
+                                haveService |= LogFormatter.IsServiceProperty(key);
+                                haveHost |= LogFormatter.IsHostProperty(key);
+                                haveTags |= LogFormatter.IsTagsProperty(key);
+                                haveEnv |= LogFormatter.IsEnvProperty(key);
+                                haveVersion |= LogFormatter.IsVersionProperty(key);
+
+                                LogFormatter.WritePropertyName(writer, key);
+                                LogFormatter.WriteValue(wrapper.Writer, item.Value);
+                            }
+                        }
+                        else
+                        {
+                            wrapper.Values.Add(scope); // add to list for inclusion in scope array
+                        }
+                    },
+                    writerWrapper);
+
+                if (writerWrapper.Values.Count > 0)
+                {
+                    writer.WritePropertyName("Scopes", escape: false);
+                    writer.WriteStartArray();
+
+                    for (var i = 0; i < writerWrapper.Values.Count; i++)
+                    {
+                        LogFormatter.WriteValue(writer, writerWrapper.Values[i]);
+                    }
+
+                    writer.WriteEndArray();
+                }
+            }
+
+            return new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate);
+        }
+
+        private static string GetLogLevelString(int logLevel) =>
+            logLevel switch
+            {
+                0 => DirectSubmissionLogLevelExtensions.Verbose, // Trace
+                1 => DirectSubmissionLogLevelExtensions.Debug,
+                2 => DirectSubmissionLogLevelExtensions.Information,
+                3 => DirectSubmissionLogLevelExtensions.Warning,
+                4 => DirectSubmissionLogLevelExtensions.Error,
+                5 => DirectSubmissionLogLevelExtensions.Fatal, // Critical
+                _ => DirectSubmissionLogLevelExtensions.Unknown,
+            };
+
+        private readonly struct WriterWrapper
+        {
+            public readonly JsonWriter Writer;
+            public readonly List<object> Values;
+
+            public WriterWrapper(JsonWriter writer)
+            {
+                Writer = writer;
+                Values = new List<object>();
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/IExternalScopeProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/IExternalScopeProvider.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="IExternalScopeProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.ComponentModel;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    /// <summary>
+    /// A duck type for Microsoft.Extensions.Logging.IExternalScopeProvider
+    /// </summary>
+    internal interface IExternalScopeProvider
+    {
+        /// <summary>
+        /// Adds scope object to the list
+        /// </summary>
+        /// <param name="state">The scope object</param>
+        /// <returns>The IDisposable token that removes scope on dispose</returns>
+        IDisposable Push(object state);
+
+        /// <summary>
+        /// Executes callback for each currently active scope objects in order of creation. All callbacks are guaranteed to be called inline from this method.
+        /// Note that original is Action&lt;object, TState&gt; callback
+        /// </summary>
+        /// <param name="callback">The callback to be executed for every scope object</param>
+        /// <param name="state">The state object to be passed into the callback.</param>
+        /// <typeparam name="TState">The type of state to accept</typeparam>
+        void ForEachScope<TState>(Action<object, TState> callback, TState state);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/ILoggerFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/ILoggerFactory.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="ILoggerFactory.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.ComponentModel;
+using System.Reflection;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for ILogLevel
+    /// </summary>
+    internal interface ILoggerFactory : IDuckType
+    {
+        /// <summary>
+        /// Used to add the ILoggerProvider
+        /// </summary>
+        /// <param name="provider">The ILoggerProvider to add</param>
+        [Duck]
+        public void AddProvider(object provider);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerDatadogLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerDatadogLogEvent.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="LoggerDatadogLogEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Text;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    internal class LoggerDatadogLogEvent : DatadogLogEvent
+    {
+        private readonly string? _serializedEvent;
+
+        public LoggerDatadogLogEvent(string? serializedEvent)
+        {
+            _serializedEvent = serializedEvent;
+        }
+
+        public override void Format(StringBuilder sb, LogFormatter formatter)
+        {
+            sb.Append(_serializedEvent);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryConstructorIntegration.cs
@@ -1,0 +1,64 @@
+﻿// <copyright file="LoggerFactoryConstructorIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    /// <summary>
+    /// LoggerFactory() calltarget instrumentation for direct log submission
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "Microsoft.Extensions.Logging",
+        TypeName = "Microsoft.Extensions.Logging.LoggerFactory",
+        MethodName = ".ctor",
+        ReturnTypeName = ClrNames.Void,
+        ParameterTypeNames = new[] { "System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.Logging.ILoggerProvider]", "Microsoft.Extensions.Options.IOptionsMonitor`1[Microsoft.Extensions.Logging.LoggerFilterOptions]" },
+        MinimumVersion = "2.0.0",
+        MaximumVersion = "3.*.*",
+        IntegrationName = LoggerIntegrationCommon.IntegrationName)]
+    [InstrumentMethod(
+        AssemblyName = "Microsoft.Extensions.Logging",
+        TypeName = "Microsoft.Extensions.Logging.LoggerFactory",
+        MethodName = ".ctor",
+        ReturnTypeName = ClrNames.Void,
+        ParameterTypeNames = new[] { "System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.Logging.ILoggerProvider]", "Microsoft.Extensions.Options.IOptionsMonitor`1[Microsoft.Extensions.Logging.LoggerFilterOptions]", "Microsoft.Extensions.Options.IOptions`1[Microsoft.Extensions.Logging.LoggerFactoryOptions]" },
+        MinimumVersion = "5.0.0",
+        MaximumVersion = "6.*.*",
+        IntegrationName = LoggerIntegrationCommon.IntegrationName)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class LoggerFactoryConstructorIntegration
+    {
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception? exception, CallTargetState state)
+        {
+            if (!TracerManager.Instance.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.ILogger))
+            {
+                return CallTargetReturn.GetDefault();
+            }
+
+            if (exception is not null)
+            {
+                // If there's an exception during the constructor, things aren't going to work anyway
+                return CallTargetReturn.GetDefault();
+            }
+
+            LoggerFactoryIntegrationCommon<TTarget>.AddDirectSubmissionLoggerProvider(instance);
+            return CallTargetReturn.GetDefault();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryIntegrationCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryIntegrationCommon.cs
@@ -1,0 +1,94 @@
+﻿// <copyright file="LoggerFactoryIntegrationCommon.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+{
+    internal static class LoggerFactoryIntegrationCommon<TLoggerFactory>
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(LoggerFactoryIntegrationCommon<TLoggerFactory>));
+
+        // ReSharper disable once StaticMemberInGenericType
+        // Internal for testing
+        internal static readonly Type? ProviderInterfaces;
+
+        static LoggerFactoryIntegrationCommon()
+        {
+            try
+            {
+                // The ILoggerProvider type is in a different assembly to the LoggerFactory, so go via the ILogger type
+                // returned by CreateLogger
+                var loggerFactoryType = typeof(TLoggerFactory);
+                var abstractionsAssembly = loggerFactoryType.GetMethod("CreateLogger")!.ReturnType.Assembly;
+                var iLoggerProviderType = abstractionsAssembly.GetType("Microsoft.Extensions.Logging.ILoggerProvider");
+                var iSupportExternalScopeType = abstractionsAssembly.GetType("Microsoft.Extensions.Logging.ISupportExternalScope");
+
+                if (iSupportExternalScopeType is null)
+                {
+                    // ISupportExternalScope is only available in v2.1+
+                    // We can just duck type ILoggerProvider directly
+                    ProviderInterfaces = iLoggerProviderType;
+                    return;
+                }
+
+                // We need to implement both ILoggerProvider and ISupportExternalScope
+                // because LoggerFactory uses pattern matching to check if we implement the latter
+                // Duck Typing can currently only implement a single interface, so emit
+                // a new interface that implements both ILoggerProvider and ISupportExternalScope
+                // and duck cast to that
+                var thisAssembly = typeof(DirectSubmissionLoggerProvider).Assembly;
+                var assemblyName = new AssemblyName("DirectLogSubmissionILoggerFactoryAssembly") { Version = thisAssembly.GetName().Version };
+
+                var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+                var moduleBuilder = (ModuleBuilder)assemblyBuilder.DefineDynamicModule("MainModule");
+
+                var typeBuilder = moduleBuilder.DefineType(
+                    "DirectSubmissionLoggerProviderProxy",
+                    TypeAttributes.Interface | TypeAttributes.Public | TypeAttributes.Abstract,
+                    parent: null,
+                    interfaces: new[] { iLoggerProviderType!, iSupportExternalScopeType });
+
+                ProviderInterfaces = typeBuilder.CreateTypeInfo()!.AsType();
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Error loading logger factory types for " + typeof(TLoggerFactory));
+                ProviderInterfaces = null;
+            }
+        }
+
+        internal static void AddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory)
+        {
+            if (ProviderInterfaces is null)
+            {
+                // there was a problem loading the assembly for some reason
+                return;
+            }
+
+            var provider = new DirectSubmissionLoggerProvider(
+                TracerManager.Instance.DirectLogSubmission.Sink,
+                TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel);
+
+            AddDirectSubmissionLoggerProvider(loggerFactory, provider);
+        }
+
+        // Internal for testing
+        internal static object AddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory, DirectSubmissionLoggerProvider provider)
+        {
+            var proxy = provider.DuckImplement(ProviderInterfaces);
+            var loggerFactoryProxy = loggerFactory.DuckCast<ILoggerFactory>();
+            loggerFactoryProxy.AddProvider(proxy);
+
+            Log.Information("Direct log submission via ILogger enabled");
+            return proxy;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionIntegration.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="AppenderCollectionIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// AppenderCollection.ToArray() calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "log4net",
+        TypeName = "log4net.Appender.AppenderCollection",
+        MethodName = "ToArray",
+        ReturnTypeName = "log4net.Appender.IAppender[]",
+        ParameterTypeNames = new string[0],
+        MinimumVersion = "2.0.0",
+        MaximumVersion = "2.*.*",
+        IntegrationName = nameof(IntegrationId.Log4Net))]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AppenderCollectionIntegration
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AppenderCollectionIntegration>();
+        private static bool _logWritten = false;
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TResponse">The type of the response</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="response">The returned ILoggerWrapper </param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
+        {
+            if (!TracerManager.Instance.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.Log4Net))
+            {
+                return new CallTargetReturn<TResponse>(response);
+            }
+
+            var updatedResponse = Log4NetCommon<TResponse>.AddAppenderToResponse(response, DirectSubmissionLog4NetAppender.Instance);
+            if (!_logWritten)
+            {
+                _logWritten = true;
+                Log.Information("Direct log submission via Log4Net enabled");
+            }
+
+            return new CallTargetReturn<TResponse>(updatedResponse);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionLegacyIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionLegacyIntegration.cs
@@ -1,0 +1,62 @@
+﻿// <copyright file="AppenderCollectionLegacyIntegration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.DirectSubmission;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// AppenderCollection.ToArray() calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "log4net",
+        TypeName = "log4net.Appender.AppenderCollection",
+        MethodName = "ToArray",
+        ReturnTypeName = "log4net.Appender.IAppender[]",
+        ParameterTypeNames = new string[0],
+        MinimumVersion = "1.0.0",
+        MaximumVersion = "1.*.*",
+        IntegrationName = nameof(IntegrationId.Log4Net))]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class AppenderCollectionLegacyIntegration
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AppenderCollectionLegacyIntegration>();
+        private static bool _logWritten = false;
+
+        /// <summary>
+        /// OnMethodEnd callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TResponse">The type of the response</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <param name="response">The returned ILoggerWrapper </param>
+        /// <param name="exception">Exception instance in case the original code threw an exception.</param>
+        /// <param name="state">Calltarget state value</param>
+        /// <returns>A default CallTargetReturn to satisfy the CallTarget contract</returns>
+        public static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, CallTargetState state)
+        {
+            if (!TracerManager.Instance.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.Log4Net))
+            {
+                return new CallTargetReturn<TResponse>(response);
+            }
+
+            var updatedResponse = Log4NetCommon<TResponse>.AddAppenderToResponse(response, DirectSubmissionLog4NetLegacyAppender.Instance);
+            if (!_logWritten)
+            {
+                _logWritten = true;
+                Log.Information("Direct log submission via Log4Net enabled");
+            }
+
+            return new CallTargetReturn<TResponse>(updatedResponse);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionLegacyIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionLegacyIntegration.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
             if (!_logWritten)
             {
                 _logWritten = true;
-                Log.Information("Direct log submission via Log4Net enabled");
+                Log.Information("Direct log submission via Log4Net Legacy enabled");
             }
 
             return new CallTargetReturn<TResponse>(updatedResponse);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetAppender.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetAppender.cs
@@ -1,0 +1,78 @@
+﻿// <copyright file="DirectSubmissionLog4NetAppender.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Threading;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for IAppender
+    /// </summary>
+    internal class DirectSubmissionLog4NetAppender
+    {
+        private static DirectSubmissionLog4NetAppender _instance = null!;
+
+        private readonly IDatadogSink _sink;
+        private readonly DirectSubmissionLogLevel _minimumLevel;
+
+        // internal for testing
+        internal DirectSubmissionLog4NetAppender(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        {
+            _sink = sink;
+            _minimumLevel = minimumLevel;
+        }
+
+        internal static DirectSubmissionLog4NetAppender Instance
+        {
+            get { return LazyInitializer.EnsureInitialized(ref _instance, CreateStaticInstance); }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of this appender
+        /// </summary>
+        [DuckReverseMethod]
+        public string Name { get; set; } = "Datadog";
+
+        /// <summary>
+        /// Closes the appender and releases resources
+        /// </summary>
+        [DuckReverseMethod]
+        public void Close()
+        {
+        }
+
+        /// <summary>
+        /// Log the logging event in Appender specific way.
+        /// </summary>
+        /// <param name="logEvent">The logging event</param>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "log4net.Core.LoggingEvent, log4net " })]
+        public void DoAppend(ILoggingEventDuck? logEvent)
+        {
+            if (logEvent is null)
+            {
+                return;
+            }
+
+            if (logEvent.Level.ToStandardLevel() < _minimumLevel)
+            {
+                return;
+            }
+
+            var log = new Log4NetDatadogLogEvent(logEvent, logEvent.TimeStampUtc);
+            _sink.EnqueueLog(log);
+        }
+
+        private static DirectSubmissionLog4NetAppender CreateStaticInstance()
+        {
+            return new DirectSubmissionLog4NetAppender(
+                TracerManager.Instance.DirectLogSubmission.Sink,
+                TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetLegacyAppender.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetLegacyAppender.cs
@@ -1,0 +1,78 @@
+﻿// <copyright file="DirectSubmissionLog4NetLegacyAppender.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Threading;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for IAppender
+    /// </summary>
+    internal class DirectSubmissionLog4NetLegacyAppender
+    {
+        private static DirectSubmissionLog4NetLegacyAppender _instance = null!;
+
+        private readonly IDatadogSink _sink;
+        private readonly DirectSubmissionLogLevel _minimumLevel;
+
+        // internal for testing
+        internal DirectSubmissionLog4NetLegacyAppender(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        {
+            _sink = sink;
+            _minimumLevel = minimumLevel;
+        }
+
+        internal static DirectSubmissionLog4NetLegacyAppender Instance
+        {
+            get { return LazyInitializer.EnsureInitialized(ref _instance, CreateStaticInstance); }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of this appender
+        /// </summary>
+        [DuckReverseMethod]
+        public string Name { get; set; } = "Datadog";
+
+        /// <summary>
+        /// Closes the appender and releases resources
+        /// </summary>
+        [DuckReverseMethod]
+        public void Close()
+        {
+        }
+
+        /// <summary>
+        /// Log the logging event in Appender specific way.
+        /// </summary>
+        /// <param name="logEvent">The logging event</param>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "log4net.Core.LoggingEvent, log4net " })]
+        public void DoAppend(ILoggingEventLegacyDuck? logEvent)
+        {
+            if (logEvent is null)
+            {
+                return;
+            }
+
+            if (logEvent.Level.ToStandardLevel() < _minimumLevel)
+            {
+                return;
+            }
+
+            var log = new Log4NetDatadogLogEvent(logEvent, logEvent.TimeStamp.ToUniversalTime());
+            _sink.EnqueueLog(log);
+        }
+
+        private static DirectSubmissionLog4NetLegacyAppender CreateStaticInstance()
+        {
+            return new DirectSubmissionLog4NetLegacyAppender(
+                TracerManager.Instance.DirectLogSubmission.Sink,
+                TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventDuck.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="ILoggingEventDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for LoggingEvent
+    /// </summary>
+    internal interface ILoggingEventDuck : ILoggingEventDuckBase
+    {
+        /// <summary>
+        /// Gets the UTC time the event was logged
+        /// </summary>
+        public DateTime TimeStampUtc { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventDuckBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventDuckBase.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="ILoggingEventDuckBase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for LoggingEvent
+    /// </summary>
+    internal interface ILoggingEventDuckBase
+    {
+        /// <summary>
+        /// Gets the name of the logger that logged the event.
+        /// </summary>
+        public string LoggerName { get; }
+
+        /// <summary>
+        /// Gets the Level of the logging event
+        /// </summary>
+        public LevelDuck Level { get; }
+
+        /// <summary>
+        /// Gets the application supplied message.
+        /// </summary>
+        public object MessageObject { get; }
+
+        /// <summary>
+        /// Gets the message, rendered through the RendererMap".
+        /// </summary>
+        public string RenderedMessage { get; }
+
+        /// <summary>
+        /// Gets the exception associated with the event
+        /// </summary>
+        public string GetExceptionString();
+
+        /// <summary>
+        /// Get all the composite properties in this event
+        /// </summary>
+        /// <returns>Dictionary containing all the properties</returns>
+        public IDictionary GetProperties();
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventLegacyDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/ILoggingEventLegacyDuck.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="ILoggingEventLegacyDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for LoggingEvent
+    /// </summary>
+    internal interface ILoggingEventLegacyDuck : ILoggingEventDuckBase
+    {
+        /// <summary>
+        /// Gets the Local time the event was logged
+        /// </summary>
+        public DateTime TimeStamp { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/LevelDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/LevelDuck.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="LevelDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for Level
+    /// </summary>
+    [DuckCopy]
+    internal struct LevelDuck
+    {
+        /// <summary>
+        /// Gets the level value
+        /// </summary>
+        public int Value;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/LevelDuckExtensions.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/LevelDuckExtensions.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="LevelDuckExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Logging.DirectSubmission;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    internal static class LevelDuckExtensions
+    {
+        private const int DebugThreshold = 30000;
+        private const int InfoThreshold = 40000;
+        private const int WarningThreshold = 60000;
+        private const int ErrorThreshold = 70000;
+        private const int FatalThreshold = 80000;
+
+        public static DirectSubmissionLogLevel ToStandardLevel(this LevelDuck level)
+            => level.Value switch
+            {
+                < DebugThreshold => DirectSubmissionLogLevel.Verbose, // ALL/Finest/Verbose/FINER/Trace/
+                >= DebugThreshold and < InfoThreshold => DirectSubmissionLogLevel.Debug,
+                >= InfoThreshold and < WarningThreshold => DirectSubmissionLogLevel.Information,
+                >= WarningThreshold and < ErrorThreshold => DirectSubmissionLogLevel.Warning,
+                >= ErrorThreshold and < FatalThreshold => DirectSubmissionLogLevel.Error,
+                >= FatalThreshold => DirectSubmissionLogLevel.Fatal, // SEVERE, Critical, Alert, Fatal, Emergency
+            };
+
+        public static string ToStandardLevelString(this LevelDuck level)
+            => level.Value switch
+            {
+                < DebugThreshold => DirectSubmissionLogLevelExtensions.Verbose, // ALL/Finest/Verbose/FINER/Trace/
+                >= DebugThreshold and < InfoThreshold => DirectSubmissionLogLevelExtensions.Debug,
+                >= InfoThreshold and < WarningThreshold => DirectSubmissionLogLevelExtensions.Information,
+                >= WarningThreshold and < ErrorThreshold => DirectSubmissionLogLevelExtensions.Warning,
+                >= ErrorThreshold and < FatalThreshold => DirectSubmissionLogLevelExtensions.Error,
+                >= FatalThreshold => DirectSubmissionLogLevelExtensions.Fatal, // SEVERE, Critical, Alert, Fatal, Emergency
+            };
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetCommon.cs
@@ -1,0 +1,56 @@
+﻿// <copyright file="Log4NetCommon.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    internal class Log4NetCommon<TResponseArray>
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Log4NetCommon<TResponseArray>));
+
+        // ReSharper disable StaticMemberInGenericType
+        private static readonly Type AppenderElementType;
+        private static object? _appenderProxy;
+
+        static Log4NetCommon()
+        {
+            AppenderElementType = typeof(TResponseArray).GetElementType()!;
+        }
+
+        public static TResponseArray AddAppenderToResponse<TAppender>(TResponseArray originalResponseArray, TAppender appender)
+        {
+            try
+            {
+                if (originalResponseArray is null)
+                {
+                    return originalResponseArray;
+                }
+
+                var originalArray = (Array)(object)originalResponseArray;
+                var originalArrayLength = originalArray.Length;
+
+                var finalArray = Array.CreateInstance(AppenderElementType, originalArrayLength + 1);
+                if (originalArrayLength > 0)
+                {
+                    Array.Copy(originalArray, finalArray, originalArrayLength);
+                }
+
+                _appenderProxy ??= appender.DuckImplement(AppenderElementType);
+                finalArray.SetValue(_appenderProxy, finalArray.Length - 1);
+
+                return (TResponseArray)(object)finalArray;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error adding Log4Net appender to response");
+                return originalResponseArray;
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetDatadogLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetDatadogLogEvent.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="Log4NetDatadogLogEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Text;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    internal class Log4NetDatadogLogEvent : DatadogLogEvent
+    {
+        private readonly ILoggingEventDuckBase _logEvent;
+        private readonly DateTime _timestamp;
+
+        public Log4NetDatadogLogEvent(ILoggingEventDuckBase logEvent, DateTime timestamp)
+        {
+            _logEvent = logEvent;
+            _timestamp = timestamp;
+        }
+
+        public override void Format(StringBuilder sb, LogFormatter formatter)
+        {
+            Log4NetLogFormatter.FormatLogEvent(formatter, sb, _logEvent, _timestamp);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetLogFormatter.cs
@@ -79,7 +79,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
             // The message object could be anything, so only generate an eventID if we have a string message
             var messageTemplate = logEntry.MessageObject as string;
 
-            return new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate);
+            return new LogPropertyRenderingDetails(
+                hasRenderedSource: haveSource,
+                hasRenderedService: haveService,
+                hasRenderedHost: haveHost,
+                hasRenderedTags: haveTags,
+                hasRenderedEnv: haveEnv,
+                hasRenderedVersion: haveVersion,
+                messageTemplate: messageTemplate);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetLogFormatter.cs
@@ -1,0 +1,85 @@
+﻿// <copyright file="Log4NetLogFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Text;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
+{
+    internal class Log4NetLogFormatter
+    {
+        public static void FormatLogEvent(LogFormatter logFormatter, StringBuilder sb, ILoggingEventDuckBase logEntry, DateTime timestamp)
+        {
+            logFormatter.FormatLog(
+                sb,
+                logEntry,
+                timestamp,
+                logEntry.RenderedMessage,
+                eventId: null,
+                logEntry.Level.ToStandardLevelString(),
+                exception: null, // We can't pass the exception here, as it might be null if the event has been serialized
+                RenderProperties);
+        }
+
+        private static LogPropertyRenderingDetails RenderProperties(JsonTextWriter writer, in ILoggingEventDuckBase logEntry)
+        {
+            var haveSource = false;
+            var haveService = false;
+            var haveHost = false;
+            var haveTags = false;
+            var haveEnv = false;
+            var haveVersion = false;
+
+            var exception = logEntry.GetExceptionString();
+            if (!string.IsNullOrEmpty(exception))
+            {
+                writer.WritePropertyName("@x", escape: false);
+                writer.WriteValue(exception);
+            }
+
+            var properties = logEntry.GetProperties();
+            foreach (var keyObj in properties.Keys)
+            {
+                var name = keyObj as string;
+                if (name is null || name.StartsWith("log4net:"))
+                {
+                    continue;
+                }
+
+                var value = properties[name];
+
+                switch (value)
+                {
+                    case MethodInfo _:
+                    case Assembly _:
+                    case Module _:
+                        continue;
+                    default:
+                        haveSource |= LogFormatter.IsSourceProperty(name);
+                        haveService |= LogFormatter.IsServiceProperty(name);
+                        haveHost |= LogFormatter.IsHostProperty(name);
+                        haveTags |= LogFormatter.IsTagsProperty(name);
+                        haveEnv |= LogFormatter.IsEnvProperty(name);
+                        haveVersion |= LogFormatter.IsVersionProperty(name);
+
+                        LogFormatter.WritePropertyName(writer, name);
+                        LogFormatter.WriteValue(writer, value);
+                        break;
+                }
+            }
+
+            // The message object could be anything, so only generate an eventID if we have a string message
+            var messageTemplate = logEntry.MessageObject as string;
+
+            return new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetLogFormatter.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
                 eventId: null,
                 logEntry.Level.ToStandardLevelString(),
                 exception: null, // We can't pass the exception here, as it might be null if the event has been serialized
-                RenderProperties);
+                (JsonTextWriter w, in ILoggingEventDuckBase e) => RenderProperties(w, in e));
         }
 
         private static LogPropertyRenderingDetails RenderProperties(JsonTextWriter writer, in ILoggingEventDuckBase logEntry)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogLegacyTarget.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogLegacyTarget.cs
@@ -1,0 +1,80 @@
+﻿// <copyright file="DirectSubmissionNLogLegacyTarget.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission
+{
+    /// <summary>
+    /// NLog Target that sends logs directly to Datadog for NLog &lt;4.5
+    /// </summary>
+    internal class DirectSubmissionNLogLegacyTarget
+    {
+        private readonly IDatadogSink _sink;
+        private readonly int _minimumLevel;
+        private readonly LogFormatter? _formatter;
+        private Func<IDictionary<string, object?>?>? _getProperties = null;
+
+        internal DirectSubmissionNLogLegacyTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+            : this(sink, minimumLevel, formatter: null)
+        {
+        }
+
+        // internal for testing
+        internal DirectSubmissionNLogLegacyTarget(
+            IDatadogSink sink,
+            DirectSubmissionLogLevel minimumLevel,
+            LogFormatter? formatter)
+        {
+            _sink = sink;
+            _formatter = formatter;
+            _minimumLevel = (int)minimumLevel;
+        }
+
+        /// <summary>
+        /// Writes logging event to the log target
+        /// </summary>
+        /// <param name="logEventInfo">Logging event to be written out</param>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "NLog.LogEventInfo, NLog" })]
+        public void Write(ILogEventInfoLegacyProxy? logEventInfo)
+        {
+            if (logEventInfo is null)
+            {
+                return;
+            }
+
+            if (logEventInfo.Level.Ordinal < _minimumLevel)
+            {
+                return;
+            }
+
+            var contextProperties = _getProperties?.Invoke();
+            var eventProperties = logEventInfo.Properties is { Count: > 0 } props ? props : null;
+
+            // We render the event to a string immediately as we need to capture the properties
+            // This is more expensive from a CPU perspective, but is necessary as the properties
+            // won't necessarily be serialized correctly otherwise (e.g. dd_span_id/dd_trace_id)
+
+            var logEvent = new LogEntry(logEventInfo, contextProperties, eventProperties);
+            var logFormatter = _formatter ?? TracerManager.Instance.DirectLogSubmission.Formatter;
+            var serializedLog = NLogLogFormatter.FormatLogEvent(logFormatter, logEvent);
+
+            _sink.EnqueueLog(new NLogDatadogLogEvent(serializedLog));
+        }
+
+        internal void SetGetContextPropertiesFunc(Func<IDictionary<string, object?>?> func)
+        {
+            _getProperties = func;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogTarget.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogTarget.cs
@@ -1,0 +1,83 @@
+﻿// <copyright file="DirectSubmissionNLogTarget.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission
+{
+    /// <summary>
+    /// NLog Target that sends logs directly to Datadog
+    /// </summary>
+    internal class DirectSubmissionNLogTarget
+    {
+        private readonly IDatadogSink _sink;
+        private readonly int _minimumLevel;
+        private readonly LogFormatter? _formatter;
+        private ITargetWithContextBaseProxy? _baseProxy;
+
+        internal DirectSubmissionNLogTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+            : this(sink, minimumLevel, formatter: null)
+        {
+        }
+
+        // internal for testing
+        internal DirectSubmissionNLogTarget(
+            IDatadogSink sink,
+            DirectSubmissionLogLevel minimumLevel,
+            LogFormatter? formatter)
+        {
+            _sink = sink;
+            _formatter = formatter;
+            _minimumLevel = (int)minimumLevel;
+        }
+
+        /// <summary>
+        /// Writes logging event to the log target
+        /// </summary>
+        /// <param name="logEventInfo">Logging event to be written out</param>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "NLog.LogEventInfo, NLog" })]
+        public void Write(ILogEventInfoProxy? logEventInfo)
+        {
+            if (logEventInfo is null)
+            {
+                return;
+            }
+
+            if (logEventInfo.Level.Ordinal < _minimumLevel)
+            {
+                return;
+            }
+
+            // Nlog automatically includes all the properties from the event, so don't need fallback properties
+            var mappedProperties = _baseProxy?.GetAllProperties(logEventInfo);
+
+            // We render the event to a string immediately as we need to capture the properties
+            // This is more expensive from a CPU perspective, but is necessary as the properties
+            // won't necessarily be serialized correctly otherwise (e.g. dd_span_id/dd_trace_id)
+
+            var logEvent = new LogEntry(logEventInfo, mappedProperties, fallbackProperties: null);
+            var logFormatter = _formatter ?? TracerManager.Instance.DirectLogSubmission.Formatter;
+            var serializedLog = NLogLogFormatter.FormatLogEvent(logFormatter, logEvent);
+
+            _sink.EnqueueLog(new NLogDatadogLogEvent(serializedLog));
+        }
+
+        internal void SetBaseProxy(ITargetWithContextBaseProxy baseProxy)
+        {
+            _baseProxy = baseProxy;
+            _baseProxy.IncludeEventProperties = true;
+            _baseProxy.IncludeMdc = true;
+            _baseProxy.IncludeMdlc = true;
+            _baseProxy.IncludeNdc = true;
+            _baseProxy.IncludeNdlc = true;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/LogEntry.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/LogEntry.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="LogEntry.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting
+{
+    internal readonly struct LogEntry
+    {
+        public LogEntry(
+            ILogEventInfoProxyBase logEventInfo,
+            IDictionary<string, object?>? properties,
+            IDictionary<object, object>? fallbackProperties)
+        {
+            LogEventInfo = logEventInfo;
+            Properties = properties;
+            FallbackProperties = fallbackProperties;
+        }
+
+        public ILogEventInfoProxyBase LogEventInfo { get; }
+
+        public IDictionary<string, object?>? Properties { get; }
+
+        public IDictionary<object, object>? FallbackProperties { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogDatadogLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogDatadogLogEvent.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="NLogDatadogLogEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting
+{
+    internal class NLogDatadogLogEvent : DatadogLogEvent
+    {
+        private readonly string _serializedEvent;
+
+        public NLogDatadogLogEvent(string serializedEvent)
+        {
+            _serializedEvent = serializedEvent;
+        }
+
+        public override void Format(StringBuilder sb, LogFormatter formatter)
+        {
+            sb.Append(_serializedEvent);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogLogFormatter.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
                 eventId: null,
                 GetLogLevelString(logEntry.Level),
                 logEntry.Exception,
-                RenderProperties);
+                (JsonTextWriter w, in LogEntry e) => RenderProperties(w, e));
         }
 
         private static LogPropertyRenderingDetails RenderProperties(JsonTextWriter writer, in LogEntry logEntryWrapper)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogLogFormatter.cs
@@ -1,0 +1,97 @@
+﻿// <copyright file="NLogLogFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting
+{
+    internal class NLogLogFormatter
+    {
+        public static string FormatLogEvent(LogFormatter logFormatter, in LogEntry logEntryWrapper)
+        {
+            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+            FormatLogEvent(logFormatter, sb, logEntryWrapper);
+            return StringBuilderCache.GetStringAndRelease(sb);
+        }
+
+        public static void FormatLogEvent(LogFormatter logFormatter, StringBuilder sb, in LogEntry logEntryWrapper)
+        {
+            var logEntry = logEntryWrapper.LogEventInfo;
+            logFormatter.FormatLog(
+                sb,
+                logEntryWrapper,
+                logEntry.TimeStamp.ToUniversalTime(),
+                logEntry.FormattedMessage,
+                eventId: null,
+                GetLogLevelString(logEntry.Level),
+                logEntry.Exception,
+                RenderProperties);
+        }
+
+        private static LogPropertyRenderingDetails RenderProperties(JsonTextWriter writer, in LogEntry logEntryWrapper)
+        {
+            var haveSource = false;
+            var haveService = false;
+            var haveHost = false;
+            var haveTags = false;
+            var haveEnv = false;
+            var haveVersion = false;
+
+            if (logEntryWrapper.Properties is not null)
+            {
+                foreach (var kvp in logEntryWrapper.Properties)
+                {
+                    var name = kvp.Key;
+                    haveSource |= LogFormatter.IsSourceProperty(name);
+                    haveService |= LogFormatter.IsServiceProperty(name);
+                    haveHost |= LogFormatter.IsHostProperty(name);
+                    haveTags |= LogFormatter.IsTagsProperty(name);
+                    haveEnv |= LogFormatter.IsEnvProperty(name);
+                    haveVersion |= LogFormatter.IsVersionProperty(name);
+
+                    LogFormatter.WritePropertyName(writer, name);
+                    LogFormatter.WriteValue(writer, kvp.Value);
+                }
+            }
+            else if (logEntryWrapper.FallbackProperties is not null)
+            {
+                foreach (var kvp in logEntryWrapper.FallbackProperties)
+                {
+                    var name = kvp.Key.ToString();
+                    haveSource |= LogFormatter.IsSourceProperty(name);
+                    haveService |= LogFormatter.IsServiceProperty(name);
+                    haveHost |= LogFormatter.IsHostProperty(name);
+                    haveTags |= LogFormatter.IsTagsProperty(name);
+                    haveEnv |= LogFormatter.IsEnvProperty(name);
+                    haveVersion |= LogFormatter.IsVersionProperty(name);
+
+                    LogFormatter.WritePropertyName(writer, name);
+                    LogFormatter.WriteValue(writer, kvp.Value);
+                }
+            }
+
+            return new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate: logEntryWrapper.LogEventInfo.Message);
+        }
+
+        private static string GetLogLevelString(LogLevelProxy logLevel) =>
+            logLevel.Ordinal switch
+            {
+                0 => DirectSubmissionLogLevelExtensions.Verbose,
+                1 => DirectSubmissionLogLevelExtensions.Debug,
+                2 => DirectSubmissionLogLevelExtensions.Information,
+                3 => DirectSubmissionLogLevelExtensions.Warning,
+                4 => DirectSubmissionLogLevelExtensions.Error,
+                5 => DirectSubmissionLogLevelExtensions.Fatal,
+                // Technically there's a 6, off, but should never have this level in a log message
+                _ => DirectSubmissionLogLevelExtensions.Unknown,
+            };
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogLogFormatter.cs
@@ -78,7 +78,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
                 }
             }
 
-            return new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate: logEntryWrapper.LogEventInfo.Message);
+            return new LogPropertyRenderingDetails(
+                hasRenderedSource: haveSource,
+                hasRenderedService: haveService,
+                hasRenderedHost: haveHost,
+                hasRenderedTags: haveTags,
+                hasRenderedEnv: haveEnv,
+                hasRenderedVersion: haveVersion,
+                messageTemplate: logEntryWrapper.LogEventInfo.Message);
         }
 
         private static string GetLogLevelString(LogLevelProxy logLevel) =>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/LogFactoryGetConfigurationForLoggerInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/LogFactoryGetConfigurationForLoggerInstrumentation.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="LogFactoryGetConfigurationForLoggerInstrumentation.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission
+{
+    /// <summary>
+    /// LogFactory.GetConfigurationForLogger calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "NLog",
+        TypeName = "NLog.LogFactory",
+        MethodName = "GetConfigurationForLogger",
+        ReturnTypeName = ClrNames.Void,
+        ParameterTypeNames = new[] { ClrNames.String, "NLog.Config.LoggingConfiguration" },
+        MinimumVersion = "2.1.0",
+        MaximumVersion = "4.*.*",
+        IntegrationName = NLogConstants.IntegrationName)]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class LogFactoryGetConfigurationForLoggerInstrumentation
+    {
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <typeparam name="TLoggingConfiguration">Type of the LoggingConfiguration object</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method</param>
+        /// <param name="name">The name of the logger</param>
+        /// <param name="configuration">The logging configuration</param>
+        /// <returns>Calltarget state value</returns>
+        public static CallTargetState OnMethodBegin<TTarget, TLoggingConfiguration>(TTarget instance, string name, TLoggingConfiguration configuration)
+        {
+            if (TracerManager.Instance.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.NLog)
+             && configuration is not null)
+            {
+                // if configuration is not-null, we've already checked that NLog is enabled
+                NLogCommon<TTarget>.AddDatadogTarget(configuration);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
@@ -1,0 +1,393 @@
+﻿// <copyright file="NLogCommon.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission
+{
+    internal static class NLogCommon<TTarget>
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(NLogCommon<TTarget>));
+
+        // ReSharper disable StaticMemberInGenericType
+        // ReSharper disable InconsistentNaming
+        private static readonly NLogVersion _nLogVersion;
+        private static readonly Type? _targetType;
+
+        private static readonly bool _hasMappedDiagnosticsContext;
+        private static readonly bool _isModernMappedDiagnosticsContext;
+        private static readonly MappedDiagnosticsProxy? _mdc;
+        private static readonly MappedDiagnosticsContextLegacyProxy _mdcLegacy;
+        private static readonly bool _hasMappedDiagnosticsLogicalContext;
+        private static readonly bool _isModernMappedDiagnosticsLogicalContext;
+        private static readonly MappedDiagnosticsProxy? _mdlc;
+        private static readonly MappedDiagnosticsLogicalContextLegacyProxy _mdlcLegacy;
+
+        private static readonly object? _targetProxy;
+        private static readonly Func<object>? _createLoggingRuleFunc;
+        // ReSharper restore InconsistentNaming
+
+        static NLogCommon()
+        {
+            try
+            {
+                var nlogAssembly = typeof(TTarget).Assembly;
+                _targetType = nlogAssembly.GetType("NLog.Targets.TargetWithContext");
+                if (_targetType is not null)
+                {
+                    _nLogVersion = NLogVersion.NLog45;
+
+                    _targetProxy = CreateNLogTargetProxy(new DirectSubmissionNLogTarget(
+                                                             TracerManager.Instance.DirectLogSubmission.Sink,
+                                                             TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel));
+                    return;
+                }
+
+                _targetType = nlogAssembly.GetType("NLog.Targets.Target");
+
+                // Type was added in NLog 4.3, so we can use it to safely determine the version
+                var testType = nlogAssembly.GetType("NLog.Config.ExceptionRenderingFormat");
+                _nLogVersion = testType is null ? NLogVersion.NLogPre43 : NLogVersion.NLog43To45;
+
+                TryGetMdcProxy(nlogAssembly, out _hasMappedDiagnosticsContext, out _isModernMappedDiagnosticsContext, out _mdc, out _mdcLegacy);
+                TryGetMdlcProxy(nlogAssembly, out _hasMappedDiagnosticsLogicalContext, out _isModernMappedDiagnosticsLogicalContext, out _mdlc, out _mdlcLegacy);
+
+                _targetProxy = CreateNLogTargetProxy(new DirectSubmissionNLogLegacyTarget(
+                                                         TracerManager.Instance.DirectLogSubmission.Sink,
+                                                         TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel));
+
+                if (_nLogVersion == NLogVersion.NLogPre43)
+                {
+                    _createLoggingRuleFunc = CreateLoggingRuleActivator(nlogAssembly);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error creating NLog target proxies for direct log shipping");
+                _targetType = null;
+                _targetProxy = null;
+            }
+        }
+
+        internal enum NLogVersion
+        {
+            NLog45 = 0,
+            NLog43To45 = 1,
+            NLogPre43 = 2,
+        }
+
+        public static void AddDatadogTarget(object loggingConfiguration)
+        {
+            if (_targetProxy is null)
+            {
+                return;
+            }
+
+            switch (_nLogVersion)
+            {
+                case NLogVersion.NLog45:
+                    AddDatadogTargetNLog45(loggingConfiguration, _targetProxy);
+                    break;
+                case NLogVersion.NLog43To45:
+                    AddDatadogTargetNLog43To45(loggingConfiguration, _targetProxy);
+                    break;
+                default:
+                    AddDatadogTargetNLogPre43(loggingConfiguration, _targetProxy);
+                    break;
+            }
+        }
+
+        public static IDictionary<string, object?>? GetContextProperties()
+        {
+            IDictionary<string, object?>? properties = null;
+            if (_hasMappedDiagnosticsContext)
+            {
+                if (_isModernMappedDiagnosticsContext)
+                {
+                    var names = _mdc!.GetNames(); // C# isn't clever enough to figure that this is never null here
+                    properties = new Dictionary<string, object?>(names.Count);
+                    foreach (var name in names)
+                    {
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            // could be a <string, string> or a <string, object>, depending on NLog version
+                            properties[name] = _mdc.GetObject(name);
+                        }
+                    }
+                }
+                else if (_mdcLegacy.ThreadDictionary is { } dict)
+                {
+                    properties = new Dictionary<string, object?>(dict.Count);
+                    foreach (string? name in dict.Keys)
+                    {
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            // could be a <string, string> or a <string, object>, depending on NLog version
+                            properties[name!] = dict[name];
+                        }
+                    }
+                }
+            }
+
+            if (_hasMappedDiagnosticsLogicalContext)
+            {
+                if (_isModernMappedDiagnosticsLogicalContext)
+                {
+                    var names = _mdlc!.GetNames(); // C# isn't clever enough to figure that this is never null here
+                    properties ??= new Dictionary<string, object?>(names.Count);
+                    foreach (var name in names)
+                    {
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            // could be a <string, string> or a <string, object>, depending on NLog version
+                            properties[name] = _mdlc.GetObject(name);
+                        }
+                    }
+                }
+                else if (_mdlcLegacy.LogicalThreadDictionary is { } dict)
+                {
+                    properties ??= new Dictionary<string, object?>(dict.Count);
+                    foreach (string? name in dict.Keys)
+                    {
+                        if (!string.IsNullOrEmpty(name))
+                        {
+                            // could be a <string, string> or a <string, object>, depending on NLog version
+                            properties[name!] = dict[name];
+                        }
+                    }
+                }
+            }
+
+            return properties;
+        }
+
+        // internal for testing
+        internal static void AddDatadogTargetNLog45(object loggingConfiguration, object targetProxy)
+        {
+            // Could also do the duck cast in the method signature, but this avoids the allocation in the instrumentation
+            // if not enabled.
+            var loggingConfigurationProxy = loggingConfiguration.DuckCast<ILoggingConfigurationProxy>();
+            if (loggingConfigurationProxy.ConfiguredNamedTargets is not null)
+            {
+                foreach (var target in loggingConfigurationProxy.ConfiguredNamedTargets)
+                {
+                    if (target is IDuckType { Instance: DirectSubmissionNLogTarget })
+                    {
+                        // already added
+                        return;
+                    }
+                }
+            }
+
+            // need to add the new target to the logging configuraiton
+            loggingConfigurationProxy.AddTarget(NLogConstants.DatadogTargetName, targetProxy);
+            loggingConfigurationProxy.AddRuleForAllLevels(targetProxy, "**", final: true);
+
+            Log.Information("Direct log submission via NLog enabled");
+        }
+
+        // internal for testing
+        internal static void AddDatadogTargetNLog43To45(object loggingConfiguration, object targetProxy)
+        {
+            // Could also do the duck cast in the method signature, but this avoids the allocation in the instrumentation
+            // if not enabled.
+            var loggingConfigurationProxy = loggingConfiguration.DuckCast<ILoggingConfigurationLegacyProxy>();
+            if (loggingConfigurationProxy.ConfiguredNamedTargets is not null)
+            {
+                foreach (var target in loggingConfigurationProxy.ConfiguredNamedTargets)
+                {
+                    if (target is IDuckType { Instance: DirectSubmissionNLogLegacyTarget })
+                    {
+                        // already added
+                        return;
+                    }
+                }
+            }
+
+            // need to add the new target to the logging configuraiton
+            loggingConfigurationProxy.AddTarget(NLogConstants.DatadogTargetName, targetProxy);
+            loggingConfigurationProxy.AddRuleForAllLevels(targetProxy, "**");
+
+            Log.Information("Direct log submission via NLog enabled");
+        }
+
+        // internal for testing
+        internal static void AddDatadogTargetNLogPre43(object loggingConfiguration, object targetProxy)
+        {
+            var loggingConfigurationProxy = loggingConfiguration.DuckCast<ILoggingConfigurationPre43Proxy>();
+
+            if (loggingConfigurationProxy.ConfiguredNamedTargets is not null)
+            {
+                foreach (var target in loggingConfigurationProxy.ConfiguredNamedTargets)
+                {
+                    if (target is IDuckType { Instance: DirectSubmissionNLogTarget })
+                    {
+                        // already added
+                        return;
+                    }
+                }
+            }
+
+            if (_createLoggingRuleFunc is null)
+            {
+                // we failed on startup, so should never get to this point
+                return;
+            }
+
+            // need to create and add the new target
+            loggingConfigurationProxy.AddTarget(NLogConstants.DatadogTargetName, targetProxy);
+
+            // Have to create a logging rule the hard way
+            var instance = _createLoggingRuleFunc();
+            var ruleProxy = instance.DuckCast<ILoggingRuleProxy>();
+
+            ruleProxy.LoggerNamePattern = "**";
+            ruleProxy.Targets.Add(targetProxy);
+            for (var i = 0; i < 6; i++)
+            {
+                ruleProxy.LogLevels[i] = true;
+            }
+
+            ruleProxy.Final = true;
+            loggingConfigurationProxy.LoggingRules.Add(instance);
+
+            Log.Information("Direct log submission via NLog enabled");
+        }
+
+        // internal for testing
+        internal static object CreateNLogTargetProxy(DirectSubmissionNLogTarget target)
+        {
+            // create a new instance of DirectSubmissionNLogTarget
+            var reverseProxy = target.DuckImplement(_targetType);
+            var targetProxy = reverseProxy.DuckCast<ITargetWithContextBaseProxy>();
+            target.SetBaseProxy(targetProxy);
+            // theoretically this should be called per logging configuration
+            // but we don't need to so hack in the call here
+            targetProxy.Initialize(null);
+            return reverseProxy;
+        }
+
+        // internal for testing
+        internal static object CreateNLogTargetProxy(DirectSubmissionNLogLegacyTarget target)
+        {
+            var reverseProxy = target.DuckImplement(_targetType);
+            if (_hasMappedDiagnosticsContext || _hasMappedDiagnosticsLogicalContext)
+            {
+                target.SetGetContextPropertiesFunc(GetContextProperties);
+            }
+
+            var targetProxy = reverseProxy.DuckCast<ITargetProxy>();
+            // theoretically this should be called per logging configuration
+            // but we don't need to so hack in the call here
+            targetProxy.Initialize(null);
+
+            return reverseProxy;
+        }
+
+        // internal for testing
+        internal static void TryGetMdcProxy(
+            Assembly nlogAssembly,
+            out bool haveMdcProxy,
+            out bool isModernMdcProxy,
+            out MappedDiagnosticsProxy? mdc,
+            out MappedDiagnosticsContextLegacyProxy mdcLegacy)
+        {
+            var mdcType = nlogAssembly.GetType("NLog.MappedDiagnosticsContext");
+            if (mdcType is not null)
+            {
+                var createTypeResult = DuckType.GetOrCreateProxyType(typeof(MappedDiagnosticsProxy), mdcType);
+                if (createTypeResult.Success)
+                {
+                    mdc = createTypeResult.CreateInstance<MappedDiagnosticsProxy>(instance: null);
+                    mdcLegacy = default;
+                    haveMdcProxy = true;
+                    isModernMdcProxy = true;
+                    return;
+                }
+
+                var createLegacyTypeResult = DuckType.GetOrCreateProxyType(typeof(MappedDiagnosticsContextLegacyProxy), mdcType);
+                if (createLegacyTypeResult.Success)
+                {
+                    mdcLegacy = createLegacyTypeResult.CreateInstance<MappedDiagnosticsContextLegacyProxy>(instance: null);
+                    mdc = default;
+                    haveMdcProxy = true;
+                    isModernMdcProxy = false;
+                    return;
+                }
+            }
+
+            haveMdcProxy = false;
+            isModernMdcProxy = false;
+            mdcLegacy = default;
+            mdc = default;
+        }
+
+        // internal for testing
+        internal static void TryGetMdlcProxy(
+            Assembly nlogAssembly,
+            out bool haveMdlcProxy,
+            out bool isModernMdlcProxy,
+            out MappedDiagnosticsProxy? mdlc,
+            out MappedDiagnosticsLogicalContextLegacyProxy mdlcLegacy)
+        {
+            var mdclType = nlogAssembly.GetType("NLog.MappedDiagnosticsLogicalContext");
+            if (mdclType is not null)
+            {
+                var createTypeResult = DuckType.GetOrCreateProxyType(typeof(MappedDiagnosticsProxy), mdclType);
+                if (createTypeResult.Success)
+                {
+                    mdlc = createTypeResult.CreateInstance<MappedDiagnosticsProxy>(instance: null);
+                    mdlcLegacy = default;
+                    haveMdlcProxy = true;
+                    isModernMdlcProxy = true;
+                    return;
+                }
+
+                var createLegacyTypeResult = DuckType.GetOrCreateProxyType(typeof(MappedDiagnosticsLogicalContextLegacyProxy), mdclType);
+                if (createLegacyTypeResult.Success)
+                {
+                    mdlcLegacy = createLegacyTypeResult.CreateInstance<MappedDiagnosticsLogicalContextLegacyProxy>(instance: null);
+                    mdlc = null;
+                    haveMdlcProxy = true;
+                    isModernMdlcProxy = false;
+                    return;
+                }
+            }
+
+            mdlc = null;
+            mdlcLegacy = default;
+            haveMdlcProxy = false;
+            isModernMdlcProxy = false;
+        }
+
+        // internal for testing
+        internal static Func<object> CreateLoggingRuleActivator(Assembly nlogAssembly)
+        {
+            var loggingRuleType = nlogAssembly.GetType("NLog.Config.LoggingRule");
+            var ctor = loggingRuleType!.GetConstructor(Type.EmptyTypes)!; // Nullable YOLO
+
+            DynamicMethod createLoggingRuleMethod = new DynamicMethod(
+                $"NLogCommon_CreateLoggingRuleActivator",
+                loggingRuleType,
+                null,
+                typeof(DuckType).Module,
+                true);
+
+            ILGenerator il = createLoggingRuleMethod.GetILGenerator();
+            il.Emit(OpCodes.Newobj, ctor);
+            il.Emit(OpCodes.Ret);
+
+            return (Func<object>)createLoggingRuleMethod.CreateDelegate(typeof(Func<object>));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
@@ -193,7 +193,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             loggingConfigurationProxy.AddTarget(NLogConstants.DatadogTargetName, targetProxy);
             loggingConfigurationProxy.AddRuleForAllLevels(targetProxy, "**", final: true);
 
-            Log.Information("Direct log submission via NLog enabled");
+            Log.Information("Direct log submission via NLog 4.5+ enabled");
         }
 
         // internal for testing
@@ -218,7 +218,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             loggingConfigurationProxy.AddTarget(NLogConstants.DatadogTargetName, targetProxy);
             loggingConfigurationProxy.AddRuleForAllLevels(targetProxy, "**");
 
-            Log.Information("Direct log submission via NLog enabled");
+            Log.Information("Direct log submission via NLog 4.3-4.5 enabled");
         }
 
         // internal for testing
@@ -261,7 +261,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             ruleProxy.Final = true;
             loggingConfigurationProxy.LoggingRules.Add(instance);
 
-            Log.Information("Direct log submission via NLog enabled");
+            Log.Information("Direct log submission via NLog <4.3 enabled");
         }
 
         // internal for testing

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogCommon.cs
@@ -283,7 +283,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             var reverseProxy = target.DuckImplement(_targetType);
             if (_hasMappedDiagnosticsContext || _hasMappedDiagnosticsLogicalContext)
             {
-                target.SetGetContextPropertiesFunc(GetContextProperties);
+                target.SetGetContextPropertiesFunc(() => GetContextProperties());
             }
 
             var targetProxy = reverseProxy.DuckCast<ITargetProxy>();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/NLogConstants.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="NLogConstants.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Configuration;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission
+{
+    internal static class NLogConstants
+    {
+        internal const string DatadogTargetName = "Datadog";
+
+        internal const string IntegrationName = nameof(IntegrationId.NLog);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILogEventInfoLegacyProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILogEventInfoLegacyProxy.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="ILogEventInfoLegacyProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for LogEventInfo  for NLog &lt; 4.5
+    /// Using virtual members, as will need to be boxed, so no advantage from using a struct
+    /// </summary>
+    internal interface ILogEventInfoLegacyProxy : ILogEventInfoProxyBase
+    {
+        /// <summary>
+        /// Gets the dictionary of per-event context properties
+        /// </summary>
+        [DuckField(Name = "properties")]
+        public IDictionary<object, object> Properties { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILogEventInfoProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILogEventInfoProxy.cs
@@ -1,0 +1,26 @@
+// <copyright file="ILogEventInfoProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for LogEventInfo  for NLog &gt; 4.5
+    /// Using virtual members, as will need to be boxed, so no advantage from using a struct
+    /// </summary>
+    internal interface ILogEventInfoProxy : ILogEventInfoProxyBase
+    {
+        /// <summary>
+        /// Gets a value indicating whether there are any per-event properties (Without allocation)
+        /// </summary>
+        public bool HasProperties { get; }
+
+        /// <summary>
+        /// Gets the dictionary of per-event context properties
+        /// </summary>
+        public IDictionary<object, object> Properties { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILogEventInfoProxyBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILogEventInfoProxyBase.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="ILogEventInfoProxyBase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for LogEventInfo  for NLog &lt; 4.5
+    /// Using interface members, as will need to be boxed, so no advantage from using a struct
+    /// </summary>
+    internal interface ILogEventInfoProxyBase
+    {
+        /// <summary>
+        /// Gets the timestamp
+        /// </summary>
+        public DateTime TimeStamp { get; }
+
+        /// <summary>
+        /// Gets the log level
+        /// </summary>
+        public LogLevelProxy Level { get; }
+
+        /// <summary>
+        /// Gets the exception
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Gets the formatted message.
+        /// </summary>
+        public string FormattedMessage { get; }
+
+        /// <summary>
+        /// Gets the log message including any parameter placeholders.
+        /// </summary>
+        public string Message { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILoggingConfigurationLegacyProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILoggingConfigurationLegacyProxy.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ILoggingConfigurationLegacyProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for LoggingConfiguration for NLog &gt; 4.3-4.5
+    /// </summary>
+    internal interface ILoggingConfigurationLegacyProxy
+    {
+        /// <summary>
+        /// Gets a collection of named targets specified in the configuration.
+        /// </summary>
+        public IEnumerable ConfiguredNamedTargets { get; }
+
+        /// <summary>
+        /// Registers the specified target object under a given name.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        /// <param name="target">The target object.</param>
+        [Duck(ParameterTypeNames = new[] { ClrNames.String, "NLog.Targets.Target, NLog" })]
+        public void AddTarget(string name, object target);
+
+        /// <summary>
+        /// Add a rule for all loglevels.
+        /// </summary>
+        /// <param name="target">Target to be written to when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        [Duck(ParameterTypeNames = new[] { "NLog.Targets.Target, NLog", ClrNames.String })]
+        public void AddRuleForAllLevels(object target, string loggerNamePattern);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILoggingConfigurationProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ILoggingConfigurationProxy.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ILoggingConfigurationProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for LoggingConfiguration for NLog 4.5+
+    /// </summary>
+    internal interface ILoggingConfigurationProxy
+    {
+        /// <summary>
+        /// Gets a collection of named targets specified in the configuration.
+        /// </summary>
+        public IEnumerable ConfiguredNamedTargets { get; }
+
+        /// <summary>
+        /// Registers the specified target object under a given name.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        /// <param name="target">The target object.</param>
+        [Duck(ParameterTypeNames = new[] { ClrNames.String, "NLog.Targets.Target, NLog" })]
+        public void AddTarget(string name, object target);
+
+        /// <summary>
+        /// Add a rule for all loglevels.
+        /// </summary>
+        /// <param name="target">Target to be written to when the rule matches.</param>
+        /// <param name="loggerNamePattern">Logger name pattern. It may include the '*' wildcard at the beginning, at the end or at both ends.</param>
+        /// <param name="final">Gets or sets a value indicating whether to quit processing any further rule when this one matches.</param>
+        [Duck(ParameterTypeNames = new[] { "NLog.Targets.Target, NLog", ClrNames.String, ClrNames.Bool })]
+        public void AddRuleForAllLevels(object target, string loggerNamePattern, bool final);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ITargetProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ITargetProxy.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="ITargetProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for TargetWithContext
+    /// Represents target that supports context capture using MDLC, MDC, NDLC and NDC
+    /// </summary>
+    internal interface ITargetProxy
+    {
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        [Duck(ExplicitInterfaceTypeName = "NLog.Internal.ISupportsInitialize", ParameterTypeNames = new[] { "NLog.Config.LoggingConfiguration" })]
+        public void Initialize(object configuration);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ITargetWithContextBaseProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/ITargetWithContextBaseProxy.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="ITargetWithContextBaseProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for TargetWithContext
+    /// Represents target that supports context capture using MDLC, MDC, NDLC and NDC
+    /// </summary>
+    internal interface ITargetWithContextBaseProxy
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether gets or sets the option to include all properties from the log events
+        /// </summary>
+        public bool IncludeEventProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the MappedDiagnosticsContext dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeMdc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the NestedDiagnosticsContext stack.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeNdc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the MappedDiagnosticsLogicalContext dictionary.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeMdlc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to include contents of the NestedDiagnosticsLogicalContext stack.
+        /// </summary>
+        /// <docgen category='Payload Options' order='10' />
+        public bool IncludeNdlc { get; set; }
+
+        /// <summary>
+        /// Creates combined dictionary of all configured properties for logEvent
+        /// </summary>
+        /// <param name="logEvent">The event to record</param>
+        /// <returns>Dictionary with all collected properties for logEvent</returns>
+        public IDictionary<string, object> GetAllProperties(ILogEventInfoProxy logEvent);
+
+        /// <summary>
+        /// Initializes this instance.
+        /// </summary>
+        /// <param name="configuration">The configuration.</param>
+        [Duck(ExplicitInterfaceTypeName = "NLog.Internal.ISupportsInitialize", ParameterTypeNames = new[] { "NLog.Config.LoggingConfiguration" })]
+        public void Initialize(object configuration);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/LogLevelProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/LogLevelProxy.cs
@@ -1,0 +1,21 @@
+// <copyright file="LogLevelProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for LogLevel
+    /// </summary>
+    [DuckCopy]
+    internal struct LogLevelProxy
+    {
+        /// <summary>
+        /// Gets the name of the log level
+        /// </summary>
+        public int Ordinal;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/MappedDiagnosticsContextLegacyProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/MappedDiagnosticsContextLegacyProxy.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="MappedDiagnosticsContextLegacyProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for MappedDiagnosticsContextProxy for NLog &lt; 4.3
+    /// Mapped Diagnostics Context - a thread-local structure that keeps a dictionary
+    /// of strings and provides methods to output them in layouts.
+    /// </summary>
+    internal struct MappedDiagnosticsContextLegacyProxy
+    {
+        /// <summary>
+        /// Gets the thread local dictionary for the type
+        /// Using an IDictionary instead of typed as in 4.0.x  this is a (string, string),
+        /// and in later versions it's a (string, object)
+        /// </summary>
+        public IDictionary ThreadDictionary;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/MappedDiagnosticsLogicalContextLegacyProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/MappedDiagnosticsLogicalContextLegacyProxy.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="MappedDiagnosticsLogicalContextLegacyProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for MappedDiagnosticsLogicalContext in NLog &lt;4.3
+    /// Async version of Mapped Diagnostics Context - a logical context structure that keeps a dictionary
+    /// of strings and provides methods to output them in layouts.  Allows for maintaining state across
+    /// asynchronous tasks and call contexts.
+    /// </summary>
+    internal struct MappedDiagnosticsLogicalContextLegacyProxy
+    {
+        /// <summary>
+        /// Gets the async  local dictionary for the type
+        /// </summary>
+        public IDictionary LogicalThreadDictionary;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/MappedDiagnosticsProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/MappedDiagnosticsProxy.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="MappedDiagnosticsProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies
+{
+    /// <summary>
+    /// Duck type for MappedDiagnosticsContext and MappedDiagnosticsLogicalContext in NLog 4.3+
+    /// Async version of Mapped Diagnostics Context - a logical context structure that keeps a dictionary
+    /// of strings and provides methods to output them in layouts.  Allows for maintaining state across
+    /// asynchronous tasks and call contexts.
+    /// </summary>
+#pragma warning disable SA1400
+#pragma warning disable SA1302
+    internal interface MappedDiagnosticsProxy
+#pragma warning restore SA1302
+#pragma warning restore SA1400
+    {
+        /// <summary>
+        /// Gets the item names
+        /// </summary>
+        /// <returns>A collection of the names of all items in current logical context.</returns>
+        public ICollection<string> GetNames();
+
+        /// <summary>
+        /// Gets the current logical context named item, as <see cref="object"/>
+        /// </summary>
+        /// <param name="item">Item name</param>
+        /// <returns>The value of <paramref name="item"/>, if defined; otherwise <c>null</c>.</returns>
+        public object GetObject(string item);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ILoggingConfigurationPre43Proxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ILoggingConfigurationPre43Proxy.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="ILoggingConfigurationPre43Proxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43
+{
+    /// <summary>
+    /// Duck type for LoggingConfiguration for NLog &lt; 4.3
+    /// </summary>
+    internal interface ILoggingConfigurationPre43Proxy
+    {
+        /// <summary>
+        /// Gets a collection of named targets specified in the configuration.
+        /// </summary>
+        public IEnumerable ConfiguredNamedTargets { get; }
+
+        /// <summary>
+        /// Gets the collection of logging rules
+        /// </summary>
+        public ILoggingRulesListProxy LoggingRules { get; }
+
+        /// <summary>
+        /// Registers the specified target object under a given name.
+        /// </summary>
+        /// <param name="name">Name of the target.</param>
+        /// <param name="target">The target object.</param>
+        [Duck(ParameterTypeNames = new[] { ClrNames.String, "NLog.Targets.Target, NLog" })]
+        public void AddTarget(string name, object target);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ILoggingRuleProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ILoggingRuleProxy.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="ILoggingRuleProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43
+{
+    /// <summary>
+    /// Duck type for LoggingRule for NLog &lt; 4.3
+    /// This is left as an interface instead of a [DuckCopy] struct as we need to
+    /// set values on the proxy too.
+    /// </summary>
+    internal interface ILoggingRuleProxy
+    {
+        /// <summary>
+        /// Gets or sets logger name pattern
+        /// </summary>
+        public string LoggerNamePattern { get; set; }
+
+        /// <summary>
+        /// Gets the collection of logging rules
+        /// </summary>
+        public ITargetListProxy Targets { get; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to quit processing any further rule when this one matches
+        /// </summary>
+        public bool Final { get; set; }
+
+        /// <summary>
+        /// Gets the loglevels
+        /// </summary>
+        [DuckField(Name = "logLevels")]
+        public bool[] LogLevels { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ILoggingRulesListProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ILoggingRulesListProxy.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="ILoggingRulesListProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.ComponentModel;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43
+{
+    /// <summary>
+    /// Duck type for IList&lt;LoggingRule&gt;
+    /// </summary>
+    internal interface ILoggingRulesListProxy
+    {
+        /// <summary>
+        /// Adds the logging rule to the collection
+        /// </summary>
+        /// <param name="item">The logging rule to add to the collection</param>
+        [Duck(ParameterTypeNames = new[] { "NLog.Config.LoggingRule, NLog" })]
+        public void Add(object item);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ITargetListProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Proxies/Pre43/ITargetListProxy.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="ITargetListProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43
+{
+    /// <summary>
+    /// Duck type for IList&lt;LoggingRule&gt;
+    /// </summary>
+    internal interface ITargetListProxy
+    {
+        /// <summary>
+        /// Adds the logging rule to the collection
+        /// </summary>
+        /// <param name="item">The logging rule to add to the collection</param>
+        [Duck(ParameterTypeNames = new[] { "NLog.Targets.Target, NLog" })]
+        public void Add(object item);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
@@ -1,0 +1,47 @@
+// <copyright file="DirectSubmissionSerilogSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    /// <summary>
+    /// Serilog Sink
+    /// </summary>
+    internal class DirectSubmissionSerilogSink
+    {
+        private readonly IDatadogSink _sink;
+        private readonly int _minimumLevel;
+
+        internal DirectSubmissionSerilogSink(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        {
+            _sink = sink;
+            _minimumLevel = (int)minimumLevel;
+        }
+
+        /// <summary>
+        /// Emit the provided log event to the sink
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        [DuckReverseMethod(ParameterTypeNames = new[] { "Serilog.Events.LogEvent, Serilog" })]
+        public void Emit(ILogEvent? logEvent)
+        {
+            if (logEvent is null)
+            {
+                return;
+            }
+
+            if ((int)logEvent.Level < _minimumLevel)
+            {
+                return;
+            }
+
+            _sink.EnqueueLog(new SerilogDatadogLogEvent(logEvent));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/DictionaryValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/DictionaryValueDuck.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="DictionaryValueDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for ScalarValue
+    /// https://github.dev/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/ScalarValue.cs
+    /// </summary>
+    [DuckCopy]
+    internal struct DictionaryValueDuck
+    {
+        /// <summary>
+        /// Gets the properties associated with the structure
+        /// </summary>
+        public IEnumerable Elements;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/DictionaryValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/DictionaryValueDuck.cs
@@ -9,8 +9,8 @@ using Datadog.Trace.DuckTyping;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
 {
     /// <summary>
-    /// Duck type for ScalarValue
-    /// https://github.dev/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/ScalarValue.cs
+    /// Duck type for DictionaryValue
+    /// https://github.dev/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/DictionaryValue.cs
     /// </summary>
     [DuckCopy]
     internal struct DictionaryValueDuck

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/KeyValuePairObjectStruct.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/KeyValuePairObjectStruct.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="KeyValuePairObjectStruct.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for KeyValuePair&lt;object, LogEventPropertyValue&gt;
+    /// </summary>
+    [DuckCopy]
+    internal struct KeyValuePairObjectStruct
+    {
+        /// <summary>
+        /// Gets the key
+        /// </summary>
+        public object Key;
+
+        /// <summary>
+        /// Gets the value (A LogEventPropertyValue (ScalarValue/StructureValue etc)
+        /// </summary>
+        public object Value;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/KeyValuePairStringStruct.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/KeyValuePairStringStruct.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="KeyValuePairStringStruct.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for KeyValuePair&lt;object, LogEventPropertyValue&gt;
+    /// </summary>
+    [DuckCopy]
+    internal struct KeyValuePairStringStruct
+    {
+        /// <summary>
+        /// Gets the key
+        /// </summary>
+        public string Key;
+
+        /// <summary>
+        /// Gets the value (A LogEventPropertyValue (ScalarValue/StructureValue etc)
+        /// </summary>
+        public object Value;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/LogEventPropertyDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/LogEventPropertyDuck.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="LogEventPropertyDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for LogEventProperty
+    /// https://github.dev/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/LogEventProperty.cs
+    /// </summary>
+    [DuckCopy]
+    internal struct LogEventPropertyDuck
+    {
+        /// <summary>
+        /// Gets the name
+        /// </summary>
+        public string Name;
+
+        /// <summary>
+        /// Gets the value
+        /// </summary>
+        public object Value;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/ScalarValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/ScalarValueDuck.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="ScalarValueDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for ScalarValue
+    /// https://github.com/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/ScalarValue.cs
+    /// </summary>
+    [DuckCopy]
+    internal struct ScalarValueDuck
+    {
+        /// <summary>
+        /// Gets the value
+        /// </summary>
+        public object Value;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SequenceValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SequenceValueDuck.cs
@@ -10,7 +10,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
 {
     /// <summary>
     /// Duck type for SequenceValue
-    /// https://github.com/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/SequenceValue.cs
+    /// https://github.dev/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/SequenceValue.cs
     /// </summary>
     [DuckCopy]
     internal struct SequenceValueDuck

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SequenceValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SequenceValueDuck.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="SequenceValueDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for ScalarValue
+    /// https://github.com/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/SequenceValue.cs
+    /// </summary>
+    [DuckCopy]
+    internal struct SequenceValueDuck
+    {
+        /// <summary>
+        /// Gets the sequence values
+        /// </summary>
+        [DuckField(Name = "_elements")]
+        public Array Elements;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SequenceValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SequenceValueDuck.cs
@@ -9,7 +9,7 @@ using Datadog.Trace.DuckTyping;
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
 {
     /// <summary>
-    /// Duck type for ScalarValue
+    /// Duck type for SequenceValue
     /// https://github.com/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/SequenceValue.cs
     /// </summary>
     [DuckCopy]

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
@@ -1,0 +1,156 @@
+﻿// <copyright file="SerilogLogFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Collections;
+using System.Text;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Serilog.Events;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    internal static class SerilogLogFormatter
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SerilogLogFormatter));
+
+        public static void FormatLogEvent(LogFormatter logFormatter, StringBuilder sb, ILogEvent logEvent)
+        {
+            var message = logEvent.RenderMessage();
+
+            logFormatter.FormatLog(
+                sb,
+                logEvent,
+                logEvent.Timestamp.UtcDateTime,
+                message,
+                eventId: null,
+                GetLogLevelString(logEvent.Level),
+                logEvent.Exception,
+                RenderProperties);
+        }
+
+        private static string GetLogLevelString(LogEventLevelDuck logLevel) =>
+            logLevel switch
+            {
+                LogEventLevelDuck.Verbose => DirectSubmissionLogLevelExtensions.Verbose,
+                LogEventLevelDuck.Debug => DirectSubmissionLogLevelExtensions.Debug,
+                LogEventLevelDuck.Information => DirectSubmissionLogLevelExtensions.Information,
+                LogEventLevelDuck.Warning => DirectSubmissionLogLevelExtensions.Warning,
+                LogEventLevelDuck.Error => DirectSubmissionLogLevelExtensions.Error,
+                LogEventLevelDuck.Fatal => DirectSubmissionLogLevelExtensions.Fatal,
+                _ => DirectSubmissionLogLevelExtensions.Unknown,
+            };
+
+        private static LogPropertyRenderingDetails RenderProperties(JsonTextWriter writer, in ILogEvent logEvent)
+        {
+            var haveSource = false;
+            var haveService = false;
+            var haveHost = false;
+            var haveTags = false;
+            var haveEnv = false;
+            var haveVersion = false;
+            foreach (var property in logEvent.Properties)
+            {
+                var duckProperty = property.DuckCast<KeyValuePairStringStruct>();
+                var name = duckProperty.Key;
+
+                haveSource |= LogFormatter.IsSourceProperty(name);
+                haveService |= LogFormatter.IsServiceProperty(name);
+                haveHost |= LogFormatter.IsHostProperty(name);
+                haveTags |= LogFormatter.IsTagsProperty(name);
+                haveEnv |= LogFormatter.IsEnvProperty(name);
+                haveVersion |= LogFormatter.IsVersionProperty(name);
+
+                LogFormatter.WritePropertyName(writer, name);
+                FormatLogEventPropertyValue(writer, duckProperty.Value);
+            }
+
+            var renderingDetails = new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate: logEvent.MessageTemplate.Text);
+            return renderingDetails;
+        }
+
+        private static void FormatLogEventPropertyValue(JsonTextWriter writer, object value)
+        {
+            // format the value correctly depending on type
+            if (value.TryDuckCast<ScalarValueDuck>(out var scalar))
+            {
+                LogFormatter.WriteValue(writer, scalar.Value);
+                return;
+            }
+
+            if (value.TryDuckCast<SequenceValueDuck>(out var sequence))
+            {
+                FormatSequence(writer, sequence.Elements);
+                return;
+            }
+
+            if (value.TryDuckCast<StructureValueDuck>(out var structure))
+            {
+                FormatStructure(writer, structure.Properties, structure.TypeTag);
+                return;
+            }
+
+            if (value.TryDuckCast<DictionaryValueDuck>(out var dictionary))
+            {
+                FormatDictionary(writer, dictionary.Elements);
+                return;
+            }
+
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug($"Unknown Serilog LogEventPropertyValue '{value.GetType()}': skipping in log message");
+                LogFormatter.WriteValue(writer, value: null);
+            }
+        }
+
+        private static void FormatSequence(JsonTextWriter writer, IEnumerable properties)
+        {
+            writer.WriteStartArray();
+            foreach (var property in properties)
+            {
+                FormatLogEventPropertyValue(writer, property!);
+            }
+
+            writer.WriteEndArray();
+        }
+
+        private static void FormatStructure(JsonTextWriter writer, IEnumerable properties, string typeTag)
+        {
+            writer.WriteStartObject();
+
+            foreach (var property in properties)
+            {
+                var duck = property.DuckCast<LogEventPropertyDuck>();
+                writer.WritePropertyName(duck.Name);
+                FormatLogEventPropertyValue(writer, duck.Value);
+            }
+
+            if (!string.IsNullOrEmpty(typeTag))
+            {
+                writer.WritePropertyName("_typeTag");
+                writer.WriteValue(typeTag);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        private static void FormatDictionary(JsonTextWriter writer, IEnumerable properties)
+        {
+            writer.WriteStartObject();
+
+            foreach (var property in properties)
+            {
+                var duck = property.DuckCast<KeyValuePairObjectStruct>();
+                writer.WritePropertyName(duck.Key?.ToString() ?? "null");
+                FormatLogEventPropertyValue(writer, duck.Value);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
@@ -70,8 +70,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
                 FormatLogEventPropertyValue(writer, duckProperty.Value);
             }
 
-            var renderingDetails = new LogPropertyRenderingDetails(haveSource, haveService, haveHost, haveTags, haveEnv, haveVersion, messageTemplate: logEvent.MessageTemplate.Text);
-            return renderingDetails;
+            return new LogPropertyRenderingDetails(
+                hasRenderedSource: haveSource,
+                hasRenderedService: haveService,
+                hasRenderedHost: haveHost,
+                hasRenderedTags: haveTags,
+                hasRenderedEnv: haveEnv,
+                hasRenderedVersion: haveVersion,
+                messageTemplate: logEvent.MessageTemplate.Text);
         }
 
         private static void FormatLogEventPropertyValue(JsonTextWriter writer, object value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/SerilogLogFormatter.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
                 eventId: null,
                 GetLogLevelString(logEvent.Level),
                 logEvent.Exception,
-                RenderProperties);
+                (JsonTextWriter w, in ILogEvent e) => RenderProperties(w, e));
         }
 
         private static string GetLogLevelString(LogEventLevelDuck logLevel) =>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/StructureValueDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/Formatting/StructureValueDuck.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="StructureValueDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Duck type for ScalarValue
+    /// https://github.dev/serilog/serilog/blob/5e93d5045585095ebcb71ef340d6accd61f01670/src/Serilog/Events/ScalarValue.cs
+    /// </summary>
+    [DuckCopy]
+    internal struct StructureValueDuck
+    {
+        /// <summary>
+        /// Gets the properties associated with the structure
+        /// These are convertible to <see cref="LogEventPropertyDuck"/>
+        /// </summary>
+        public IEnumerable Properties;
+
+        /// <summary>
+        /// Gets the type of the structure
+        /// </summary>
+        public string TypeTag;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/ILogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/ILogEvent.cs
@@ -1,0 +1,50 @@
+// <copyright file="ILogEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for LogEvent
+    /// </summary>
+    internal interface ILogEvent : IDuckType
+    {
+        /// <summary>
+        /// Gets the time at which the event occurred.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// Gets the level of the event.
+        /// </summary>
+        public LogEventLevelDuck Level { get; }
+
+        /// <summary>
+        /// Gets the message template describing the event.
+        /// </summary>
+        public MessageTemplateProxy MessageTemplate { get; }
+
+        /// <summary>
+        /// Gets properties associated with the event, including those presented in <see cref="MessageTemplate"/>.
+        /// </summary>
+        public IEnumerable Properties { get; }
+
+        /// <summary>
+        /// Gets an exception associated with the event, or null.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Render the message template given the properties associated
+        /// with the event, and return the result.
+        /// </summary>
+        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+        /// <returns>The rendered message</returns>
+        public string RenderMessage(IFormatProvider formatProvider = null);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/ILoggerConfiguration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/ILoggerConfiguration.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="ILoggerConfiguration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections;
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    /// <summary>
+    /// Duck typing for LoggerConfiguration
+    /// Interface, as used in instrumentation constraint
+    /// </summary>
+    internal interface ILoggerConfiguration
+    {
+        /// <summary>
+        /// Gets the
+        /// </summary>
+        [DuckField(Name = "_logEventSinks")]
+        public IList LogEventSinks { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LogEventLevelDuck.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LogEventLevelDuck.cs
@@ -1,0 +1,48 @@
+// <copyright file="LogEventLevelDuck.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    /// <summary>
+    /// Duck type for LogEventLevel
+    /// </summary>
+    internal enum LogEventLevelDuck
+    {
+        /// <summary>
+        /// Anything and everything you might want to know about
+        /// a running block of code.
+        /// </summary>
+        Verbose,
+
+        /// <summary>
+        /// Internal system events that aren't necessarily
+        /// observable from the outside.
+        /// </summary>
+        Debug,
+
+        /// <summary>
+        /// The lifeblood of operational intelligence - things
+        /// happen.
+        /// </summary>
+        Information,
+
+        /// <summary>
+        /// Service is degraded or endangered.
+        /// </summary>
+        Warning,
+
+        /// <summary>
+        /// Functionality is unavailable, invariants are broken
+        /// or data is lost.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// If you have a pager, it goes off when one of these
+        /// occurs.
+        /// </summary>
+        Fatal
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerConfigurationInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerConfigurationInstrumentation.cs
@@ -1,0 +1,79 @@
+﻿// <copyright file="LoggerConfigurationInstrumentation.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    /// <summary>
+    /// LoggerConfiguration.CreateLogger() calltarget instrumentation
+    /// </summary>
+    [InstrumentMethod(
+        AssemblyName = "Serilog",
+        TypeName = "Serilog.LoggerConfiguration",
+        MethodName = "CreateLogger",
+        ReturnTypeName = "Serilog.Core.Logger",
+        ParameterTypeNames = new string[0],
+        MinimumVersion = "1.0.0",
+        MaximumVersion = "2.*.*",
+        IntegrationName = nameof(IntegrationId.Serilog))]
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class LoggerConfigurationInstrumentation
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LoggerConfigurationInstrumentation>();
+
+        /// <summary>
+        /// OnMethodBegin callback
+        /// </summary>
+        /// <typeparam name="TTarget">Type of the target</typeparam>
+        /// <param name="instance">Instance value, aka `this` of the instrumented method.</param>
+        /// <returns>Calltarget state value</returns>
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+            where TTarget : ILoggerConfiguration, IDuckType
+        {
+            if (TracerManager.Instance.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.Serilog))
+            {
+                TryAddSink(instance);
+            }
+
+            return CallTargetState.GetDefault();
+        }
+
+        private static void TryAddSink<TTarget>(TTarget instance)
+            where TTarget : ILoggerConfiguration, IDuckType
+        {
+            var sinkAlreadyAdded = false;
+
+            // if we've already added the sink, nothing more to do.
+            foreach (var logEventSink in instance.LogEventSinks)
+            {
+                if (logEventSink is DirectSubmissionSerilogSink
+                 || logEventSink?.GetType().FullName == "Serilog.Sinks.Datadog.Logs.DatadogSink")
+                {
+                    sinkAlreadyAdded = true;
+                    break;
+                }
+            }
+
+            if (!sinkAlreadyAdded)
+            {
+                var targetType = instance.Type.Assembly.GetType("Serilog.Core.ILogEventSink");
+                var sink = new DirectSubmissionSerilogSink(
+                    TracerManager.Instance.DirectLogSubmission.Sink,
+                    TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel);
+
+                var proxy = sink.DuckImplement(targetType);
+                instance.LogEventSinks.Add(proxy);
+                Log.Information("Direct log submission via Serilog enabled");
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/MessageTemplateProxy.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/MessageTemplateProxy.cs
@@ -1,0 +1,21 @@
+// <copyright file="MessageTemplateProxy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.DuckTyping;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    /// <summary>
+    /// Duck typing for MessageTemplate
+    /// </summary>
+    [DuckCopy]
+    internal struct MessageTemplateProxy
+    {
+        /// <summary>
+        /// Gets the raw text describing the template
+        /// </summary>
+        public string Text;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/SerilogDatadogLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/SerilogDatadogLogEvent.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="SerilogDatadogLogEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
+{
+    internal class SerilogDatadogLogEvent : DatadogLogEvent
+    {
+        private readonly ILogEvent _logEvent;
+
+        public SerilogDatadogLogEvent(ILogEvent logEvent)
+        {
+            _logEvent = logEvent;
+        }
+
+        public override void Format(StringBuilder sb, LogFormatter formatter)
+        {
+            SerilogLogFormatter.FormatLogEvent(formatter, sb, _logEvent);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/InstrumentationDefinitions.Generated.cs
@@ -126,6 +126,8 @@ namespace Datadog.Trace.ClrProfiler
                 new("System.Net.Http.WinHttpHandler", "System.Net.Http.WinHttpHandler", "SendAsync",  new[] { "System.Threading.Tasks.Task`1<System.Net.Http.HttpResponseMessage>", "System.Net.Http.HttpRequestMessage", "System.Threading.CancellationToken" }, 4, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.WinHttpHandler.WinHttpHandlerIntegration"),
 
                 // ILogger
+                new("Microsoft.Extensions.Logging", "Microsoft.Extensions.Logging.LoggerFactory", ".ctor",  new[] { "System.Void", "System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.Logging.ILoggerProvider]", "Microsoft.Extensions.Options.IOptionsMonitor`1[Microsoft.Extensions.Logging.LoggerFilterOptions]" }, 2, 0, 0, 3, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.LoggerFactoryConstructorIntegration"),
+                new("Microsoft.Extensions.Logging", "Microsoft.Extensions.Logging.LoggerFactory", ".ctor",  new[] { "System.Void", "System.Collections.Generic.IEnumerable`1[Microsoft.Extensions.Logging.ILoggerProvider]", "Microsoft.Extensions.Options.IOptionsMonitor`1[Microsoft.Extensions.Logging.LoggerFilterOptions]", "Microsoft.Extensions.Options.IOptions`1[Microsoft.Extensions.Logging.LoggerFactoryOptions]" }, 5, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.LoggerFactoryConstructorIntegration"),
                 new("Microsoft.Extensions.Logging", "Microsoft.Extensions.Logging.LoggerFactoryScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerFactoryScopeProviderForEachScopeIntegration"),
                 new("Microsoft.Extensions.Logging.Abstractions", "Microsoft.Extensions.Logging.LoggerExternalScopeProvider", "ForEachScope",  new[] { "System.Void", "System.Action`2[System.Object,!!0]", "!!0" }, 2, 0, 0, 6, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.LoggerExternalScopeProviderForEachScopeIntegration"),
 
@@ -139,6 +141,8 @@ namespace Datadog.Trace.ClrProfiler
                 new("Confluent.Kafka", "Confluent.Kafka.Producer`2+TypedDeliveryHandlerShim_Action", ".ctor",  new[] { "System.Void", "System.String", "!0", "!1", "System.Action`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaProduceSyncDeliveryHandlerIntegration"),
 
                 // Log4Net
+                new("log4net", "log4net.Appender.AppenderCollection", "ToArray",  new[] { "log4net.Appender.IAppender[]" }, 2, 0, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission.AppenderCollectionIntegration"),
+                new("log4net", "log4net.Appender.AppenderCollection", "ToArray",  new[] { "log4net.Appender.IAppender[]" }, 1, 0, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission.AppenderCollectionLegacyIntegration"),
                 new("log4net", "log4net.Util.AppenderAttachedImpl", "AppendLoopOnAppenders",  new[] { "System.Int32", "log4net.Core.LoggingEvent" }, 1, 0, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net.AppenderAttachedImplIntegration"),
 
                 // MongoDb
@@ -192,6 +196,7 @@ namespace Datadog.Trace.ClrProfiler
                 new("MySqlConnector", "MySqlConnector.MySqlCommand", "ExecuteScalarAsync",  new[] { "System.Threading.Tasks.Task`1<System.Object>", "System.Threading.CancellationToken" }, 1, 0, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteScalarAsyncIntegration"),
 
                 // NLog
+                new("NLog", "NLog.LogFactory", "GetConfigurationForLogger",  new[] { "System.Void", "System.String", "NLog.Config.LoggingConfiguration" }, 2, 1, 0, 4, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.LogFactoryGetConfigurationForLoggerInstrumentation"),
                 new("NLog", "NLog.LoggerImpl", "Write",  new[] { "System.Void", "System.Type", "NLog.Internal.TargetWithFilterChain", "NLog.LogEventInfo", "NLog.LogFactory" }, 1, 0, 0, 4, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjection.LoggerImplWriteIntegration"),
 
                 // Npgsql
@@ -240,6 +245,7 @@ namespace Datadog.Trace.ClrProfiler
                 // Serilog
                 new("Serilog", "Serilog.Core.Logger", "Dispatch",  new[] { "System.Void", "Serilog.Events.LogEvent" }, 2, 0, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInjection.LoggerDispatchInstrumentation"),
                 new("Serilog", "Serilog.Core.Pipeline.Logger", "Dispatch",  new[] { "System.Void", "Serilog.Events.LogEvent" }, 1, 4, 0, 1, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInjection.LoggerDispatchInstrumentation"),
+                new("Serilog", "Serilog.LoggerConfiguration", "CreateLogger",  new[] { "Serilog.Core.Logger" }, 1, 0, 0, 2, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.LoggerConfigurationInstrumentation"),
 
                 // ServiceStackRedis
                 new("ServiceStack.Redis", "ServiceStack.Redis.RedisNativeClient", "SendReceive",  new[] { "T", "System.Byte[][]", "System.Func`1[!!0]", "System.Action`1[System.Func`1[!!0]]", "System.Boolean" }, 4, 0, 0, 5, 65535, 65535, assemblyFullName, "Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.ServiceStack.RedisNativeClientSendReceiveIntegration"),

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.DirectLogSubmission.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.DirectLogSubmission.cs
@@ -1,0 +1,82 @@
+﻿// <copyright file="ConfigurationKeys.DirectLogSubmission.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Logging.DirectSubmission;
+
+namespace Datadog.Trace.Configuration
+{
+    internal static partial class ConfigurationKeys
+    {
+        internal static class DirectLogSubmission
+        {
+            /// <summary>
+            /// Configuration key for a list of direct log submission integrations to enable.
+            /// Only selected integrations are enabled for direct log submission
+            /// Default is empty (direct log submission disabled).
+            /// Supports multiple values separated with semi-colons.
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionEnabledIntegrations"/>
+            public const string EnabledIntegrations = "DD_LOGS_DIRECT_SUBMISSION_INTEGRATIONS";
+
+            /// <summary>
+            /// Set the name of the originating host for direct logs submission.
+            /// Required for direct logs submission (default is machine name).
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionHost"/>
+            public const string Host = "DD_LOGS_DIRECT_SUBMISSION_HOST";
+
+            /// <summary>
+            /// Set the originating source for direct logs submission.
+            /// Default is 'csharp'
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionSource"/>
+            public const string Source = "DD_LOGS_DIRECT_SUBMISSION_SOURCE";
+
+            /// <summary>
+            /// Configuration key for a list of tags to be applied globally to all logs directly submitted.
+            /// Supports multiple key key-value pairs which are comma-separated, and for which the key and
+            /// value are colon-separated. For example Key1:Value1, Key2:Value2
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionGlobalTags"/>
+            public const string GlobalTags = "DD_LOGS_DIRECT_SUBMISSION_TAGS";
+
+            /// <summary>
+            /// Configuration key for the url to send logs to.
+            /// Default value is <c>https://http-intake.logs.datadoghq.com:443</c>.
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionUrl"/>
+            public const string Url = "DD_LOGS_DIRECT_SUBMISSION_URL";
+
+            /// <summary>
+            /// Configuration key for the minimum level logs should have to be sent to the intake.
+            /// Default value is <c>Information</c>.
+            /// Should be one of <c>Verbose</c>,<c>Debug</c>,<c>Information</c>,<c>Warning</c>,<c>Error</c>,<c>Fatal</c>
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionMinimumLevel"/>
+            public const string MinimumLevel = "DD_LOGS_DIRECT_SUBMISSION_MINIMUM_LEVEL";
+
+            /// <summary>
+            /// Configuration key for the maximum number of logs to send at one time
+            /// Default value is <c>1,000</c>, the maximum accepted by the Datadog log API
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionBatchSizeLimit"/>
+            public const string BatchSizeLimit = "DD_LOGS_DIRECT_SUBMISSION_MAX_BATCH_SIZE";
+
+            /// <summary>
+            /// Configuration key for the maximum number of logs to hold in internal queue at any one time
+            /// Default value is <c>100,000</c>.
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionQueueSizeLimit"/>
+            public const string QueueSizeLimit = "DD_LOGS_DIRECT_SUBMISSION_MAX_QUEUE_SIZE";
+
+            /// <summary>
+            /// Configuration key for the time to wait between checking for batches
+            /// Default value is <c>2</c>s.
+            /// </summary>
+            /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionBatchPeriod"/>
+            public const string BatchPeriodSeconds = "DD_LOGS_DIRECT_SUBMISSION_BATCH_PERIOD_SECONDS";
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -106,6 +106,8 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Configuration key for a list of tags to be applied globally to spans.
+        /// Supports multiple key key-value pairs which are comma-separated, and for which the key and
+        /// value are colon-separated. For example Key1:Value1, Key2:Value2
         /// </summary>
         /// <seealso cref="TracerSettings.GlobalTags"/>
         public const string GlobalTags = "DD_TAGS";

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
@@ -61,6 +62,10 @@ namespace Datadog.Trace.Configuration
             TraceBatchInterval = settings.TraceBatchInterval;
             RouteTemplateResourceNamesEnabled = settings.RouteTemplateResourceNamesEnabled;
             DelayWcfInstrumentationEnabled = settings.DelayWcfInstrumentationEnabled;
+
+            // TODO: Should we load the API key in a normal way? We don't for AAS?
+            var apiKey = System.Environment.GetEnvironmentVariable(ConfigurationKeys.ApiKey);
+            LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings, apiKey);
 
             // we cached the static instance here, because is being used in the hotpath
             // by IsIntegrationEnabled method (called from all integrations)
@@ -211,6 +216,8 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled"/>
         internal bool RouteTemplateResourceNamesEnabled { get; }
+
+        internal ImmutableDirectLogSubmissionSettings LogSubmissionSettings { get; }
 
         /// <summary>
         /// Gets a value indicating whether to enable the updated WCF instrumentation that delays execution

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -63,9 +63,7 @@ namespace Datadog.Trace.Configuration
             RouteTemplateResourceNamesEnabled = settings.RouteTemplateResourceNamesEnabled;
             DelayWcfInstrumentationEnabled = settings.DelayWcfInstrumentationEnabled;
 
-            // TODO: Should we load the API key in a normal way? We don't for AAS?
-            var apiKey = System.Environment.GetEnvironmentVariable(ConfigurationKeys.ApiKey);
-            LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings, apiKey);
+            LogSubmissionSettings = ImmutableDirectLogSubmissionSettings.Create(settings.LogSubmissionSettings);
 
             // we cached the static instance here, because is being used in the hotpath
             // by IsIntegrationEnabled method (called from all integrations)

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
@@ -42,5 +42,8 @@ namespace Datadog.Trace.Configuration
         Oracle,
         SqlClient, // SQL Server
         Sqlite,
+        Serilog,
+        Log4Net,
+        NLog,
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
@@ -161,6 +162,8 @@ namespace Datadog.Trace.Configuration
 
             DelayWcfInstrumentationEnabled = source?.GetBool(ConfigurationKeys.FeatureFlags.DelayWcfInstrumentationEnabled)
                                             ?? false;
+
+            LogSubmissionSettings = new DirectLogSubmissionSettings(source);
         }
 
         /// <summary>
@@ -335,6 +338,11 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled"/>
         internal bool RouteTemplateResourceNamesEnabled { get; }
+
+        /// <summary>
+        /// Gets or sets the direct log submission settings.
+        /// </summary>
+        internal DirectLogSubmissionSettings LogSubmissionSettings { get; set; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
@@ -1,0 +1,70 @@
+﻿// <copyright file="DirectLogSubmissionManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+
+namespace Datadog.Trace.Logging.DirectSubmission
+{
+    internal class DirectLogSubmissionManager : IDisposable
+    {
+        private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<DirectLogSubmissionManager>();
+
+        private DirectLogSubmissionManager(ImmutableDirectLogSubmissionSettings settings, IDatadogSink sink, LogFormatter formatter)
+        {
+            Settings = settings;
+            Sink = sink;
+            Formatter = formatter;
+        }
+
+        public ImmutableDirectLogSubmissionSettings Settings { get; }
+
+        public IDatadogSink Sink { get; }
+
+        public LogFormatter Formatter { get; }
+
+        public static DirectLogSubmissionManager Create(
+            DirectLogSubmissionManager? previous,
+            ImmutableDirectLogSubmissionSettings settings,
+            string serviceName,
+            string env,
+            string serviceVersion)
+        {
+            var formatter = new LogFormatter(settings, serviceName, env, serviceVersion);
+            if (previous is not null)
+            {
+                // Only the formatter uses settings that are configurable in code.
+                // If that ever changes, need to update the log-shipping integrations that
+                // currently cache the sink/settings instances
+                return new DirectLogSubmissionManager(previous.Settings, previous.Sink, formatter);
+            }
+
+            if (!settings.IsEnabled)
+            {
+                return new DirectLogSubmissionManager(settings, new NullDatadogSink(), formatter);
+            }
+
+            var apiFactory = LogsTransportStrategy.Get(settings);
+            var logsApi = new LogsApi(settings.IntakeUrl, settings.ApiKey, apiFactory);
+
+            return new DirectLogSubmissionManager(settings, new DatadogSink(logsApi, formatter, settings.BatchingOptions), formatter);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Logger.Debug("Running shutdown tasks for logs direct submission");
+                Sink?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Error flushing logs on shutdown");
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -63,6 +63,8 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 seconds is null or <= 0
                     ? DefaultBatchPeriodSeconds
                     : seconds.Value);
+
+            ApiKey = source?.GetString(ConfigurationKeys.ApiKey);
         }
 
         /// <summary>
@@ -118,5 +120,10 @@ namespace Datadog.Trace.Logging.DirectSubmission
         /// </summary>
         /// <seealso cref="ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds"/>
         internal TimeSpan DirectLogSubmissionBatchPeriod { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Datadog API key
+        /// </summary>
+        internal string ApiKey { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -1,0 +1,122 @@
+﻿// <copyright file="DirectLogSubmissionSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.PlatformHelpers;
+
+namespace Datadog.Trace.Logging.DirectSubmission
+{
+    /// <summary>
+    /// Contains settings for Direct Log Submission.
+    /// </summary>
+    internal class DirectLogSubmissionSettings
+    {
+        private const string DefaultSource = "csharp";
+        private const string DefaultIntakeUrl = "https://http-intake.logs.datadoghq.com:443";
+        private const DirectSubmissionLogLevel DefaultMinimumLevel = DirectSubmissionLogLevel.Information;
+        private const int DefaultBatchSizeLimit = 1000;
+        private const int DefaultQueueSizeLimit = 100_000;
+        private const int DefaultBatchPeriodSeconds = 2;
+
+        public DirectLogSubmissionSettings()
+            : this(source: null)
+        {
+        }
+
+        public DirectLogSubmissionSettings(IConfigurationSource source)
+        {
+            DirectLogSubmissionHost = source?.GetString(ConfigurationKeys.DirectLogSubmission.Host)
+                                   ?? HostMetadata.Instance.Hostname;
+            DirectLogSubmissionSource = source?.GetString(ConfigurationKeys.DirectLogSubmission.Source) ?? DefaultSource;
+            DirectLogSubmissionUrl = source?.GetString(ConfigurationKeys.DirectLogSubmission.Url) ?? DefaultIntakeUrl;
+
+            DirectLogSubmissionMinimumLevel = DirectSubmissionLogLevelExtensions.Parse(
+                source?.GetString(ConfigurationKeys.DirectLogSubmission.MinimumLevel), DefaultMinimumLevel);
+
+            DirectLogSubmissionGlobalTags = source?.GetDictionary(ConfigurationKeys.DirectLogSubmission.GlobalTags)
+                                                   ?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
+                                                   .ToDictionary(kvp => kvp.Key.Trim(), kvp => kvp.Value.Trim())
+                                         ?? new Dictionary<string, string>();
+
+            var logSubmissionIntegrations = source?.GetString(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations)
+                                                  ?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries) ??
+                                            Enumerable.Empty<string>();
+            DirectLogSubmissionEnabledIntegrations = new HashSet<string>(logSubmissionIntegrations, StringComparer.OrdinalIgnoreCase);
+
+            var batchSizeLimit = source?.GetInt32(ConfigurationKeys.DirectLogSubmission.BatchSizeLimit);
+            DirectLogSubmissionBatchSizeLimit = batchSizeLimit is null or <= 0
+                                                    ? DefaultBatchSizeLimit
+                                                    : batchSizeLimit.Value;
+
+            var queueSizeLimit = source?.GetInt32(ConfigurationKeys.DirectLogSubmission.QueueSizeLimit);
+            DirectLogSubmissionQueueSizeLimit = queueSizeLimit is null or <= 0
+                                                    ? DefaultQueueSizeLimit
+                                                    : queueSizeLimit.Value;
+
+            var seconds = source?.GetInt32(ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds);
+            DirectLogSubmissionBatchPeriod = TimeSpan.FromSeconds(
+                seconds is null or <= 0
+                    ? DefaultBatchPeriodSeconds
+                    : seconds.Value);
+        }
+
+        /// <summary>
+        /// Gets or Sets the integrations enabled for direct log submission
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.EnabledIntegrations" />
+        internal HashSet<string> DirectLogSubmissionEnabledIntegrations { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the originating host name for direct logs submission
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.Host" />
+        internal string DirectLogSubmissionHost { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the originating source for direct logs submission
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.Source" />
+        internal string DirectLogSubmissionSource { get; set; }
+
+        /// <summary>
+        /// Gets or sets the global tags, which are applied to all directly submitted logs
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.GlobalTags" />
+        internal IDictionary<string, string> DirectLogSubmissionGlobalTags { get; set; }
+
+        /// <summary>
+        /// Gets or sets the url to send logs to
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.Url" />
+        internal string DirectLogSubmissionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum level logs should have to be sent to the intake.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.Url" />
+        internal DirectSubmissionLogLevel DirectLogSubmissionMinimumLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of logs to send at one time
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.BatchSizeLimit"/>
+        internal int DirectLogSubmissionBatchSizeLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of logs to hold in internal queue at any one time
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.QueueSizeLimit"/>
+        internal int DirectLogSubmissionQueueSizeLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time to wait between checking for batches
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DirectLogSubmission.BatchPeriodSeconds"/>
+        internal TimeSpan DirectLogSubmissionBatchPeriod { get; set; }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectSubmissionLogLevel.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectSubmissionLogLevel.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="DirectSubmissionLogLevel.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.ComponentModel;
+
+namespace Datadog.Trace.Logging.DirectSubmission
+{
+    /// <summary>
+    /// The unified log levels to use with direct submission
+    /// </summary>
+    [Browsable(false)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public enum DirectSubmissionLogLevel
+    {
+        /// <summary>
+        /// The most verbose level. Also known as Trace
+        /// </summary>
+        Verbose = 0,
+
+        /// <summary>
+        /// Debug
+        /// </summary>
+        Debug = 1,
+
+        /// <summary>
+        /// The default log level
+        /// </summary>
+        Information = 2,
+
+        /// <summary>
+        /// Warning
+        /// </summary>
+        Warning = 3,
+
+        /// <summary>
+        /// Error
+        /// </summary>
+        Error = 4,
+
+        /// <summary>
+        /// The least verbose/most severe level. Also known as critical
+        /// </summary>
+        Fatal = 5,
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectSubmissionLogLevelExtensions.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectSubmissionLogLevelExtensions.cs
@@ -1,0 +1,47 @@
+﻿// <copyright file="DirectSubmissionLogLevelExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+namespace Datadog.Trace.Logging.DirectSubmission
+{
+    internal static class DirectSubmissionLogLevelExtensions
+    {
+        public const string Verbose = "Verbose";
+        public const string Debug = "Debug";
+        public const string Information = "Information";
+        public const string Warning = "Warning";
+        public const string Error = "Error";
+        public const string Fatal = "Fatal";
+
+        public const string Unknown = "UNKNOWN";
+
+        public static string GetName(this DirectSubmissionLogLevel logLevel)
+            => logLevel switch
+            {
+                DirectSubmissionLogLevel.Verbose => Verbose,
+                DirectSubmissionLogLevel.Debug => Debug,
+                DirectSubmissionLogLevel.Information => Information,
+                DirectSubmissionLogLevel.Warning => Warning,
+                DirectSubmissionLogLevel.Error => Error,
+                DirectSubmissionLogLevel.Fatal => Fatal,
+                _ => Unknown,
+            };
+
+        public static DirectSubmissionLogLevel Parse(string? value, DirectSubmissionLogLevel defaultLevel)
+            => value?.ToUpperInvariant() switch
+            {
+                "TRACE" => DirectSubmissionLogLevel.Verbose,
+                "VERBOSE" => DirectSubmissionLogLevel.Verbose,
+                "DEBUG" => DirectSubmissionLogLevel.Debug,
+                "INFO" => DirectSubmissionLogLevel.Information,
+                "INFORMATION" => DirectSubmissionLogLevel.Information,
+                "WARNING" => DirectSubmissionLogLevel.Warning,
+                "ERROR" => DirectSubmissionLogLevel.Error,
+                "CRITICAL" => DirectSubmissionLogLevel.Fatal,
+                "FATAL" => DirectSubmissionLogLevel.Fatal,
+                _ => defaultLevel
+            };
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
@@ -20,6 +20,7 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Formatting
 {
@@ -39,7 +40,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
         {
             if (messageTemplate == null)
             {
-                throw new ArgumentNullException(nameof(messageTemplate));
+                ThrowHelper.ThrowArgumentNullException(nameof(messageTemplate));
             }
 
             // Jenkins one-at-a-time https://en.wikipedia.org/wiki/Jenkins_hash_function

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="EventIdHash.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// based on https://github.com/serilog/serilog-formatting-compact/blob/8393e0ab8c2bc746fc733a4f20731b9e1f20f811/src/Serilog.Formatting.Compact/Formatting/Compact/EventIdHash.cs
+// Copyright 2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Formatting
+{
+    /// <summary>
+    /// Hash functions for message templates. See <see cref="Compute"/>.
+    /// </summary>
+    internal static class EventIdHash
+    {
+        /// <summary>
+        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>. The
+        /// resulting hash value can be uses as an event id in lieu of transmitting the
+        /// full template string.
+        /// </summary>
+        /// <param name="messageTemplate">A message template.</param>
+        /// <returns>A 32-bit hash of the template.</returns>
+        public static uint Compute(string messageTemplate)
+        {
+            if (messageTemplate == null)
+            {
+                throw new ArgumentNullException(nameof(messageTemplate));
+            }
+
+            // Jenkins one-at-a-time https://en.wikipedia.org/wiki/Jenkins_hash_function
+            unchecked
+            {
+                uint hash = 0;
+                for (var i = 0; i < messageTemplate.Length; ++i)
+                {
+                    hash += messageTemplate[i];
+                    hash += (hash << 10);
+                    hash ^= (hash >> 6);
+                }
+
+                hash += (hash << 3);
+                hash ^= (hash >> 11);
+                hash += (hash << 15);
+                return hash;
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -218,7 +218,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
                 writer.WriteValue(_version);
             }
 
-            if (_host is not null && !renderingDetails.HasRenderedSource)
+            if (_host is not null && !renderingDetails.HasRenderedHost)
             {
                 writer.WritePropertyName(HostPropertyName, escape: false);
                 writer.WriteValue(_host);

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
     internal class LogFormatter
     {
         private const string SourcePropertyName = "ddsource";
-        private const string ServicePropertyName = "ddservice";
+        private const string ServicePropertyName = "service";
         private const string HostPropertyName = "host";
         private const string TagsPropertyName = "ddtags";
         private const string EnvPropertyName = "dd_env";

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -137,6 +137,13 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             writer.WriteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
         }
 
+        internal static JsonTextWriter GetJsonWriter(StringBuilder builder)
+        {
+            var writer = new JsonTextWriter(new StringWriter(builder));
+            writer.Formatting = Vendors.Newtonsoft.Json.Formatting.None;
+            return writer;
+        }
+
         /// <summary>
         /// Format the log, based on <see cref="Datadog.Trace.Vendors.Serilog.Formatting.Json.JsonFormatter"/>
         /// and CompactFormatter
@@ -152,9 +159,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             Exception? exception,
             FormatDelegate<T> renderPropertiesDelegate)
         {
-            var sw = new StringWriter(builder);
-            using var writer = new JsonTextWriter(sw);
-            writer.Formatting = Vendors.Newtonsoft.Json.Formatting.None;
+            using var writer = GetJsonWriter(builder);
 
             // Based on JsonFormatter
             writer.WriteStartObject();

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -1,0 +1,236 @@
+﻿// <copyright file="LogFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Formatting
+{
+    internal class LogFormatter
+    {
+        private const string SourcePropertyName = "ddsource";
+        private const string ServicePropertyName = "ddservice";
+        private const string HostPropertyName = "host";
+        private const string TagsPropertyName = "ddtags";
+        private const string EnvPropertyName = "dd_env";
+        private const string VersionPropertyName = "dd_version";
+
+        private readonly string? _source;
+        private readonly string? _service;
+        private readonly string? _host;
+        private readonly string? _globalTags;
+        private readonly string? _env;
+        private readonly string? _version;
+
+        public LogFormatter(
+            ImmutableDirectLogSubmissionSettings settings,
+            string serviceName,
+            string env,
+            string version)
+        {
+            _source = string.IsNullOrEmpty(settings.Source) ? null : settings.Source;
+            _service = string.IsNullOrEmpty(serviceName) ? null : serviceName;
+            _host = string.IsNullOrEmpty(settings.Host) ? null : settings.Host;
+            _globalTags = string.IsNullOrEmpty(settings.GlobalTags) ? null : settings.GlobalTags;
+            _env = string.IsNullOrEmpty(env) ? null : env;
+            _version = string.IsNullOrEmpty(version) ? null : version;
+        }
+
+        internal delegate LogPropertyRenderingDetails FormatDelegate<T>(JsonTextWriter writer, in T state);
+
+        internal static bool IsSourceProperty(string? propertyName) =>
+            string.Equals(propertyName, SourcePropertyName, StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsServiceProperty(string? propertyName) =>
+            string.Equals(propertyName, ServicePropertyName, StringComparison.OrdinalIgnoreCase)
+         || string.Equals(propertyName, "dd_service", StringComparison.OrdinalIgnoreCase)
+         || string.Equals(propertyName, "dd.service", StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsHostProperty(string? propertyName) =>
+            string.Equals(propertyName, HostPropertyName, StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsTagsProperty(string? propertyName) =>
+            string.Equals(propertyName, TagsPropertyName, StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsEnvProperty(string? propertyName) =>
+            string.Equals(propertyName, EnvPropertyName, StringComparison.OrdinalIgnoreCase)
+         || string.Equals(propertyName, "dd.env", StringComparison.OrdinalIgnoreCase);
+
+        internal static bool IsVersionProperty(string? propertyName) =>
+            string.Equals(propertyName, VersionPropertyName, StringComparison.OrdinalIgnoreCase)
+         || string.Equals(propertyName, "dd.version", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Helper for writing property names in JSON
+        /// </summary>
+        internal static void WritePropertyName(JsonWriter writer, string name)
+        {
+            if (name.Length > 0 && name[0] == '@')
+            {
+                // Escape first '@' by doubling
+                name = '@' + name;
+            }
+
+            writer.WritePropertyName(name);
+        }
+
+        /// <summary>
+        /// Helper for writing values as JSON
+        /// </summary>
+        internal static void WriteValue(JsonWriter writer, object? value)
+        {
+            if (value is null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            if (value is string str)
+            {
+                writer.WriteValue(str);
+                return;
+            }
+
+            if (value is ValueType)
+            {
+                switch (value)
+                {
+                    case int or uint or long or byte or sbyte or short or ushort:
+                        writer.WriteValue(Convert.ToInt64(value));
+                        return;
+                    case ulong ulongValue: // can't safely be cast to long
+                        writer.WriteValue(ulongValue);
+                        return;
+                    case decimal decimalValue:
+                        writer.WriteValue(decimalValue);
+                        return;
+                    case double d:
+                        writer.WriteValue(d);
+                        return;
+                    case float f:
+                        writer.WriteValue(f);
+                        return;
+                    case bool b:
+                        writer.WriteValue(b);
+                        return;
+                    case char c:
+                        writer.WriteValue(c);
+                        return;
+                    case DateTime dt:
+                        writer.WriteValue(dt);
+                        return;
+                    case DateTimeOffset dto:
+                        writer.WriteValue(dto);
+                        return;
+                    case TimeSpan timeSpan:
+                        writer.WriteValue(timeSpan);
+                        return;
+                }
+            }
+
+            writer.WriteValue(Convert.ToString(value, CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Format the log, based on <see cref="Datadog.Trace.Vendors.Serilog.Formatting.Json.JsonFormatter"/>
+        /// and CompactFormatter
+        /// </summary>
+        /// <typeparam name="T">The type of state being formatted</typeparam>
+        internal void FormatLog<T>(
+            StringBuilder builder,
+            in T state,
+            DateTime timestamp,
+            string message,
+            int? eventId,
+            string logLevel,
+            Exception? exception,
+            FormatDelegate<T> renderPropertiesDelegate)
+        {
+            var sw = new StringWriter(builder);
+            using var writer = new JsonTextWriter(sw);
+            writer.Formatting = Vendors.Newtonsoft.Json.Formatting.None;
+
+            // Based on JsonFormatter
+            writer.WriteStartObject();
+
+            writer.WritePropertyName("@t", escape: false);
+            writer.WriteValue(timestamp.ToString("O"));
+
+            writer.WritePropertyName("@m", escape: false);
+            writer.WriteValue(message);
+
+            if (eventId.HasValue)
+            {
+                writer.WritePropertyName("@i", escape: false);
+                writer.WriteValue(eventId);
+            }
+
+            if (logLevel != "Information")
+            {
+                writer.WritePropertyName("@l", escape: false);
+                writer.WriteValue(logLevel);
+            }
+
+            if (exception != null)
+            {
+                writer.WritePropertyName("@x", escape: false);
+                writer.WriteValue(exception.ToString());
+            }
+
+            var renderingDetails = renderPropertiesDelegate(writer, in state);
+
+            if (!eventId.HasValue && !string.IsNullOrEmpty(renderingDetails.MessageTemplate))
+            {
+                // compute an eventID based on the message template (smaller than using the message template itself)
+                var id = EventIdHash.Compute(renderingDetails.MessageTemplate!); // we already checked it's not null
+                writer.WritePropertyName("@i", escape: false);
+                writer.WriteValue(id.ToString("x8"));
+            }
+
+            // add ddTrace values (if not already added, and not null)
+            if (_source is not null && !renderingDetails.HasRenderedSource)
+            {
+                writer.WritePropertyName(SourcePropertyName, escape: false);
+                writer.WriteValue(_source);
+            }
+
+            if (_service is not null && !renderingDetails.HasRenderedService)
+            {
+                writer.WritePropertyName(ServicePropertyName, escape: false);
+                writer.WriteValue(_service);
+            }
+
+            if (_env is not null && !renderingDetails.HasRenderedEnv)
+            {
+                writer.WritePropertyName(EnvPropertyName, escape: false);
+                writer.WriteValue(_env);
+            }
+
+            if (_version is not null && !renderingDetails.HasRenderedVersion)
+            {
+                writer.WritePropertyName(VersionPropertyName, escape: false);
+                writer.WriteValue(_version);
+            }
+
+            if (_host is not null && !renderingDetails.HasRenderedSource)
+            {
+                writer.WritePropertyName(HostPropertyName, escape: false);
+                writer.WriteValue(_host);
+            }
+
+            if (_globalTags is not null && !renderingDetails.HasRenderedTags)
+            {
+                writer.WritePropertyName(TagsPropertyName, escape: false);
+                writer.WriteValue(_globalTags);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogPropertyRenderingDetails.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogPropertyRenderingDetails.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="LogPropertyRenderingDetails.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+namespace Datadog.Trace.Logging.DirectSubmission.Formatting
+{
+    internal readonly struct LogPropertyRenderingDetails
+    {
+        public readonly bool HasRenderedSource;
+        public readonly bool HasRenderedService;
+        public readonly bool HasRenderedHost;
+        public readonly bool HasRenderedTags;
+        public readonly bool HasRenderedEnv;
+        public readonly bool HasRenderedVersion;
+        public readonly string? MessageTemplate;
+
+        public LogPropertyRenderingDetails(
+            bool hasRenderedSource,
+            bool hasRenderedService,
+            bool hasRenderedHost,
+            bool hasRenderedTags,
+            bool hasRenderedEnv,
+            bool hasRenderedVersion,
+            string? messageTemplate)
+        {
+            HasRenderedSource = hasRenderedSource;
+            HasRenderedService = hasRenderedService;
+            HasRenderedHost = hasRenderedHost;
+            HasRenderedTags = hasRenderedTags;
+            HasRenderedEnv = hasRenderedEnv;
+            HasRenderedVersion = hasRenderedVersion;
+            MessageTemplate = messageTemplate;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -74,18 +74,15 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
         public BatchingSinkOptions BatchingOptions { get; }
 
-        public static ImmutableDirectLogSubmissionSettings Create(
-            TracerSettings settings,
-            string? apiKey) => Create(settings.LogSubmissionSettings, apiKey);
+        public static ImmutableDirectLogSubmissionSettings Create(TracerSettings settings)
+            => Create(settings.LogSubmissionSettings);
 
-        public static ImmutableDirectLogSubmissionSettings Create(
-            DirectLogSubmissionSettings settings,
-            string? apiKey)
+        public static ImmutableDirectLogSubmissionSettings Create(DirectLogSubmissionSettings settings)
             => Create(
                 host: settings.DirectLogSubmissionHost,
                 source: settings.DirectLogSubmissionSource,
                 intakeUrl: settings.DirectLogSubmissionUrl,
-                apiKey: apiKey,
+                apiKey: settings.ApiKey,
                 minimumLevel: settings.DirectLogSubmissionMinimumLevel,
                 globalTags: settings.DirectLogSubmissionGlobalTags,
                 enabledLogShippingIntegrations: settings.DirectLogSubmissionEnabledIntegrations,

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -1,0 +1,224 @@
+﻿// <copyright file="ImmutableDirectLogSubmissionSettings.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+
+namespace Datadog.Trace.Logging.DirectSubmission
+{
+    /// <summary>
+    /// Contains direct-log-submission-specific settings
+    /// </summary>
+    internal class ImmutableDirectLogSubmissionSettings
+    {
+        internal static readonly IntegrationId[] SupportedIntegrations =
+        {
+            IntegrationId.Serilog,
+            IntegrationId.ILogger,
+            IntegrationId.Log4Net,
+            IntegrationId.NLog,
+        };
+
+        private readonly bool[] _enabledIntegrations;
+
+        private ImmutableDirectLogSubmissionSettings(
+            string host,
+            string source,
+            string globalTags,
+            Uri intakeUrl,
+            string apiKey,
+            bool isEnabled,
+            DirectSubmissionLogLevel minimumLevel,
+            bool[] enabledIntegrations,
+            List<string> validationErrors,
+            List<string> enabledIntegrationNames,
+            BatchingSinkOptions batchingOptions)
+        {
+            Host = host;
+            Source = source;
+            GlobalTags = globalTags;
+            IntakeUrl = intakeUrl;
+            ApiKey = apiKey;
+            ValidationErrors = validationErrors;
+            EnabledIntegrationNames = enabledIntegrationNames;
+            MinimumLevel = minimumLevel;
+            _enabledIntegrations = enabledIntegrations;
+            IsEnabled = isEnabled;
+            BatchingOptions = batchingOptions;
+        }
+
+        public bool IsEnabled { get; }
+
+        public DirectSubmissionLogLevel MinimumLevel { get; }
+
+        public string Host { get; }
+
+        public string Source { get; }
+
+        public string GlobalTags { get; }
+
+        public Uri IntakeUrl { get; }
+
+        public string ApiKey { get; }
+
+        public List<string> ValidationErrors { get; }
+
+        public List<string> EnabledIntegrationNames { get; }
+
+        public BatchingSinkOptions BatchingOptions { get; }
+
+        public static ImmutableDirectLogSubmissionSettings Create(
+            TracerSettings settings,
+            string? apiKey) => Create(settings.LogSubmissionSettings, apiKey);
+
+        public static ImmutableDirectLogSubmissionSettings Create(
+            DirectLogSubmissionSettings settings,
+            string? apiKey)
+            => Create(
+                host: settings.DirectLogSubmissionHost,
+                source: settings.DirectLogSubmissionSource,
+                intakeUrl: settings.DirectLogSubmissionUrl,
+                apiKey: apiKey,
+                minimumLevel: settings.DirectLogSubmissionMinimumLevel,
+                globalTags: settings.DirectLogSubmissionGlobalTags,
+                enabledLogShippingIntegrations: settings.DirectLogSubmissionEnabledIntegrations,
+                batchingOptions: new BatchingSinkOptions(
+                    batchSizeLimit: settings.DirectLogSubmissionBatchSizeLimit,
+                    queueLimit: settings.DirectLogSubmissionQueueSizeLimit,
+                    period: settings.DirectLogSubmissionBatchPeriod));
+
+        public static ImmutableDirectLogSubmissionSettings Create(
+            string? host,
+            string? source,
+            string? intakeUrl,
+            string? apiKey,
+            DirectSubmissionLogLevel minimumLevel,
+            IDictionary<string, string> globalTags,
+            ICollection<string> enabledLogShippingIntegrations,
+            BatchingSinkOptions batchingOptions)
+        {
+            if (enabledLogShippingIntegrations.Count == 0)
+            {
+                // not trying to enable log submission, so don't log any errors and create a _null_ implementation
+                return CreateNullSettings();
+            }
+
+            var isEnabled = true;
+            var validationErrors = new List<string>();
+
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                isEnabled = false;
+                validationErrors.Add($"Missing required setting '{ConfigurationKeys.DirectLogSubmission.Host}'.");
+            }
+
+            if (string.IsNullOrWhiteSpace(source))
+            {
+                isEnabled = false;
+                validationErrors.Add($"Missing required setting '{ConfigurationKeys.DirectLogSubmission.Source}'.");
+            }
+
+            if (!Uri.TryCreate(intakeUrl, UriKind.Absolute, out var intakeUri))
+            {
+                isEnabled = false;
+                validationErrors.Add($"The intake url '{intakeUrl}' was not a valid URL.");
+            }
+
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                isEnabled = false;
+                validationErrors.Add($"Missing required settings '{ConfigurationKeys.ApiKey}'.");
+            }
+
+            var stringifiedTags = StringifyGlobalTags(globalTags);
+            var enabledIntegrations = new bool[IntegrationRegistry.Ids.Count];
+            var enabledIntegrationNames = new List<string>(SupportedIntegrations.Length);
+
+            foreach (var integrationName in enabledLogShippingIntegrations)
+            {
+                if (!IntegrationRegistry.Ids.TryGetValue(integrationName, out var integrationId))
+                {
+                    validationErrors.Add(
+                        "Unknown integration: " + integrationName +
+                        ". Use a valid logs integration name: " +
+                        string.Join(", ", SupportedIntegrations.Select(x => IntegrationRegistry.Names[(int)x])));
+                    continue;
+                }
+
+                if (!SupportedIntegrations.Contains((IntegrationId)integrationId))
+                {
+                    validationErrors.Add(
+                        "Integration: " + integrationName + " is not a supported direct log submission integration. " +
+                        "Use one of " + string.Join(", ", SupportedIntegrations.Select(x => IntegrationRegistry.Names[(int)x])));
+                    continue;
+                }
+
+                enabledIntegrationNames.Add(integrationName);
+                enabledIntegrations[integrationId] = true;
+            }
+
+            return new ImmutableDirectLogSubmissionSettings(
+                host: host ?? string.Empty,
+                source: source ?? string.Empty,
+                globalTags: stringifiedTags,
+                intakeUrl: intakeUri!,
+                apiKey: apiKey ?? string.Empty,
+                isEnabled: isEnabled,
+                minimumLevel: minimumLevel,
+                enabledIntegrations: enabledIntegrations,
+                validationErrors,
+                enabledIntegrationNames,
+                batchingOptions);
+        }
+
+        private static string StringifyGlobalTags(IDictionary<string, string> globalTags)
+        {
+            if (globalTags.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var sb = new StringBuilder();
+            foreach (var tagPair in globalTags)
+            {
+                sb.Append(tagPair.Key)
+                  .Append(':')
+                  .Append(tagPair.Value)
+                  .Append(';');
+            }
+
+            // remove final joiner
+            return sb.ToString(startIndex: 0, length: sb.Length - 1);
+        }
+
+        public static ImmutableDirectLogSubmissionSettings CreateNullSettings()
+        {
+            var emptyList = new List<string>(0);
+            // not trying to enable log submission, so don't log any errors and create a _null_ implementation
+            return new ImmutableDirectLogSubmissionSettings(
+                host: string.Empty,
+                source: string.Empty,
+                globalTags: string.Empty,
+                intakeUrl: new Uri("http://localhost"),
+                apiKey: string.Empty,
+                isEnabled: false,
+                minimumLevel: DirectSubmissionLogLevel.Fatal,
+                enabledIntegrations: Array.Empty<bool>(),
+                validationErrors: emptyList,
+                enabledIntegrationNames: emptyList,
+                batchingOptions: new BatchingSinkOptions(batchSizeLimit: 1, queueLimit: 1, TimeSpan.MaxValue));
+        }
+
+        public bool IsIntegrationEnabled(IntegrationId integrationId)
+        {
+            return IsEnabled && _enabledIntegrations[(int)integrationId];
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -1,0 +1,27 @@
+// <copyright file="LogsTransportStrategy.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+
+namespace Datadog.Trace.Logging.DirectSubmission
+{
+    internal static class LogsTransportStrategy
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
+
+        public static IApiRequestFactory Get(ImmutableDirectLogSubmissionSettings settings)
+        {
+#if NETCOREAPP
+            Log.Information("Using {FactoryType} for log submission transport.", nameof(HttpClientRequestFactory));
+            return new HttpClientRequestFactory();
+#else
+            Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
+            return new ApiWebRequestFactory();
+#endif
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
 {
     internal static class LogsTransportStrategy
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Tracer>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(LogsTransportStrategy));
 
         public static IApiRequestFactory Get(ImmutableDirectLogSubmissionSettings settings)
         {

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogLogEvent.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogLogEvent.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="DatadogLogEvent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System.Text;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal abstract class DatadogLogEvent
+    {
+        /// <summary>
+        /// Formats the event to the provided <see cref="StringBuilder"/>
+        /// </summary>
+        /// <param name="sb">The builder to format the log into</param>
+        /// <param name="formatter">A formatter for log events</param>
+        public abstract void Format(StringBuilder sb, LogFormatter formatter);
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
@@ -115,7 +115,12 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                     if (requiredTotalSize > _serializedLogs.Length && requiredTotalSize <= MaxTotalSizeBytes)
                     {
                         // grow the array
-                        var newSize = Math.Min(_serializedLogs.Length * 2, MaxTotalSizeBytes);
+                        var newSize = _serializedLogs.Length;
+                        while (newSize < requiredTotalSize)
+                        {
+                            newSize = Math.Min(newSize * 2, MaxTotalSizeBytes);
+                        }
+
                         var newArray = new byte[newSize];
                         Array.Copy(_serializedLogs, 0, newArray, 0, _serializedLogs.Length);
                         _serializedLogs = newArray;

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
@@ -1,0 +1,179 @@
+﻿// <copyright file="DatadogSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal class DatadogSink : BatchingSink, IDatadogSink
+    {
+        // Maximum size for a single log is 1MB, we slightly on the cautious side
+        internal const int MaxMessageSizeBytes = 1000 * 1024;
+
+        // Maximum content size per payload is 5MB compressed
+        // Stay conservative with max payload size of 3MB
+        internal const int MaxTotalSizeBytes = (3 * 1024 * 1024);
+
+        // Initial size of the per-event string builder
+        // Should be big enough to handle _most_ logs to avoid too many initial resizes
+        internal const int InitialBuilderSizeBytes = 10 * 1024; // 10 KB
+
+        // Initial size of the full serialized set of logs
+        // Should be big enough to handle _most_ cases to avoid too many resizes
+        internal const int InitialAllLogsSizeBytes = 100 * 1024; // 0.1 MB
+
+        // These are specific to the JSON/HTTP formatting, so probably shouldn't be constants
+        // but this will do for now
+        private const byte PrefixAsUtf8Byte = 0x5b; // '['
+        private const byte SuffixAsUtf8Byte = 0x5D; // ']'
+        private const byte SeparatorAsUtf8Byte = 0x2C; // ','
+
+        private readonly IDatadogLogger _logger = DatadogLogging.GetLoggerFor<DatadogSink>();
+        private readonly ILogsApi _api;
+        private readonly LogFormatter _formatter;
+        private readonly Action<DatadogLogEvent>? _oversizeLogCallback;
+        private readonly StringBuilder _logStringBuilder = new(InitialBuilderSizeBytes);
+        private byte[] _serializedLogs = new byte[InitialAllLogsSizeBytes];
+        private int _byteCount = 0;
+        private int _logCount = 0;
+
+        public DatadogSink(ILogsApi api, LogFormatter formatter, BatchingSinkOptions sinkOptions)
+            : this(api, formatter, sinkOptions, oversizeLogCallback: null, sinkDisabledCallback: null)
+        {
+        }
+
+        public DatadogSink(
+            ILogsApi api,
+            LogFormatter formatter,
+            BatchingSinkOptions sinkOptions,
+            Action<DatadogLogEvent>? oversizeLogCallback,
+            Action? sinkDisabledCallback)
+            : base(sinkOptions, sinkDisabledCallback)
+        {
+            _api = api;
+            _formatter = formatter;
+            _oversizeLogCallback = oversizeLogCallback;
+        }
+
+        /// <summary>
+        /// Emit a batch of log events to Datadog logs-backend.
+        /// </summary>
+        /// <param name="events">The events to emit.</param>
+        protected override async Task<bool> EmitBatch(Queue<DatadogLogEvent> events)
+        {
+            var allSucceeded = true;
+            try
+            {
+                if (events.Count == 0)
+                {
+                    return true;
+                }
+
+                // Add to the first log
+                _serializedLogs[0] = PrefixAsUtf8Byte;
+                _logCount = 0;
+                _byteCount = 1;
+
+                foreach (var log in events)
+                {
+                    // reset the string builder
+                    _logStringBuilder.Clear();
+                    if (_logStringBuilder.Capacity > MaxMessageSizeBytes)
+                    {
+                        // A rogue giant message could cause the builder to grow significantly more than MaxMessageSizeBytes
+                        // so reset the string builder when we get very large
+                        _logStringBuilder.Capacity = InitialBuilderSizeBytes;
+                    }
+
+                    log.Format(_logStringBuilder, _formatter);
+
+                    // would be nice to avoid this, but can't see a way without direct UTF8 serialization (System.Text.Json)
+                    // Currently a rogue giant message still pays the serialization cost but is then thrown away
+                    var serializedLog = _logStringBuilder.ToString();
+
+                    var logSize = Encoding.UTF8.GetByteCount(serializedLog);
+                    if (logSize > MaxMessageSizeBytes)
+                    {
+                        // Note that the logs intake will actually accept oversized logs, and then truncate them to 1MB
+                        // We could continue to send the log as long as the total size isn't over 5MB, but not sure if
+                        // it's worth it or not, so excluding for now.
+                        _logger.Error<int, string>("Log dropped as too large ({Size} bytes) to send to logs intake: {Log}", logSize, serializedLog);
+                        _oversizeLogCallback?.Invoke(log);
+                        continue;
+                    }
+
+                    var requiredTotalSize = _byteCount + logSize + 1; // + 1 for the separate/suffix
+                    if (requiredTotalSize > _serializedLogs.Length && requiredTotalSize <= MaxTotalSizeBytes)
+                    {
+                        // grow the array
+                        var newSize = Math.Min(_serializedLogs.Length * 2, MaxTotalSizeBytes);
+                        var newArray = new byte[newSize];
+                        Array.Copy(_serializedLogs, 0, newArray, 0, _serializedLogs.Length);
+                        _serializedLogs = newArray;
+                    }
+
+                    if (requiredTotalSize > MaxTotalSizeBytes)
+                    {
+                        // send what we have, add the log to the subsequent chunk
+                        var result = await ReplaceFinalSeparatorAndSendChunk().ConfigureAwait(false);
+                        allSucceeded &= result;
+                    }
+
+                    // add the log to the batch
+                    var bytesWritten = Encoding.UTF8.GetBytes(serializedLog, 0, serializedLog.Length, _serializedLogs, _byteCount);
+                    Debug.Assert(bytesWritten == logSize, "Actual bytes written should equal the log size");
+
+                    _byteCount += bytesWritten;
+
+                    // add the separator
+                    _serializedLogs[_byteCount] = SeparatorAsUtf8Byte;
+                    _byteCount++;
+                    _logCount++;
+                }
+
+                if (_logCount > 0)
+                {
+                    var result = await ReplaceFinalSeparatorAndSendChunk().ConfigureAwait(false);
+                    allSucceeded &= result;
+                }
+
+                return allSucceeded;
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "An error occured sending logs to Datadog");
+                return false;
+            }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            _api.Dispose();
+        }
+
+        private async Task<bool> ReplaceFinalSeparatorAndSendChunk()
+        {
+            // Too large for this batch, so replace final separator and send what we have
+            Debug.Assert(_byteCount > 0, "Shouldn't ever be in a situation where we have 0 bytes");
+
+            _serializedLogs[_byteCount - 1] = SuffixAsUtf8Byte;
+            var result = await _api.SendLogsAsync(new ArraySegment<byte>(_serializedLogs, 0, _byteCount), _logCount).ConfigureAwait(false);
+
+            // reset everything and on to the next log
+            _logCount = 0;
+            // keep the initial suffix
+            _byteCount = 1;
+            return result;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
     internal class DatadogSink : BatchingSink, IDatadogSink
     {
-        // Maximum size for a single log is 1MB, we slightly on the cautious side
+        // Maximum size for a single log is 1MB, we slightly err on the cautious side
         internal const int MaxMessageSizeBytes = 1000 * 1024;
 
         // Maximum content size per payload is 5MB compressed

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDatadogSink.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="IDatadogSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal interface IDatadogSink : IDisposable
+    {
+        /// <summary>
+        /// Emit the provided log event to the sink. If the sink is being disposed or
+        /// the app domain unloaded, then the event is ignored.
+        /// </summary>
+        /// <param name="logEvent">Log event to emit.</param>
+        /// <exception cref="ArgumentNullException">The event is null.</exception>
+        void EnqueueLog(DatadogLogEvent logEvent);
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/ILogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/ILogsApi.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="ILogsApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal interface ILogsApi : IDisposable
+    {
+        Task<bool> SendLogsAsync(ArraySegment<byte> logs, int numberOfLogs);
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApi.cs
@@ -1,0 +1,167 @@
+﻿// <copyright file="LogsApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal class LogsApi : ILogsApi
+    {
+        internal const string LogIntakePath = "api/v2/logs";
+        internal const string IntakeHeaderNameApiKey = "DD-API-KEY";
+
+        private const string MimeType = "application/json";
+
+        private const int MaxNumberRetries = 5;
+        private const int InitialSleepDurationMs = 500;
+
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LogsApi>();
+
+        private readonly string _apiKey;
+        private readonly IApiRequestFactory _apiRequestFactory;
+        private readonly Uri _logsIntakeEndpoint;
+
+        public LogsApi(Uri baseEndpoint, string apiKey, IApiRequestFactory apiRequestFactory)
+        {
+            var builder = new UriBuilder(baseEndpoint);
+            builder.Path = builder.Path.EndsWith("/")
+                               ? builder.Path + LogIntakePath
+                               : builder.Path + "/" + LogIntakePath;
+
+            _logsIntakeEndpoint = builder.Uri;
+            _apiKey = apiKey;
+            _apiRequestFactory = apiRequestFactory;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public async Task<bool> SendLogsAsync(ArraySegment<byte> logs, int numberOfLogs)
+        {
+            var retriesRemaining = MaxNumberRetries - 1;
+            var nextSleepDuration = InitialSleepDurationMs;
+
+            Log.Debug<int>("Sending {Count} logs to the logs intake", numberOfLogs);
+
+            while (true)
+            {
+                IApiRequest request;
+
+                try
+                {
+                    request = _apiRequestFactory.Create(_logsIntakeEndpoint);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "An error occurred while generating request to send logs to the intake at {IntakeEndpoint}", _apiRequestFactory.Info(_logsIntakeEndpoint));
+                    return false;
+                }
+
+                // Set additional headers
+                request.AddHeader(IntakeHeaderNameApiKey, _apiKey);
+
+                Exception? exception = null;
+                var isFinalTry = retriesRemaining <= 0;
+                var shouldRetry = true;
+
+                try
+                {
+                    IApiResponse? response = null;
+
+                    try
+                    {
+                        // TODO: Metrics/Telemetry?
+                        response = await request.PostAsync(logs, MimeType).ConfigureAwait(false);
+
+                        if (response.StatusCode is >= 200 and < 300)
+                        {
+                            Log.Debug<int>("Successfully sent {Count} logs to the intake", numberOfLogs);
+                            return true;
+                        }
+
+                        shouldRetry = response.StatusCode switch
+                        {
+                            400 => false, // Bad request (likely an issue in the payload formatting)
+                            401 => false, // Unauthorized (likely a missing API Key)
+                            403 => false, // Permission issue (likely using an invalid API Key)
+                            408 => true, // Request Timeout, request should be retried after some time
+                            413 => false, // Payload too large (batch is above 5MB uncompressed)
+                            429 => true, // Too Many Requests, request should be retried after some time
+                            >= 400 and < 500 => false, // generic "client" error, don't retry
+                            _ => true // Something else, probably server error, do retry
+                        };
+
+                        if (!shouldRetry || isFinalTry)
+                        {
+                            try
+                            {
+                                var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                                Log.Error<int, string>("Failed to submit logs with status code {StatusCode} and message: {ResponseContent}", response.StatusCode, responseContent);
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.Error<int>(ex, "Unable to read response for failed request with status code {StatusCode}", response.StatusCode);
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        response?.Dispose();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+#if DEBUG
+                    if (ex.InnerException is InvalidOperationException)
+                    {
+                        Log.Error<int, string>(ex, "An error occurred while sending {Count} logs to the intake at {IntakeEndpoint}", numberOfLogs, _apiRequestFactory.Info(_logsIntakeEndpoint));
+                        return false;
+                    }
+#endif
+                }
+
+                // Error handling block
+                if (!shouldRetry || isFinalTry)
+                {
+                    // stop retrying
+                    Log.Error<int, string>(exception, "An error occurred while sending {Count} traces to the intake at {IntakeEndpoint}", numberOfLogs, _apiRequestFactory.Info(_logsIntakeEndpoint));
+                    return false;
+                }
+
+                // Before retry delay
+                if (IsSocketException(exception))
+                {
+                    Log.Debug(exception, "Unable to communicate with the logs intake at {IntakeEndpoint}", _apiRequestFactory.Info(_logsIntakeEndpoint));
+                }
+
+                // Execute retry delay
+                await Task.Delay(nextSleepDuration).ConfigureAwait(false);
+                retriesRemaining--;
+                nextSleepDuration *= 2;
+            }
+        }
+
+        private static bool IsSocketException(Exception? exception)
+        {
+            while (exception is not null)
+            {
+                if (exception is SocketException)
+                {
+                    return true;
+                }
+
+                exception = exception.InnerException;
+            }
+
+            return false;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDatadogSink.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="NullDatadogSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal class NullDatadogSink : IDatadogSink
+    {
+        public void Dispose()
+        {
+        }
+
+        public void EnqueueLog(DatadogLogEvent logEvent)
+        {
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -1,0 +1,223 @@
+﻿// <copyright file="BatchingSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    internal abstract class BatchingSink : IDisposable
+    {
+        internal const int FailuresBeforeCircuitBreak = 10;
+
+        private readonly IDatadogLogger _log = DatadogLogging.GetLoggerFor<BatchingSink>();
+        private readonly int _batchSizeLimit;
+        private readonly TimeSpan _flushPeriod;
+        private readonly TimeSpan _circuitBreakPeriod;
+        private readonly BoundedConcurrentQueue<DatadogLogEvent> _queue;
+        private readonly Queue<DatadogLogEvent> _waitingBatch = new();
+        private readonly CircuitBreaker _circuitBreaker;
+        private readonly Task _flushTask;
+        private readonly Action? _disableSinkAction;
+        private readonly TaskCompletionSource<bool> _processExit = new();
+        private volatile bool _enqueueLogEnabled = true;
+
+        protected BatchingSink(BatchingSinkOptions sinkOptions, Action? disableSinkAction)
+        {
+            if (sinkOptions == null)
+            {
+                throw new ArgumentNullException(nameof(sinkOptions));
+            }
+
+            if (sinkOptions.BatchSizeLimit <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sinkOptions), "The batch size limit must be greater than zero.");
+            }
+
+            if (sinkOptions.Period <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(sinkOptions), "The period must be greater than zero.");
+            }
+
+            _disableSinkAction = disableSinkAction;
+
+            _batchSizeLimit = sinkOptions.BatchSizeLimit;
+            _flushPeriod = sinkOptions.Period;
+            _circuitBreakPeriod = sinkOptions.CircuitBreakPeriod;
+
+            _queue = new BoundedConcurrentQueue<DatadogLogEvent>(sinkOptions.QueueLimit);
+            _circuitBreaker = new CircuitBreaker(FailuresBeforeCircuitBreak);
+
+            _flushTask = Task.Run(FlushBuffersTaskLoopAsync);
+            _flushTask.ContinueWith(
+                t =>
+                {
+                    _log.Error(t.Exception, "Error in flush task");
+                    _disableSinkAction?.Invoke();
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
+        }
+
+        /// <summary>
+        /// Emit the provided log event to the sink. If the sink is being disposed or
+        /// the app domain unloaded, then the event is ignored.
+        /// </summary>
+        /// <param name="logEvent">Log event to emit.</param>
+        /// <exception cref="ArgumentNullException">The event is null.</exception>
+        public void EnqueueLog(DatadogLogEvent logEvent)
+        {
+            if (logEvent == null)
+            {
+                throw new ArgumentNullException(nameof(logEvent));
+            }
+
+            if (_processExit.Task.IsCompleted || !_enqueueLogEnabled)
+            {
+                return;
+            }
+
+            _queue.TryEnqueue(logEvent);
+        }
+
+        public virtual void Dispose()
+        {
+            Dispose(finalFlush: true);
+        }
+
+        public void Dispose(bool finalFlush)
+        {
+            _processExit.TrySetResult(finalFlush);
+            _flushTask.GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Emit a batch of log events, running to completion synchronously.
+        /// </summary>
+        /// <param name="events">The events to emit.</param>
+        /// <returns><c>true</c> if the batch was emitted successfully. <c>false</c> if there was an error</returns>
+        protected abstract Task<bool> EmitBatch(Queue<DatadogLogEvent> events);
+
+        private async Task FlushBuffersTaskLoopAsync()
+        {
+            while (true)
+            {
+                if (_processExit.Task.IsCompleted)
+                {
+                    _log.Debug("Terminating Log submission loop");
+                    if (_processExit.Task.Result)
+                    {
+                        var maxShutDownDelay = Task.Delay(20_000);
+                        var finalFlushTask = FlushLogs();
+                        var completed = await Task.WhenAny(finalFlushTask, maxShutDownDelay).ConfigureAwait(false);
+
+                        if (completed != finalFlushTask)
+                        {
+                            _log.Warning("Could not finish flushing all logs before process end");
+                        }
+                    }
+
+                    return;
+                }
+
+                var circuitStatus = await FlushLogs().ConfigureAwait(false);
+
+                await HandleCircuitStatus(circuitStatus).ConfigureAwait(false);
+            }
+        }
+
+        private async Task<CircuitStatus> FlushLogs()
+        {
+            try
+            {
+                var status = CircuitStatus.Closed;
+                var haveMultipleBatchesToSend = false;
+                do
+                {
+                    while (_waitingBatch.Count < _batchSizeLimit &&
+                           _queue.TryDequeue(out var next))
+                    {
+                        _waitingBatch.Enqueue(next);
+                    }
+
+                    if (_waitingBatch.Count == 0)
+                    {
+                        // If the first batch was full, then use that status.
+                        // If this is the first batch in this loop, then there were no logs to send
+                        // So can't say anything about the status of the API.
+                        return haveMultipleBatchesToSend ? status : _circuitBreaker.MarkSkipped();
+                    }
+
+                    var success = await EmitBatch(_waitingBatch).ConfigureAwait(false);
+                    if (success)
+                    {
+                        status = _circuitBreaker.MarkSuccess();
+                        haveMultipleBatchesToSend = _waitingBatch.Count >= _batchSizeLimit;
+                        if (haveMultipleBatchesToSend)
+                        {
+                            _waitingBatch.Clear();
+                        }
+                    }
+                    else
+                    {
+                        return _circuitBreaker.MarkFailure();
+                    }
+                }
+                while (haveMultipleBatchesToSend);
+
+                return status;
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Exception while emitting periodic batch");
+                return _circuitBreaker.MarkFailure();
+            }
+            finally
+            {
+                _waitingBatch.Clear();
+            }
+        }
+
+        private Task HandleCircuitStatus(CircuitStatus status)
+        {
+            var delayTillNextEmit = _flushPeriod;
+            switch (status)
+            {
+                case CircuitStatus.PermanentlyBroken:
+                    _processExit.TrySetResult(false);
+                    _enqueueLogEnabled = false;
+                    _disableSinkAction?.Invoke();
+
+                    // clear the queue
+                    while (_queue.TryDequeue(out _)) { }
+
+                    return _processExit.Task;
+
+                case CircuitStatus.Broken:
+                    // circuit breaker is broken, so stop queuing more logs
+                    // for now but don't disable log shipping entirely
+                    _enqueueLogEnabled = false;
+                    // Wait a while before trying again
+                    delayTillNextEmit = _circuitBreakPeriod;
+                    break;
+
+                case CircuitStatus.HalfBroken:
+                    // circuit breaker is tentatively open. Start queuing logs again
+                    _enqueueLogEnabled = true;
+                    break;
+
+                case CircuitStatus.Closed:
+                default:
+                    _enqueueLogEnabled = true;
+                    break;
+            }
+
+            return Task.WhenAny(
+                Task.Delay(delayTillNextEmit),
+                _processExit.Task);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         private readonly CircuitBreaker _circuitBreaker;
         private readonly Task _flushTask;
         private readonly Action? _disableSinkAction;
-        private readonly TaskCompletionSource<bool> _processExit = new();
+        private readonly TaskCompletionSource<bool> _processExit = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private volatile bool _enqueueLogEnabled = true;
 
         protected BatchingSink(BatchingSinkOptions sinkOptions, Action? disableSinkAction)

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
 {
@@ -30,17 +31,17 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         {
             if (sinkOptions == null)
             {
-                throw new ArgumentNullException(nameof(sinkOptions));
+                ThrowHelper.ThrowArgumentNullException(nameof(sinkOptions));
             }
 
             if (sinkOptions.BatchSizeLimit <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(sinkOptions), "The batch size limit must be greater than zero.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(sinkOptions), "The batch size limit must be greater than zero.");
             }
 
             if (sinkOptions.Period <= TimeSpan.Zero)
             {
-                throw new ArgumentOutOfRangeException(nameof(sinkOptions), "The period must be greater than zero.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(sinkOptions), "The period must be greater than zero.");
             }
 
             _disableSinkAction = disableSinkAction;
@@ -72,7 +73,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         {
             if (logEvent == null)
             {
-                throw new ArgumentNullException(nameof(logEvent));
+                ThrowHelper.ThrowArgumentNullException(nameof(logEvent));
             }
 
             if (_processExit.Task.IsCompleted || !_enqueueLogEnabled)

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkOptions.cs
@@ -1,0 +1,73 @@
+﻿// <copyright file="BatchingSinkOptions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// based on https://github.com/serilog/serilog-sinks-periodicbatching/blob/66a74768196758200bff67077167cde3a7e346d5/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/PeriodicBatchingSinkOptions.cs
+// Copyright 2013-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#nullable enable
+
+using System;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    internal class BatchingSinkOptions
+    {
+        public BatchingSinkOptions(
+            int batchSizeLimit,
+            int queueLimit,
+            TimeSpan period)
+         : this(
+             batchSizeLimit,
+             queueLimit,
+             period,
+             circuitBreakPeriod: TimeSpan.FromTicks(period.Ticks))
+        {
+        }
+
+        public BatchingSinkOptions(
+            int batchSizeLimit,
+            int queueLimit,
+            TimeSpan period,
+            TimeSpan circuitBreakPeriod)
+        {
+            BatchSizeLimit = batchSizeLimit;
+            QueueLimit = queueLimit;
+            Period = period;
+            CircuitBreakPeriod = circuitBreakPeriod;
+        }
+
+        /// <summary>
+        /// Gets the maximum number of events to include in a single batch.
+        /// </summary>
+        public int BatchSizeLimit { get; }
+
+        /// <summary>
+        /// Gets the time to wait between checking for event batches.
+        /// </summary>
+        public TimeSpan Period { get; }
+
+        /// <summary>
+        /// Gets the time to ignore logs when repeated failures to emit a batch cause the circuit to break.
+        /// </summary>
+        public TimeSpan CircuitBreakPeriod { get; }
+
+        /// <summary>
+        /// Gets maximum number of events to hold in the sink's internal queue, or <c>null</c>
+        /// for an unbounded queue.
+        /// </summary>
+        public int? QueueLimit { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -1,0 +1,100 @@
+﻿// <copyright file="BoundedConcurrentQueue.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// Based on https://github.com/serilog/serilog-sinks-periodicbatching/blob/66a74768196758200bff67077167cde3a7e346d5/src/Serilog.Sinks.PeriodicBatching/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+// Copyright 2013-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    internal class BoundedConcurrentQueue<T>
+    {
+        private const int Unbounded = -1;
+
+        private readonly ConcurrentQueue<T> _queue = new();
+        private readonly int _queueLimit;
+
+        private int _counter;
+
+        public BoundedConcurrentQueue(int? queueLimit = null)
+        {
+            if (queueLimit is <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(queueLimit), "Queue limit must be positive, or `null` to indicate unbounded.");
+            }
+
+            _queueLimit = queueLimit ?? Unbounded;
+        }
+
+        public int Count => _queue.Count;
+
+        public bool TryDequeue([NotNullWhen(returnValue: true)] out T? item)
+        {
+            if (_queueLimit == Unbounded)
+            {
+                return _queue.TryDequeue(out item!);
+            }
+
+            var result = false;
+            try
+            { }
+            finally
+            {
+                // prevent state corrupt while aborting
+                if (_queue.TryDequeue(out item!))
+                {
+                    Interlocked.Decrement(ref _counter);
+                    result = true;
+                }
+            }
+
+            return result;
+        }
+
+        public bool TryEnqueue(T item)
+        {
+            if (_queueLimit == Unbounded)
+            {
+                _queue.Enqueue(item);
+                return true;
+            }
+
+            var result = true;
+            try
+            { }
+            finally
+            {
+                if (Interlocked.Increment(ref _counter) <= _queueLimit)
+                {
+                    _queue.Enqueue(item);
+                }
+                else
+                {
+                    Interlocked.Decrement(ref _counter);
+                    result = false;
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -23,6 +23,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
 {
@@ -39,7 +40,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         {
             if (queueLimit is <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(queueLimit), "Queue limit must be positive, or `null` to indicate unbounded.");
+                ThrowHelper.ThrowArgumentOutOfRangeException(nameof(queueLimit), "Queue limit must be positive, or `null` to indicate unbounded.");
             }
 
             _queueLimit = queueLimit ?? Unbounded;

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/CircuitBreaker.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/CircuitBreaker.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="CircuitBreaker.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    /// <summary>
+    /// A simple circuit breaker for periodic batching, which, if never succeeds remains permanently broken
+    /// </summary>
+    internal class CircuitBreaker
+    {
+        private readonly int _failuresBeforeBroken;
+        private bool _hasEverSucceeded = false;
+        private int _consecutiveFailureCount = 0;
+
+        private CircuitStatus _state = CircuitStatus.Closed;
+
+        public CircuitBreaker(int failuresBeforeBroken)
+        {
+            _failuresBeforeBroken = failuresBeforeBroken;
+        }
+
+        public CircuitStatus MarkSuccess()
+        {
+            _hasEverSucceeded = true;
+            _consecutiveFailureCount = 0;
+
+            _state = _state switch
+            {
+                CircuitStatus.HalfBroken => CircuitStatus.Closed,
+                CircuitStatus.Broken => CircuitStatus.HalfBroken,
+                _ => _state
+            };
+
+            return _state;
+        }
+
+        public CircuitStatus MarkFailure()
+        {
+            _consecutiveFailureCount++;
+
+            _state = _state switch
+            {
+                CircuitStatus.HalfBroken => CircuitStatus.Broken,
+                _ when !_hasEverSucceeded && _consecutiveFailureCount >= _failuresBeforeBroken => CircuitStatus.PermanentlyBroken,
+                _ when _consecutiveFailureCount >= _failuresBeforeBroken => CircuitStatus.Broken,
+                _ => _state,
+            };
+
+            return _state;
+        }
+
+        public CircuitStatus MarkSkipped()
+        {
+            _state = _state switch
+            {
+                // treat it as a success, so we can start testing logs
+                CircuitStatus.Broken => CircuitStatus.HalfBroken,
+                // otherwise, leave things as they are
+                _ => _state,
+            };
+            return _state;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/CircuitStatus.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/CircuitStatus.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="CircuitStatus.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    internal enum CircuitStatus
+    {
+        Closed,
+        Broken,
+        HalfBroken,
+        PermanentlyBroken,
+    }
+}

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ISampler sampler, IScopeManager scopeManager, IDogStatsd statsd)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings?.Build(), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -1,4 +1,4 @@
-// <copyright file="TracerManager.cs" company="Datadog">
+﻿// <copyright file="TracerManager.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -12,6 +12,7 @@ using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
@@ -46,6 +47,7 @@ namespace Datadog.Trace
             IScopeManager scopeManager,
             IDogStatsd statsd,
             RuntimeMetricsWriter runtimeMetricsWriter,
+            DirectLogSubmissionManager directLogSubmission,
             string defaultServiceName)
         {
             Settings = settings;
@@ -55,6 +57,7 @@ namespace Datadog.Trace
             Statsd = statsd;
             RuntimeMetrics = runtimeMetricsWriter;
             DefaultServiceName = defaultServiceName;
+            DirectLogSubmission = directLogSubmission;
         }
 
         /// <summary>
@@ -93,6 +96,8 @@ namespace Datadog.Trace
         /// Gets the <see cref="ISampler"/> instance used by this <see cref="IDatadogTracer"/> instance.
         /// </summary>
         public ISampler Sampler { get; }
+
+        public DirectLogSubmissionManager DirectLogSubmission { get; }
 
         public IDogStatsd Statsd { get; }
 
@@ -326,6 +331,22 @@ namespace Datadog.Trace
                     writer.WritePropertyName("appsec_libddwaf_version");
                     writer.WriteValue(Security.Instance.DdlibWafVersion?.ToString() ?? "(none)");
 
+                    writer.WritePropertyName("direct_logs_submission_enabled_integrations");
+                    writer.WriteStartArray();
+
+                    foreach (var integration in instanceSettings.LogSubmissionSettings.EnabledIntegrationNames)
+                    {
+                        writer.WriteValue(integration);
+                    }
+
+                    writer.WriteEndArray();
+
+                    writer.WritePropertyName("direct_logs_submission_enabled");
+                    writer.WriteValue(instanceSettings.LogSubmissionSettings.IsEnabled);
+
+                    writer.WritePropertyName("direct_logs_submission_error");
+                    writer.WriteValue(string.Join(", ", instanceSettings.LogSubmissionSettings.ValidationErrors));
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }
@@ -377,6 +398,7 @@ namespace Datadog.Trace
             {
                 _instance?.AgentWriter.FlushAndCloseAsync().Wait();
                 _heartbeatTimer?.Dispose();
+                _instance?.DirectLogSubmission?.Dispose();
             }
             catch (Exception ex)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -1,10 +1,16 @@
-// <copyright file="ILoggerTests.cs" company="Datadog">
+﻿// <copyright file="ILoggerTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -31,10 +37,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
         }
 
-        [SkippableFact]
+        [SkippableTheory]
+        [InlineData(false)]
+        [InlineData(true)]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogs()
+        public void InjectsLogs(bool enableLogShipping)
         {
             // One of the traces starts by manual opening a span when the background service starts,
             // and then it sends a HTTP request to the server.
@@ -51,6 +59,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 4;
 #endif
 
+            using var logsIntake = new MockLogsIntake();
+            if (enableLogShipping)
+            {
+                EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.ILogger), nameof(InjectsLogs));
+            }
+
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent.Port, aspNetCorePort: 0))
             {
@@ -59,6 +73,37 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 ValidateLogCorrelation(spans, _logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount);
             }
+        }
+
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void DirectlyShipsLogs()
+        {
+            var hostName = "integration_ilogger_tests";
+            using var logsIntake = new MockLogsIntake();
+
+            EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.ILogger), hostName);
+
+            var agentPort = TcpPortProvider.GetOpenPort();
+            using var agent = new MockTracerAgent(agentPort);
+            using var processResult = RunSampleAndWaitForExit(agent.Port, aspNetCorePort: 0);
+
+            Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+
+            var logs = logsIntake.Logs;
+
+            using var scope = new AssertionScope();
+            logs.Should().NotBeNull();
+            logs.Should().HaveCountGreaterOrEqualTo(12); // have an unknown number of "Waiting for app started handling requests"
+            logs.Should()
+                .OnlyContain(x => x.Service == "LogsInjection.ILogger")
+                .And.OnlyContain(x => x.Host == hostName)
+                .And.OnlyContain(x => x.Source == "csharp")
+                .And.OnlyContain(x => x.Env == "integration_tests")
+                .And.OnlyContain(x => x.Version == "1.0.0")
+                .And.OnlyContain(x => x.Exception == null)
+                .And.OnlyContain(x => x.LogLevel == DirectSubmissionLogLevel.Information);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -5,8 +5,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -29,13 +34,27 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
+        public static IEnumerable<object[]> GetTestData()
+        {
+            foreach (var item in PackageVersions.Serilog)
+            {
+                yield return item.Concat(false);
+                yield return item.Concat(true);
+            }
+        }
+
         [SkippableTheory]
-        [MemberData(nameof(PackageVersions.Serilog), MemberType = typeof(PackageVersions))]
+        [MemberData(nameof(GetTestData))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled(string packageVersion)
+        public void InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            using var logsIntake = new MockLogsIntake();
+            if (enableLogShipping)
+            {
+                EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), nameof(InjectsLogsWhenEnabled));
+            }
 
             var expectedCorrelatedTraceCount = 1;
             var expectedCorrelatedSpanCount = 1;
@@ -52,12 +71,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [SkippableTheory]
-        [MemberData(nameof(PackageVersions.Serilog), MemberType = typeof(PackageVersions))]
+        [MemberData(nameof(GetTestData))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void DoesNotInjectLogsWhenDisabled(string packageVersion)
+        public void DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
+            using var logsIntake = new MockLogsIntake();
+            if (enableLogShipping)
+            {
+                EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), nameof(InjectsLogsWhenEnabled));
+            }
 
             var expectedCorrelatedTraceCount = 0;
             var expectedCorrelatedSpanCount = 0;
@@ -71,6 +95,46 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var logFiles = GetLogFiles(packageVersion, logsInjectionEnabled: false);
                 ValidateLogCorrelation(spans, logFiles, expectedCorrelatedTraceCount, expectedCorrelatedSpanCount, packageVersion, disableLogCorrelation: true);
             }
+        }
+
+        [SkippableTheory]
+        [MemberData(nameof(PackageVersions.Serilog), MemberType = typeof(PackageVersions))]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public void DirectlyShipsLogs(string packageVersion)
+        {
+            var hostName = "integration_serilog_tests";
+            using var logsIntake = new MockLogsIntake();
+
+            SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), hostName);
+
+            var agentPort = TcpPortProvider.GetOpenPort();
+            using var agent = new MockTracerAgent(agentPort);
+            using var processResult = RunSampleAndWaitForExit(agent.Port, packageVersion: packageVersion);
+
+            Assert.True(processResult.ExitCode >= 0, $"Process exited with code {processResult.ExitCode} and exception: {processResult.StandardError}");
+
+            var logs = logsIntake.Logs;
+
+            using var scope = new AssertionScope();
+            logs.Should().NotBeNull();
+            logs.Should().HaveCountGreaterOrEqualTo(3);
+            logs.Should()
+                .OnlyContain(x => x.Service == "LogsInjection.Serilog")
+                .And.OnlyContain(x => x.Env == "integration_tests")
+                .And.OnlyContain(x => x.Version == "1.0.0")
+                .And.OnlyContain(x => x.Host == hostName)
+                .And.OnlyContain(x => x.Source == "csharp")
+                .And.OnlyContain(x => x.Exception == null)
+                .And.OnlyContain(x => x.LogLevel == DirectSubmissionLogLevel.Information);
+
+            logs
+               .Where(x => !x.Message.Contains(ExcludeMessagePrefix))
+               .Should()
+               .NotBeEmpty()
+               .And.OnlyContain(x => !string.IsNullOrEmpty(x.TraceId))
+               .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
         }
 
         private LogFileTest[] GetLogFiles(string packageVersion, bool logsInjectionEnabled)

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
@@ -1,0 +1,136 @@
+﻿// <copyright file="DirectSubmissionLoggerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if NETCOREAPP
+
+using System;
+using System.Collections.Concurrent;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission;
+using Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions.Internal;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.ILogger
+{
+    public class DirectSubmissionLoggerTests
+    {
+        [Fact]
+        public void LoggerEnqueuesLogMessage()
+        {
+            var sink = new TestSink();
+            var logger = GetLogger(sink);
+
+            var level = (int)DirectSubmissionLogLevel.Error;
+            logger.IsEnabled(level).Should().BeTrue();
+            logger.Log(
+                logLevel: level,
+                eventId: 123,
+                state: "someValue",
+                exception: null,
+                (state, ex) => $"This is {state}");
+
+            sink.Events.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void LoggerCanRenderLogMessage()
+        {
+            var sink = new TestSink();
+            var formatter = LogSettingsHelper.GetFormatter();
+            var logger = GetLogger(sink);
+
+            var level = (int)DirectSubmissionLogLevel.Error;
+            logger.IsEnabled(level).Should().BeTrue();
+            var state = "someValue";
+            var eventId = 123;
+            logger.Log(
+                logLevel: level,
+                eventId: eventId,
+                state: state,
+                exception: null,
+                (s, ex) => $"This is {s}");
+
+            var log = sink.Events.Should().ContainSingle().Subject;
+            var sb = new StringBuilder();
+            log.Format(sb, formatter);
+
+            var formatted = sb.ToString();
+            formatted.Should()
+                     .NotBeNullOrWhiteSpace()
+                     .And.Contain(state)
+                     .And.Contain(eventId.ToString())
+                     .And.Contain($"This is {state}");
+        }
+
+        [Fact]
+        public void ShouldNotEmitLogWhenNotEnabled()
+        {
+            var sink = new TestSink();
+            var formatter = LogSettingsHelper.GetFormatter();
+            var logger = new DirectSubmissionLogger(
+                name: "TestLogger",
+                scopeProvider: new NullScopeProvider(),
+                sink: sink,
+                logFormatter: formatter,
+                minimumLogLevel: DirectSubmissionLogLevel.Information);
+
+            var level = (int)DirectSubmissionLogLevel.Debug;
+            logger.IsEnabled(level).Should().BeFalse();
+            logger.Log(
+                logLevel: level,
+                eventId: 123,
+                state: "someValue",
+                exception: null,
+                (s, ex) => $"This is {s}");
+
+            sink.Events.Should().BeEmpty();
+        }
+
+        private static DirectSubmissionLogger GetLogger(TestSink sink)
+        {
+            var settings = LogSettingsHelper.GetValidSettings();
+            return new DirectSubmissionLogger(
+                name: "TestLogger",
+                scopeProvider: new NullScopeProvider(),
+                sink: sink,
+                logFormatter: LogSettingsHelper.GetFormatter(),
+                minimumLogLevel: settings.MinimumLevel);
+        }
+
+        internal class TestSink : IDatadogSink
+        {
+            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+
+            public void Dispose()
+            {
+            }
+
+            public void EnqueueLog(DatadogLogEvent logEvent)
+            {
+                Events.Enqueue(logEvent);
+            }
+        }
+
+        internal class NullScopeProvider : IExternalScopeProvider
+        {
+            public IDisposable Push(object state)
+            {
+                return NullScope.Instance;
+            }
+
+            public void ForEachScope<TState>(Action<object, TState> callback, TState state)
+            {
+            }
+        }
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
@@ -1,0 +1,242 @@
+﻿// <copyright file="ILoggerDuckTypingTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+using Xunit;
+using IExternalScopeProvider = Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.IExternalScopeProvider;
+using ILoggerFactory = Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.ILoggerFactory;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.ILogger
+{
+    public class ILoggerDuckTypingTests
+    {
+        private readonly NullDatadogSink _sink;
+        private readonly LogFormatter _formatter;
+        private readonly Type _iloggerProviderType;
+
+        public ILoggerDuckTypingTests()
+        {
+            _sink = new NullDatadogSink();
+            _formatter = LogSettingsHelper.GetFormatter();
+            _iloggerProviderType = LoggerFactoryIntegrationCommon<ILoggerProvider>.ProviderInterfaces;
+        }
+
+        [Fact]
+        public void CanDuckTypeILoggerFactory()
+        {
+            var loggerFactory = new LoggerFactory();
+            var testProvider = new ConsoleLoggerProvider(new DummyOptionsMonitor());
+
+            var proxy = loggerFactory.DuckCast<ILoggerFactory>();
+            proxy.Should().NotBeNull();
+            proxy.AddProvider(testProvider);
+        }
+
+        [Fact]
+        public void CanReverseDuckTypeTestLogger()
+        {
+            var loggerFactory = new TestLogger();
+
+            var proxy = loggerFactory.DuckImplement(typeof(Microsoft.Extensions.Logging.ILogger));
+            proxy.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void CanReverseDuckTypeILogger()
+        {
+            var logger = new DirectSubmissionLogger("Test logger", null, _sink, _formatter, DirectSubmissionLogLevel.Debug);
+            var proxy = (Microsoft.Extensions.Logging.ILogger)logger.DuckImplement(typeof(Microsoft.Extensions.Logging.ILogger));
+
+            proxy.BeginScope(123).Should().NotBeNull();
+            proxy.IsEnabled(LogLevel.Error).Should().BeTrue();
+            proxy.Log(LogLevel.Error, "This is my message with a {Parameter}", 123);
+        }
+
+        [Fact]
+        public void CanReverseDuckTypeILogger2()
+        {
+            var logger = new TestLogger();
+            var proxy = (Microsoft.Extensions.Logging.ILogger)logger.DuckImplement(typeof(Microsoft.Extensions.Logging.ILogger));
+
+            proxy.BeginScope(123).Should().NotBeNull();
+            proxy.IsEnabled(LogLevel.Error).Should().BeTrue();
+            proxy.Log(LogLevel.Error, "This is my message with a {Parameter}", 123);
+
+            logger.Logs.Should().ContainSingle("This is my message with a 123");
+        }
+
+        [Fact]
+        public void CanReverseDuckTypeILoggerProvider()
+        {
+            var loggerProvider = new DirectSubmissionLoggerProvider(_sink, _formatter, DirectSubmissionLogLevel.Debug);
+            var proxyProvider = (ILoggerProvider)loggerProvider.DuckImplement(_iloggerProviderType);
+
+            var logger = proxyProvider.CreateLogger("Some category");
+
+            logger.BeginScope(123).Should().NotBeNull();
+            logger.IsEnabled(LogLevel.Error).Should().BeTrue();
+            logger.Log(LogLevel.Error, "This is my message with a {Parameter}", 123);
+        }
+
+        [Fact]
+        public void CanAddLoggerProvider()
+        {
+            var loggerFactory = new LoggerFactory();
+            var instance = loggerFactory.DuckCast<ILoggerFactory>();
+
+            var provider = new TestLoggerProvider();
+            var proxy = provider.DuckImplement(_iloggerProviderType);
+
+            instance.AddProvider(proxy);
+
+            var logger = loggerFactory.CreateLogger("This is a test");
+
+            logger.BeginScope(123).Should().NotBeNull();
+            logger.BeginScope("some string").Should().NotBeNull();
+            logger.IsEnabled(LogLevel.Error).Should().BeTrue();
+            logger.Log(LogLevel.Error, "This is my message with a {Parameter}", 123);
+
+            provider.Logger.Logs.Should().ContainSingle("This is my message with a 123");
+        }
+
+        [Fact]
+        public void CanDuckTypeExternalScopeProvider()
+        {
+            var scopeProvider = new LoggerExternalScopeProvider();
+            var proxy = scopeProvider.DuckCast<IExternalScopeProvider>();
+
+            proxy.Should().NotBeNull();
+            using var scope = proxy.Push(123);
+            scope.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void CanDuckTypeExternalScopeProviderAndUseWithProxyProvider()
+        {
+            var scopeProvider = new LoggerExternalScopeProvider();
+            var loggerProvider = new DirectSubmissionLoggerProvider(new NullDatadogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug);
+            var proxyProvider = (ISupportExternalScope)loggerProvider.DuckImplement(_iloggerProviderType);
+            proxyProvider.SetScopeProvider(scopeProvider);
+
+            var logger = loggerProvider.CreateLogger("Test logger name");
+
+            using var scope = logger.BeginScope(123);
+            scope.Should().NotBeNull();
+            logger.IsEnabled(3).Should().BeTrue();
+            logger.Log(logLevel: 3, 12, state: 123, null, (state, ex) => $"This is my message with a {state}");
+        }
+
+        [Fact]
+        public void CanSetProviderUsingHelper()
+        {
+            var factory = new LoggerFactory();
+            var loggerProvider = new DirectSubmissionLoggerProvider(new NullDatadogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug);
+            LoggerFactoryIntegrationCommon<LoggerFactory>.AddDirectSubmissionLoggerProvider(factory, loggerProvider);
+        }
+
+        public sealed class DummyOptionsMonitor : IOptionsMonitor<ConsoleLoggerOptions>
+        {
+            public ConsoleLoggerOptions CurrentValue { get; } = new ConsoleLoggerOptions();
+
+            public IDisposable OnChange(Action<ConsoleLoggerOptions, string> listener) => null;
+
+            public ConsoleLoggerOptions Get(string name) => CurrentValue;
+        }
+
+        /// <summary>
+        /// Duck type for ILoggerProvider
+        /// </summary>
+        internal class TestLoggerProvider
+        {
+            public TestLogger Logger { get; } = new();
+
+            public IExternalScopeProvider ScopeProvider { get; private set; }
+
+            /// <summary>
+            /// Creates a new <see cref="ILogger"/> instance.
+            /// </summary>
+            /// <param name="categoryName">The category name for messages produced by the logger.</param>
+            /// <returns>The instance of <see cref="ILogger"/> that was created.</returns>
+            [DuckReverseMethod]
+            public TestLogger CreateLogger(string categoryName)
+            {
+                return Logger;
+            }
+
+            /// <inheritdoc cref="IDisposable.Dispose"/>
+            [DuckReverseMethod]
+            public void Dispose()
+            {
+            }
+
+            /// <summary>
+            /// Method for ISupportExternalScope
+            /// </summary>
+            /// <param name="scopeProvider">The provider of scope data</param>
+            [DuckReverseMethod(ParameterTypeNames = new[] { "Microsoft.Extensions.Logging.IExternalScopeProvider, Microsoft.Extensions.Logging.Abstractions" })]
+            public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+            {
+                ScopeProvider = scopeProvider;
+            }
+        }
+
+        internal class TestLogger
+        {
+            public List<string> Logs { get; } = new();
+
+            [DuckReverseMethod(ParameterTypeNames = new[]
+            {
+                "Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.Abstractions",
+                "Microsoft.Extensions.Logging.EventId, Microsoft.Extensions.Logging.Abstractions",
+                "TState",
+                "System.Exception",
+                "Func`3"
+            })]
+            public void Log<TState>(int logLevel, object eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                Logs.Add(formatter(state, exception));
+            }
+
+            /// <summary>
+            /// Checks if the given <paramref name="logLevel"/> is enabled.
+            /// </summary>
+            /// <param name="logLevel">Level to be checked.</param>
+            /// <returns><c>true</c> if enabled.</returns>
+            [DuckReverseMethod(ParameterTypeNames = new[] { "Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.Abstractions" })]
+            public bool IsEnabled(int logLevel) => true;
+
+            /// <summary>
+            /// Begins a logical operation scope.
+            /// </summary>
+            /// <param name="state">The identifier for the scope.</param>
+            /// <typeparam name="TState">The type of the state to begin scope for.</typeparam>
+            /// <returns>An <see cref="IDisposable"/> that ends the logical operation scope on dispose.</returns>
+            [DuckReverseMethod(ParameterTypeNames = new[] { "Microsoft.Extensions.Logging.LogLevel, Microsoft.Extensions.Logging.Abstractions" })]
+            public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+
+            private class NullDisposable : IDisposable
+            {
+                public static readonly NullDisposable Instance = new();
+
+                public void Dispose()
+                {
+                }
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/LoggerLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/LoggerLogFormatterTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
                 "This is a test with a {Value}",
                 123);
 
-            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""host"":""some_host""}";
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""service"":""MyTestService"",""host"":""some_host""}";
 
             logger.Logs.Should().ContainSingle(expected);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/LoggerLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/LoggerLogFormatterTests.cs
@@ -1,0 +1,115 @@
+﻿// <copyright file="LoggerLogFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETCOREAPP
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.Formatting;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.ILogger
+{
+    public class LoggerLogFormatterTests
+    {
+        [Fact]
+        public void SerializesEventCorrectly()
+        {
+            var formatter = LogSettingsHelper.GetFormatter();
+            var scopeProvider = new LoggerExternalScopeProvider();
+            var logger = new TestLogger(scopeProvider, formatter, new DateTime(2021, 09, 13, 10, 40, 57));
+
+            scopeProvider.Push(new Dictionary<string, object> { { "OtherProperty", 62 } });
+
+            logger.Log(
+                LogLevel.Debug,
+                new InvalidOperationException("Oops, just a test!"),
+                "This is a test with a {Value}",
+                123);
+
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""host"":""some_host""}";
+
+            logger.Logs.Should().ContainSingle(expected);
+        }
+
+        [Fact]
+        public void DoesntAddPropertiesThatAreAlreadyAddedTwice()
+        {
+            var formatter = LogSettingsHelper.GetFormatter();
+            var scopeProvider = new LoggerExternalScopeProvider();
+            var logger = new TestLogger(scopeProvider, formatter, new DateTime(2021, 09, 13, 10, 40, 57));
+            var properties  = new Dictionary<string, object>
+            {
+                { "Host", nameof(DoesntAddPropertiesThatAreAlreadyAddedTwice) + "host" },
+                { "dd_service", nameof(DoesntAddPropertiesThatAreAlreadyAddedTwice) + "service" },
+                { "ddsource", nameof(DoesntAddPropertiesThatAreAlreadyAddedTwice) + "source" },
+                { "ddtags", nameof(DoesntAddPropertiesThatAreAlreadyAddedTwice) + ":tag" },
+            };
+
+            using (var s = scopeProvider.Push(properties))
+            {
+                logger.Log(
+                    LogLevel.Debug,
+                    new InvalidOperationException("Oops, just a test!"),
+                    "This is a test with a {Value} and a {Host}",
+                    123,
+                    "some host");
+            }
+
+            var log = logger.Logs.Should().ContainSingle().Subject;
+
+            var json = JObject.Parse(log);
+
+            // should have all the added properties
+            foreach (var property in properties)
+            {
+                json.Properties()
+                    .Where(x => string.Equals(property.Key, x.Name, StringComparison.OrdinalIgnoreCase))
+                    .Should()
+                    .ContainSingle()
+                    .Which.Value.ToString()
+                    .Should()
+                    .Be(property.Value.ToString());
+            }
+        }
+
+        internal class TestLogger : Microsoft.Extensions.Logging.ILogger
+        {
+            private readonly IExternalScopeProvider _provider;
+            private readonly LogFormatter _formatter;
+            private readonly DateTime _timestamp;
+
+            public TestLogger(IExternalScopeProvider provider, LogFormatter formatter, DateTime timestamp)
+            {
+                _provider = provider;
+                _formatter = formatter;
+                _timestamp = timestamp;
+            }
+
+            public List<string> Logs { get; } = new();
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                var provider = _provider.DuckCast<Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.IExternalScopeProvider>();
+                var logEntry = new LogEntry<TState>(_timestamp, (int)logLevel, "some_cat", eventId.GetHashCode(), state, exception, formatter, provider);
+                var log = LoggerLogFormatter.FormatLogEvent(_formatter, in logEntry);
+                Logs.Add(log);
+            }
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public IDisposable BeginScope<TState>(TState state) => _provider.Push(state);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/LoggerLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/LoggerLogFormatterTests.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
             var logger = new TestLogger(scopeProvider, formatter, new DateTime(2021, 09, 13, 10, 40, 57));
 
             scopeProvider.Push(new Dictionary<string, object> { { "OtherProperty", 62 } });
+            scopeProvider.Push("Some other value");
 
             logger.Log(
                 LogLevel.Debug,
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
                 "This is a test with a {Value}",
                 123);
 
-            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""service"":""MyTestService"",""host"":""some_host""}";
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""Scopes"":[""Some other value""]""@i"":""a9a87aee"",""ddsource"":""csharp"",""service"":""MyTestService"",""host"":""some_host""}";
 
             logger.Logs.Should().ContainSingle(expected);
         }
@@ -56,7 +57,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
                 { "ddtags", nameof(DoesntAddPropertiesThatAreAlreadyAddedTwice) + ":tag" },
             };
 
-            using (var s = scopeProvider.Push(properties))
+            using (scopeProvider.Push(properties))
+            using (scopeProvider.Push("Another value"))
             {
                 logger.Log(
                     LogLevel.Debug,

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/DirectSubmissionLog4NetAppenderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/DirectSubmissionLog4NetAppenderTests.cs
@@ -1,0 +1,121 @@
+﻿// <copyright file="DirectSubmissionLog4NetAppenderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using log4net;
+using log4net.Appender;
+using log4net.Config;
+using log4net.Core;
+using log4net.Util;
+using Xunit;
+using Level = log4net.Core.Level;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Log4Net
+{
+    public class DirectSubmissionLog4NetAppenderTests
+    {
+        [Fact]
+        public void LoggerEnqueuesLogMessage()
+        {
+            var sink = new Log4NetHelper.TestSink();
+            var appender = Log4NetHelper.GetAppender(sink, DirectSubmissionLogLevel.Debug);
+
+            var level = Level.Error;
+            var logEvent = new LoggingEvent(
+                new LoggingEventData
+                {
+                    Message = "This is {SomeValue}",
+                    LoggerName = nameof(DirectSubmissionLog4NetAppenderTests),
+#if LOG4NET_2
+                    TimeStampUtc = DateTime.UtcNow,
+#else
+                    TimeStamp = DateTime.Now,
+#endif
+                    Level = level,
+                    Properties = new PropertiesDictionary { ["SomeValue"] = "someValue!" }
+                });
+
+            var proxy = Log4NetHelper.DuckCastLogEvent(logEvent);
+            appender.DoAppend(proxy);
+
+            sink.Events.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void ShouldNotEmitLogWhenNotEnabled()
+        {
+            var sink = new Log4NetHelper.TestSink();
+            var appender = Log4NetHelper.GetAppender(sink, DirectSubmissionLogLevel.Warning);
+
+            var level = Level.Info;
+            var logEvent = new LoggingEvent(
+                new LoggingEventData
+                {
+                    Message = "This is {SomeValue}",
+                    LoggerName = nameof(DirectSubmissionLog4NetAppenderTests),
+#if LOG4NET_2
+                    TimeStampUtc = DateTime.UtcNow,
+#else
+                    TimeStamp = DateTime.Now,
+#endif
+                    Level = level,
+                    Properties = new PropertiesDictionary { ["SomeValue"] = "someValue!" }
+                });
+
+            var proxy = Log4NetHelper.DuckCastLogEvent(logEvent);
+            appender.DoAppend(proxy);
+
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LoggerIncludesPropertiesInLog()
+        {
+            var formatter = LogSettingsHelper.GetFormatter();
+            var memoryAppender = new MemoryAppender();
+            var sink = new Log4NetHelper.TestSink();
+            var appender = Log4NetHelper.GetAppender(sink, DirectSubmissionLogLevel.Debug);
+            var appenderProxy = (IAppender)appender.DuckImplement(typeof(IAppender));
+            var repository = log4net.LogManager.GetRepository();
+            BasicConfigurator.Configure(repository, memoryAppender, appenderProxy);
+            var logger = LogManager.GetLogger(typeof(DirectSubmissionLog4NetAppenderTests));
+
+            // Set an ambient property
+            var someKey = "some key";
+            var someValue = "some Value";
+            log4net.ThreadContext.Properties[someKey] = someValue;
+
+            // write the log
+            var message = "This is a value";
+            logger.Error(message);
+
+            // remove the context before rendering
+            log4net.ThreadContext.Properties.Remove(someKey);
+
+            var logEvent = sink.Events.Should().ContainSingle().Subject;
+
+            // get the rendered log
+            var sb = new StringBuilder();
+            logEvent.Format(sb, formatter);
+            var log = sb.ToString();
+
+            log.Should()
+               .Contain(message)
+               .And.Contain(someKey)
+               .And.Contain(someValue)
+               .And.Contain(DirectSubmissionLogLevelExtensions.Error);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetDuckTypingTests.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="Log4NetDuckTypingTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission;
+using FluentAssertions;
+using log4net.Appender;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Log4Net
+{
+    public class Log4NetDuckTypingTests
+    {
+        [Fact]
+        public void CanIncreaseSizeOfIAppenderArray()
+        {
+            var appenders = new IAppender[] { };
+            var results = Log4NetCommon<IAppender[]>.AddAppenderToResponse(
+                appenders,
+                new DirectSubmissionLog4NetAppender(null, 0));
+
+            results.Length.Should().Be(1);
+        }
+
+        [Fact]
+        public void CanWriteLogToAppender()
+        {
+            var appenders = new IAppender[] { };
+            var results = Log4NetCommon<IAppender[]>.AddAppenderToResponse(
+                appenders,
+                new DirectSubmissionLog4NetAppender(null, 0));
+
+            results.Length.Should().Be(1);
+
+            foreach (var result in results)
+            {
+                result.Name.Should().Be("Datadog");
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="Log4NetHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Concurrent;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using log4net.Core;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Log4Net
+{
+    internal class Log4NetHelper
+    {
+#if LOG4NET_2
+        public static DirectSubmissionLog4NetAppender GetAppender(IDatadogSink sink, DirectSubmissionLogLevel level)
+            => new(sink, level);
+
+        public static ILoggingEventDuck DuckCastLogEvent(LoggingEvent logEvent)
+            => logEvent.DuckCast<ILoggingEventDuck>();
+#else
+        public static DirectSubmissionLog4NetLegacyAppender GetAppender(IDatadogSink sink, DirectSubmissionLogLevel level)
+            => new(sink, level);
+
+        public static ILoggingEventLegacyDuck DuckCastLogEvent(LoggingEvent logEvent)
+            => logEvent.DuckCast<ILoggingEventLegacyDuck>();
+#endif
+
+        internal class TestSink : IDatadogSink
+        {
+            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+
+            public void Dispose()
+            {
+            }
+
+            public void EnqueueLog(DatadogLogEvent logEvent)
+            {
+                Events.Enqueue(logEvent);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetLogFormatterTests.cs
@@ -1,0 +1,75 @@
+﻿// <copyright file="Log4NetLogFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using log4net.Core;
+using log4net.Util;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Log4Net
+{
+    public class Log4NetLogFormatterTests
+    {
+        [Fact]
+        public void SerializesEventCorrectly()
+        {
+            var logEvent = GetLogEvent();
+            var formatter = LogSettingsHelper.GetFormatter();
+            var sb = new StringBuilder();
+#if LOG4NET_2
+            var log = logEvent.DuckCast<ILoggingEventDuck>();
+            Log4NetLogFormatter.FormatLogEvent(formatter, sb, log, log.TimeStampUtc);
+#else
+            var log = logEvent.DuckCast<ILoggingEventLegacyDuck>();
+            Log4NetLogFormatter.FormatLogEvent(formatter, sb, log, log.TimeStamp);
+#endif
+            var actual = sb.ToString();
+
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""@i"":""aad9c020"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            actual.Should().Be(expected);
+        }
+
+        private static LoggingEvent GetLogEvent()
+        {
+            var loggingEvent = new LoggingEvent(
+                typeof(Log4NetLogFormatterTests),
+                repository: null,
+                loggerName: "Something",
+                level: Level.Debug,
+                message: "This is a test with a 123",
+                exception: new InvalidOperationException("Oops, just a test!"));
+            loggingEvent.Properties["Value"] = 123;
+
+            // Yes, this is very annoying
+            var loggingDate = new DateTimeOffset(2021, 09, 13, 10, 40, 57, TimeSpan.Zero).UtcDateTime;
+            var fieldInfo = typeof(LoggingEvent)
+               .GetField("m_data", BindingFlags.Instance | BindingFlags.NonPublic);
+            object boxed = fieldInfo!.GetValue(loggingEvent);
+
+#if LOG4NET_2
+            typeof(LoggingEventData).GetProperty("TimeStampUtc")!
+                                    .SetValue(boxed, loggingDate);
+#else
+            typeof(LoggingEventData).GetField("TimeStamp")!
+                                    .SetValue(boxed, loggingDate);
+#endif
+
+            fieldInfo.SetValue(loggingEvent, boxed);
+
+#if LOG4NET_2
+            Assert.Equal(loggingDate, loggingEvent.TimeStampUtc);
+#else
+            Assert.Equal(loggingDate, loggingEvent.TimeStamp);
+#endif
+            return loggingEvent;
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetLogFormatterTests.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
 #endif
             var actual = sb.ToString();
 
-            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""@i"":""aad9c020"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""@i"":""aad9c020"",""ddsource"":""csharp"",""service"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
             actual.Should().Be(expected);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/DirectSubmissionNLogTargetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/DirectSubmissionNLogTargetTests.cs
@@ -1,0 +1,124 @@
+﻿// <copyright file="DirectSubmissionNLogTargetTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if !NETCOREAPP
+using System.Collections.Concurrent;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using NLog;
+using NLog.Config;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NLog
+{
+    public class DirectSubmissionNLogTargetTests
+    {
+        [Fact]
+        public void LoggerEnqueuesLogMessage()
+        {
+            var sink = new NLogHelper.TestSink();
+            var nlogSink = NLogHelper.CreateTarget(sink, DirectSubmissionLogLevel.Debug);
+            var targetProxy = (global::NLog.Targets.Target)NLogCommon<LoggingConfiguration>.CreateNLogTargetProxy(nlogSink);
+
+            var level = LogLevel.Error;
+            var logEvent = new LogEventInfo(level, nameof(LoggerEnqueuesLogMessage), "This is some value");
+
+            var proxy = NLogHelper.GetLogEventProxy(logEvent);
+            nlogSink.Write(proxy);
+
+            sink.Events.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void ShouldNotEmitLogWhenNotEnabled()
+        {
+            var sink = new NLogHelper.TestSink();
+            var nlogSink = NLogHelper.CreateTarget(sink, DirectSubmissionLogLevel.Warning);
+            var targetProxy = (global::NLog.Targets.Target)NLogCommon<LoggingConfiguration>.CreateNLogTargetProxy(nlogSink);
+
+            var level = LogLevel.Info;
+            var logEvent = new LogEventInfo(level, nameof(LoggerEnqueuesLogMessage), "This is some value");
+
+            var proxy = NLogHelper.GetLogEventProxy(logEvent);
+            nlogSink.Write(proxy);
+
+            sink.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void LoggerIncludesPropertiesInLog()
+        {
+            var formatter = LogSettingsHelper.GetFormatter();
+            var sink = new NLogHelper.TestSink();
+            var target = NLogHelper.CreateTarget(sink, DirectSubmissionLogLevel.Debug);
+            var targetProxy = NLogCommon<LoggingConfiguration>.CreateNLogTargetProxy(target);
+
+            var config = new LoggingConfiguration();
+            NLogHelper.AddTargetToConfig(config, targetProxy);
+
+            var logFactory = new LogFactory(config);
+            var logger = logFactory.GetLogger(nameof(LoggerIncludesPropertiesInLog));
+
+            // We don't currently record NDC/NDLC
+#if NLOG_45
+            var messageTemplate = "This is a message with {Value}";
+#else
+            var messageTemplate = "This is a message with {0}";
+#endif
+            var mdcKey = "some mdcKey";
+            var mdcValue = "some mdcValue";
+#if !NLOG_2
+            var mdclKey = "some mdclKey";
+            var mdclValue = "some mdclValue";
+#endif
+            // var nestedScope = "some nested name";
+            // var nestedDictionary = new Dictionary<string, object> { { "nlcKey", 657 } };
+            // var dictValues = nestedDictionary.First();
+            try
+            {
+                MappedDiagnosticsContext.Set(mdcKey, mdcValue);
+#if !NLOG_2
+                MappedDiagnosticsLogicalContext.Set(mdclKey, mdclValue);
+#endif
+                logger.Error(messageTemplate, 123);
+            }
+            finally
+            {
+                MappedDiagnosticsContext.Remove(mdcKey);
+#if !NLOG_2
+                MappedDiagnosticsLogicalContext.Remove(mdclKey);
+#endif
+            }
+
+            var logEvent = sink.Events.Should().ContainSingle().Subject;
+
+            // get the rendered log
+            var sb = new StringBuilder();
+            logEvent.Format(sb, formatter);
+            var log = sb.ToString();
+
+            log.Should()
+               .Contain("This is a message with 123")
+               .And.Contain(mdcKey)
+               .And.Contain(mdcValue)
+#if !NLOG_2
+               .And.Contain(mdclKey)
+               .And.Contain(mdclValue)
+#endif
+               // .And.Contain(nestedScope)
+               // .And.Contain(dictValues.Key)
+               // .And.Contain(dictValues.Value.ToString())
+               .And.Contain(DirectSubmissionLogLevelExtensions.Error);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogDuckTypingTests.cs
@@ -1,0 +1,273 @@
+﻿// <copyright file="NLogDuckTypingTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETCOREAPP
+using System;
+using System.Linq;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies.Pre43;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using FluentAssertions;
+using NLog.Common;
+using NLog.Config;
+using NLog.Targets;
+using Xunit;
+using LogEventInfo = NLog.LogEventInfo;
+using LogLevel = NLog.LogLevel;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NLog
+{
+    public class NLogDuckTypingTests
+    {
+#if NLOG_45
+        [Fact]
+        public void CanDuckTypeLoggingConfigurationInModernNlog()
+        {
+            var instance = new LoggingConfiguration();
+            instance.DuckCast<ILoggingConfigurationProxy>();
+            instance.TryDuckCast(out ILoggingConfigurationProxy duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+            duck.ConfiguredNamedTargets.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CanDuckTypeLogInfoInModernNLog()
+        {
+            var instance = LogEventInfo.Create(
+                logLevel: LogLevel.Fatal,
+                loggerName: "LoggerName",
+                message: "Some message {Value}",
+                exception: new InvalidOperationException(),
+                formatProvider: null,
+                parameters: new object[] { 123 });
+
+            var duck = instance.DuckCast<ILogEventInfoProxy>();
+            duck.Should().NotBeNull();
+            duck.Level.Should().NotBeNull();
+            duck.Level.Ordinal.Should().Be(LogLevel.Fatal.Ordinal);
+            duck.FormattedMessage.Should().Be(instance.FormattedMessage);
+            duck.Exception.Should().Be(instance.Exception);
+            duck.HasProperties.Should().BeTrue();
+
+            var instanceWithoutProperties = LogEventInfo.Create(
+                logLevel: LogLevel.Fatal,
+                loggerName: "LoggerName",
+                message: "Some message");
+
+            instanceWithoutProperties.HasProperties.Should().BeFalse();
+            var duckWithoutProperties = instanceWithoutProperties.DuckCast<ILogEventInfoProxy>();
+
+            duckWithoutProperties.HasProperties.Should().BeFalse();
+
+            instanceWithoutProperties.Properties["TestKey"] = "TestValue";
+            duckWithoutProperties.HasProperties.Should().BeTrue();
+            duckWithoutProperties.Properties.Should().ContainKey("TestKey").WhichValue.Should().Be("TestValue");
+        }
+#elif NLOG_43
+        [Fact]
+        public void CanDuckTypeLoggingConfigurationLegacyInLegacyNlog()
+        {
+            var instance = new LoggingConfiguration();
+            instance.DuckCast<LoggingConfigurationLegacyProxy>();
+            instance.TryDuckCast(out LoggingConfigurationLegacyProxy duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+            duck.ConfiguredNamedTargets.Should().BeEmpty();
+        }
+#elif NLOG_2 || NLOG_30
+        [Fact]
+        public void CanDuckTypeLoggingConfigurationLegacyPre43InAncientNlog()
+        {
+            var instance = new LoggingConfiguration();
+            instance.LoggingRules.Should().BeEmpty();
+            instance.DuckCast<LoggingConfigurationPre43Proxy>();
+            instance.TryDuckCast(out LoggingConfigurationPre43Proxy duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+            duck.ConfiguredNamedTargets.Should().BeEmpty();
+            var rule = new LoggingRule();
+            duck.LoggingRules.Add(rule);
+            instance.LoggingRules.Should().ContainSingle().Which.Should().Be(rule);
+        }
+
+        [Fact]
+        public void CanDuckTypeLoggingRuleInPre43()
+        {
+            var rule = new LoggingRule();
+            var proxy = rule.DuckCast<LoggingRuleProxy>();
+
+            proxy.LoggerNamePattern = "TEST";
+            for (int i = 0; i < 6; i++)
+            {
+                proxy.LogLevels[i] = true;
+            }
+
+            rule.LoggerNamePattern.Should().Be("TEST");
+            rule.Levels
+               ?.Select(x => x.Ordinal)
+                .Should()
+                .NotBeNull()
+                .And.ContainInOrder(0, 1, 2, 3, 4, 5);
+        }
+#endif
+
+        [Fact]
+        public void CanReverseDuckTypeTarget()
+        {
+            var targetType = typeof(Target);
+            var target = NLogHelper.CreateTarget(new NullDatadogSink(), DirectSubmissionLogLevel.Debug);
+            var proxy = NLogCommon<Target>.CreateNLogTargetProxy(target);
+
+            proxy.Should().NotBeNull();
+            proxy.GetType().Should().BeDerivedFrom(targetType);
+
+            var message = "the message";
+            var logInfo = new AsyncLogEventInfo(LogEventInfo.Create(LogLevel.Error, "test", message), _ => { });
+            var typedProxy = ((Target)proxy);
+            typedProxy.WriteAsyncLogEvent(logInfo); // should not throw
+
+#if NLOG_45
+            var proxyOfProxy = proxy.DuckCast<ITargetWithContextBaseProxy>();
+            proxyOfProxy.Should().NotBeNull();
+
+            var results = proxyOfProxy.GetAllProperties(logInfo.LogEvent.DuckCast<ILogEventInfoProxy>());
+            results.Should().NotBeNull();
+
+            target.SetBaseProxy(proxyOfProxy);
+#endif
+        }
+
+#if !NLOG_45
+        [Fact]
+        public void CanDuckTypeLogInfoInLegacyNLog()
+        {
+#if NLOG_2
+            var instance = new LogEventInfo(
+                level: LogLevel.Fatal,
+                loggerName: "LoggerName",
+                message: "Some message {0}",
+                exception: new InvalidOperationException(),
+                formatProvider: null,
+                parameters: new object[] { 123 });
+#else
+            var instance = LogEventInfo.Create(
+                logLevel: LogLevel.Fatal,
+                loggerName: "LoggerName",
+                message: "Some message {0}",
+                exception: new InvalidOperationException(),
+                formatProvider: null,
+                parameters: new object[] { 123 });
+#endif
+            var duck = instance.DuckCast<LogEventInfoLegacyProxy>();
+            duck.Should().NotBeNull();
+            duck.Level.Should().NotBeNull();
+            duck.Level.Ordinal.Should().Be(LogLevel.Fatal.Ordinal);
+            duck.LoggerName.Should().Be(instance.LoggerName);
+            duck.FormattedMessage.Should().Be(instance.FormattedMessage);
+            duck.Exception.Should().Be(instance.Exception);
+            duck.HasProperties.Should().BeFalse();
+
+            instance.Properties["TestKey"] = "TestValue";
+            duck.HasProperties.Should().BeTrue();
+            duck.Properties.Should().ContainKey("TestKey").WhichValue.Should().Be("TestValue");
+        }
+
+        [Fact]
+        public void CanDuckTypeMdc()
+        {
+            var assembly = typeof(Target).Assembly;
+            NLogCommon<Target>.TryGetMdcProxy(
+                assembly,
+                out var haveProxy,
+                out var isModernMdcProxy,
+                out var mdc,
+                out var mdcLegacy);
+            haveProxy.Should().BeTrue();
+            if (isModernMdcProxy)
+            {
+                mdc.Should().NotBeNull();
+                mdc.GetNames().Should().BeEmpty();
+            }
+            else
+            {
+                mdcLegacy.ThreadDictionary.Should().BeEmpty();
+            }
+
+            var key = "mykey";
+            var value = "myvalue";
+            global::NLog.MappedDiagnosticsContext.Set(key, value);
+            if (isModernMdcProxy)
+            {
+                var containsKey = mdc.GetNames().Should().NotBeNull().And.ContainSingle().Subject;
+                mdc.GetObject(containsKey)
+                   .Should()
+                   .NotBeNull()
+                   .And.Be(value);
+
+                global::NLog.MappedDiagnosticsContext.Remove(key);
+                mdc.GetNames().Should().BeEmpty();
+            }
+            else
+            {
+                mdcLegacy.ThreadDictionary.Keys.Cast<string>().Should().ContainSingle(key);
+                mdcLegacy.ThreadDictionary[key].Should().Be(value);
+
+                global::NLog.MappedDiagnosticsContext.Remove(key);
+                mdcLegacy.ThreadDictionary.Should().BeEmpty();
+            }
+        }
+
+#if !NLOG_2
+        [Fact]
+        public void CanDuckTypeMdlc()
+        {
+            var assembly = typeof(Target).Assembly;
+            NLogCommon<Target>.TryGetMdlcProxy(
+                assembly,
+                out var haveProxy,
+                out var isModernMdlcProxy,
+                out var mdlc,
+                out var mdlcLegacy);
+            haveProxy.Should().BeTrue();
+
+            if (isModernMdlcProxy)
+            {
+                mdlc.Should().NotBeNull();
+                mdlc.GetNames().Should().BeEmpty();
+            }
+            else
+            {
+                mdlcLegacy.LogicalThreadDictionary.Should().BeEmpty();
+            }
+
+            var key = "mykey";
+            var value = "myvalue";
+            global::NLog.MappedDiagnosticsLogicalContext.Set(key, value);
+            if (isModernMdlcProxy)
+            {
+                var containsKey = mdlc.GetNames().Should().NotBeNull().And.ContainSingle().Subject;
+                mdlc.GetObject(containsKey)
+                    .Should()
+                    .NotBeNull()
+                    .And.Be(value);
+
+                global::NLog.MappedDiagnosticsLogicalContext.Remove(key);
+                mdlc.GetNames().Should().BeEmpty();
+            }
+            else
+            {
+                mdlcLegacy.LogicalThreadDictionary.Keys.Cast<string>().Should().ContainSingle(key);
+                mdlcLegacy.LogicalThreadDictionary[key].Should().Be(value);
+
+                global::NLog.MappedDiagnosticsLogicalContext.Remove(key);
+                mdlcLegacy.LogicalThreadDictionary.Should().BeEmpty();
+            }
+        }
+#endif
+#endif
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="NLogHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if !NETCOREAPP
+using System.Collections.Concurrent;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.TestHelpers;
+using NLog;
+using NLog.Config;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NLog
+{
+    internal static class NLogHelper
+    {
+#if NLOG_45
+        public static DirectSubmissionNLogTarget CreateTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+            => new(sink, minimumLevel, LogSettingsHelper.GetFormatter());
+
+        public static ILogEventInfoProxy GetLogEventProxy(LogEventInfo logEvent)
+            => logEvent.DuckCast<ILogEventInfoProxy>();
+
+        public static void AddTargetToConfig(LoggingConfiguration config, object targetProxy)
+            => NLogCommon<LoggingConfiguration>.AddDatadogTargetNLog45(config, targetProxy);
+#else
+        public static DirectSubmissionNLogLegacyTarget CreateTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+            => new(sink, minimumLevel, SettingsHelper.GetFormatter());
+
+        public static LogEventInfoLegacyProxy GetLogEventProxy(LogEventInfo logEvent)
+            => logEvent.DuckCast<LogEventInfoLegacyProxy>();
+#endif
+
+#if NLOG_43
+        public static void AddTargetToConfig(LoggingConfiguration config, object targetProxy)
+            => NLogCommon<LoggingConfiguration>.AddDatadogTargetNLog43To45(config, targetProxy);
+#elif !NLOG_45
+        public static void AddTargetToConfig(LoggingConfiguration config, object targetProxy)
+            => NLogCommon<LoggingConfiguration>.AddDatadogTargetNLogPre43(config, targetProxy);
+#endif
+
+        public class TestSink : IDatadogSink
+        {
+            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+
+            public void Dispose()
+            {
+            }
+
+            public void EnqueueLog(DatadogLogEvent logEvent)
+            {
+                Events.Enqueue(logEvent);
+            }
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogLogFormatterTests.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="NLogLogFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#if !NETCOREAPP
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using NLog;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NLog
+{
+    public class NLogLogFormatterTests
+    {
+        [Fact]
+        public void SerializesEventCorrectlyWhenPropertiesAreAvailable()
+        {
+            var logEvent = GetLogEvent();
+            var log = NLogHelper.GetLogEventProxy(logEvent);
+            var properties = new Dictionary<string, object>
+            {
+                { "Value", 123 },
+                { "OtherProperty", 62 },
+            };
+
+            var wrapper = new LogEntry(log, properties, fallbackProperties: null);
+
+            var formatter = LogSettingsHelper.GetFormatter();
+
+            var sb = new StringBuilder();
+            NLogLogFormatter.FormatLogEvent(formatter, sb, wrapper);
+            var actual = sb.ToString();
+
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""e5450052"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void SerializesEventCorrectlyWhenUsingFallbackProperties()
+        {
+            var logEvent = GetLogEvent();
+            var log = NLogHelper.GetLogEventProxy(logEvent);
+            var fallback = new Dictionary<object, object>
+            {
+                { "Value", 123 },
+                { "OtherProperty", 62 },
+            };
+
+            var wrapper = new LogEntry(log, properties: null, fallback);
+
+            var formatter = LogSettingsHelper.GetFormatter();
+
+            var sb = new StringBuilder();
+            NLogLogFormatter.FormatLogEvent(formatter, sb, wrapper);
+            var actual = sb.ToString();
+
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""e5450052"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            actual.Should().Be(expected);
+        }
+
+        private static LogEventInfo GetLogEvent()
+        {
+            return new LogEventInfo(
+                LogLevel.Debug,
+                loggerName: nameof(NLogLogFormatterTests),
+                message: "This is a test with a {0}",
+                formatProvider: CultureInfo.InvariantCulture,
+                parameters: new object[] { 123 },
+                exception: new InvalidOperationException("Oops, just a test!"))
+            {
+                TimeStamp = new DateTime(2021, 09, 13, 10, 40, 57, DateTimeKind.Utc),
+            };
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogLogFormatterTests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
             NLogLogFormatter.FormatLogEvent(formatter, sb, wrapper);
             var actual = sb.ToString();
 
-            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""e5450052"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""e5450052"",""ddsource"":""csharp"",""service"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
             actual.Should().Be(expected);
         }
 
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
             NLogLogFormatter.FormatLogEvent(formatter, sb, wrapper);
             var actual = sb.ToString();
 
-            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""e5450052"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""e5450052"",""ddsource"":""csharp"",""service"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
             actual.Should().Be(expected);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/DirectSubmissionSerilogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/DirectSubmissionSerilogSinkTests.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="DirectSubmissionSerilogSinkTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.Serilog.Capturing;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+using FluentAssertions;
+using Xunit;
+using static Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog.SerilogHelper;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog
+{
+    public class DirectSubmissionSerilogSinkTests
+    {
+        [Fact]
+        public void LoggerEnqueuesLogMessage()
+        {
+            var sink = new TestSink();
+            var serilogSink = new DirectSubmissionSerilogSink(sink, DirectSubmissionLogLevel.Debug);
+
+            var level = LogEventLevel.Error;
+            GetSerilogMessageProcessor()
+                         .Process("This is {SomeValue}", new object[] { "someValue" }, out var parsedTemplate, out var boundProperties);
+            var logEvent = new LogEvent(DateTimeOffset.Now, level, exception: null, parsedTemplate, boundProperties);
+
+            var proxy = logEvent.DuckCast<ILogEvent>();
+            serilogSink.Emit(proxy);
+
+            sink.Events.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void LoggerCanRenderLogMessage()
+        {
+            var sink = new TestSink();
+            var serilogSink = new DirectSubmissionSerilogSink(sink, DirectSubmissionLogLevel.Debug);
+
+            var level = LogEventLevel.Error;
+            var rawText = "someValue";
+            GetSerilogMessageProcessor()
+                         .Process("This is {SomeValue}", new object[] { "someValue" }, out var parsedTemplate, out var boundProperties);
+            var logEvent = new LogEvent(DateTimeOffset.Now, level, exception: null, parsedTemplate, boundProperties);
+
+            var proxy = logEvent.DuckCast<ILogEvent>();
+            serilogSink.Emit(proxy);
+
+            var log = sink.Events.Should().ContainSingle().Subject;
+            var sb = new StringBuilder();
+            var formatter = LogSettingsHelper.GetFormatter();
+            log.Format(sb, formatter);
+
+            var formatted = sb.ToString();
+            formatted.Should()
+                     .NotBeNullOrWhiteSpace()
+                     .And.Contain(rawText)
+                     .And.Contain($@"This is \""{rawText}\""");
+        }
+
+        [Fact]
+        public void ShouldNotEmitLogWhenNotEnabled()
+        {
+            var sink = new TestSink();
+            var serilogSink = new DirectSubmissionSerilogSink(sink, DirectSubmissionLogLevel.Warning);
+
+            var level = LogEventLevel.Information;
+            GetSerilogMessageProcessor()
+               .Process("This is {SomeValue}", new object[] { "someValue" }, out var parsedTemplate, out var boundProperties);
+            var logEvent = new LogEvent(DateTimeOffset.Now, level, exception: null, parsedTemplate, boundProperties);
+
+            var proxy = logEvent.DuckCast<ILogEvent>();
+            serilogSink.Emit(proxy);
+
+            sink.Events.Should().BeEmpty();
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogDuckTypingTests.cs
@@ -1,0 +1,213 @@
+﻿// <copyright file="SerilogDuckTypingTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Vendors.Serilog;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.Serilog.Parsing;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+using static Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog.SerilogHelper;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog
+{
+    public class SerilogDuckTypingTests
+    {
+        [Fact]
+        public void CanDuckTypeMessageTemplate()
+        {
+            var instance = new Vendors.Serilog.Events.MessageTemplate("Some text", Enumerable.Empty<MessageTemplateToken>());
+            instance.TryDuckCast(out MessageTemplateProxy duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+            duck.Text.Should().Be(instance.Text);
+        }
+
+        [Fact]
+        public void CanDuckTypeLogEvent()
+        {
+            var instance = new LogEvent(
+                DateTimeOffset.UtcNow,
+                LogEventLevel.Error,
+                new Exception(),
+                new Vendors.Serilog.Events.MessageTemplate("Some text", Enumerable.Empty<MessageTemplateToken>()),
+                new[] { new LogEventProperty("SomeProp", new ScalarValue(123)) });
+
+            instance.TryDuckCast(out ILogEvent duck).Should().BeTrue();
+            var intLevel = (int)instance.Level;
+            var intLevel2 = (LogEventLevelDuck)duck.Level;
+            duck.Should().NotBeNull();
+            duck.Exception.Should().Be(instance.Exception);
+            intLevel2.Should().Be(intLevel);
+            duck.Timestamp.Should().Be(instance.Timestamp);
+            duck.MessageTemplate.Text.Should().Be(instance.MessageTemplate.Text);
+            var properties = new List<KeyValuePairStringStruct>();
+
+            foreach (var duckProperty in duck.Properties)
+            {
+                properties.Add(duckProperty.DuckCast<KeyValuePairStringStruct>());
+            }
+
+            foreach (var property in instance.Properties)
+            {
+                properties.Should()
+                    .ContainSingle(
+                         x => x.Key == property.Key
+                           && x.Value.ToString() == property.Value.ToString());
+            }
+        }
+
+        [Fact]
+        public void CanDuckTypeLoggerConfiguration()
+        {
+            var config = new LoggerConfiguration();
+
+            config.TryDuckCast(out ILoggerConfiguration duckConfig).Should().BeTrue();
+            duckConfig.Should().NotBeNull();
+            duckConfig.LogEventSinks.Should().BeEmpty();
+
+            Type sinkType = typeof(ILogEventSink);
+            var sink = new TestSerilogSink();
+
+            var duckSink = sink.DuckImplement(sinkType);
+            duckConfig.LogEventSinks.Add(duckSink);
+
+            var logger = config.CreateLogger();
+            var message = "This is a test";
+            logger.Information(message);
+
+            sink.Logs.Should().ContainSingle(x => x == message);
+        }
+
+        [Fact]
+        public void CanReverseDuckTypeSerilogSink()
+        {
+            var sink = new DirectSubmissionSerilogSink(
+                new TestSink(),
+                DirectSubmissionLogLevel.Information);
+
+            Type sinkType = typeof(ILogEventSink);
+            var duckSink = (ILogEventSink)sink.DuckImplement(sinkType);
+
+            GetSerilogMessageProcessor()
+                         .Process("This is {SomeValue}", new object[] { "someValue" }, out var parsedTemplate, out var boundProperties);
+            var logEvent = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, exception: null, parsedTemplate, boundProperties);
+
+            duckSink.Emit(logEvent);
+        }
+
+        [Theory]
+        [InlineData(123)]
+        [InlineData("test")]
+        [InlineData(1.23)]
+        public void CanDuckTypeScalarLogValue(object value)
+        {
+            var scalar = new ScalarValue(value);
+
+            scalar.TryDuckCast<ScalarValueDuck>(out var duck).Should().BeTrue();
+            duck.Value.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(123, 456, 789)]
+        [InlineData("test", "testage")]
+        [InlineData(1.23, 4.56)]
+        public void CanDuckTypeSequenceValue(params object[] values)
+        {
+            var seq = new SequenceValue(values.Select(x => new ScalarValue(x)));
+
+            seq.TryDuckCast<SequenceValueDuck>(out var duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+            using var scope = new AssertionScope();
+            var wrappedValues = new object[values.Length];
+            var i = 0;
+            foreach (var element in duck.Elements)
+            {
+                element.TryDuckCast<ScalarValueDuck>(out var scalar).Should().BeTrue();
+                wrappedValues[i] = scalar.Value;
+                i++;
+            }
+
+            wrappedValues.Should().ContainInOrder(values);
+        }
+
+        [Theory]
+        [InlineData(123, 456, 789)]
+        [InlineData("test", "testage")]
+        [InlineData(1.23, 4.56)]
+        public void CanDuckTypeStructureValue(params object[] values)
+        {
+            var typeTag = "MyTestClass";
+            var structure = new StructureValue(
+                values.Select((x, i) => new LogEventProperty($"Value{i}", new ScalarValue(x))),
+                typeTag);
+
+            structure.TryDuckCast<StructureValueDuck>(out var duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+            duck.TypeTag.Should().Be(typeTag);
+
+            var duckValues = duck.Properties
+                                 .Cast<object>()
+                                 .Select(x => x.DuckCast<LogEventPropertyDuck>())
+                                 .ToList();
+
+            duckValues.Select(x => x.Name)
+                      .Should()
+                      .ContainInOrder(values.Select((_, i) => $"Value{i}"));
+
+            duckValues.Select(x => x.Value.DuckCast<ScalarValueDuck>().Value)
+                      .Should()
+                      .ContainInOrder(values);
+        }
+
+        [Theory]
+        [InlineData(123, 456, 789)]
+        [InlineData("test", "testage")]
+        [InlineData(1.23, 4.56)]
+        public void CanDuckTypeDictionaryValue(params object[] values)
+        {
+            var dict = new DictionaryValue(
+                values.Select(
+                    (x, i) => new KeyValuePair<ScalarValue, LogEventPropertyValue>(
+                        new ScalarValue($"Value{i}"),
+                        new ScalarValue(x))));
+
+            dict.TryDuckCast<DictionaryValueDuck>(out var duck).Should().BeTrue();
+            duck.Should().NotBeNull();
+
+            var duckValues = duck.Elements
+                                 .Cast<object>()
+                                 .Select(x => x.DuckCast<KeyValuePairObjectStruct>())
+                                 .ToList();
+
+            duckValues.Select(x => x.Key.DuckCast<ScalarValueDuck>().Value)
+                      .Should()
+                      .ContainInOrder(values.Select((_, i) => $"Value{i}"));
+
+            duckValues.Select(x => x.Value.DuckCast<ScalarValueDuck>().Value)
+                      .Should()
+                      .ContainInOrder(values);
+        }
+
+        internal class TestSerilogSink
+        {
+            public List<string> Logs { get; } = new();
+
+            [DuckReverseMethod(ParameterTypeNames = new[] { "Datadog.Trace.Vendors.Serilog.Events.LogEvent, Datadog.Trace" })]
+            public void Emit(ILogEvent logEvent)
+            {
+                Logs.Add(logEvent.RenderMessage());
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="SerilogHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Vendors.Serilog.Capturing;
+using Datadog.Trace.Vendors.Serilog.Core;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog
+{
+    internal static class SerilogHelper
+    {
+        public static MessageTemplateProcessor GetSerilogMessageProcessor()
+        {
+            // Use some "default" values
+            return new MessageTemplateProcessor(
+                new PropertyValueConverter(
+                    maximumDestructuringDepth: 10,
+                    maximumStringLength: int.MaxValue,
+                    maximumCollectionCount: int.MaxValue,
+                    additionalScalarTypes: Enumerable.Empty<Type>(),
+                    additionalDestructuringPolicies: Enumerable.Empty<IDestructuringPolicy>(),
+                    propagateExceptions: false));
+        }
+
+        internal class TestSink : IDatadogSink
+        {
+            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+
+            public void Dispose()
+            {
+            }
+
+            public void EnqueueLog(DatadogLogEvent logEvent)
+            {
+                Events.Enqueue(logEvent);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogLogFormatterTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
             SerilogLogFormatter.FormatLogEvent(formatter, sb, log);
             var actual = sb.ToString();
 
-            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""service"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
             actual.Should().Be(expected);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogLogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogLogFormatterTests.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="SerilogLogFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission.Formatting;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.Serilog;
+using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.Serilog.Parsing;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Serilog
+{
+    public class SerilogLogFormatterTests
+    {
+        [Fact]
+        public void SerializesEventCorrectly()
+        {
+            var logEvent = GetLogEvent();
+            var log = logEvent.DuckCast<ILogEvent>();
+
+            var formatter = LogSettingsHelper.GetFormatter();
+
+            var sb = new StringBuilder();
+            SerilogLogFormatter.FormatLogEvent(formatter, sb, log);
+            var actual = sb.ToString();
+
+            var expected = @"{""@t"":""2021-09-13T10:40:57.0000000Z"",""@m"":""This is a test with a 123"",""@l"":""Debug"",""@x"":""System.InvalidOperationException: Oops, just a test!"",""Value"":123,""OtherProperty"":62,""@i"":""a9a87aee"",""ddsource"":""csharp"",""ddservice"":""MyTestService"",""dd_env"":""integration_tests"",""dd_version"":""1.0.0"",""host"":""some_host""}";
+            actual.Should().Be(expected);
+        }
+
+        private static LogEvent GetLogEvent()
+        {
+            new LoggerConfiguration()
+               .CreateLogger()
+               .BindMessageTemplate(
+                    "This is a test with a {Value}",
+                    new object[] { 123 },
+                    out var messageTemplate,
+                    out var boundProperties);
+
+            // simulate properties added via scopes
+            boundProperties = boundProperties
+               .Concat(new[] { new LogEventProperty("OtherProperty", new ScalarValue(62)) });
+
+            return new LogEvent(
+                timestamp: new DateTimeOffset(2021, 09, 13, 10, 40, 57, TimeSpan.Zero),
+                LogEventLevel.Debug,
+                exception: new InvalidOperationException("Oops, just a test!"),
+                messageTemplate: messageTemplate,
+                boundProperties);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -1,7 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Log4NetVersion Condition="'$(Log4NetVersion)' == '' AND $(TargetFramework.StartsWith('net4'))">1.2.11</Log4NetVersion>
+    <Log4NetVersion Condition="'$(Log4NetVersion)' == '' AND !$(TargetFramework.StartsWith('net4'))">2.0.12</Log4NetVersion>
+    <DefineConstants Condition="'$(Log4NetVersion)'&gt;='2.0.0'">$(DefineConstants);LOG4NET_2</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
+    <PackageReference Include="log4net" Version="$(Log4NetVersion)" />
 
     <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/Datadog.Trace.ClrProfiler.Managed.Tests.csproj
@@ -1,5 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <NLogVersion Condition="'$(NLogVersion)' == ''">4.5.2</NLogVersion>
+    <DefineConstants Condition="'$(NLogVersion)'&lt;'4.0.0'">$(DefineConstants);NLOG_2</DefineConstants>
+    <DefineConstants Condition="'$(NLogVersion)'&gt;='4.0.0' and '$(NLogVersion)'&lt;'4.3.0'">$(DefineConstants);NLOG_30</DefineConstants>
+    <DefineConstants Condition="'$(NLogVersion)'&gt;='4.3.0' and '$(NLogVersion)'&lt;'4.5.0'">$(DefineConstants);NLOG_43</DefineConstants>
+    <DefineConstants Condition="'$(NLogVersion)'&gt;='4.5.0'">$(DefineConstants);NLOG_45</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <Log4NetVersion Condition="'$(Log4NetVersion)' == '' AND $(TargetFramework.StartsWith('net4'))">1.2.11</Log4NetVersion>
     <Log4NetVersion Condition="'$(Log4NetVersion)' == '' AND !$(TargetFramework.StartsWith('net4'))">2.0.12</Log4NetVersion>
     <DefineConstants Condition="'$(Log4NetVersion)'&gt;='2.0.0'">$(DefineConstants);LOG4NET_2</DefineConstants>
@@ -8,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.4.3" />
     <PackageReference Include="log4net" Version="$(Log4NetVersion)" />
+    <PackageReference Include="NLog" Version="$(NLogVersion)" Condition=" $(TargetFramework.StartsWith('net4'))" />
 
     <PackageReference Include="coverlet.collector" Version="3.0.4-preview.32">
       <PrivateAssets>all</PrivateAssets>

--- a/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="LogSettingsHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+
+namespace Datadog.Trace.TestHelpers
+{
+    internal class LogSettingsHelper
+    {
+        public static LogFormatter GetFormatter() => new(
+            GetValidSettings(),
+            serviceName: "MyTestService",
+            env: "integration_tests",
+            version: "1.0.0");
+
+        public static ImmutableDirectLogSubmissionSettings GetValidSettings()
+        {
+            return ImmutableDirectLogSubmissionSettings.Create(
+                host: "some_host",
+                source: "csharp",
+                intakeUrl: "https://localhost:1234",
+                apiKey: "abcdef",
+                minimumLevel: DirectSubmissionLogLevel.Debug,
+                globalTags: new Dictionary<string, string>(),
+                enabledLogShippingIntegrations: ImmutableDirectLogSubmissionSettings.SupportedIntegrations.Select(x => x.ToString()).ToList(),
+                batchingOptions: new BatchingSinkOptions(1000, 100_000, TimeSpan.FromSeconds(2)));
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
@@ -1,0 +1,256 @@
+﻿// <copyright file="MockLogsIntake.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.Specialized;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+
+namespace Datadog.Trace.TestHelpers
+{
+    public class MockLogsIntake : IDisposable
+    {
+        private static readonly JsonSerializer JsonSerializer = new();
+        private readonly HttpListener _listener;
+        private readonly Thread _listenerThread;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+
+        public MockLogsIntake(int? initialPort = null, int retries = 5)
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+            var port = initialPort ?? TcpPortProvider.GetOpenPort();
+
+            // try up to 5 consecutive ports before giving up
+            while (true)
+            {
+                // seems like we can't reuse a listener if it fails to start,
+                // so create a new listener each time we retry
+                var listener = new HttpListener();
+                listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+                listener.Prefixes.Add($"http://localhost:{port}/");
+                listener.Prefixes.Add($"http://127.0.0.1:{port}/v1/input/");
+                listener.Prefixes.Add($"http://localhost:{port}/v1/input/");
+                listener.Prefixes.Add($"http://127.0.0.1:{port}/api/v2/logs/");
+                listener.Prefixes.Add($"http://localhost:{port}/api/v2/logs/");
+
+                try
+                {
+                    listener.Start();
+
+                    // successfully listening
+                    Port = port;
+                    _listener = listener;
+
+                    _listenerThread = new Thread(HandleHttpRequests);
+                    _listenerThread.Start();
+
+                    return;
+                }
+                catch (HttpListenerException) when (retries > 0)
+                {
+                    // only catch the exception if there are retries left
+                    port = TcpPortProvider.GetOpenPort();
+                    retries--;
+                }
+
+                // always close listener if exception is thrown,
+                // whether it was caught or not
+                listener.Close();
+            }
+        }
+
+        public event EventHandler<EventArgs<HttpListenerContext>> RequestReceived;
+
+        public event EventHandler<EventArgs<IList<Log>>> RequestDeserialized;
+
+        /// <summary>
+        /// Gets the TCP port that this intake is listening on.
+        /// Can be different from <see cref="MockLogsIntake"/>'s <c>initialPort</c>
+        /// parameter if listening on that port fails.
+        /// </summary>
+        public int Port { get; }
+
+        public IImmutableList<Log> Logs { get; private set; } = ImmutableList<Log>.Empty;
+
+        public IImmutableList<NameValueCollection> RequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to skip deserialization of traces.
+        /// </summary>
+        public bool ShouldDeserializeLogs { get; set; } = true;
+
+        public void Dispose()
+        {
+            _listener?.Stop();
+            _cancellationTokenSource.Cancel();
+        }
+
+        private void AssertHeader(
+            NameValueCollection headers,
+            string headerKey,
+            Func<string, bool> assertion)
+        {
+            var header = headers.Get(headerKey);
+
+            if (string.IsNullOrEmpty(header))
+            {
+                throw new Exception($"Every submission to the intake should have a {headerKey} header.");
+            }
+
+            if (!assertion(header))
+            {
+                throw new Exception($"Failed assertion for {headerKey} on {header}");
+            }
+        }
+
+        private void HandleHttpRequests()
+        {
+            while (_listener.IsListening)
+            {
+                try
+                {
+                    var ctx = _listener.GetContext();
+                    RequestReceived?.Invoke(this, new EventArgs<HttpListenerContext>(ctx));
+                    if (ShouldDeserializeLogs)
+                    {
+                        var logs = Log.DeserializeFromStream(ctx.Request.InputStream);
+                        RequestDeserialized?.Invoke(this, new EventArgs<IList<Log>>(logs));
+
+                        lock (this)
+                        {
+                            // we only need to lock when replacing the logs collection,
+                            // not when reading it because it is immutable
+                            Logs = Logs.AddRange(logs);
+                            RequestHeaders = RequestHeaders.Add(new NameValueCollection(ctx.Request.Headers));
+                        }
+                    }
+
+                    // NOTE: HttpStreamRequest doesn't support Transfer-Encoding: Chunked
+                    // (Setting content-length avoids that)
+
+                    ctx.Response.ContentType = "application/json";
+                    var buffer = Encoding.UTF8.GetBytes("{}");
+                    ctx.Response.ContentLength64 = buffer.LongLength;
+                    ctx.Response.OutputStream.Write(buffer, 0, buffer.Length);
+                    ctx.Response.Close();
+                }
+                catch (HttpListenerException)
+                {
+                    // listener was stopped,
+                    // ignore to let the loop end and the method return
+                }
+                catch (ObjectDisposedException)
+                {
+                    // the response has been already disposed.
+                }
+                catch (InvalidOperationException)
+                {
+                    // this can occur when setting Response.ContentLength64, with the framework claiming that the response has already been submitted
+                    // for now ignore, and we'll see if this introduces downstream issues
+                }
+                catch (Exception) when (!_listener.IsListening)
+                {
+                    // we don't care about any exception when listener is stopped
+                }
+            }
+        }
+
+        public class Log
+        {
+            [JsonProperty("@t")]
+            public DateTimeOffset Timestamp { get; set; }
+
+            [JsonProperty("@m")]
+            public string Message { get; set; }
+
+            [JsonProperty("@i")]
+            public string EventId { get; set; }
+
+            [JsonProperty("@x")]
+            public Exception Exception { get; set; }
+
+            // Not required, defaults to Information if not provided
+            [JsonProperty("@l")]
+            public DirectSubmissionLogLevel LogLevel { get; set; } = DirectSubmissionLogLevel.Information;
+
+            [JsonProperty("ddsource")]
+            public string Source { get; set; }
+
+            [JsonProperty("host")]
+            public string Host { get; set; }
+
+            [JsonProperty("ddtags")]
+            public string Tags { get; set; }
+
+            [JsonProperty("dd_env")]
+            public string Env { get; set; }
+
+            [JsonProperty("dd_version")]
+            public string Version { get; set; }
+
+            [JsonProperty("dd_service")]
+            public string Service { get; set; }
+
+            [JsonProperty("dd_trace_id")]
+            public string TraceId { get; set; }
+
+            [JsonProperty("dd_span_id")]
+            public string SpanId { get; set; }
+
+            [JsonExtensionData]
+            internal Dictionary<string, JToken> OtherProperties { get; } = new();
+
+            [JsonProperty("ddservice")]
+            private string Service1
+            {
+                set => Service = value;
+            }
+
+            [JsonProperty("dd.service")]
+            private string Service2
+            {
+                set => Service = value;
+            }
+
+            [JsonProperty("dd.trace_id")]
+            private string TraceId1
+            {
+                set => TraceId = value;
+            }
+
+            [JsonProperty("dd.span_id")]
+            private string SpanId1
+            {
+                set => SpanId = value;
+            }
+
+            [JsonProperty("dd.env")]
+            private string Env2
+            {
+                set => Env = value;
+            }
+
+            [JsonProperty("dd.version")]
+            private string Version2
+            {
+                set => Version = value;
+            }
+
+            public static List<Log> DeserializeFromStream(Stream stream)
+            {
+                using var sr = new StreamReader(stream);
+                using var jsonTextReader = new JsonTextReader(sr);
+                return JsonSerializer.Deserialize<List<Log>>(jsonTextReader);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockLogsIntake.cs
@@ -209,7 +209,7 @@ namespace Datadog.Trace.TestHelpers
             [JsonExtensionData]
             internal Dictionary<string, JToken> OtherProperties { get; } = new();
 
-            [JsonProperty("ddservice")]
+            [JsonProperty("service")]
             private string Service1
             {
                 set => Service = value;

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -14,6 +14,7 @@ using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -347,6 +348,14 @@ namespace Datadog.Trace.TestHelpers
         protected void SetAppSecBlockingEnabled(bool appSecBlockingEnabled)
         {
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecBlockingEnabled, appSecBlockingEnabled ? "true" : "false");
+        }
+
+        protected void EnableDirectLogSubmission(int intakePort, string integrationName, string host = "integration_tests")
+        {
+            SetEnvironmentVariable(ConfigurationKeys.DirectLogSubmission.Host, host);
+            SetEnvironmentVariable(ConfigurationKeys.DirectLogSubmission.Url, $"http://127.0.0.1:{intakePort}");
+            SetEnvironmentVariable(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, integrationName);
+            SetEnvironmentVariable(ConfigurationKeys.ApiKey, "DUMMY_KEY_REQUIRED_FOR_DIRECT_SUBMISSION");
         }
 
         protected async Task<IImmutableList<MockSpan>> GetWebServerSpans(

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectSubmissionLogLevelExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectSubmissionLogLevelExtensionsTests.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="DirectSubmissionLogLevelExtensionsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Linq;
+using Datadog.Trace.Logging.DirectSubmission;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission
+{
+    public class DirectSubmissionLogLevelExtensionsTests
+    {
+        [Fact]
+        public void GetName_IsValidForAllLevels()
+        {
+            var allValues = Enum.GetValues(typeof(DirectSubmissionLogLevel))
+                                .Cast<DirectSubmissionLogLevel>();
+
+            foreach (var value in allValues)
+            {
+                value.GetName().Should().NotBeNullOrEmpty();
+            }
+        }
+
+        [Fact]
+        public void GetName_HandlesUnknownLogLevels()
+        {
+            ((DirectSubmissionLogLevel)123).GetName().Should().Be("UNKNOWN");
+        }
+
+        [Fact]
+        public void Parse_IsValidForAllValidValues()
+        {
+            var allValues = Enum.GetValues(typeof(DirectSubmissionLogLevel))
+                                .Cast<DirectSubmissionLogLevel>();
+
+            foreach (var value in allValues)
+            {
+                var parsed = DirectSubmissionLogLevelExtensions.Parse(value.ToString(), defaultLevel: (DirectSubmissionLogLevel)123);
+                parsed.Should().Be(value);
+            }
+        }
+
+        [Theory]
+        [InlineData("TRACE")]
+        [InlineData("Trace")]
+        [InlineData("trace")]
+        [InlineData("Verbose")]
+        [InlineData("verbose")]
+        public void Parse_ReturnsExpectedForKnownValues(string value)
+        {
+            var defaultValue = (DirectSubmissionLogLevel)123;
+            var parsed = DirectSubmissionLogLevelExtensions.Parse(value, defaultValue);
+            parsed.Should().Be(DirectSubmissionLogLevel.Verbose);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("INVALID")]
+        [InlineData("NOT_A_LEVEL")]
+        public void Parse_ReturnsDefaultForUnknownValues(string value)
+        {
+            var defaultValue = (DirectSubmissionLogLevel)123;
+            var parsed = DirectSubmissionLogLevelExtensions.Parse(value, defaultValue);
+            parsed.Should().Be(defaultValue);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/EventIdHashTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/EventIdHashTests.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="EventIdHashTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// based on https://github.com/serilog/serilog-formatting-compact/blob/8393e0ab8c2bc746fc733a4f20731b9e1f20f811/test/Serilog.Formatting.Compact.Tests/EventIdHashTests.cs
+
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
+{
+    public class EventIdHashTests
+    {
+        [Fact]
+        public void HashingIsConsistent()
+        {
+            var h1 = EventIdHash.Compute("Template 1");
+            var h2 = EventIdHash.Compute("Template 1");
+            Assert.Equal(h1, h2);
+        }
+
+        [Fact]
+        public void DistinctHashesAreComputed()
+        {
+            var h1 = EventIdHash.Compute("Template 1");
+            var h2 = EventIdHash.Compute("Template 2");
+            Assert.NotEqual(h1, h2);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
@@ -1,0 +1,219 @@
+﻿// <copyright file="LogFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
+{
+    public class LogFormatterTests : IDisposable
+    {
+        private const string Host = "the_host";
+        private const string Source = "csharp";
+        private const string Service = "TestService";
+        private const string Env = "integrationTests";
+        private const string Version = "1.0.0";
+        private readonly LogFormatter _formatter;
+        private readonly JsonTextWriter _writer;
+        private readonly StringBuilder _sb;
+
+        public LogFormatterTests()
+        {
+            var settings = ImmutableDirectLogSubmissionSettings.Create(
+                host: Host,
+                source: Source,
+                intakeUrl: "http://localhost",
+                apiKey: "some_value",
+                minimumLevel: DirectSubmissionLogLevel.Debug,
+                globalTags: new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } },
+                enabledLogShippingIntegrations: new List<string> { nameof(IntegrationId.ILogger) },
+                batchingOptions: new BatchingSinkOptions(batchSizeLimit: 100, queueLimit: 1000, TimeSpan.FromSeconds(2)));
+            settings.IsEnabled.Should().BeTrue();
+
+            _formatter = new LogFormatter(
+                settings,
+                serviceName: Service,
+                env: Env,
+                version: Version);
+
+            _sb = new StringBuilder();
+            _writer = LogFormatter.GetJsonWriter(_sb);
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)_writer)?.Dispose();
+        }
+
+        [Theory]
+        [InlineData("name", "\"name\":")]
+        [InlineData("@name", "\"@@name\":")]
+        [InlineData("@", "\"@@\":")]
+        public void EscapesPropertyNames(string property, string expected)
+        {
+            LogFormatter.WritePropertyName(_writer, property);
+            _sb.ToString().Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, "null")]
+        [InlineData("some string", "\"some string\"")]
+        [InlineData(1234, "1234")]
+        [InlineData(1234L, "1234")]
+        [InlineData(1234UL, "1234")]
+        [InlineData(123.50D, "123.5")]
+        [InlineData(123.50F, "123.5")]
+        [InlineData('c', "\"c\"")]
+        public void WritesValueCorrectly(object value, string expected)
+        {
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be(expected);
+        }
+
+        [Fact]
+        public void WritesDecimalValueCorrectly()
+        {
+            var value = 123.5M;
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be("123.5");
+        }
+
+        [Fact]
+        public void WritesDateValueCorrectly()
+        {
+            var value = new DateTime(year: 2020, month: 3, day: 7, hour: 11, minute: 23, second: 26, millisecond: 500, DateTimeKind.Utc);
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be("\"2020-03-07T11:23:26.5Z\"");
+        }
+
+        [Fact]
+        public void WritesDateTimeOffsetValueCorrectly()
+        {
+            var value = new DateTimeOffset(year: 2020, month: 3, day: 7, hour: 11, minute: 23, second: 26, millisecond: 500, offset: TimeSpan.Zero);
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be("\"2020-03-07T11:23:26.5+00:00\"");
+        }
+
+        [Fact]
+        public void WritesTimespanCorrectly()
+        {
+            var value = TimeSpan.FromSeconds(100);
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be("\"00:01:40\"");
+        }
+
+        [Fact]
+        public void WritesFormattableObjectCorrectly()
+        {
+            var value = new FormattableObject { SomeValue = "testing!" };
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be("\"SomeValue = testing!\"");
+        }
+
+        [Fact]
+        public void WritesObjectCorrectly()
+        {
+            var value = new TestObject { SomeValue = "testing!" };
+            LogFormatter.WriteValue(_writer, value);
+            _sb.ToString().Should().Be("\"Datadog.Trace.Tests.Logging.DirectSubmission.Formatting.LogFormatterTests+TestObject\"");
+        }
+
+        [Theory]
+        [MemberData(nameof(TestData.AllOptions), MemberType = typeof(TestData))]
+        public void WritesLogFormatCorrectly(
+            bool hasRenderedSource,
+            bool hasRenderedService,
+            bool hasRenderedHost,
+            bool hasRenderedTags,
+            bool hasRenderedEnv,
+            bool hasRenderedVersion)
+        {
+            var timestamp = new DateTime(year: 2020, month: 3, day: 7, hour: 11, minute: 23, second: 26, millisecond: 500, DateTimeKind.Utc);
+            var sb = new StringBuilder();
+            var state = new TestObject();
+            var message = "Some message";
+            var logLevel = "Info";
+
+            _formatter.FormatLog(sb, state, timestamp, message, eventId: null, logLevel, exception: null, RenderProperties);
+
+            var log = sb.ToString();
+
+            log
+               .Should()
+               .Contain(timestamp.ToString("o"))
+               .And.Contain(message)
+               .And.Contain(logLevel);
+
+            using var scope = new AssertionScope();
+            HasExpectedValue(log, !hasRenderedSource, $"\"ddsource\":\"{Source}\"");
+            HasExpectedValue(log, !hasRenderedService, $"\"ddservice\":\"{Service}\"");
+            HasExpectedValue(log, !hasRenderedHost, $"\"host\":\"{Host}\"");
+            HasExpectedValue(log, !hasRenderedTags, $"\"ddtags\":\"Key1:Value1;Key2:Value2\"");
+            HasExpectedValue(log, !hasRenderedEnv, $"\"dd_env\":\"{Env}\"");
+            HasExpectedValue(log, !hasRenderedVersion, $"\"dd_version\":\"{Version}\"");
+
+            LogPropertyRenderingDetails RenderProperties(JsonTextWriter jsonTextWriter, in TestObject o) =>
+                new LogPropertyRenderingDetails(
+                    hasRenderedSource: hasRenderedSource,
+                    hasRenderedService: hasRenderedService,
+                    hasRenderedHost: hasRenderedHost,
+                    hasRenderedTags: hasRenderedTags,
+                    hasRenderedEnv: hasRenderedEnv,
+                    hasRenderedVersion: hasRenderedVersion,
+                    messageTemplate: null);
+
+            static void HasExpectedValue(string log, bool shouldContain, string value)
+            {
+                if (shouldContain)
+                {
+                    log.Should().Contain(value);
+                }
+                else
+                {
+                    log.Should().NotContain(value);
+                }
+            }
+        }
+
+        private class TestData
+        {
+            private static readonly bool[] Options = { true, false };
+
+            public static IEnumerable<object[]> AllOptions
+                => from src in Options
+                   from service in Options
+                   from host in Options
+                   from tags in Options
+                   from env in Options
+                   from version in Options
+                   select new object[] { src, service, host, tags, env, version };
+        }
+
+        private class FormattableObject : IFormattable
+        {
+            public string SomeValue { get; set; }
+
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                return "SomeValue = " + SomeValue;
+            }
+        }
+
+        private class TestObject
+        {
+            public string SomeValue { get; set; }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
@@ -158,7 +158,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
 
             using var scope = new AssertionScope();
             HasExpectedValue(log, !hasRenderedSource, $"\"ddsource\":\"{Source}\"");
-            HasExpectedValue(log, !hasRenderedService, $"\"ddservice\":\"{Service}\"");
+            HasExpectedValue(log, !hasRenderedService, $"\"service\":\"{Service}\"");
             HasExpectedValue(log, !hasRenderedHost, $"\"host\":\"{Host}\"");
             HasExpectedValue(log, !hasRenderedTags, $"\"ddtags\":\"Key1:Value1;Key2:Value2\"");
             HasExpectedValue(log, !hasRenderedEnv, $"\"dd_env\":\"{Env}\"");

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -1,0 +1,160 @@
+﻿// <copyright file="ImmutableDirectLogSubmissionSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission
+{
+    public class ImmutableDirectLogSubmissionSettingsTests
+    {
+        private static readonly List<string> AllIntegrations =
+            ImmutableDirectLogSubmissionSettings.SupportedIntegrations.Select(x => x.ToString()).ToList();
+
+        private static readonly NameValueCollection Defaults =  new()
+        {
+            { ConfigurationKeys.LogsInjectionEnabled, "1" },
+            { ConfigurationKeys.DirectLogSubmission.Host, "integration_tests" },
+            { ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, string.Join(";", AllIntegrations) },
+        };
+
+        [Fact]
+        public void ValidSettingsAreValid()
+        {
+            var settings = LogSettingsHelper.GetValidSettings();
+            settings.IsEnabled.Should().BeTrue();
+        }
+
+        [Fact]
+        public void ValidDefaultsAreValid()
+        {
+            var apiKey = "some_key";
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(Defaults));
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings, apiKey);
+
+            logSettings.IsEnabled.Should().BeTrue();
+            logSettings.ValidationErrors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData(null)]
+        public void InvalidApiKeyIsInvalid(string apiKey)
+        {
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(Defaults));
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings, apiKey);
+
+            logSettings.IsEnabled.Should().BeFalse();
+            logSettings.ValidationErrors.Should().NotBeEmpty();
+        }
+
+        [Theory]
+        [InlineData("VeryVerbose", DirectSubmissionLogLevel.Information)]
+        [InlineData("", DirectSubmissionLogLevel.Information)]
+        [InlineData(null, DirectSubmissionLogLevel.Information)]
+        [InlineData("Verbose", DirectSubmissionLogLevel.Verbose)]
+        [InlineData("trace", DirectSubmissionLogLevel.Verbose)]
+        [InlineData("Debug", DirectSubmissionLogLevel.Debug)]
+        [InlineData("Info", DirectSubmissionLogLevel.Information)]
+        [InlineData("Warning", DirectSubmissionLogLevel.Warning)]
+        [InlineData("ERROR", DirectSubmissionLogLevel.Error)]
+        [InlineData("Fatal", DirectSubmissionLogLevel.Fatal)]
+        [InlineData("critical", DirectSubmissionLogLevel.Fatal)]
+        public void ParsesLogLevelsCorrectly(string value, DirectSubmissionLogLevel expected)
+        {
+            var apiKey = "some_key";
+            var updatedSettings = new NameValueCollection(Defaults);
+            updatedSettings[ConfigurationKeys.DirectLogSubmission.MinimumLevel] = value;
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(updatedSettings));
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings, apiKey);
+
+            logSettings.IsEnabled.Should().BeTrue();
+            logSettings.ValidationErrors.Should().BeEmpty();
+            logSettings.MinimumLevel.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Host, "")]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Host, "   ")]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Source, "")]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Source, "   ")]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Url, "")]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Url, "   ")]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.Url, "localhost")]
+        public void InvalidSettingDisablesDirectLogSubmission(string setting, string value)
+        {
+            var apiKey = "some_key";
+
+            var updatedSettings = new NameValueCollection(Defaults);
+            updatedSettings[setting] = value;
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(updatedSettings));
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings, apiKey);
+
+            logSettings.IsEnabled.Should().BeFalse();
+            logSettings.ValidationErrors.Should().NotBeEmpty();
+        }
+
+        [Theory]
+        [InlineData(ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, "Garbage")]
+        public void InvalidSettingWarnsButDoesNotDisableDirectLogSubmission(string setting, string value)
+        {
+            var apiKey = "some_key";
+
+            var updatedSettings = new NameValueCollection(Defaults);
+            updatedSettings[setting] = value;
+
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(updatedSettings));
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings, apiKey);
+
+            logSettings.IsEnabled.Should().BeTrue();
+            logSettings.ValidationErrors.Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void CanLoadSettingsFromTracerSettings()
+        {
+            var apiKey = "some_key";
+            var hostName = "integration_tests";
+            var intake = "http://localhost:1234";
+            var enabledIntegrations = ImmutableDirectLogSubmissionSettings.SupportedIntegrations
+                                                                 .Select(x => x.ToString())
+                                                                 .ToList();
+
+            var collection = new NameValueCollection
+            {
+                { ConfigurationKeys.LogsInjectionEnabled, "1" },
+                { ConfigurationKeys.DirectLogSubmission.Host, hostName },
+                { ConfigurationKeys.DirectLogSubmission.Url, intake },
+                { ConfigurationKeys.DirectLogSubmission.EnabledIntegrations, string.Join(";", enabledIntegrations) },
+                { ConfigurationKeys.DirectLogSubmission.GlobalTags, "sometag:value" },
+            };
+
+            IConfigurationSource source = new NameValueConfigurationSource(collection);
+            var tracerSettings = new TracerSettings(source);
+
+            var logSettings = ImmutableDirectLogSubmissionSettings.Create(tracerSettings, apiKey);
+
+            using var scope = new AssertionScope();
+            logSettings.ApiKey.Should().Be(apiKey);
+            logSettings.Host.Should().Be(hostName);
+            logSettings.IntakeUrl?.ToString().Should().Be("http://localhost:1234/");
+            logSettings.GlobalTags.Should().Be("sometag:value");
+            logSettings.IsEnabled.Should().BeTrue();
+            logSettings.MinimumLevel.Should().Be(DirectSubmissionLogLevel.Information);
+            logSettings.Source.Should().Be("csharp");
+            logSettings.ValidationErrors.Should().BeEmpty();
+            logSettings.EnabledIntegrationNames.Should().Equal(enabledIntegrations);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -1,0 +1,278 @@
+﻿// <copyright file="DatadogSinkTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
+{
+    public class DatadogSinkTests
+    {
+        private const int DefaultQueueLimit = 100_000;
+        private static readonly TimeSpan TinyWait = TimeSpan.FromMilliseconds(50);
+
+        [Fact]
+        public void SinkSendsMessagesToLogsApi()
+        {
+            var mutex = new ManualResetEventSlim();
+
+            var logsApi = new TestLogsApi(_ =>
+            {
+                mutex.Set();
+                return true;
+            });
+            var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
+            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message"));
+
+            // Wait for the logs to be sent, should be done in 50ms
+            mutex.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            logsApi.Logs.Should().ContainSingle();
+        }
+
+        [Fact]
+        public void SinkRejectsGiantMessages()
+        {
+            var mutex = new ManualResetEventSlim();
+
+            var logsApi = new TestLogsApi();
+            var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
+            var sink = new DatadogSink(
+                logsApi,
+                LogSettingsHelper.GetFormatter(),
+                options,
+                oversizeLogCallback: _ => mutex.Set(),
+                sinkDisabledCallback: () => { });
+
+            var message = new StringBuilder().Append('x', repeatCount: 1024 * 1024).ToString();
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, message));
+
+            // Wait for the logs to be sent, should be done in 50ms
+            mutex.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            logsApi.Logs.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void SinkSendsMessageAsJsonBatch()
+        {
+            var mutex = new ManualResetEventSlim();
+            int logsReceived = 0;
+            const int expectedCount = 2;
+
+            bool LogsSentCallback(int x)
+            {
+                if (Interlocked.Add(ref logsReceived, x) == expectedCount)
+                {
+                    mutex.Set();
+                }
+
+                return true;
+            }
+
+            var logsApi = new TestLogsApi(LogsSentCallback);
+            var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
+            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+
+            var firstMessage = "First message";
+            var secondMessage = "Second message";
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, firstMessage));
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Information, secondMessage));
+
+            mutex.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+            logsApi.Logs.Should().NotBeEmpty();
+
+            var logs = logsApi.Logs
+                              .Select(batch => Encoding.UTF8.GetString(batch.Logs.Array))
+                              .SelectMany(batch => JsonConvert.DeserializeObject<List<TestLogEvent>>(batch))
+                              .ToList();
+
+            logs.Should().NotBeNull();
+            logs.Count.Should().Be(2);
+            logs[0].Level.Should().Be(DirectSubmissionLogLevel.Debug);
+            logs[0].Message.Should().Be(firstMessage);
+            logs[1].Level.Should().Be(DirectSubmissionLogLevel.Information);
+            logs[1].Message.Should().Be(secondMessage);
+        }
+
+        [Fact]
+        public void SinkSendsMultipleBatches()
+        {
+            var mutex = new ManualResetEventSlim();
+            int logsReceived = 0;
+            const int expectedCount = 5;
+
+            bool LogsSentCallback(int x)
+            {
+                if (Interlocked.Add(ref logsReceived, x) == expectedCount)
+                {
+                    mutex.Set();
+                }
+
+                return true;
+            }
+
+            var logsApi = new TestLogsApi(LogsSentCallback);
+            var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
+            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message"));
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Information, "Second message"));
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Information, "Third message"));
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Information, "Fourth message"));
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Information, "Fifth message"));
+
+            mutex.Wait(TimeSpan.FromSeconds(10)).Should().BeTrue();
+
+            logsApi.Logs.Should().HaveCountGreaterOrEqualTo(3); // batch size is 2, so at least 3 batches
+
+            var logs = logsApi.Logs
+                              .Select(batch => Encoding.UTF8.GetString(batch.Logs.Array))
+                              .SelectMany(batch => JsonConvert.DeserializeObject<List<TestLogEvent>>(batch))
+                              .ToList();
+
+            logs.Count.Should().Be(5);
+            logs.Select(x => x.Message).Should().OnlyHaveUniqueItems();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task EmitBatchEchoesLogsApiReturnValue(bool logsApiResponse)
+        {
+            var mutex = new ManualResetEventSlim();
+            bool LogsSentCallback(int x)
+            {
+                mutex.Set();
+
+                return logsApiResponse;
+            }
+
+            var logsApi = new TestLogsApi(LogsSentCallback);
+            var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
+            var sink = new TestSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            var log = new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message");
+            var queue = new Queue<DatadogLogEvent>();
+            queue.Enqueue(log);
+
+            var result = await sink.CallEmitBatch(queue);
+
+            result.Should().Be(logsApiResponse);
+        }
+
+        [Fact]
+        public void IfCircuitBreakerBreaksThenNoApiRequestsAreSent()
+        {
+            var mutex = new ManualResetEventSlim();
+            int logsReceived = 0;
+
+            bool LogsSentCallback(int x)
+            {
+                Interlocked.Add(ref logsReceived, x);
+                mutex.Set();
+                return false;
+            }
+
+            var logsApi = new TestLogsApi(LogsSentCallback);
+            var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
+            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+
+            for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
+            {
+                sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "A message"));
+                mutex.Wait(10_000).Should().BeTrue();
+                mutex.Reset();
+            }
+
+            // circuit should be broken
+            sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "A message"));
+            mutex.Wait(3_000).Should().BeFalse(); // don't expect it to be set
+
+            logsReceived.Should().Be(BatchingSink.FailuresBeforeCircuitBreak);
+        }
+
+        internal class TestLogEvent : DatadogLogEvent
+        {
+            public TestLogEvent(DirectSubmissionLogLevel level, string message)
+            {
+                Level = level;
+                Message = message;
+            }
+
+            [JsonConverter(typeof(StringEnumConverter))]
+            public DirectSubmissionLogLevel Level { get; }
+
+            public string Message { get; }
+
+            public override void Format(StringBuilder sb, LogFormatter formatter)
+            {
+                sb.Append(JsonConvert.SerializeObject(this));
+            }
+        }
+
+        internal class TestLogsApi : ILogsApi
+        {
+            private readonly Func<int, bool> _logsSentCallback;
+
+            public TestLogsApi(Func<int, bool> logsSentCallback = null)
+            {
+                _logsSentCallback = logsSentCallback;
+            }
+
+            public Queue<SentMessage> Logs { get; } = new();
+
+            public void Dispose()
+            {
+            }
+
+            public Task<bool> SendLogsAsync(ArraySegment<byte> logs, int numberOfLogs)
+            {
+                // create a copy of it
+                Logs.Enqueue(new SentMessage(new ArraySegment<byte>(logs.ToArray()), numberOfLogs));
+                var result = _logsSentCallback?.Invoke(numberOfLogs) ?? true;
+                return Task.FromResult(result);
+            }
+        }
+
+        internal class SentMessage
+        {
+            public SentMessage(ArraySegment<byte> logs, int numberOfLogs)
+            {
+                Logs = logs;
+                NumberOfLogs = numberOfLogs;
+            }
+
+            public ArraySegment<byte> Logs { get; }
+
+            public int NumberOfLogs { get; }
+        }
+
+        internal class TestSink : DatadogSink
+        {
+            public TestSink(ILogsApi api, LogFormatter formatter, BatchingSinkOptions sinkOptions)
+                : base(api, formatter, sinkOptions)
+            {
+            }
+
+            public Task<bool> CallEmitBatch(Queue<DatadogLogEvent> events)
+            {
+                return EmitBatch(events);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
@@ -1,0 +1,213 @@
+﻿// <copyright file="LogsApiTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
+{
+    public class LogsApiTests
+    {
+        private const string DefaultIntake = "https://http-intake.logs.datadoghq.com:443";
+        private const int NumberOfLogs = 1;
+        private static readonly ArraySegment<byte> Logs = new(
+            Encoding.UTF8.GetBytes("{\"Level\":\"Debug\",\"Message\":\"Well done, you sent a message\"}"));
+
+        private static readonly Func<Uri, TestApiRequest> SingleFaultyRequest = x => new FaultyApiRequest(x);
+
+        [Theory]
+        [InlineData("http://http-intake.logs.datadoghq.com", "http://http-intake.logs.datadoghq.com/api/v2/logs")]
+        [InlineData("http://http-intake.logs.datadoghq.com/", "http://http-intake.logs.datadoghq.com/api/v2/logs")]
+        [InlineData("https://http-intake.logs.datadoghq.com:443", "https://http-intake.logs.datadoghq.com:443/api/v2/logs")]
+        [InlineData("http://localhost:8080", "http://localhost:8080/api/v2/logs")]
+        [InlineData("http://localhost:8080/sub-path", "http://localhost:8080/sub-path/api/v2/logs")]
+        [InlineData("http://localhost:8080/sub-path/", "http://localhost:8080/sub-path/api/v2/logs")]
+        public async Task SendsRequestToCorrectUrl(string baseUri, string expected)
+        {
+            var baseEndpoint = new Uri(baseUri);
+            var requestFactory = new TestRequestFactory();
+
+            var api = new LogsApi(baseEndpoint, "SECR3TZ", requestFactory);
+            var result = await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            requestFactory.RequestsSent.Should()
+                          .OnlyContain(x => x.Endpoint == new Uri(expected));
+
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldRetryRequestsWhenTheyFail()
+        {
+            // two faults, then success
+            var requestFactory = new TestRequestFactory(SingleFaultyRequest, SingleFaultyRequest);
+
+            var apiKey = "SECR3TZ";
+            var api = new LogsApi(new Uri(DefaultIntake), apiKey, requestFactory);
+            var result = await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            requestFactory.RequestsSent
+                          .Where(x => x is FaultyApiRequest)
+                          .Should()
+                          .HaveCount(2);
+
+            requestFactory.RequestsSent
+                          .Where(x => x is not FaultyApiRequest)
+                          .Should()
+                          .HaveCount(1);
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task ShouldAddApiKeyToAllRequests()
+        {
+            var requestFactory = new TestRequestFactory(SingleFaultyRequest);
+
+            var apiKey = "SECR3TZ";
+            var api = new LogsApi(new Uri(DefaultIntake), apiKey, requestFactory);
+            await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            requestFactory.RequestsSent.Should()
+                          .NotBeEmpty()
+                          .And.OnlyContain(x => x.ExtraHeaders.ContainsKey(LogsApi.IntakeHeaderNameApiKey))
+                          .And.OnlyContain(x => x.ExtraHeaders[LogsApi.IntakeHeaderNameApiKey] == apiKey);
+        }
+
+        [Fact]
+        public async Task ShouldSetContentTypeForAllRequests()
+        {
+            var requestFactory = new TestRequestFactory(SingleFaultyRequest);
+
+            var api = new LogsApi(new Uri(DefaultIntake), "SECR3TZ", requestFactory);
+            await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            using var scope = new AssertionScope();
+            requestFactory.RequestsSent.Should().NotBeEmpty();
+            foreach (var request in requestFactory.RequestsSent)
+            {
+                request.Responses.Should()
+                       .ContainSingle()
+                       .And.OnlyContain(x => x.ContentType == "application/json");
+            }
+        }
+
+        [Fact]
+        public async Task ShouldNotRetryWhenClientError()
+        {
+            var requestFactory = new TestRequestFactory(x => new FaultyApiRequest(x, statusCode: 400));
+
+            var api = new LogsApi(new Uri(DefaultIntake), "SECR3TZ", requestFactory);
+            var result = await api.SendLogsAsync(Logs, NumberOfLogs);
+
+            using var scope = new AssertionScope();
+            var request = requestFactory.RequestsSent.Should().ContainSingle().Subject;
+            request.Responses.Should().ContainSingle().Which.StatusCode.Should().Be(400);
+
+            result.Should().BeFalse();
+        }
+
+        internal class TestRequestFactory : IApiRequestFactory
+        {
+            private readonly Func<Uri, TestApiRequest>[] _requestsToSend;
+
+            public TestRequestFactory(params Func<Uri, TestApiRequest>[] requestsToSend)
+            {
+                _requestsToSend = requestsToSend;
+            }
+
+            public List<TestApiRequest> RequestsSent { get; } = new();
+
+            public string Info(Uri endpoint) => endpoint.ToString();
+
+            public IApiRequest Create(Uri endpoint)
+            {
+                var request = (_requestsToSend is null || RequestsSent.Count >= _requestsToSend.Length)
+                                  ? new TestApiRequest(endpoint)
+                                  : _requestsToSend[RequestsSent.Count](endpoint);
+
+                RequestsSent.Add(request);
+
+                return request;
+            }
+        }
+
+        internal class TestApiRequest : IApiRequest
+        {
+            private readonly int _statusCode;
+
+            public TestApiRequest(Uri endpoint, int statusCode = 200)
+            {
+                _statusCode = statusCode;
+                Endpoint = endpoint;
+            }
+
+            public Uri Endpoint { get; }
+
+            public Dictionary<string, string> ExtraHeaders { get; } = new();
+
+            public List<TestApiResponse> Responses { get; } = new();
+
+            public void AddHeader(string name, string value)
+            {
+                ExtraHeaders.Add(name, value);
+            }
+
+            public Task<IApiResponse> PostAsync(ArraySegment<byte> traces, string contentType)
+            {
+                var response = new TestApiResponse(_statusCode, "The message body", contentType);
+                Responses.Add(response);
+
+                return Task.FromResult((IApiResponse)response);
+            }
+
+            public Task<IApiResponse> PostAsJsonAsync(IEvent events, JsonSerializer serializer)
+                => throw new NotImplementedException();
+        }
+
+        internal class FaultyApiRequest : TestApiRequest
+        {
+            public FaultyApiRequest(Uri endpoint, int statusCode = 500)
+                : base(endpoint, statusCode)
+            {
+            }
+        }
+
+        internal class TestApiResponse : IApiResponse
+        {
+            private readonly string _body;
+
+            public TestApiResponse(int statusCode, string body, string contentType)
+            {
+                StatusCode = statusCode;
+                _body = body;
+                ContentType = contentType;
+            }
+
+            public string ContentType { get; }
+
+            public int StatusCode { get; }
+
+            public long ContentLength => _body?.Length ?? 0;
+
+            public void Dispose()
+            {
+            }
+
+            public string GetHeader(string headerName) => throw new NotImplementedException();
+
+            public Task<string> ReadAsStringAsync() => Task.FromResult(_body);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -1,0 +1,195 @@
+﻿// <copyright file="BatchingSinkTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    public class BatchingSinkTests
+    {
+        private const int DefaultQueueLimit = 100_000;
+        private static readonly TimeSpan TinyWait = TimeSpan.FromMilliseconds(200);
+        private static readonly TimeSpan CircuitBreakPeriod = TimeSpan.FromSeconds(1);
+
+        private static readonly BatchingSinkOptions DefaultBatchingOptions
+            = new(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait, circuitBreakPeriod: CircuitBreakPeriod);
+
+        private readonly ITestOutputHelper _output;
+
+        public BatchingSinkTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        // Some very, very approximate tests here :)
+
+        [Fact]
+        public void WhenRunning_AndAnEventIsQueued_ItIsWrittenToABatchOnDispose()
+        {
+            var sink = new InMemoryBatchedSink(DefaultBatchingOptions);
+            var evt = new TestEvent("Some event");
+
+            sink.EnqueueLog(evt);
+            sink.Dispose();
+
+            sink.Batches.Count.Should().Be(1);
+            sink.Batches.TryPeek(out var batch).Should().BeTrue();
+            batch.Should().BeEquivalentTo(new List<DatadogLogEvent> { evt });
+        }
+
+        [Fact]
+        public void WhenRunning_AndAnEventIsQueued_ItIsWrittenToABatch()
+        {
+            var sink = new InMemoryBatchedSink(DefaultBatchingOptions);
+            var evt = new TestEvent("Some event");
+
+            sink.EnqueueLog(evt);
+            var batches = WaitForBatches(sink);
+
+            batches.Count.Should().Be(1);
+            sink.Batches.TryPeek(out var batch).Should().BeTrue();
+            batch.Should().BeEquivalentTo(new List<DatadogLogEvent> { evt });
+        }
+
+        [Fact]
+        public void AfterDisposed_AndAnEventIsQueued_ItIsNotWrittenToABatch()
+        {
+            var sink = new InMemoryBatchedSink(DefaultBatchingOptions);
+            var evt = new TestEvent("Some event");
+            sink.Dispose();
+            sink.EnqueueLog(evt);
+
+            // slightly arbitrary time to wait
+            Thread.Sleep(1_000);
+            sink.Batches.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AfterMultipleFailures_SinkIsPermanentlyDisabled()
+        {
+            var mutex = new ManualResetEventSlim();
+            var emitResults = Enumerable.Repeat(false, BatchingSink.FailuresBeforeCircuitBreak);
+            var sink = new InMemoryBatchedSink(
+                DefaultBatchingOptions,
+                () => mutex.Set(),
+                emitResults.ToArray());
+            var evt = new TestEvent("Some event");
+
+            for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
+            {
+                sink.EnqueueLog(evt);
+                WaitForBatches(sink, batchCount: i + 1);
+            }
+
+            mutex.Wait(10_000).Should().BeTrue($"Sink should be disabled after {BatchingSink.FailuresBeforeCircuitBreak} faults");
+        }
+
+        [Fact]
+        public void AfterInitialSuccessThenMultipleFailures_SinkIsTemporarilyDisabled()
+        {
+            var emitResults = new[] { true }
+               .Concat(Enumerable.Repeat(false, BatchingSink.FailuresBeforeCircuitBreak));
+
+            var sink = new InMemoryBatchedSink(
+                DefaultBatchingOptions,
+                emitResults: emitResults.ToArray());
+            var evt = new TestEvent("Some event");
+
+            // Initial success ensures we don't permanently disable the sink
+            _output.WriteLine("Queueing first event and waiting for sink");
+            sink.EnqueueLog(evt);
+            WaitForBatches(sink, batchCount: 1);
+
+            // Put the sink in a broken status (temporary)
+            for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
+            {
+                _output.WriteLine($"Queueing broken event {i + 1}");
+                sink.EnqueueLog(evt);
+                WaitForBatches(sink, batchCount: i + 2);
+            }
+
+            // initial enqueue should be ignored
+            _output.WriteLine($"Queueing event when broken circuit");
+            sink.EnqueueLog(evt);
+            Thread.Sleep(CircuitBreakPeriod);
+            Thread.Sleep(CircuitBreakPeriod);
+            // ensure we _don't_ have any more batches
+            sink.Batches.Count.Should().Be(BatchingSink.FailuresBeforeCircuitBreak + 1);
+
+            // queue another log now circuit is partially open
+            _output.WriteLine($"Queueing event in partially open sink");
+            sink.EnqueueLog(evt);
+            WaitForBatches(sink, batchCount: BatchingSink.FailuresBeforeCircuitBreak + 2);
+        }
+
+        private static ConcurrentStack<IList<DatadogLogEvent>> WaitForBatches(InMemoryBatchedSink pbs, int batchCount = 1)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(10_000);
+            var batches = pbs.Batches;
+            while (batches.Count < batchCount && DateTime.UtcNow < deadline)
+            {
+                Thread.Sleep(TinyWait);
+                batches = pbs.Batches;
+            }
+
+            return batches;
+        }
+
+        internal class TestEvent : DatadogLogEvent
+        {
+            private readonly string _evt;
+
+            public TestEvent(string evt)
+            {
+                _evt = evt;
+            }
+
+            public override void Format(StringBuilder sb, LogFormatter formatter)
+            {
+                sb.Append(_evt);
+            }
+        }
+
+        private class InMemoryBatchedSink : BatchingSink
+        {
+            private readonly bool[] _emitResults;
+            private int _emitCount = -1;
+
+            public InMemoryBatchedSink(
+                BatchingSinkOptions sinkOptions,
+                Action disableSinkAction = null,
+                bool[] emitResults = null)
+                : base(sinkOptions, disableSinkAction)
+            {
+                _emitResults = emitResults ?? Array.Empty<bool>();
+            }
+
+            public ConcurrentStack<IList<DatadogLogEvent>> Batches { get; } = new();
+
+            protected override Task<bool> EmitBatch(Queue<DatadogLogEvent> events)
+            {
+                Batches.Push(events.ToList());
+                _emitCount++;
+                var result = _emitCount < _emitResults.Length
+                                 ? _emitResults[_emitCount]
+                                 : true;
+
+                return Task.FromResult(result);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueueTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueueTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
                 queue.TryEnqueue(i);
             }
 
-            queue.Count.Should().Be(limit);
+            queue.InnerQueue.Count.Should().Be(limit);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueueTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BoundedConcurrentQueueTests.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="BoundedConcurrentQueueTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+// Based on https://github.com/serilog/serilog-sinks-periodicbatching/blob/66a74768196758200bff67077167cde3a7e346d5/test/Serilog.Sinks.PeriodicBatching.Tests/BoundedConcurrentQueueTests.cs
+
+using System;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    public class BoundedConcurrentQueueTests
+    {
+        [Fact]
+        public void WhenBoundedShouldNotExceedLimit()
+        {
+            const int limit = 100;
+            var queue = new BoundedConcurrentQueue<int>(limit);
+
+            for (var i = 0; i < limit * 2; i++)
+            {
+                queue.TryEnqueue(i);
+            }
+
+            queue.Count.Should().Be(limit);
+        }
+
+        [Theory]
+        [InlineData(-42)]
+        [InlineData(0)]
+        public void WhenInvalidLimitWillThrow(int limit)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BoundedConcurrentQueue<int>(limit));
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/CircuitBreakerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/CircuitBreakerTests.cs
@@ -1,0 +1,128 @@
+﻿// <copyright file="CircuitBreakerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
+{
+    public class CircuitBreakerTests
+    {
+        private const int FailuresUntilBroken = 5;
+        private readonly CircuitBreaker _circuitBreaker;
+
+        public CircuitBreakerTests()
+        {
+            _circuitBreaker = new CircuitBreaker(FailuresUntilBroken);
+        }
+
+        public static IEnumerable<object[]> GetAllStatuses()
+            => Enum.GetValues(typeof(CircuitStatus))
+                   .Cast<CircuitStatus>()
+                   .Select(x => new object[] { x });
+
+        [Fact]
+        public void SuccessAfterHalfBreakClosesCircuit()
+        {
+            TryEnterState(CircuitStatus.HalfBroken);
+            for (var i = 0; i < FailuresUntilBroken - 1; i++)
+            {
+                _circuitBreaker.MarkSuccess().Should().Be(CircuitStatus.Closed);
+            }
+        }
+
+        [Fact]
+        public void FailureAfterHalfBreakBreaksCircuit()
+        {
+            TryEnterState(CircuitStatus.HalfBroken);
+            _circuitBreaker.MarkFailure().Should().Be(CircuitStatus.Broken);
+        }
+
+        [Fact]
+        public void PermanentBreakIsNeverUndone()
+        {
+            TryEnterState(CircuitStatus.PermanentlyBroken);
+            for (var i = 0; i < 100 - 1; i++)
+            {
+                _circuitBreaker.MarkSuccess().Should().Be(CircuitStatus.PermanentlyBroken);
+            }
+        }
+
+        [Fact]
+        public void SuccessAfterBrokenMovesToHalfBreak()
+        {
+            TryEnterState(CircuitStatus.Broken);
+            _circuitBreaker.MarkSuccess().Should().Be(CircuitStatus.HalfBroken);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllStatuses))]
+        internal void SkipDoesntChangeStatus_ExceptForBroken(CircuitStatus status)
+        {
+            TryEnterState(status);
+
+            if (status == CircuitStatus.Broken)
+            {
+                _circuitBreaker.MarkSkipped().Should().Be(CircuitStatus.HalfBroken);
+            }
+            else
+            {
+                _circuitBreaker.MarkSkipped().Should().Be(status);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAllStatuses))]
+        internal void CanEnterExpectedState(CircuitStatus status)
+        {
+            TryEnterState(status);
+        }
+
+        private void TryEnterState(CircuitStatus required)
+        {
+            CircuitStatus actual = default;
+            switch (required)
+            {
+                case CircuitStatus.Closed:
+                    for (var i = 0; i < 100; i++)
+                    {
+                        actual = _circuitBreaker.MarkSuccess();
+                    }
+
+                    break;
+
+                case CircuitStatus.Broken:
+                    actual = _circuitBreaker.MarkSuccess();
+                    for (var i = 0; i < FailuresUntilBroken; i++)
+                    {
+                        actual = _circuitBreaker.MarkFailure();
+                    }
+
+                    break;
+
+                case CircuitStatus.PermanentlyBroken:
+                    for (var i = 0; i < FailuresUntilBroken; i++)
+                    {
+                        actual = _circuitBreaker.MarkFailure();
+                    }
+
+                    break;
+
+                case CircuitStatus.HalfBroken:
+                    TryEnterState(CircuitStatus.Broken);
+                    actual = _circuitBreaker.MarkSuccess();
+                    break;
+                default:
+                    throw new InvalidOperationException("Unknown status: " + required);
+            }
+
+            actual.Should().Be(required);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/MockLogsIntakeTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/MockLogsIntakeTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void CanDeserializeJson()
         {
-            var serialized = "[{\"@t\":\"2021-09-28T14:47:02.6486114Z\",\"@m\":\"[ExcludeMessage]Building pipeline\",\"@i\":\"c5676978\",\"ddsource\":\"csharp\",\"ddservice\":\"LogsInjection.ILogger\",\"host\":\"integration_ilogger_tests\",\"dd.env\":\"integration_tests\",\"dd.version\":\"1.0.0\",\"dd.trace_id\":\"8172771144023044714\",\"dd.span_id\":\"870590545642546651\"}]";
+            var serialized = "[{\"@t\":\"2021-09-28T14:47:02.6486114Z\",\"@m\":\"[ExcludeMessage]Building pipeline\",\"@i\":\"c5676978\",\"ddsource\":\"csharp\",\"service\":\"LogsInjection.ILogger\",\"host\":\"integration_ilogger_tests\",\"dd.env\":\"integration_tests\",\"dd.version\":\"1.0.0\",\"dd.trace_id\":\"8172771144023044714\",\"dd.span_id\":\"870590545642546651\"}]";
             using var ms = new MemoryStream(Encoding.UTF8.GetBytes(serialized));
 
             var logs = MockLogsIntake.Log.DeserializeFromStream(ms);

--- a/tracer/test/Datadog.Trace.Tests/MockLogsIntakeTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/MockLogsIntakeTests.cs
@@ -1,0 +1,91 @@
+﻿// <copyright file="MockLogsIntakeTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.DirectSubmission.Formatting;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Tests.Logging.DirectSubmission;
+using Datadog.Trace.Tests.Logging.DirectSubmission.Sink;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests
+{
+    public class MockLogsIntakeTests
+    {
+        [Fact]
+        public void CanDeserializeJson()
+        {
+            var serialized = "[{\"@t\":\"2021-09-28T14:47:02.6486114Z\",\"@m\":\"[ExcludeMessage]Building pipeline\",\"@i\":\"c5676978\",\"ddsource\":\"csharp\",\"ddservice\":\"LogsInjection.ILogger\",\"host\":\"integration_ilogger_tests\",\"dd.env\":\"integration_tests\",\"dd.version\":\"1.0.0\",\"dd.trace_id\":\"8172771144023044714\",\"dd.span_id\":\"870590545642546651\"}]";
+            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(serialized));
+
+            var logs = MockLogsIntake.Log.DeserializeFromStream(ms);
+
+            logs.Should().NotBeNull();
+            var log = logs.Should().ContainSingle().Subject;
+            log.Message.Should().Be("[ExcludeMessage]Building pipeline");
+            log.EventId.Should().Be("c5676978");
+            log.Source.Should().Be("csharp");
+            log.Service.Should().Be("LogsInjection.ILogger");
+            log.Host.Should().Be("integration_ilogger_tests");
+            log.Env.Should().Be("integration_tests");
+            log.Version.Should().Be("1.0.0");
+            log.TraceId.Should().Be("8172771144023044714");
+            log.SpanId.Should().Be("870590545642546651");
+        }
+
+        [Fact]
+        public void CanDeserializeFormattedLogs()
+        {
+            var formatter = LogSettingsHelper.GetFormatter();
+            var log1 = GetLog(formatter, "This is a {Value}", DirectSubmissionLogLevel.Warning, new Dictionary<string, string> { { "Value", "SomeValue" } });
+            var log2 = GetLog(formatter, "This is another template with some other value", DirectSubmissionLogLevel.Information, new Dictionary<string, string> { { "Value", "SomeOtherValue" } });
+
+            var serialized = $"[{log1},{log2}]";
+            using var ms = new MemoryStream(Encoding.UTF8.GetBytes(serialized));
+
+            var logs = MockLogsIntake.Log.DeserializeFromStream(ms);
+
+            logs.Should().NotBeNull();
+            logs.Should().HaveCount(2);
+        }
+
+        private static string GetLog(
+            LogFormatter formatter,
+            string message,
+            DirectSubmissionLogLevel level,
+            Dictionary<string, string> properties)
+        {
+            var sb = new StringBuilder();
+
+            formatter.FormatLog(
+                sb,
+                sb, // not used here
+                DateTime.UtcNow,
+                message,
+                null,
+                level.GetName(),
+                exception: null,
+                RenderPropertiesDelegate);
+            return sb.ToString();
+
+            LogPropertyRenderingDetails RenderPropertiesDelegate(JsonTextWriter writer, in StringBuilder stringBuilder)
+            {
+                foreach (var pair in properties)
+                {
+                    writer.WritePropertyName(pair.Key);
+                    writer.WriteValue(pair.Value);
+                }
+
+                return new LogPropertyRenderingDetails(false, false, false, false, false, false, message);
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(null, null, null, null, null, null, null)
+                : base(null, null, null, null, null, null, null, null)
             {
             }
         }

--- a/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
@@ -7,6 +7,7 @@ using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger;
 using Datadog.Trace.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using IExternalScopeProvider = Microsoft.Extensions.Logging.IExternalScopeProvider;
 
 namespace Benchmarks.Trace
 {

--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/LogsInjection.NLog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">1.0.0.505</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == '' AND $(TargetFramework.StartsWith('net4')) ">2.1.0</ApiVersion>
     <ApiVersion Condition="'$(ApiVersion)' == '' AND !$(TargetFramework.StartsWith('net4')) ">4.5.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='4.0.0'">$(DefineConstants);NLOG_4_0</DefineConstants>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='4.6.0'">$(DefineConstants);NLOG_4_6</DefineConstants>


### PR DESCRIPTION
> This PR is a refactoring of #1945, to try and make it easier to review. Each commit is self contained and (hopefully) understandable, so should make it easier to review them in order!🤞

This PR adds support for directly shipping logs to the Datadog intake, so customers don't have to configure log tailing in the agent etc. Supports all our existing logs injection frameworks

- Microsoft.Extensions.Logging.ILogger
- Serilog
- log4Net
- NLog 2.1+ (This is more restrictive than for logs injection, but I don't think it's worth the effort to go earlier, until we have telemetry that says otherwise)

## Approach

This takes the same overall approach as [the official Datadog Serilog Sink](https://github.com/DataDog/serilog-sinks-datadog-logs), though it deviates in various places for performance and ergonomic reasons.

I initially partially vendored-in the Serilog batching sink provider, however subsequently reworked this quite significantly after feedback in #1945 (thanks Colin!), in particular to add circuit-breaker features to handle configuration errors. Similar to other components, we have a singleton `DatadogSink`, (which implements the vendored `BatchingSink`) and is responsible for formatting and sending batches of logs. The `LogsApi` type takes care of the transport (similar to the `Api` class for traces). 

For serialization, I used a similar formatting to the `CompactJsonFormatter`, as that's supported in [the logs documentation](https://docs.datadoghq.com/logs/log_collection/csharp/?tab=serilog), serializing efficiently where possible. Without _System.Text.Json_'s `Utf8Writer`, the best I could do to reduce memory impact was to reuse a `StringBuilder`, and have a persistent buffer for the UTF8 bytes. Given System.Text.Json is built-in to `netcore3.1`+, I wonder if we should use that where available 🤔

We use automatic instrumentation to add the sinks as required, which then farms off the logs to the singleton `DatadogSink`.

## Testing

Added integration tests for each framework
* Tested that enabling log shipping has no impact on logs injection
* Can receive logs, and they have the TWoL tags added correctly (where expected)

Also did manual testing of each framework, and confirmed I can see the logs in the UI:

![image](https://user-images.githubusercontent.com/18755388/135502639-a1d8d26e-38e8-4dc3-87da-37fd20cf0cc9.png)

@DataDog/apm-dotnet