### PR TITLE
Add internal "start" api to `Tracer`/`TracerManager`

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDatadogSink.cs
@@ -17,5 +17,10 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         /// <param name="logEvent">Log event to emit.</param>
         /// <exception cref="ArgumentNullException">The event is null.</exception>
         void EnqueueLog(DatadogLogEvent logEvent);
+
+        /// <summary>
+        /// Start the background process to send logs to the backend
+        /// </summary>
+        void Start();
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDatadogSink.cs
@@ -15,5 +15,9 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         public void EnqueueLog(DatadogLogEvent logEvent)
         {
         }
+
+        public void Start()
+        {
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -149,7 +149,7 @@ namespace Datadog.Trace
         internal void Start()
         {
             // Must be idempotent and thread safe
-
+            DirectLogSubmission?.Sink.Start();
         }
 
         private static async Task CleanUpOldTracerManager(TracerManager oldManager, TracerManager newManager)

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -143,6 +143,15 @@ namespace Datadog.Trace
             }
         }
 
+        /// <summary>
+        /// Start internal processes that require Tracer.Instance is already set
+        /// </summary>
+        internal void Start()
+        {
+            // Must be idempotent and thread safe
+
+        }
+
         private static async Task CleanUpOldTracerManager(TracerManager oldManager, TracerManager newManager)
         {
             try

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
@@ -117,6 +117,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
             {
                 Events.Enqueue(logEvent);
             }
+
+            public void Start()
+            {
+            }
         }
 
         internal class NullScopeProvider : IExternalScopeProvider

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
@@ -40,6 +40,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
             {
                 Events.Enqueue(logEvent);
             }
+
+            public void Start()
+            {
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
@@ -55,6 +55,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
             {
                 Events.Enqueue(logEvent);
             }
+
+            public void Start()
+            {
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
@@ -39,6 +39,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
             {
                 Events.Enqueue(logEvent);
             }
+
+            public void Start()
+            {
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             });
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
             var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            sink.Start();
 
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message"));
 
@@ -59,6 +60,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
                 options,
                 oversizeLogCallback: _ => mutex.Set(),
                 sinkDisabledCallback: () => { });
+            sink.Start();
 
             var message = new StringBuilder().Append('x', repeatCount: 1024 * 1024).ToString();
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, message));
@@ -88,6 +90,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
             var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            sink.Start();
 
             var firstMessage = "First message";
             var secondMessage = "Second message";
@@ -130,6 +133,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
             var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            sink.Start();
 
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message"));
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Information, "Second message"));
@@ -166,6 +170,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
             var sink = new TestSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            sink.Start();
             var log = new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message");
             var queue = new Queue<DatadogLogEvent>();
             queue.Enqueue(log);
@@ -191,6 +196,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
             var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            sink.Start();
 
             for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
             {


### PR DESCRIPTION
This PR adds a `Start()` API to avoid issues related to instrumenting types that we use as part of our infrastructure.

For example, this requirement was identified as part of the Telemetry work, in which calling `Tracer.Instance` initializes a `TracerManager`, and the `TelemetryController` immediately starts it's "push" loop. This loop uses `HttpClient`, which is auto-instrumented, and hence calls `Tracer.Instance` as part of the instrumentation (before checking for "do not trace" headers).

The call to `Tracer.Instance` all happens as part of the _same_ call stack that called the _initial_ `Tracer.Instance`, and hence is reentrant (and the `lock` does nothing to stop it). The end result is that we have _two_ `TracerManager` instances, which is a situation we were trying to avoid in the first place with `TracerManager` 😱 

> Another (additional) solution would be to configure a `DoNotTrace` class, and only access `Tracer.Instance` if this class allows is. But that approach has more general applicability, probably shouldn't be part of Datadog.Trace.dll, and should be publicly exposed, so this PR is somewhat of a stop gap before we cement that.

For safety, the direct log submission task doesn't start shipping until after `TracerManager.Start()` is called.

- [ ] Should the `AgentWriter` be updated to use this approach too? I don't think it's necessary, as we won't call `HttpClient` unless we have added a trace, which can't be done before the Tracer is started anyway 🤷‍♂️ 


@DataDog/apm-dotnet