### PR TITLE
Azure functions enabled by default, but still unpluggable

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -141,8 +141,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
         if (!functions_worker_runtime_value.empty() && !IsAzureFunctionsEnabled())
         {
-            Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler explicitly disabled for Azure Functions. "
-                         "Enable instrumentation with DD_TRACE_AZURE_FUNCTIONS_ENABLED.");
+            Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler explicitly disabled for Azure Functions.");
             return E_FAIL;
         }
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -141,8 +141,8 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
         if (!functions_worker_runtime_value.empty() && !IsAzureFunctionsEnabled())
         {
-            Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler disabled: Azure Functions are not officially "
-                         "supported. Enable instrumentation with DD_TRACE_AZURE_FUNCTIONS_ENABLED.");
+            Logger::Info("DATADOG TRACER DIAGNOSTICS - Profiler explicitly disabled for Azure Functions. "
+                         "Enable instrumentation with DD_TRACE_AZURE_FUNCTIONS_ENABLED.");
             return E_FAIL;
         }
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/environment_variables_util.h
@@ -83,7 +83,7 @@ bool IsAzureAppServices()
 
 bool IsAzureFunctionsEnabled()
 {
-    CheckIfTrue(GetEnvironmentValue(environment::azure_functions_enabled));
+    ToBooleanWithDefault(GetEnvironmentValue(environment::azure_functions_enabled), true);
 }
 
 bool IsVersionCompatibilityEnabled()


### PR DESCRIPTION
With Azure Functions Public Beta tomorrow, the feature has to be enabled by default.
As it's still a beta, I let the the feature flag (plus we still don't support out of process functions)

AIT-347

@DataDog/apm-dotnet