### PR TITLE
Add some more documentation

### DIFF
--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -40,14 +40,16 @@ public class ClientQueryIteratorsIntegrations
     
     // Include ONE of the following:
     
-    // 👇 Async method
+    // 👇 Async method, with different behavior based on the return type
+    //   - Task<TReturn>: returnValue is set to the Result
+    //   - Task: TReturn is set to typeof(object) and returnValue is set to null
     internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
     {
         state.Scope?.DisposeWithException(exception);
         return returnValue;
     }
     
-    // 👇 Method with return value TReturn
+    // 👇 Method with return type TReturn
     internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
     {
         // Run your "method end" code here

--- a/docs/development/AutomaticInstrumentation.md
+++ b/docs/development/AutomaticInstrumentation.md
@@ -63,6 +63,10 @@ public class ClientQueryIteratorsIntegrations
 }
 ```
 
+> Note that both `OnMethodBegin` and `OnMethodEnd` are optional. If you only need one of the integration points, you can omit the others
+
+ 
+
 ### Instrumentation attributes
 
 A source generator is used to automatically "find" all custom instrumentation classes in the app and generate a list of them to pass to the native CLR profiler. We do this by using one of two attributes:

--- a/docs/development/DuckTyping.md
+++ b/docs/development/DuckTyping.md
@@ -372,7 +372,7 @@ In summary:
 <details>
 <summary>Best practices benchmarks</summary>
         
-[Benchmark Code](../../../test/benchmarks/Benchmarks.Trace/DuckTyping/DuckTypeMethodCallComparisonBenchmark.cs)
+[Benchmark Code](../../tracer/test/benchmarks/Benchmarks.Trace/DuckTyping/DuckTypeMethodCallComparisonBenchmark.cs)
         
 ``` ini
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.22000

--- a/tracer/README.MD
+++ b/tracer/README.MD
@@ -37,7 +37,7 @@ You can develop the tracer on various environments.
 - Optional: [nuget.exe CLI](https://www.nuget.org/downloads) v5.3 or newer
 - Optional: [WiX Toolset 3.11.1](http://wixtoolset.org/releases/) or newer to build Windows installer (msi)
   - [WiX Toolset Visual Studio Extension](https://wixtoolset.org/releases/) to build installer from Visual Studio
-- Optional: [Docker for Windows](https://docs.docker.com/docker-for-windows/) to build Linux binaries and run integration tests on Linux containers. See [section on Docker Compose](#building-and-running-tests-with-docker-compose).
+- Optional: [Docker for Windows](https://docs.docker.com/docker-for-windows/) to build Linux binaries and run integration tests on Linux containers.
   - Requires Windows 10 (1607 Anniversary Update, Build 14393 or newer)
 
 Microsoft provides [evaluation developer VMs](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines) with Windows and Visual Studio pre-installed.
@@ -101,8 +101,8 @@ You can use Rider and CLion to develop on macOS. Building and testing can be don
 
 ## Additional Technical Documentation
 
-* [Implementing an automatic instrumentation](./src/Datadog.Trace/ClrProfiler/README.md)
-* [Duck typing: usages, best practices, and benchmarks](./src/Datadog.Trace/DuckTyping/README.md)
+* [Implementing an automatic instrumentation](../docs/development/AutomaticInstrumentation.md)
+* [Duck typing: usages, best practices, and benchmarks](../docs/development/DuckTyping.md)
 * [Datadog.Trace NuGet package README](../docs/Datadog.Trace/README.md)
 
 ## Further Reading


### PR DESCRIPTION
Based on feedback from #2310

- Moves the ducktyping + instrumentation docs to the _docs_ folder (and fixed links)
- Adds small section on using constraints for duck typing
- Minor additional fixes

@DataDog/apm-dotnet