### PR TITLE
more clean up in `SpanContextPropagator.Extract()`

### DIFF
--- a/tracer/src/Datadog.Trace/Headers/HeadersCollectionAdapter.cs
+++ b/tracer/src/Datadog.Trace/Headers/HeadersCollectionAdapter.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Headers
         {
             if (_headers.TryGetValue(name, out var values))
             {
-                return values.ToArray();
+                return values;
             }
 
             return Enumerable.Empty<string>();

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Logging;
@@ -30,15 +31,7 @@ namespace Datadog.Trace
 
         private SpanContextPropagator()
         {
-            IEnumerable<string?> ReadOnlyDictionaryValueGetter(IReadOnlyDictionary<string, string?>? carrier, string name)
-            {
-                if (carrier != null && carrier.TryGetValue(name, out var value))
-                {
-                    yield return value;
-                }
-            }
-
-            _readOnlyDictionaryValueGetterDelegate = ReadOnlyDictionaryValueGetter;
+            _readOnlyDictionaryValueGetterDelegate = (carrier, name) => carrier != null && carrier.TryGetValue(name, out var value) ? new[] { value } : Enumerable.Empty<string?>();
         }
 
         public static SpanContextPropagator Instance { get; } = new();

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
@@ -3,11 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 


### PR DESCRIPTION
Follow-up of #2180.

In `SpanContextPropagator`, refactor method `Extract(IReadOnlyDictionary<string, string>)` as a call to `Extract<T>(T, Func<...>)` to consolidate all header extraction logic into a single method.