### PR TITLE
add `SpanContext.None`

### DIFF
--- a/tracer/src/Datadog.Trace/ReadOnlySpanContext.cs
+++ b/tracer/src/Datadog.Trace/ReadOnlySpanContext.cs
@@ -1,0 +1,22 @@
+// <copyright file="ReadOnlySpanContext.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace;
+
+internal class ReadOnlySpanContext : ISpanContext
+{
+    public ReadOnlySpanContext(ulong traceId, ulong spanId, string serviceName)
+    {
+        TraceId = traceId;
+        SpanId = spanId;
+        ServiceName = serviceName;
+    }
+
+    public ulong TraceId { get; }
+
+    public ulong SpanId { get; }
+
+    public string ServiceName { get; }
+}

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -24,9 +24,9 @@ namespace Datadog.Trace
         };
 
         /// <summary>
-        /// An <see cref="ISpanContext"/> with default values. Can be used as the parent in
-        /// <see cref="Tracer.ActivateSpan"/> when creating a new <see cref="Span"/> to
-        /// specify that the new span should have not parent. The resulting span will be the root span of a new trace.
+        /// An <see cref="ISpanContext"/> with default values. Can be used as the value for
+        /// <see cref="SpanCreationSettings.Parent"/> in <see cref="Tracer.StartActive(string, SpanCreationSettings)"/>
+        /// to specify that the new span should not inherit the currently active scope as its parent.
         /// </summary>
         public static readonly ISpanContext Empty = new ReadOnlySpanContext(traceId: 0, spanId: 0, serviceName: null);
 

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace
         /// <see cref="SpanCreationSettings.Parent"/> in <see cref="Tracer.StartActive(string, SpanCreationSettings)"/>
         /// to specify that the new span should not inherit the currently active scope as its parent.
         /// </summary>
-        public static readonly ISpanContext Empty = new ReadOnlySpanContext(traceId: 0, spanId: 0, serviceName: null);
+        public static readonly ISpanContext None = new ReadOnlySpanContext(traceId: 0, spanId: 0, serviceName: null);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SpanContext"/> class

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -24,6 +24,13 @@ namespace Datadog.Trace
         };
 
         /// <summary>
+        /// An <see cref="ISpanContext"/> with default values. Can be used as the parent in
+        /// <see cref="Tracer.ActivateSpan"/> when creating a new <see cref="Span"/> to
+        /// specify that the new span should have not parent. The resulting span will be the root span of a new trace.
+        /// </summary>
+        public static readonly ISpanContext Empty = new ReadOnlySpanContext(traceId: 0, spanId: 0, serviceName: null);
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SpanContext"/> class
         /// from a propagated context. <see cref="Parent"/> will be null
         /// since this is a root context locally.

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -234,7 +234,7 @@ namespace Datadog.Trace
     }
     public class SpanContext : Datadog.Trace.ISpanContext, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IReadOnlyDictionary<string, string>, System.Collections.IEnumerable
     {
-        public static readonly Datadog.Trace.ISpanContext Empty;
+        public static readonly Datadog.Trace.ISpanContext None;
         public SpanContext(ulong? traceId, ulong spanId, Datadog.Trace.SamplingPriority? samplingPriority = default, string serviceName = null) { }
         public Datadog.Trace.ISpanContext Parent { get; }
         public ulong? ParentId { get; }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.PublicApiHasNotChanged.verified.txt
@@ -234,6 +234,7 @@ namespace Datadog.Trace
     }
     public class SpanContext : Datadog.Trace.ISpanContext, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IReadOnlyCollection<System.Collections.Generic.KeyValuePair<string, string>>, System.Collections.Generic.IReadOnlyDictionary<string, string>, System.Collections.IEnumerable
     {
+        public static readonly Datadog.Trace.ISpanContext Empty;
         public SpanContext(ulong? traceId, ulong spanId, Datadog.Trace.SamplingPriority? samplingPriority = default, string serviceName = null) { }
         public Datadog.Trace.ISpanContext Parent { get; }
         public ulong? ParentId { get; }


### PR DESCRIPTION
See issue #2267.

Add a static `SpanContext.None` that can be used to explicitly prevent a span from inheriting the currently active span as its parent. This replaces the `ignoreActiveScope` parameter from .NET Tracer 1.x:

```csharp
// Don't inherit the currently active span as the parent.
var startNewTrace = new SpanCreationSettings { Parent = SpanContext.None };

// This scope is now the root of a new trace.
// NOTE: It is also the active span in `Tracer.Instance.ActiveScope`. 
var scope = Tracer.Instance.StartActive("span-name", startNewTrace);
```

Open questions:
- ~Property name: `SpanContext.Empty` or `SpanContext.None`?~
- ~Underlying type: `SpanContext` or a new internal `ReadOnlySpanContext` type?~