### PR TITLE
[DEPENDABOT] Ignore Patches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
       - "area:dependabot"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
-      - dependency-name: "*" # Ignore minors and patches for all integrations, majors change the signature
-        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "*" # Ignore patches for all integrations
+        update-types: ["version-update:semver-patch"]
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
       - "area:dependabot"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
+      - dependency-name: "*" # Ignore minors and patches for all integrations, majors change the signature
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
   # Src libraries
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace"


### PR DESCRIPTION
Reduces Dependabot noise for our integrations tracking.
We only really care about ~major~ minor versions where the API may change.
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#specifying-dependencies-and-versions-to-ignore

@DataDog/apm-dotnet