### PR TITLE
Add additional constructor to TracerSettings

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -29,6 +29,18 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values,
+        /// or using the default sources. Calling <c>new TracerSettings(true)</c> is equivalent to
+        /// calling <c>TracerSettings.FromDefaultSources()</c>
+        /// </summary>
+        /// <param name="useDefaultSources">If <c>true</c>, creates a <see cref="TracerSettings"/> populated from
+        /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>
+        public TracerSettings(bool useDefaultSources)
+            : this(useDefaultSources ? CreateDefaultConfigurationSource() : null)
+        {
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class
         /// using the specified <see cref="IConfigurationSource"/> to initialize values.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -30,8 +30,8 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values,
-        /// or using the default sources. Calling <c>new TracerSettings(true)</c> is equivalent to
-        /// calling <c>TracerSettings.FromDefaultSources()</c>
+        /// or initializes the configuration from environment variables and configuration files.
+        /// Calling <c>new TracerSettings(true)</c> is equivalent to calling <c>TracerSettings.FromDefaultSources()</c>
         /// </summary>
         /// <param name="useDefaultSources">If <c>true</c>, creates a <see cref="TracerSettings"/> populated from
         /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -138,6 +138,7 @@ namespace Datadog.Trace.Configuration
     {
         public TracerSettings() { }
         public TracerSettings(Datadog.Trace.Configuration.IConfigurationSource source) { }
+        public TracerSettings(bool useDefaultSources) { }
         [System.Obsolete("App Analytics has been replaced by Tracing without Limits. For more information s" +
             "ee https://docs.datadoghq.com/tracing/legacy_app_analytics/")]
         public bool AnalyticsEnabled { get; set; }


### PR DESCRIPTION
A recent issue #2257 surfaced the fact that `TracerSettings.FromDefaultSources()` is not very discoverable for users. This PR adds an additional constructor overload, `TracerSettings(bool useDefaultSources)` to make this option more discoverable 

@DataDog/apm-dotnet