### PR TITLE
Add a test to detect when the CLI home folder is missing

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -31,10 +31,10 @@
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
       </PropertyGroup>
       <ItemGroup>
-        <!--<Content Include="..\Datadog.Monitoring.Distribution\home\**\*.*" LinkBase="home">
+        <Content Include="..\Datadog.Monitoring.Distribution\home\**\*.*" LinkBase="home">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
           <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-        </Content>-->
+        </Content>
       </ItemGroup>
     </When>
     <Otherwise>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -31,10 +31,10 @@
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
       </PropertyGroup>
       <ItemGroup>
-        <Content Include="..\Datadog.Monitoring.Distribution\home\**\*.*" LinkBase="home">
+        <!--<Content Include="..\Datadog.Monitoring.Distribution\home\**\*.*" LinkBase="home">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
           <CopyToPublishDirectory>Always</CopyToPublishDirectory>
-        </Content>
+        </Content>-->
       </ItemGroup>
     </When>
     <Otherwise>

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
@@ -83,6 +83,7 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
 
             helper.Process.ExitCode.Should().Be(0);
             helper.StandardOutput.Should().NotContainEquivalentOf("error");
+            helper.ErrorOutput.Should().BeEmpty();
         }
 
         private static string GetRunnerToolTargetFolder()

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
@@ -40,8 +40,6 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
         [InlineData('=')]
         public void SetCi(char separator)
         {
-            Environment.SetEnvironmentVariable("TF_BUILD", "1");
-
             var commandLine = $"--set-ci --dd-env{separator}TestEnv --dd-service{separator}TestService --dd-version{separator}TestVersion --tracer-home{separator}TestTracerHome --agent-url{separator}TestAgentUrl --env-vars{separator}VAR1=A,VAR2=B";
 
             using var helper = StartProcess(commandLine, ("TF_BUILD", "1"));
@@ -71,6 +69,20 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
             environmentVariables["DD_TRACE_AGENT_URL"].Should().Be("TestAgentUrl");
             environmentVariables["VAR1"].Should().Be("A");
             environmentVariables["VAR2"].Should().Be("B");
+        }
+
+        [Fact]
+        public void LocateTracerHome()
+        {
+            var commandLine = "--set-ci";
+
+            using var helper = StartProcess(commandLine, ("TF_BUILD", "1"));
+
+            helper.Process.WaitForExit();
+            helper.Drain();
+
+            helper.Process.ExitCode.Should().Be(0);
+            helper.StandardOutput.Should().NotContainEquivalentOf("error");
         }
 
         private static string GetRunnerToolTargetFolder()


### PR DESCRIPTION
First removing the home folder to confirm that the test fails

Edit: the test is failing as expected:
```
  Failed Datadog.Trace.Tools.Runner.ArtifactTests.LegacyCommandLineArgumentsTests.LocateTracerHome [1 s]
  Error Message:
   Expected helper.Process.ExitCode to be 0, but found 1.
  Stack Trace:
     at FluentAssertions.Execution.XUnit2TestFramework.Throw(String message)
   at FluentAssertions.Execution.TestFrameworkProvider.Throw(String message)
   at FluentAssertions.Execution.DefaultAssertionStrategy.HandleFailure(String message)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Execution.AssertionScope.FailWith(Func`1 failReasonFunc)
   at FluentAssertions.Execution.AssertionScope.FailWith(String message, Object[] args)
   at FluentAssertions.Numeric.NumericAssertions`1.Be(T expected, String because, Object[] becauseArgs)
   at Datadog.Trace.Tools.Runner.ArtifactTests.LegacyCommandLineArgumentsTests.LocateTracerHome() in D:\a\1\s\tracer\test\Datadog.Trace.Tools.Runner.ArtifactTests\LegacyCommandLineArgumentsTests.cs:line 84
```
Trying again after fixing the csproj

Edit 2: The test is green after fixing the csproj 👍 