### PR TITLE
Remove chmod +x from createLogPath.sh

### DIFF
--- a/tracer/build/artifacts/createLogPath.sh
+++ b/tracer/build/artifacts/createLogPath.sh
@@ -2,4 +2,4 @@
 set -euxo pipefail
 
 mkdir -p /var/log/datadog/dotnet
-chmod a+rwx /var/log/datadog/dotnet
+chmod a+rw /var/log/datadog/dotnet


### PR DESCRIPTION
We shouldn't set execute on files in the log folder

@DataDog/apm-dotnet