### PR TITLE
Fix some test data

### DIFF
--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Fields/ReferenceType/ReferenceTypeFieldErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Fields/ReferenceType/ReferenceTypeFieldErrorTests.cs
@@ -19,7 +19,12 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ReferenceType
 {
     public class ReferenceTypeFieldErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[] { ObscureObject.GetFieldPublicObject(), ObscureObject.GetFieldInternalObject(), ObscureObject.GetFieldPrivateObject(), };
+        public static IEnumerable<object> SourceObjects() => new object[]
+        {
+            nameof(ObscureObject.GetFieldPublicObject),
+            nameof(ObscureObject.GetFieldInternalObject),
+            nameof(ObscureObject.GetFieldPrivateObject),
+        };
 
         public static IEnumerable<object[]> Valid() =>
             from source in SourceObjects()
@@ -47,8 +52,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
 
@@ -59,8 +65,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(WrongFieldNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
 
@@ -70,8 +77,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Fields/TypeChaining/TypeChainingFieldErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Fields/TypeChaining/TypeChainingFieldErrorTests.cs
@@ -19,7 +19,12 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.TypeChaining
 {
     public class TypeChainingFieldErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[] { ObscureObject.GetFieldPublicObject(), ObscureObject.GetFieldInternalObject(), ObscureObject.GetFieldPrivateObject(), };
+        public static IEnumerable<object> SourceObjects() => new object[]
+        {
+            nameof(ObscureObject.GetFieldPublicObject),
+            nameof(ObscureObject.GetFieldInternalObject),
+            nameof(ObscureObject.GetFieldPrivateObject),
+        };
 
         public static IEnumerable<object[]> Valid() =>
             from source in SourceObjects()
@@ -59,8 +64,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
 
@@ -71,8 +77,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(WrongFieldNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -81,8 +88,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -91,8 +99,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(WrongChainedReturnTypes))]
-        public void WrongChainedReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongChainedReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -101,8 +110,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.TypeChaining
 
         [Theory(Skip = "We can't currently detect incorrect return types in these cases")]
         [MemberData(nameof(WrongChainedReturnTypesForInterfaces))]
-        public void WrongChainedReturnTypesForInterfacesThrow(Type duckType, object obscureObject)
+        public void WrongChainedReturnTypesForInterfacesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Fields/ValueType/ValueTypeFieldErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Fields/ValueType/ValueTypeFieldErrorTests.cs
@@ -18,7 +18,12 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ValueType
 {
     public class ValueTypeFieldErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[] { ObscureObject.GetFieldPublicObject(), ObscureObject.GetFieldInternalObject(), ObscureObject.GetFieldPrivateObject(), };
+        public static IEnumerable<object> SourceObjects() => new object[]
+        {
+            nameof(ObscureObject.GetFieldPublicObject),
+            nameof(ObscureObject.GetFieldInternalObject),
+            nameof(ObscureObject.GetFieldPrivateObject),
+        };
 
         public static IEnumerable<object[]> Valid() =>
             from source in SourceObjects()
@@ -46,8 +51,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
 
@@ -58,8 +64,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(WrongFieldNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -68,8 +75,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/Generics/GenericMethodErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/Generics/GenericMethodErrorTests.cs
@@ -20,11 +20,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
 {
     public class GenericMethodErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[]
+        public static IEnumerable<object> SourceObjects() => new object[]
         {
-            ObscureObject.GetPropertyPublicObject(),
-            ObscureObject.GetPropertyInternalObject(),
-            ObscureObject.GetPropertyPrivateObject(),
+            nameof(ObscureObject.GetPropertyPublicObject),
+            nameof(ObscureObject.GetPropertyInternalObject),
+            nameof(ObscureObject.GetPropertyPrivateObject),
         };
 
         public static IEnumerable<object[]> Valid() =>
@@ -65,8 +65,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCastUnlessNet45AndPrivate(Type duckType, object obscureObject)
+        public void ValidCanCastUnlessNet45AndPrivate(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
 
             obscureObject.DuckIs(duckType).Should().BeTrue();
@@ -75,8 +76,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
 
         [Theory]
         [MemberData(nameof(WrongMethodNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -85,8 +87,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
 
         [Theory(Skip = "We can't currently correctly detect incorrect return types")]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -95,8 +98,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
 
         [Theory]
         [MemberData(nameof(WrongArgumentTypes))]
-        public void WrongArgumentTypesThrow(Type duckType, object obscureObject)
+        public void WrongArgumentTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -105,8 +109,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.Generics
 
         [Theory]
         [MemberData(nameof(WrongNumberOfArguments))]
-        public void WrongNumberOfArgumentsThrow(Type duckType, object obscureObject)
+        public void WrongNumberOfArgumentsThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/NonGenerics/NonGenericMethodErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Methods/NonGenerics/NonGenericMethodErrorTests.cs
@@ -21,11 +21,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 {
     public class NonGenericMethodErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[]
+        public static IEnumerable<object> SourceObjects() => new object[]
         {
-            ObscureObject.GetPropertyPublicObject(),
-            ObscureObject.GetPropertyInternalObject(),
-            ObscureObject.GetPropertyPrivateObject(),
+            nameof(ObscureObject.GetPropertyPublicObject),
+            nameof(ObscureObject.GetPropertyInternalObject),
+            nameof(ObscureObject.GetPropertyPrivateObject),
         };
 
         public static IEnumerable<object[]> Valid() =>
@@ -73,8 +73,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
             var valid = obscureObject.DuckCast(duckType);
@@ -82,8 +83,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 
         [Theory]
         [MemberData(nameof(WrongMethodNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -92,8 +94,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 
         [Theory]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -102,8 +105,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 
         [Theory]
         [MemberData(nameof(WrongArgumentTypes))]
-        public void WrongArgumentTypesThrow(Type duckType, object obscureObject)
+        public void WrongArgumentTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -112,8 +116,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 
         [Theory]
         [MemberData(nameof(WrongNumberOfArguments))]
-        public void WrongNumberOfArgumentsThrow(Type duckType, object obscureObject)
+        public void WrongNumberOfArgumentsThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -122,8 +127,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Methods.NonGenerics
 
         [Theory]
         [MemberData(nameof(WrongArgumentModifiers))]
-        public void WrongArgumentModifierThrow(Type duckType, object obscureObject)
+        public void WrongArgumentModifierThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Properties/ReferenceType/ReferenceTypePropertyErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Properties/ReferenceType/ReferenceTypePropertyErrorTests.cs
@@ -18,7 +18,12 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ReferenceType
 {
     public class ReferenceTypePropertyErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[] { ObscureObject.GetPropertyPublicObject(), ObscureObject.GetPropertyInternalObject(), ObscureObject.GetPropertyPrivateObject(), };
+        public static IEnumerable<object> SourceObjects() => new object[]
+        {
+            nameof(ObscureObject.GetPropertyPublicObject),
+            nameof(ObscureObject.GetPropertyInternalObject),
+            nameof(ObscureObject.GetPropertyPrivateObject),
+        };
 
         public static IEnumerable<object[]> Valid() =>
             from source in SourceObjects()
@@ -46,8 +51,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
 
@@ -58,8 +64,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(WrongPropertyNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -68,8 +75,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ReferenceType
 
         [Theory(Skip = "We can't currently detect incorrect return types for properties")]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Properties/TypeChaining/TypeChainingPropertyErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Properties/TypeChaining/TypeChainingPropertyErrorTests.cs
@@ -19,11 +19,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.TypeChaining
 {
     public class TypeChainingPropertyErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[]
+        public static IEnumerable<object> SourceObjects() => new object[]
         {
-            ObscureObject.GetPropertyPublicObject(),
-            ObscureObject.GetPropertyInternalObject(),
-            ObscureObject.GetPropertyPrivateObject(),
+            nameof(ObscureObject.GetPropertyPublicObject),
+            nameof(ObscureObject.GetPropertyInternalObject),
+            nameof(ObscureObject.GetPropertyPrivateObject),
         };
 
         public static IEnumerable<object[]> Valid() =>
@@ -60,8 +60,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
 
@@ -72,8 +73,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(WrongPropertyNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -82,8 +84,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.TypeChaining
 
         [Theory(Skip = "We can't currently detect incorrect return types for properties")]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -92,8 +95,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.TypeChaining
 
         [Theory(Skip = "We can't currently detect incorrect return types for properties")]
         [MemberData(nameof(WrongChainedReturnTypes))]
-        public void WrongChainedReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongChainedReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Properties/ValueType/ValueTypePropertyErrorTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Errors/Properties/ValueType/ValueTypePropertyErrorTests.cs
@@ -18,11 +18,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ValueType
 {
     public class ValueTypePropertyErrorTests
     {
-        public static IEnumerable<object> SourceObjects() => new[]
+        public static IEnumerable<object> SourceObjects() => new object[]
         {
-            ObscureObject.GetPropertyPublicObject(),
-            ObscureObject.GetPropertyInternalObject(),
-            ObscureObject.GetPropertyPrivateObject(),
+            nameof(ObscureObject.GetPropertyPublicObject),
+            nameof(ObscureObject.GetPropertyInternalObject),
+            nameof(ObscureObject.GetPropertyPrivateObject),
         };
 
         public static IEnumerable<object[]> Valid() =>
@@ -51,8 +51,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Valid))]
-        public void ValidCanCast(Type duckType, object obscureObject)
+        public void ValidCanCast(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeTrue();
 
@@ -63,8 +64,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(WrongPropertyNames))]
-        public void WrongNamesThrow(Type duckType, object obscureObject)
+        public void WrongNamesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);
@@ -73,8 +75,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Errors.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(WrongReturnTypes))]
-        public void WrongReturnTypesThrow(Type duckType, object obscureObject)
+        public void WrongReturnTypesThrow(Type duckType, string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             using var scope = new AssertionScope();
             obscureObject.DuckIs(duckType).Should().BeFalse();
             Action cast = () => obscureObject.DuckCast(duckType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -11,20 +11,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
 {
     public class ReferenceTypeFieldTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetFieldPublicObject() },
-                new object[] { ObscureObject.GetFieldInternalObject() },
-                new object[] { ObscureObject.GetFieldPrivateObject() },
+                nameof(ObscureObject.GetFieldPublicObject),
+                nameof(ObscureObject.GetFieldInternalObject),
+                nameof(ObscureObject.GetFieldPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticReadonlyFieldsSetException(object obscureObject)
+        public void StaticReadonlyFieldsSetException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
                 obscureObject.DuckCast<IObscureStaticReadonlyErrorDuckType>();
@@ -33,8 +32,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReadonlyFieldsSetException(object obscureObject)
+        public void ReadonlyFieldsSetException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
                 obscureObject.DuckCast<IObscureReadonlyErrorDuckType>();
@@ -43,8 +43,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticReadonlyFields(object obscureObject)
+        public void StaticReadonlyFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -72,8 +73,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticFields(object obscureObject)
+        public void StaticFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -163,8 +165,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReadonlyFields(object obscureObject)
+        public void ReadonlyFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -192,8 +195,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Fields(object obscureObject)
+        public void Fields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/TypeChainingFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/TypeChainingFieldTests.cs
@@ -13,20 +13,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
 {
     public class TypeChainingFieldTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetFieldPublicObject() },
-                new object[] { ObscureObject.GetFieldInternalObject() },
-                new object[] { ObscureObject.GetFieldPrivateObject() },
+                nameof(ObscureObject.GetFieldPublicObject),
+                nameof(ObscureObject.GetFieldInternalObject),
+                nameof(ObscureObject.GetFieldPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticReadonlyFieldsSetException(object obscureObject)
+        public void StaticReadonlyFieldsSetException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
                 obscureObject.DuckCast<IObscureStaticReadonlyErrorDuckType>();
@@ -35,8 +34,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReadonlyFieldsSetException(object obscureObject)
+        public void ReadonlyFieldsSetException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
                 obscureObject.DuckCast<IObscureReadonlyErrorDuckType>();
@@ -45,8 +45,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticReadonlyFields(object obscureObject)
+        public void StaticReadonlyFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -94,8 +95,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticFields(object obscureObject)
+        public void StaticFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -137,8 +139,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReadonlyFields(object obscureObject)
+        public void ReadonlyFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -186,8 +189,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Fields(object obscureObject)
+        public void Fields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -11,20 +11,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 {
     public class ValueTypeFieldTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetFieldPublicObject() },
-                new object[] { ObscureObject.GetFieldInternalObject() },
-                new object[] { ObscureObject.GetFieldPrivateObject() },
+                nameof(ObscureObject.GetFieldPublicObject),
+                nameof(ObscureObject.GetFieldInternalObject),
+                nameof(ObscureObject.GetFieldPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticReadonlyFieldsSetException(object obscureObject)
+        public void StaticReadonlyFieldsSetException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
                 obscureObject.DuckCast<IObscureStaticReadonlyErrorDuckType>();
@@ -33,8 +32,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReadonlyFieldsSetException(object obscureObject)
+        public void ReadonlyFieldsSetException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypeFieldIsReadonlyException>(() =>
             {
                 obscureObject.DuckCast<IObscureReadonlyErrorDuckType>();
@@ -43,8 +43,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticReadonlyFields(object obscureObject)
+        public void StaticReadonlyFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -72,8 +73,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticFields(object obscureObject)
+        public void StaticFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -163,8 +165,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReadonlyFields(object obscureObject)
+        public void ReadonlyFields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -192,8 +195,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Fields(object obscureObject)
+        public void Fields(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -283,8 +287,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void NullableOfKnown(object obscureObject)
+        public void NullableOfKnown(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -12,20 +12,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
 {
     public class MethodTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetPropertyPublicObject() },
-                new object[] { ObscureObject.GetPropertyInternalObject() },
-                new object[] { ObscureObject.GetPropertyPrivateObject() },
+                nameof(ObscureObject.GetPropertyPublicObject),
+                nameof(ObscureObject.GetPropertyInternalObject),
+                nameof(ObscureObject.GetPropertyPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void ReturnMethods(object obscureObject)
+        public void ReturnMethods(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -69,8 +68,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void VoidMethods(object obscureObject)
+        public void VoidMethods(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -93,8 +93,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void RefParametersMethods(object obscureObject)
+        public void RefParametersMethods(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -161,8 +162,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void OutParametersMethods(object obscureObject)
+        public void OutParametersMethods(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -284,8 +286,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void DefaultGenericsMethods(object obscureObject)
+        public void DefaultGenericsMethods(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IDefaultGenericMethodDuckType>();
             var duckAbstract = obscureObject.DuckCast<DefaultGenericMethodDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<DefaultGenericMethodDuckTypeVirtualClass>();
@@ -358,8 +361,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GenericsWithAttributeResolution(object obscureObject)
+        public void GenericsWithAttributeResolution(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IGenericsWithAttribute>();
             var duckAttribute = obscureObject.DuckCast<AbstractGenericsWithAttribute>();
             var duckVirtual = obscureObject.DuckCast<VirtualGenericsWithAttribute>();

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/ObscureObject.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/ObscureObject.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 
 #pragma warning disable SA1201 // Elements must appear in the correct order
@@ -37,6 +38,11 @@ namespace Datadog.Trace.DuckTyping.Tests
         public static object GetPropertyInternalObject() => propertyInternalObject;
 
         public static object GetPropertyPrivateObject() => propertyPrivateObject;
+
+        public static object GetObject(string methodName)
+            => typeof(ObscureObject)
+              .GetMethod(methodName, BindingFlags.Static | BindingFlags.Public)!
+              .Invoke(null, Array.Empty<object>());
 
         // ***
         public enum TestEnum

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Generic;
 using Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType.ProxiesDefinitions;
 using Xunit;
 
@@ -11,20 +10,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 {
     public class ReferenceTypePropertyTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetPropertyPublicObject() },
-                new object[] { ObscureObject.GetPropertyInternalObject() },
-                new object[] { ObscureObject.GetPropertyPrivateObject() },
+                nameof(ObscureObject.GetPropertyPublicObject),
+                nameof(ObscureObject.GetPropertyInternalObject),
+                nameof(ObscureObject.GetPropertyPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticGetOnlyPropertyException(object obscureObject)
+        public void StaticGetOnlyPropertyException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
                 obscureObject.DuckCast<IObscureStaticErrorDuckType>();
@@ -33,8 +31,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GetOnlyPropertyException(object obscureObject)
+        public void GetOnlyPropertyException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
                 obscureObject.DuckCast<IObscureErrorDuckType>();
@@ -43,8 +42,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticGetOnlyProperties(object obscureObject)
+        public void StaticGetOnlyProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -72,8 +72,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticProperties(object obscureObject)
+        public void StaticProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -171,8 +172,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GetOnlyProperties(object obscureObject)
+        public void GetOnlyProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -200,8 +202,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Properties(object obscureObject)
+        public void Properties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -299,8 +302,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Indexer(object obscureObject)
+        public void Indexer(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -323,8 +327,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StructCopy(object obscureObject)
+        public void StructCopy(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckStructCopy = obscureObject.DuckCast<ObscureDuckTypeStruct>();
 
             Assert.Equal("10", duckStructCopy.PublicStaticGetReferenceType);
@@ -350,8 +355,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void UnionTest(object obscureObject)
+        public void UnionTest(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IDuckTypeUnion>();
 
             Assert.Equal("40", duckInterface.PublicGetSetReferenceType);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/TypeChainingPropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/TypeChainingPropertyTests.cs
@@ -11,20 +11,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 {
     public class TypeChainingPropertyTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetPropertyPublicObject() },
-                new object[] { ObscureObject.GetPropertyInternalObject() },
-                new object[] { ObscureObject.GetPropertyPrivateObject() },
+                nameof(ObscureObject.GetPropertyPublicObject),
+                nameof(ObscureObject.GetPropertyInternalObject),
+                nameof(ObscureObject.GetPropertyPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticGetOnlyPropertyException(object obscureObject)
+        public void StaticGetOnlyPropertyException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
                 obscureObject.DuckCast<IObscureStaticErrorDuckType>();
@@ -33,8 +32,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GetOnlyPropertyException(object obscureObject)
+        public void GetOnlyPropertyException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
                 obscureObject.DuckCast<IObscureErrorDuckType>();
@@ -43,8 +43,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticGetOnlyProperties(object obscureObject)
+        public void StaticGetOnlyProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -92,8 +93,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticProperties(object obscureObject)
+        public void StaticProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -144,8 +146,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GetOnlyProperties(object obscureObject)
+        public void GetOnlyProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -193,8 +196,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Properties(object obscureObject)
+        public void Properties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -245,8 +249,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StructCopy(object obscureObject)
+        public void StructCopy(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckStructCopy = obscureObject.DuckCast<ObscureDuckTypeStruct>();
 
             Assert.Equal(42, duckStructCopy.PublicStaticGetSelfType.MagicNumber);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -12,20 +12,19 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 {
     public partial class ValueTypePropertyTests
     {
-        public static IEnumerable<object[]> Data()
-        {
-            return new[]
+        public static TheoryData<string> Data() =>
+            new()
             {
-                new object[] { ObscureObject.GetPropertyPublicObject() },
-                new object[] { ObscureObject.GetPropertyInternalObject() },
-                new object[] { ObscureObject.GetPropertyPrivateObject() },
+                nameof(ObscureObject.GetPropertyPublicObject),
+                nameof(ObscureObject.GetPropertyInternalObject),
+                nameof(ObscureObject.GetPropertyPrivateObject),
             };
-        }
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticGetOnlyPropertyException(object obscureObject)
+        public void StaticGetOnlyPropertyException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
                 obscureObject.DuckCast<IObscureStaticErrorDuckType>();
@@ -34,8 +33,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GetOnlyPropertyException(object obscureObject)
+        public void GetOnlyPropertyException(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             Assert.Throws<DuckTypePropertyCantBeWrittenException>(() =>
             {
                 obscureObject.DuckCast<IObscureErrorDuckType>();
@@ -44,8 +44,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticGetOnlyProperties(object obscureObject)
+        public void StaticGetOnlyProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -73,8 +74,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StaticProperties(object obscureObject)
+        public void StaticProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -172,8 +174,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void GetOnlyProperties(object obscureObject)
+        public void GetOnlyProperties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -201,8 +204,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Properties(object obscureObject)
+        public void Properties(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -300,8 +304,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void Indexer(object obscureObject)
+        public void Indexer(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -324,8 +329,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void NullableOfKnown(object obscureObject)
+        public void NullableOfKnown(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -415,8 +421,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void KnownEnum(object obscureObject)
+        public void KnownEnum(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
@@ -446,8 +453,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
 
         [Theory]
         [MemberData(nameof(Data))]
-        public void StructCopy(object obscureObject)
+        public void StructCopy(string obscureObjectName)
         {
+            var obscureObject = ObscureObject.GetObject(obscureObjectName);
             var duckStructCopy = obscureObject.DuckCast<ObscureDuckTypeStruct>();
 
             Assert.Equal(10, duckStructCopy.PublicStaticGetValueType);

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreRazorPagesTestData.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreRazorPagesTestData.cs
@@ -49,7 +49,6 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
             { "/", 200, false, "GET /", ConventionalParentTags("Index", route: string.Empty), 2, null, ConventionalChildTags("Index", route: string.Empty), null, null },
             { "/Index", 200, false, "GET /index", ConventionalParentTags("Index"), 2, null, ConventionalChildTags("Index"), null, null },
             { "/Privacy", 200, false, "GET /privacy", ConventionalParentTags("Privacy"), 2, null, ConventionalChildTags("Privacy"), null, null },
-            { "/Error", 500, true, "GET /error", ConventionalParentTags("Error"), 2, null, ConventionalChildTags("Error"), null, null },
             { "/Products", 200, false, "GET /products", ConventionalParentTags("Products/Index", route: "Products"), 2, null, ConventionalChildTags("Products/Index", route: "Products"), null, null },
             { "/Products/Index", 200, false, "GET /products/index", ConventionalParentTags("Products/Index"), 2, null, ConventionalChildTags("Products/Index"), null, null },
             { "/Products/Product", 404, false, "GET /products/product", EmptyTags(), 1, null, null, null, null },


### PR DESCRIPTION
We have some duplicate data in the Razor Pages test data which causes spam in the logs when there's a _real_ error.

We were also incorrectly trying to serialize `object[]` in duck typing tests, which has been causing errors like the following in unit tests (and consequently hasn't been running all the tests in CI)

```
[xUnit.net 00:00:01.50] Datadog.Trace.DuckTyping.Tests: Non-serializable data ('System.Object[]') found for 'Datadog.Trace.DuckTyping.Tests.Properties.ValueType.ValueTypePropertyTests.StaticGetOnlyPropertyException'; falling back to single test case.
```

@DataDog/apm-dotnet