### PR TITLE
[AAS] Default debug logs to false

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AzureAppServices.cs
@@ -140,7 +140,7 @@ namespace Datadog.Trace.PlatformHelpers
 
                     Runtime = FrameworkDescription.Instance.Name;
 
-                    DebugModeEnabled = GetVariableIfExists(Configuration.ConfigurationKeys.DebugEnabled, environmentVariables)?.ToBoolean() ?? true;
+                    DebugModeEnabled = GetVariableIfExists(Configuration.ConfigurationKeys.DebugEnabled, environmentVariables)?.ToBoolean() ?? false;
                 }
             }
             catch (Exception ex)

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -347,7 +347,7 @@ namespace Datadog.Trace.Tests
             {
                 // due to the service name fallback, if this runs at the same time as AzureAppServicesMetadataTests,
                 // then AzureAppServices.IsRelevant returns true, and we may pull the service name from the AAS env vars
-                var expectedServiceNames = TestRunners.ValidNames.Concat(new[] { AzureAppServicesMetadataTests.DeploymentId });
+                var expectedServiceNames = TestRunners.ValidNames.Concat(new[] { AzureAppServicesTests.DeploymentId });
                 Assert.Contains(span.ServiceName, expectedServiceNames);
             }
             else


### PR DESCRIPTION
Makes sure that agent logs aren't debug by default. Allows us to remove the `DD_LOG_LEVEL` from the extension.

@DataDog/apm-dotnet