### PR TITLE
Simplify direct log submission configuration (especially AAS)

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.DirectLogSubmission.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.DirectLogSubmission.cs
@@ -44,7 +44,8 @@ namespace Datadog.Trace.Configuration
 
             /// <summary>
             /// Configuration key for the url to send logs to.
-            /// Default value is <c>https://http-intake.logs.datadoghq.com:443</c>.
+            /// Default value uses the domain set in <see cref="ConfigurationKeys.Site"/>, so defaults to
+            /// <c>https://http-intake.logs.datadoghq.com:443</c>.
             /// </summary>
             /// <seealso cref="DirectLogSubmissionSettings.DirectLogSubmissionUrl"/>
             public const string Url = "DD_LOGS_DIRECT_SUBMISSION_URL";

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -265,8 +265,8 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
 
         /// <summary>
-        /// Configuration key for setting the default Datadog destination site, used by the Agent.
-        /// Defaults to datadoghq.com
+        /// Configuration key for setting the default Datadog destination site.
+        /// Defaults to "datadoghq.com".
         /// </summary>
         public const string Site = "DD_SITE";
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -265,6 +265,12 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
 
         /// <summary>
+        /// Configuration key for setting the default Datadog destination site, used by the Agent.
+        /// Defaults to datadoghq.com
+        /// </summary>
+        public const string Site = "DD_SITE";
+
+        /// <summary>
         /// Configuration key for overriding which URLs are skipped by the tracer.
         /// </summary>
         /// <seealso cref="TracerSettings.HttpClientExcludedUrlSubstrings"/>

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="DirectLogSubmissionSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.DirectSubmission
+{
+    public class DirectLogSubmissionSettingsTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("somethingelse.com")]
+        public void WhenDirectLogSubmissionUrlIsProvider_UseIt(string ddSite)
+        {
+            var expected = "http://some_url.com";
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.DirectLogSubmission.Url, expected },
+                { ConfigurationKeys.Site, ddSite },
+            }));
+
+            tracerSettings.LogSubmissionSettings.DirectLogSubmissionUrl.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WhenUrlIsNotProvided_AndSiteIsProvided_UsesIt(string url)
+        {
+            var domain = "my-domain.net";
+            var expected = "https://http-intake.logs.my-domain.net:443";
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
+            {
+                { ConfigurationKeys.DirectLogSubmission.Url, url },
+                { ConfigurationKeys.Site, domain },
+            }));
+
+            tracerSettings.LogSubmissionSettings.DirectLogSubmissionUrl.Should().Be(expected);
+        }
+
+        [Fact]
+        public void WhenNeitherSiteOrUrlAreProvided_UsesDefault()
+        {
+            var expected = "https://http-intake.logs.datadoghq.com:443";
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()));
+
+            tracerSettings.LogSubmissionSettings.DirectLogSubmissionUrl.Should().Be(expected);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [InlineData(null)]
         [InlineData("")]
         [InlineData("somethingelse.com")]
-        public void WhenDirectLogSubmissionUrlIsProvider_UseIt(string ddSite)
+        public void WhenDirectLogSubmissionUrlIsProvided_UseIt(string ddSite)
         {
             var expected = "http://some_url.com";
             var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -88,7 +88,6 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         [InlineData(ConfigurationKeys.DirectLogSubmission.Host, "   ")]
         [InlineData(ConfigurationKeys.DirectLogSubmission.Source, "")]
         [InlineData(ConfigurationKeys.DirectLogSubmission.Source, "   ")]
-        [InlineData(ConfigurationKeys.DirectLogSubmission.Url, "")]
         [InlineData(ConfigurationKeys.DirectLogSubmission.Url, "   ")]
         [InlineData(ConfigurationKeys.DirectLogSubmission.Url, "localhost")]
         public void InvalidSettingDisablesDirectLogSubmission(string setting, string value)


### PR DESCRIPTION
In AAS, you already have to provide `DD_SITE` to configure tracing. It makes sense to use this value when assigning the default default direct log submission URL instead of always defaulting to `"datadoghq.com"`.

This means one less step to configure direct log submission in AAS, reducing it down to just setting `DD_LOGS_DIRECT_SUBMISSION_INTEGRATIONS=NLog` (for example).

In other environments where you want to send to non-datadoghq.com, you would still _either_ need to set e.g. `DD_SITE=datadoghq.eu` or `DD_LOGS_DIRECT_SUBMISSION_URL=https://http-intake.logs.datadoghq.eu:443"`. I think encouraging users to set `DD_SITE` makes the most sense (as will be applicable for other features, e.g. agentless, telemetry etc)

@DataDog/apm-dotnet