### PR TITLE
Add `#if NETFRAMEWORK` to System.Web integrations

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ExceptionHandlerExtensions_HandleAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ExceptionHandlerExtensions_HandleAsync_Integration.cs
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
+#if NETFRAMEWORK
+
 using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -61,3 +62,4 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         }
     }
 }
+#endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#if NETFRAMEWORK
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
@@ -48,3 +49,4 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         }
     }
 }
+#endif

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#if NETFRAMEWORK
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
@@ -45,3 +46,4 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         }
     }
 }
+#endif


### PR DESCRIPTION
Identified in #2288. System.Web can't be referenced by netcoreapp apps, so no point including them.

@DataDog/apm-dotnet