### PR TITLE
Setup Code Scanning for dd-trace-dotnet

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'csharp', 'javascript' ]
+        language: [ 'csharp', 'javascript' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,57 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master, hotfix/**/*, release/**/* ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'csharp', 'javascript' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   tracer:
-    name: Analyze Tracer
+    name: Analyze Profiler
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -45,7 +45,7 @@ jobs:
       
 
   profiler:
-    name: Analyze PRofiler
+    name: Analyze Tracer
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,12 +16,12 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'csharp', 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         language: [ 'csharp', 'javascript' ]
+#         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+#         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,9 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - name: Build dd-trace-dotnet
+      run: |
+          run: ./tracer/build.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,13 +13,6 @@ jobs:
       contents: read
       security-events: write
 
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         language: [ 'csharp', 'javascript' ]
-#         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-#         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -33,6 +26,8 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
     - name: Build dd-trace-dotnet
       run: |
         ./tracer/build.sh BuildProfilerHome BuildNativeLoader
@@ -49,13 +44,6 @@ jobs:
       contents: read
       security-events: write
 
-#     strategy:
-#       fail-fast: false
-#       matrix:
-#         language: [ 'csharp', 'javascript' ]
-#         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-#         # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -69,6 +57,8 @@ jobs:
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
     - name: Build dd-trace-dotnet
       run: |
         ./tracer/build.sh BuildTracerHome

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,13 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, hotfix/**/*, release/**/* ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ master, hotfix/**/* ]
 
 jobs:
-  tracer:
+  profiler:
     name: Analyze Profiler
     runs-on: ubuntu-latest
     permissions:
@@ -44,7 +41,7 @@ jobs:
       uses: github/codeql-action/analyze@v1
       
 
-  profiler:
+  tracer:
     name: Analyze Tracer
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Build dd-trace-dotnet
-      if: ${{ language == 'csharp' }}
+      if: ${{ language }} == 'csharp'
       run: |
         ./tracer/build.sh
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,14 +31,14 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: csharp, javascript
+        languages: csharp, cpp
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Build dd-trace-dotnet
       run: |
-        ./tracer/build.sh
+        ./tracer/build.sh BuildTracerHome BuildProfilerHome BuildNativeLoader ZipMonitoringHome
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: ${{ matrix.language }}
+        languages: csharp, javascript
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Build dd-trace-dotnet
+      if: ${{ language == 'csharp' }}
       run: |
         ./tracer/build.sh
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Build dd-trace-dotnet
       run: |
-          run: ./tracer/build.sh
+        ./tracer/build.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,6 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Build dd-trace-dotnet
-      if: ${{ language }} == 'csharp'
       run: |
         ./tracer/build.sh
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,8 +8,8 @@ on:
     branches: [ master ]
 
 jobs:
-  analyze:
-    name: Analyze
+  tracer:
+    name: Analyze Tracer
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -38,7 +38,44 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
     - name: Build dd-trace-dotnet
       run: |
-        ./tracer/build.sh BuildTracerHome BuildProfilerHome BuildNativeLoader ZipMonitoringHome
+        ./tracer/build.sh BuildProfilerHome BuildNativeLoader
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
+      
+
+  profiler:
+    name: Analyze PRofiler
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+#     strategy:
+#       fail-fast: false
+#       matrix:
+#         language: [ 'csharp', 'javascript' ]
+#         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+#         # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: csharp, cpp
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+    - name: Build dd-trace-dotnet
+      run: |
+        ./tracer/build.sh BuildTracerHome
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
+

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -191,6 +191,7 @@ partial class Build
         .Executes(() =>
         {
             var buildDirectory = NativeProfilerProject.Directory / "build";
+            EnsureExistingDirectory(buildDirectory);
 
             CMake.Value(
                 arguments: $"-B {buildDirectory} -S {NativeProfilerProject.Directory} -DCMAKE_BUILD_TYPE=Release");


### PR DESCRIPTION
Static code analysis on dd-trace-dotnet using Github's Code Scanning.

This PR has Github workflow configs to trigger the Code Scanning on every PR and on push to master, release, and hot-fix branches. It is a part of Datadog compliance requirements to regularly perform code-scanning on all the customer installed code. As of now only default security based CodeQL queries are configured. We can gradually add queries for Code Quality later.