### PR TITLE
A no-op pipeline for non code PRs

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -3,6 +3,7 @@ pr:
     exclude:
       - .
     include:
+      - tracer/dependabot/
       - blog/
       - docs/
       - tracer/README.md

--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -1,8 +1,18 @@
 pr:
-  branches:
+  paths:
+    exclude:
+      - .
     include:
-      - docs/*
+      - blog/
+      - docs/
       - tracer/README.md
+      - tracer/src/Datadog.Trace/DuckTyping/README.md
+      - tracer/samples
+      - .github/
+      - LICENSE
+      - LICENSE-3rdparty.csv
+      - NOTICE
+      
 
 # Global variables
 variables:

--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -10,9 +10,86 @@ variables:
 
 # Stages
 stages:
-  - stage: ${{ job }}
-    dependsOn: []
-    jobs:
-    - template: steps/update-github-status-jobs.yml
-      parameters:
-        jobs: []
+- stage: build_arm64
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: build_linux
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: build_windows
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: unit_tests_arm64
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: unit_tests_linux
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: unit_tests_windows
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: integration_tests_arm64
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: integration_tests_linux
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: integration_tests_windows
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: integration_tests_windows_iis
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: dotnet_tool
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []
+
+- stage: package_windows
+  dependsOn: []
+  jobs:
+  - template: steps/update-github-status-jobs.yml
+    parameters:
+      jobs: []

--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -1,25 +1,15 @@
-trigger:
-
 pr:
   branches:
     include:
       - docs/*
       - tracer/README.md
 
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No build required" '
-
 # Global variables
 variables:
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])]
-  requiredJobs: [build_arm64, build_linux, build_windows, unit_tests_arm64, unit_tests_linux, unit_tests_windows, integration_tests_arm64, integration_tests_linux, integration_tests_windows, integration_tests_windows_iis, dotnet_tool, package_windows]
 
 # Stages
 stages:
-- ${{ each job in parameters.jobs }}:
   - stage: ${{ job }}
     dependsOn: []
     jobs:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -47,9 +47,16 @@ pr:
       - '*' # default
   paths:
     exclude:
-      - tracer/dependabot/*
-      - docs/*
+      - tracer/dependabot/
+      - blog/
+      - docs/
       - tracer/README.md
+      - tracer/src/Datadog.Trace/DuckTyping/README.md
+      - tracer/samples
+      - .github/
+      - LICENSE
+      - LICENSE-3rdparty.csv
+      - NOTICE
 
 schedules:
   - cron: "0 3 * * *"


### PR DESCRIPTION
Following #2287, the no-op pipeline is broken.
This pipeline is supposed to run to make sure we can merge commits where the ultimate-pipeline wouldn't run (PRs with no code) without force merge.
This no-op pipeline will then send a success status for all jobs that are required to merge on master.  

@DataDog/apm-dotnet