### PR TITLE
Add shared installer file to the list of updated files in version bump

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -120,6 +120,7 @@ partial class Build
             var expectedFileChanges = new []
             {
                 "docs/CHANGELOG.md",
+                "shared/src/msi-installer/WindowsInstaller.wixproj",
                 "tracer/build/_build/Build.cs",
                 "tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj",
                 "tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj",


### PR DESCRIPTION
Following #2256, we need to allow the shared windowsinstaller project as part of the bump process



@DataDog/apm-dotnet