### PR TITLE
Add workaround to support VS2022 with Nuke

### DIFF
--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -20,8 +20,6 @@ partial class Build
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {
-            var project = ProfilerDirectory.GlobFiles("**/Datadog.Profiler.Native.Windows.vcxproj").Single();
-
             // If we're building for x64, build for x86 too
             var platforms =
                 Equals(TargetPlatform, MSBuildTargetPlatform.x64)

--- a/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
+++ b/tracer/build/_build/NukeExtensions/DotNetSettingsExtensions.cs
@@ -99,9 +99,26 @@ internal static partial class DotNetSettingsExtensions
     {
         var vsRoot = Environment.GetEnvironmentVariable("VSTUDIO_ROOT");
 
-        return settings
-            .When(!string.IsNullOrEmpty(vsRoot),
-                c => c.SetProcessToolPath(Path.Combine(vsRoot, "MSBuild", "Current", "Bin", "MSBuild.exe")));
+        // Workaround until Nuke supports VS 2022
+        string toolPath;
+        try
+        {
+            toolPath = string.IsNullOrEmpty(vsRoot)
+                           ? MSBuildToolPathResolver.Resolve()
+                           : Path.Combine(vsRoot, "MSBuild", "Current", "Bin", "MSBuild.exe");
+        }
+        catch
+        {
+
+            var editions = new[] { "Enterprise", "Professional", "Community", "BuildTools", "Preview" };
+            toolPath = editions
+                      .Select(edition => Path.Combine(
+                                  EnvironmentInfo.SpecialFolder(SpecialFolders.ProgramFiles)!,
+                                  $@"Microsoft Visual Studio\2022\{edition}\MSBuild\Current\Bin\msbuild.exe"))
+                      .First(File.Exists);
+        }
+
+        return settings.SetProcessToolPath(toolPath);
     }
 
     /// <summary>


### PR DESCRIPTION
Nuke supports VS2022 in main, but not currently in any released package. This patches in support for it until it does

> I originally included this in #2230 which upgrades Nuke, but I'm seeing weird build errors there, so just want to get this fix in as-is.

@DataDog/apm-dotnet