### PR TITLE
Make releases instant(ish)

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4,9 +4,9 @@ trigger:
       - master
       - release/*
       - hotfix/*
-      - refs/tags/*
     exclude:
       - refs/pull/*/head
+      - refs/tags/*
   paths:
     exclude:
       - docs/*

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - release/.x
     types: [closed]
 
 jobs:

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - main
-      - release/.x
+      - release/1.x
     types: [closed]
 
 jobs:

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -25,18 +25,21 @@ jobs:
       - name: "Select branch"
         id: select_branch
         run: |
-          tag=${{ github.event.release.tag_name}}
-          if [[ $tag = v1.* ]]
-          then
-            echo "::set-output name=ref::refs/heads/release/1.x"
-          else
-            echo "::set-output name=ref::refs/heads/master"
-          fi
+          if( "${{ github.event.release.tag_name}}".StartsWith("v1.")) {
+            echo "::set-output name=ref::release/1.x"
+          } else {
+            echo "::set-output name=ref::master"
+          }
 
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.select_branch.outputs.ref }}"
+          ref: ${{ steps.select_branch.outputs.ref }}
+
+      - name: "Configure Git Credentials"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -1,30 +1,42 @@
-name: Create version bump PR
+name: Auto version bump on release completed
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Next Version Number (x.x.x)'
-        required: true
-      is_prerelease:
-        description: 'Is Prerelease version? (true/false)'
-        default: 'false'
-        required: true
+  release:
+    types: [published]
 
 jobs:
   bump_version:
+    # If this is a 1.x release, do the version bump in the release/1.x branch
+    # If this is a 2.x.0 release, do the version bump on master
+    # If this is a 2.x.x hotfix release, _don't_ do a version bump
+    if: |
+      startsWith(github.event.release.tag_name, 'v1.')
+      || (startsWith(github.event.release.tag_name, 'v2.')
+        && endsWith(github.event.release.tag_name, '.0'))
+
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      Version: "${{ github.event.inputs.version }}"
-      IsPrerelease: "${{ github.event.inputs.is_prerelease }}"
 
     steps:
       - name: Support longpaths
         run: git config --system core.longpaths true
 
+      - name: "Select branch"
+        id: select_branch
+        run: |
+          tag=${{ github.event.release.tag_name}}
+          if [[ $tag = v1.* ]]
+          then
+            echo "::set-output name=ref::refs/heads/release/1.x"
+          else
+            echo "::set-output name=ref::refs/heads/master"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.select_branch.outputs.ref }}"
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -32,21 +44,22 @@ jobs:
 
       - name: "Update Changelog"
         run: .\tracer\build.ps1 UpdateChangeLog
+        env:
+          RELEASE_NOTES: ${{ github.event.release.body }}
+
+      - name: "CalculateNextVersion"
+        run: .\tracer\build.ps1 CalculateNextVersion
+        id: versions
 
       - name: "Bump Version"
         run: .\tracer\build.ps1 UpdateVersion UpdateMsiContents
+        env:
+          Version: ${{ steps.versions.outputs.version }}
+          IsPrerelease: ${{ steps.versions.outputs.isprerelease }}
 
       - name: "Verify Changes"
         id: changes
         run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump
-
-      - name: "Output version"
-        id: versions
-        run: .\tracer\build.ps1 OutputCurrentVersionToGitHub
-
-      - name: "Rename vNext milestone"
-        id: rename
-        run: .\tracer\build.ps1 RenameVNextMilestone
 
       - name: Create Pull Request
         id: pr
@@ -57,7 +70,6 @@ jobs:
           commit-message: "[Version Bump] ${{steps.versions.outputs.full_version}}"
           delete-branch: true
           title: "[Version Bump] ${{steps.versions.outputs.full_version}}"
-          milestone: "${{steps.rename.outputs.milestone}}"
           reviewers: "DataDog/apm-dotnet"
           body: "${{steps.changes.outputs.release_notes}}"
 

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -1,17 +1,21 @@
 name: Auto update benchmark branches
 
 on:
-  push:
-    tags:
-      - '**'
-      - '!v1*'
+  release:
+    types: [published]
 
 jobs:
   update_benchmark_branches:
+    # only run on "normal" 2.0 branches
+    if: |
+      startsWith(github.event.release.tag_name, 'v2.')
+      && endsWith(github.event.release.tag_name, '.0')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -34,25 +38,27 @@ jobs:
           # Reverse the order
           # Skip the 1st result (so we will have 2 benchmarks at most)
           # Then do the complex dance to rename all the branches
+          echo 'Looking for benchmark branches...'
           BRANCHES=$(git branch -a  \
             | grep -F 'origin/benchmarks' \
             | grep -Fv -e 'benchmarks/1.27.1' \
             | cut -c 18- \
             | tac | tail -n +2)
+          
+          echo "Found branches:"
+          echo "$BRANCHES"
+
           for orig in $BRANCHES; do
            archived=archived_$orig;
            echo "Renaming $orig to $archived"
-           git branch $orig origin/$orig
-           git branch -m $orig $archived;
+           git branch $archived origin/$orig
+           git push origin -u $archived 
            git push origin --delete $orig;
-           git branch --unset-upstream $archived;
-           git push origin -u $archived;
            git branch -d $archived;
           done
 
-      - name: Create benchmarks branch
-        uses: peterjgrainger/action-create-branch@v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          branch: 'benchmarks/${{steps.versions.outputs.full_version}}'
+      - name: "Push new benchmarks branch"
+        run: |
+          new_branch=benchmarks/${{steps.versions.outputs.full_version}}
+          git checkout -b $new_branch ${{ github.event.release.tag_name }}
+          git push origin -u $new_branch

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -1,14 +1,13 @@
-name: Auto tag version bump commit
+name: Auto update benchmark branches
 
 on:
   push:
-    branches: [ master, main, release/*, hotfix/* ]
-    tags-ignore:
+    tags:
       - '**'
+      - '!v1*'
 
 jobs:
-  tag_version_bump_commit:
-    if: startsWith(github.event.head_commit.message, '[Version Bump]')
+  update_benchmark_branches:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,12 +26,6 @@ jobs:
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: "Create and push git tag"
-        id: version
-        run: |
-          git tag "v${{steps.versions.outputs.full_version}}"
-          git push origin "v${{steps.versions.outputs.full_version}}"
-
       - name: "Clean up old benchmark branches"
         run: |
           # find all remote benchmarks/* branches (by literal string)
@@ -48,6 +41,7 @@ jobs:
             | tac | tail -n +2)
           for orig in $BRANCHES; do
            archived=archived_$orig;
+           echo "Renaming $orig to $archived"
            git branch $orig origin/$orig
            git branch -m $orig $archived;
            git push origin --delete $orig;

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -1,4 +1,4 @@
-name: Create draft release from latest tag
+name: Create draft release
 
 on:
   workflow_dispatch:
@@ -18,27 +18,47 @@ jobs:
         with:
           dotnet-version: '6.0.x'
 
+      - name: "Configure Git Credentials"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: "Get current version"
-        id: version
+        id: versions
         run: ./tracer/build.sh OutputCurrentVersionToGitHub
 
-      - name: "Download assets from Azure Pipelines"
+      - name: "Download build assets from Azure Pipelines"
         id: assets
         run: ./tracer/build.sh DownloadAzurePipelineArtifacts
+        env:
+          TargetBranch: ${{ env.GITHUB_REF }}
 
-      - name: "Extract release notes from changelog"
+      - name: "Generate release notes"
         id: release_notes
-        run: ./tracer/build.sh ExtractReleaseNotes
+        run: ./tracer/build.sh GenerateReleaseNotes
         env:
           PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
+
+      - name: "Create and push git tag"
+        run: |
+          git tag "v${{steps.versions.outputs.full_version}}"
+          git push origin "v${{steps.versions.outputs.full_version}}"
+
+      - name: "Rename vNext milestone"
+        id: rename
+        # We don't rename vNext/vNext-v1 for hotfix releases
+        if: ${{ !contains(env.GITHUB_REF, 'hotfix') }}
+        run: .\tracer\build.ps1 RenameVNextMilestone
+        env:
+          Version: ${{steps.versions.outputs.full_version}}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
-          name: "${{steps.version.outputs.full_version}}"
-          tag_name: "v${{steps.version.outputs.full_version}}"
-          prerelease: ${{steps.version.outputs.isprerelease}}
+          name: "${{steps.versions.outputs.full_version}}"
+          tag_name: "v${{steps.versions.outputs.full_version}}"
+          prerelease: ${{steps.versions.outputs.isprerelease}}
           body: ${{steps.release_notes.outputs.release_notes}}
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -31,7 +31,7 @@ jobs:
         id: assets
         run: ./tracer/build.sh DownloadAzurePipelineArtifacts
         env:
-          TargetBranch: ${{ env.GITHUB_REF }}
+          TargetBranch: ${{ github.event.ref }}
 
       - name: "Generate release notes"
         id: release_notes
@@ -39,18 +39,18 @@ jobs:
         env:
           PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
 
+      - name: "Rename vNext milestone"
+        id: rename
+        # We don't rename vNext/vNext-v1 for hotfix releases
+        if: ${{ !contains(github.event.ref, 'hotfix') }}
+        run: ./tracer/build.sh RenameVNextMilestone
+        env:
+          Version: ${{steps.versions.outputs.full_version}}
+
       - name: "Create and push git tag"
         run: |
           git tag "v${{steps.versions.outputs.full_version}}"
           git push origin "v${{steps.versions.outputs.full_version}}"
-
-      - name: "Rename vNext milestone"
-        id: rename
-        # We don't rename vNext/vNext-v1 for hotfix releases
-        if: ${{ !contains(env.GITHUB_REF, 'hotfix') }}
-        run: .\tracer\build.ps1 RenameVNextMilestone
-        env:
-          Version: ${{steps.versions.outputs.full_version}}
 
       - name: Create Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Support longpaths
         run: git config --system core.longpaths true
 
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: "Configure Git Credentials"
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      - name: Checkout
-        uses: actions/checkout@v2
 
       - uses: actions/setup-dotnet@v1
         with:
@@ -41,14 +41,11 @@ jobs:
 
       - name: "Verify Changes"
         id: changes
-        run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump
+        run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump -ExpectChangelogUpdate false
 
       - name: "Push hotfix branch"
-        uses: github-actions-x/commit@v2.8
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          push-branch: "hotfix/${{ steps.versions.outputs.full_version }}"
-          commit-message: "[Version Bump] ${{steps.versions.outputs.full_version}}"
-          files: .
-          name: ${{ github.actor }}
-          email: "${{ github.actor }}@users.noreply.github.com"
+        run: |
+          git checkout -b hotfix/${{ steps.versions.outputs.full_version }}
+          git add .
+          git commit -m "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          git push origin -u hotfix/${{ steps.versions.outputs.full_version }}

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -1,0 +1,54 @@
+name: Create hotfix branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Hotfix Version Number (x.x.x)'
+        required: true
+      is_prerelease:
+        description: 'Is Prerelease version? (true/false)'
+        default: 'false'
+        required: true
+
+jobs:
+  bump_version:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      Version: "${{ github.event.inputs.version }}"
+      IsPrerelease: "${{ github.event.inputs.is_prerelease }}"
+
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: "Configure Git Credentials"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: "Bump Version"
+        id: versions
+        run: .\tracer\build.ps1 UpdateVersion UpdateMsiContents OutputCurrentVersionToGitHub
+
+      - name: "Verify Changes"
+        id: changes
+        run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump
+
+      - name: "Push hotfix branch"
+        uses: github-actions-x/commit@v2.8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: "hotfix/${{ steps.versions.outputs.full_version }}"
+          commit-message: "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          files: .
+          name: ${{ github.actor }}
+          email: "${{ github.actor }}@users.noreply.github.com"

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -1,0 +1,56 @@
+name: Force manual version bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Next Version Number (x.x.x)'
+        required: true
+      is_prerelease:
+        description: 'Is Prerelease version? (true/false)'
+        default: 'false'
+        required: true
+
+jobs:
+  bump_version:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      Version: "${{ github.event.inputs.version }}"
+      IsPrerelease: "${{ github.event.inputs.is_prerelease }}"
+
+    steps:
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: "Bump Version"
+        id: versions
+        run: .\tracer\build.ps1 UpdateVersion UpdateMsiContents OutputCurrentVersionToGitHub
+
+      - name: "Verify Changes"
+        id: changes
+        run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump - ExpectChangelogUpdate false
+
+      - name: Create Pull Request
+        id: pr
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "version-bump-${{steps.versions.outputs.full_version}}"
+          commit-message: "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          delete-branch: true
+          title: "[Version Bump] ${{steps.versions.outputs.full_version}}"
+          reviewers: "DataDog/apm-dotnet"
+          body: "${{steps.changes.outputs.release_notes}}"
+
+      - name: Display output
+        run: |
+          echo "Pull Request Number - ${{ steps.pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.pr.outputs.pull-request-url }}"

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -95,6 +95,7 @@ partial class Build
 
     Target OutputCurrentVersionToGitHub => _ => _
        .Unlisted()
+       .After(UpdateVersion, UpdateMsiContents)
        .Requires(() => Version)
        .Executes(() =>
         {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -468,6 +468,7 @@ partial class Build
                 {
                     if (string.Equals(build.SourceVersion, commitSha, StringComparison.OrdinalIgnoreCase))
                     {
+                        // Found a build for the commit, so should have an artifact
                         try
                         {
                             artifact = await buildHttpClient.GetArtifactAsync(
@@ -479,7 +480,9 @@ partial class Build
                         }
                         catch (ArtifactNotFoundException)
                         {
-                            Logger.Info($"Could not find {artifactName} artifact for build {build.Id}. Skipping");
+                            Logger.Error($"Error: could not find {artifactName} artifact for build {build.Id} for commit {commitSha}. " +
+                                         $"Ensure the build has completed successfully for this commit before creating a release");
+                            throw;
                         }
                     }
                 }

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -482,7 +482,13 @@ partial class Build
                 {
                     if (string.Equals(build.SourceVersion, commitSha, StringComparison.OrdinalIgnoreCase))
                     {
-                        // Found a build for the commit, so should have an artifact
+                        // Found a build for the commit, so should be successful and have an artifact
+                        if (build.Result != BuildResult.Succeeded && build.Result != BuildResult.PartiallySucceeded)
+                        {
+                            Logger.Error($"::error::The build for commit {commitSha} was not successful. Please retry any failed stages for the build before creating a release");
+                            throw new Exception("Latest build for branch was not successful. Please retry the build before creating a release");
+                        }
+
                         try
                         {
                             artifact = await buildHttpClient.GetArtifactAsync(
@@ -509,7 +515,7 @@ partial class Build
 
             if (artifact is null)
             {
-                Logger.Error($"::error::Could not find artifacts called {artifactName} for release. Please manually trigger a fresh build of the pipeline if required.");
+                Logger.Error($"::error::Could not find artifacts called {artifactName} for release. Please ensure the pipeline is running correctly for commits to this branch");
                 throw new Exception("Could not find any artifacts to create a release");
             }
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -262,6 +262,20 @@ partial class Build
                 throw new Exception("Release notes were empty");
             }
 
+            var sb = new StringBuilder(releaseNotes.Length);
+            using (var reader = new StringReader(releaseNotes))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    if (!line.StartsWith("⚠ 1. Download the NuGet packages")
+                     && !line.StartsWith("⚠ 2. Download the signed"))
+                    {
+                        sb.AppendLine(line);
+                    }
+                }
+            }
+
             Console.WriteLine("Updating changelog...");
 
             var changelogPath = RootDirectory / "docs" / "CHANGELOG.md";
@@ -279,7 +293,7 @@ partial class Build
                 file.WriteLine();
                 file.WriteLine($"## [Release {FullVersion}](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v{FullVersion})");
                 file.WriteLine();
-                file.WriteLine(releaseNotes);
+                file.WriteLine(sb);
                 file.WriteLine();
 
                 // Write the remainder
@@ -330,7 +344,7 @@ partial class Build
                                  SortDirection = SortDirection.Ascending,
                              });
 
-            Console.WriteLine($"Found {issues.Count} issues, building changelog");
+            Console.WriteLine($"Found {issues.Count} issues, building release notes.");
 
             var sb = new StringBuilder();
             sb.AppendLine($"⚠ 1. Download the NuGet packages for the release from [this link]({artifactsLink}) and upload to nuget.org");

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -451,7 +451,11 @@ partial class Build
 
             // start from the current commit, and keep looking backwards until we find a commit that has a build
             // that has successful artifacts. Should only be called from branches with a linear history (i.e. single parent)
-            const int maxCommitsBack = 30;
+            // This solves a potential issue where we previously selecting a build by start order, not by the actual
+            // git commit order. Generally that shouldn't be an issue, but if we manually trigger builds on master
+            // (which we sometimes do e.g. trying to bisect and issue, or retrying flaky test for coverage reasons),
+            // then we could end up selecting the wrong build.
+            const int maxCommitsBack = 20;
             for (var i = 0; i < maxCommitsBack; i++)
             {
                 var commitSha = GitTasks.Git($"log {TargetBranch}~{i} -1 --pretty=%H")


### PR DESCRIPTION
This PR tries to redesign the release process to make it as close to a one-click-instant-release process as we can. 

## What we had before

Prior to this change, when we wanted to do a release, we had to:

- Create a version bump PR.
- Wait for the CI to build it. (1hr +)
- Merge the PR.
- Github action auto-tags the commit, and triggers another build.
- Wait for the CI to build it. (1hr +)
- Create the release

We have at least two full builds in there, which makes the release process take a long time

## What this PR does

> This PR tries to handle normal releases, releases to the 1.x branch, and hotfix releases. That makes everything a bit trickier than it would be otherwise!

With these changes, we turn things on their head somewhat:

- Create a release using GitHub actions (requires that we are already at the correct version)
  - Select the correct branch. For a 1.x release, select the `release/1.x` branch, otherwise select the main branch.
  - Find the last build on master that has the release artifacts. Necessary now that we don't _always_ build them (noop-pipeline)
  - Generate the release notes from the `vNext` milestone
  - Tag the commit and push
  - Rename the (`vNext`/`vNext-v1`) milestone
  - Create the draft release

This creates the release immediately (ish), at which point we can do the remaining steps (i.e. trigger GitLab + download signed artifacts, fetch from Nuget, curate release notes). Once they're happy they can publish the release. This triggers another workflow:

- Create a version bump commit
  - If the release was a 1.x release, run against the `release/1.x` branch. If the release was a 2.x release, run against `master`. If the release was a hotfix (i.e. patch release), then _don't_ create a version bump commit at all.
  - Calculate the next version - minor bump for standard releases, patch bump for 1.x releases.
  - Update the changelog with the previous release notes. (This isn't ideal, see below)
  - Bump the version, verify changes, and create a PR

This final step will trigger a build, but the release is already done at this point, so that build isn't a blocker. Nevertheless, we'll want to merge it ASAP.

## Downsides to this approach

The biggest downside to this approach is that the changelog doesn't get updated until the _subsequent_ commit that we released. There _are_ ways around this, but they all require adding an extra step in the "create release" process, where you have to wait for someone to approve the changelog PR. If we want that, that's fine, and it adds a check before someone can create a new release, but the process outlined here enables "solo" releases too.

Another downside is it forces our versioning strategy to be:
- patch only in `release/1.x`
- minor only in `master`
- patch/other for `hotfix/`

Personally I think this is fine, but it's pretty rigid.

## Additional changes

- We no longer need to create new builds on tag pushes, so I've removed that. Instead, we just do the benchmark-branch pruning on tag push (I don't think that's working tho, need to dig into it further)
- Auto add merged PRs to the `release/1.x` branch to the `vNext-v1` milestone. Makes creating releases on the v1 branch as easy as master
- Add a workflow for creating a hotfix branch. This creates a `hotfix/` branch from whichever branch/tag you specify when running the action, and to explicitly set the version. Maybe we should force you to select a tag when doing this, as typically we will want to branch from the last release?


## Outstanding work

- [x] Make sure it all works in a dummy repository
- [ ] Automatically upload the NuGet packages
- [ ] Streamline the Gitlab process (auto trigger build based on tag push?)
- [ ] AAS...

@DataDog/apm-dotnet