### PR TITLE
Try fix master CI pipeline

### DIFF
--- a/.azure-pipelines/noop-pipeline.yml
+++ b/.azure-pipelines/noop-pipeline.yml
@@ -1,4 +1,7 @@
-trigger: none
+trigger:
+  branches:
+    exclude:
+      - "*"
 
 pr:
   paths:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -9,14 +9,11 @@ trigger:
       - refs/pull/*/head
   paths:
     exclude:
-      - docs/*
+      - docs/
       - tracer/README.MD
-      - .github/*
-      - tracer/dependabot/*
-      - "*.md"
-      - LICENSE
+      - .github/
+      - tracer/dependabot/
       - LICENSE-3rdparty.csv
-      - NOTICE
       - .azure-pipelines/noop-pipeline.yml
 # The following is a list of shared asset locations.
 # This is the config for the Tracer CI pipeline,


### PR DESCRIPTION
After https://github.com/DataDog/dd-trace-dotnet/commit/84aff95c56e78e9c802a6186d554c8993b897cf3, CI runs for `master` stopped happening. The scheduled runs kept going, and PR validation is still working, it's just the merges to master that are broken. 

I can't see any reason that commit should have broken things, so trying some things:

- Don't use wildcards in paths ([not supported](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#paths))
- Try remove `NOTICE`/`LICENSE` from `exclude` - maybe they're being interpreted as folders and confusing something? We never change them anyway, so no biggy
- Try replacing `trigger:none` in the `noop-pipeline`. _No way_ this should affect the main pipeline, but I don't trust AzDo.

We won't know if it's worked till we merge this though 🙄 Yay CI.

@DataDog/apm-dotnet