### PR TITLE
Add regression tests for running in partial trust environments

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -430,9 +430,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.1x"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.VersionConflict.2x", "tracer\test\test-applications\integrations\Samples.VersionConflict.2x\Samples.VersionConflict.2x.csproj", "{3BC38BE0-B6FF-4B05-BC63-3614A5CF9393}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IBM.Data.DB2.DBCommand", "tracer\test\test-applications\regression\IBM.Data.DB2.DBCommand\IBM.Data.DB2.DBCommand.csproj", "{E961D189-3EF9-4D79-95A1-78D825B73B01}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IBM.Data.DB2.DBCommand", "tracer\test\test-applications\regression\IBM.Data.DB2.DBCommand\IBM.Data.DB2.DBCommand.csproj", "{E961D189-3EF9-4D79-95A1-78D825B73B01}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Devart.Data.DBCommand", "tracer\test\test-applications\regression\Devart.Data.DBCommand\Devart.Data.DBCommand.csproj", "{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Devart.Data.DBCommand", "tracer\test\test-applications\regression\Devart.Data.DBCommand\Devart.Data.DBCommand.csproj", "{24834112-8C25-4A3D-BDD3-0ACEC825FF2C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjectionHelper.VersionConflict", "tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj", "{E9D55D41-B161-492F-9EC7-FF2F2231A587}"
 EndProject
@@ -465,6 +465,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.Tests", "tracer\test\Datadog.Trace.Tools.Runner.Tests\Datadog.Trace.Tools.Runner.Tests.csproj", "{595BB494-CD26-4A51-8E5B-009219E3F2AE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.Telemetry", "tracer\test\test-applications\integrations\Samples.Telemetry\Samples.Telemetry.csproj", "{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.AutomaticInstrumentation", "tracer\test\test-applications\regression\Sandbox.AutomaticInstrumentation\Sandbox.AutomaticInstrumentation.csproj", "{10619BA2-AED1-482A-8570-BB7C7B83DDDC}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -2254,6 +2256,18 @@ Global
 		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}.Release|x86.Build.0 = Release|x86
 		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7}.Release|Any CPU.ActiveCfg = Release|x86
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|Any CPU.Build.0 = Debug|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|x64.ActiveCfg = Debug|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|x64.Build.0 = Debug|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|x86.ActiveCfg = Debug|x86
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Debug|x86.Build.0 = Debug|x86
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|Any CPU.ActiveCfg = Release|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|Any CPU.Build.0 = Release|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|x64.ActiveCfg = Release|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|x64.Build.0 = Release|x64
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|x86.ActiveCfg = Release|x86
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -2423,6 +2437,7 @@ Global
 		{887AC8BA-35A6-4646-BF9A-59357155805E} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{595BB494-CD26-4A51-8E5B-009219E3F2AE} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{2D1FF937-3237-4A1B-9C6C-82FA5E22CAD7} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{10619BA2-AED1-482A-8570-BB7C7B83DDDC} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1098,6 +1098,7 @@ partial class Build
                 "Samples.OracleMDA.Core", // We don't test these yet
                 "MismatchedTracerVersions",
                 "IBM.Data.DB2.DBCommand",
+                "Sandbox.AutomaticInstrumentation", // Doesn't run on Linux
             };
 
             // These sample projects are built using RestoreAndBuildSamplesForPackageVersions

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -876,7 +876,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
 
         first_jit_compilation_app_domains.insert(module_metadata->app_domain_id);
 
-        hr = RunILStartupHook(module_metadata->metadata_emit, module_id, function_token);
+        hr = RunILStartupHook(module_metadata->metadata_emit, module_id, function_token, caller, *module_metadata);
         if (FAILED(hr))
         {
             Logger::Warn("JITCompilationStarted: Call to RunILStartupHook() failed for ", module_id, " ",
@@ -1389,7 +1389,7 @@ HRESULT CorProfiler::RewriteForDistributedTracing(const ModuleMetadata& module_m
     {
         Logger::Info(GetILCodes("After -> GetDistributedTracer. ", &getterRewriter,
                                 GetFunctionInfo(module_metadata.metadata_import, getDistributedTraceMethodDef),
-                                module_metadata));
+                                module_metadata.metadata_import));
     }
 
     return hr;
@@ -1410,7 +1410,7 @@ const std::string indent_values[] = {
 };
 
 std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
-                                    const ModuleMetadata& module_metadata)
+                                    const ComPtr<IMetaDataImport2>& metadata_import)
 {
     std::stringstream orig_sstream;
     orig_sstream << title;
@@ -1432,7 +1432,7 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
     if (localVarSig != mdTokenNil)
     {
         auto hr =
-            module_metadata.metadata_import->GetSigFromToken(localVarSig, &originalSignature, &originalSignatureSize);
+            metadata_import->GetSigFromToken(localVarSig, &originalSignature, &originalSignatureSize);
         if (SUCCEEDED(hr))
         {
             orig_sstream << std::endl
@@ -1539,7 +1539,7 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
 
             if (cInstr->m_opcode == CEE_CALL || cInstr->m_opcode == CEE_CALLVIRT || cInstr->m_opcode == CEE_NEWOBJ)
             {
-                const auto memberInfo = GetFunctionInfo(module_metadata.metadata_import, (mdMemberRef) cInstr->m_Arg32);
+                const auto memberInfo = GetFunctionInfo(metadata_import, (mdMemberRef) cInstr->m_Arg32);
                 orig_sstream << "  | ";
                 orig_sstream << ToString(memberInfo.type.name);
                 orig_sstream << ".";
@@ -1560,7 +1560,7 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
                      cInstr->m_opcode == CEE_UNBOX_ANY || cInstr->m_opcode == CEE_NEWARR ||
                      cInstr->m_opcode == CEE_INITOBJ)
             {
-                const auto typeInfo = GetTypeInfo(module_metadata.metadata_import, (mdTypeRef) cInstr->m_Arg32);
+                const auto typeInfo = GetTypeInfo(metadata_import, (mdTypeRef) cInstr->m_Arg32);
                 orig_sstream << "  | ";
                 orig_sstream << ToString(typeInfo.name);
             }
@@ -1568,7 +1568,7 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
             {
                 WCHAR szString[1024];
                 ULONG szStringLength;
-                auto hr = module_metadata.metadata_import->GetUserString((mdString) cInstr->m_Arg32, szString, 1024,
+                auto hr = metadata_import->GetUserString((mdString) cInstr->m_Arg32, szString, 1024,
                                                                          &szStringLength);
                 if (SUCCEEDED(hr))
                 {
@@ -1609,7 +1609,7 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
 // Startup methods
 //
 HRESULT CorProfiler::RunILStartupHook(const ComPtr<IMetaDataEmit2>& metadata_emit, const ModuleID module_id,
-                                      const mdToken function_token)
+                                      const mdToken function_token, const FunctionInfo& caller, const ModuleMetadata& module_metadata)
 {
     mdMethodDef ret_method_token;
     auto hr = GenerateVoidILStartupMethod(module_id, &ret_method_token);
@@ -2247,6 +2247,16 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     pNewInstr = rewriter_void.NewILInstr();
     pNewInstr->m_opcode = CEE_RET;
     rewriter_void.InsertBefore(pFirstInstr, pNewInstr);
+
+    if (IsDumpILRewriteEnabled())
+    {
+        mdToken token = 0;
+        TypeInfo typeInfo{};
+        WSTRING methodName = WStr("__DDVoidMethodCall__");
+        FunctionInfo caller(token, methodName, typeInfo, MethodSignature(), FunctionMethodSignature());
+        Logger::Info(
+            GetILCodes("*** GenerateVoidILStartupMethod(): Modified Code: ", &rewriter_void, caller, metadata_import));
+    }
 
     hr = rewriter_void.Export();
     if (FAILED(hr))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -81,12 +81,12 @@ private:
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);
     std::string GetILCodes(const std::string& title, ILRewriter* rewriter, const FunctionInfo& caller,
-                           const ModuleMetadata& module_metadata);
+                           const ComPtr<IMetaDataImport2>& metadata_import);
     HRESULT RewriteForDistributedTracing(const ModuleMetadata& module_metadata, ModuleID module_id);
     //
     // Startup methods
     //
-    HRESULT RunILStartupHook(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token);
+    HRESULT RunILStartupHook(const ComPtr<IMetaDataEmit2>&, const ModuleID module_id, const mdToken function_token, const FunctionInfo& caller, const ModuleMetadata& module_metadata);
     HRESULT GenerateVoidILStartupMethod(const ModuleID module_id, mdMethodDef* ret_method_token);
     HRESULT AddIISPreStartInitFlags(const ModuleID module_id, const mdToken function_token);
 

--- a/tracer/src/Datadog.Trace.ClrProfiler.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Native/method_rewriter.cpp
@@ -149,7 +149,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     if (IsDumpILRewriteEnabled())
     {
         original_code = corProfiler->GetILCodes("*** CallTarget_RewriterCallback(): Original Code: ", &rewriter,
-                                                *caller, module_metadata);
+                                                *caller, module_metadata.metadata_import);
     }
 
     // *** Create the rewriter wrapper helper
@@ -546,7 +546,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     if (IsDumpILRewriteEnabled())
     {
         Logger::Info(original_code);
-        Logger::Info(corProfiler->GetILCodes("*** Rewriter(): Modified Code: ", &rewriter, *caller, module_metadata));
+        Logger::Info(corProfiler->GetILCodes("*** Rewriter(): Modified Code: ", &rewriter, *caller, module_metadata.metadata_import));
     }
 
     hr = rewriter.Export();

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Datadog.Trace.AppSec.Transports;
 using Datadog.Trace.AppSec.Transports.Http;
@@ -36,6 +37,10 @@ namespace Datadog.Trace.AppSec
         private readonly IWaf _waf;
         private readonly InstrumentationGateway _instrumentationGateway;
         private readonly SecuritySettings _settings;
+
+#if NETFRAMEWORK
+        private readonly bool _usingIntegratedPipeline;
+#endif
 
         static Security()
         {
@@ -93,7 +98,17 @@ namespace Datadog.Trace.AppSec
                     {
                         _instrumentationGateway.RequestEnd += InstrumentationGatewayInstrumentationGatewayEvent;
 #if NETFRAMEWORK
-                        if (System.Web.HttpRuntime.UsingIntegratedPipeline)
+                        try
+                        {
+                            _usingIntegratedPipeline = TryGetUsingIntegratedPipelineBool();
+                        }
+                        catch (Exception ex)
+                        {
+                            _usingIntegratedPipeline = false;
+                            Log.Error(ex, "Unable to query the IIS pipeline. Request and response information may be limited.");
+                        }
+
+                        if (_usingIntegratedPipeline)
                         {
                             _instrumentationGateway.LastChanceToWriteTags += InstrumentationGateway_AddHeadersResponseTags;
                         }
@@ -308,7 +323,7 @@ namespace Datadog.Trace.AppSec
             {
                 _instrumentationGateway.RequestEnd -= InstrumentationGatewayInstrumentationGatewayEvent;
 #if NETFRAMEWORK
-                if (System.Web.HttpRuntime.UsingIntegratedPipeline)
+                if (_usingIntegratedPipeline)
                 {
                     _instrumentationGateway.LastChanceToWriteTags -= InstrumentationGateway_AddHeadersResponseTags;
                 }
@@ -319,5 +334,15 @@ namespace Datadog.Trace.AppSec
 
             Dispose();
         }
+
+#if NETFRAMEWORK
+        /// <summary>
+        /// ! This method should be called from within a try-catch block !
+        /// If the application is running in partial trust, then trying to call this method will result in
+        /// a SecurityException to be thrown at the method CALLSITE, not inside the <c>TryGetUsingIntegratedPipelineBool(..)</c> method itself.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool TryGetUsingIntegratedPipelineBool() => System.Web.HttpRuntime.UsingIntegratedPipeline;
+#endif
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxAutomaticInstrumentationSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxAutomaticInstrumentationSmokeTest.cs
@@ -16,11 +16,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         {
         }
 
-        [Fact(Skip = "This test fails because the startup hook throws a System.Security.VerificationException")]
+        [Fact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public void Fails()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            CheckForSmoke(shouldDeserializeTraces: false, expectedExitCode: -10);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxAutomaticInstrumentationSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxAutomaticInstrumentationSmokeTest.cs
@@ -1,0 +1,27 @@
+// <copyright file="SandboxAutomaticInstrumentationSmokeTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NET461
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class SandboxAutomaticInstrumentationSmokeTest : SmokeTestBase
+    {
+        public SandboxAutomaticInstrumentationSmokeTest(ITestOutputHelper output)
+            : base(output, "Sandbox.AutomaticInstrumentation")
+        {
+        }
+
+        [Fact(Skip = "This test fails because the startup hook throws a System.Security.VerificationException")]
+        [Trait("Category", "Smoke")]
+        public void NoExceptions()
+        {
+            CheckForSmoke(shouldDeserializeTraces: false);
+        }
+    }
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxManualTracingSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxManualTracingSmokeTest.cs
@@ -17,8 +17,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         }
 
         [SkippableFact]
+        [Trait("Category", "Smoke")]
         public void NoExceptions()
         {
+            EnvironmentHelper.DisableAutomaticInstrumentation();
             CheckForSmoke(shouldDeserializeTraces: false);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxManualTracingSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxManualTracingSmokeTest.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         [Trait("Category", "Smoke")]
         public void NoExceptions()
         {
-            EnvironmentHelper.DisableAutomaticInstrumentation();
+            EnvironmentHelper.SetAutomaticInstrumentation(false);
             CheckForSmoke(shouldDeserializeTraces: false);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -49,7 +49,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         /// Method to execute a smoke test.
         /// </summary>
         /// <param name="shouldDeserializeTraces">Optimization parameter, pass false when the resulting traces aren't being verified</param>
-        protected void CheckForSmoke(bool shouldDeserializeTraces = true)
+        /// <param name="expectedExitCode">Expected exit code</param>
+        protected void CheckForSmoke(bool shouldDeserializeTraces = true, int expectedExitCode = 0)
         {
             var applicationPath = EnvironmentHelper.GetSampleApplicationPath().Replace(@"\\", @"\");
             Output.WriteLine($"Application path: {applicationPath}");
@@ -138,9 +139,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                         Output.WriteLine($"StandardError:{Environment.NewLine}{standardError}");
                     }
 
-                    int exitCode = process.ExitCode;
-
-                    result = new ProcessResult(process, standardOutput, standardError, exitCode);
+                    result = new ProcessResult(process, standardOutput, standardError, process.ExitCode);
                 }
 
                 Spans = agent.Spans;
@@ -154,9 +153,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
             }
 #endif
 
-            var successCode = 0;
-            Assert.True(successCode == result.ExitCode, $"Non-success exit code {result.ExitCode}");
-            Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");
+            Assert.True(expectedExitCode == result.ExitCode, $"Expected exit code: {expectedExitCode}, actual exit code: {result.ExitCode}");
+
+            if (expectedExitCode == 0)
+            {
+                Assert.True(string.IsNullOrEmpty(result.StandardError), $"Expected no errors in smoke test: {result.StandardError}");
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -67,6 +67,8 @@ namespace Datadog.Trace.TestHelpers
 
         public TestTransports TransportType { get; set; } = TestTransports.Tcp;
 
+        public bool AutomaticInstrumentationEnabled { get; private set; } = true;
+
         public bool DebugModeEnabled { get; set; }
 
         public Dictionary<string, string> CustomEnvironmentVariables { get; set; } = new Dictionary<string, string>();
@@ -191,17 +193,20 @@ namespace Datadog.Trace.TestHelpers
             string profilerEnabled = _requiresProfiling ? "1" : "0";
             environmentVariables["DD_DOTNET_TRACER_HOME"] = TracerHome;
 
-            if (IsCoreClr())
+            if (AutomaticInstrumentationEnabled)
             {
-                environmentVariables["CORECLR_ENABLE_PROFILING"] = profilerEnabled;
-                environmentVariables["CORECLR_PROFILER"] = EnvironmentTools.ProfilerClsId;
-                environmentVariables["CORECLR_PROFILER_PATH"] = ProfilerPath;
-            }
-            else
-            {
-                environmentVariables["COR_ENABLE_PROFILING"] = profilerEnabled;
-                environmentVariables["COR_PROFILER"] = EnvironmentTools.ProfilerClsId;
-                environmentVariables["COR_PROFILER_PATH"] = ProfilerPath;
+                if (IsCoreClr())
+                {
+                    environmentVariables["CORECLR_ENABLE_PROFILING"] = profilerEnabled;
+                    environmentVariables["CORECLR_PROFILER"] = EnvironmentTools.ProfilerClsId;
+                    environmentVariables["CORECLR_PROFILER_PATH"] = ProfilerPath;
+                }
+                else
+                {
+                    environmentVariables["COR_ENABLE_PROFILING"] = profilerEnabled;
+                    environmentVariables["COR_PROFILER"] = EnvironmentTools.ProfilerClsId;
+                    environmentVariables["COR_PROFILER_PATH"] = ProfilerPath;
+                }
             }
 
             if (DebugModeEnabled)
@@ -450,6 +455,11 @@ namespace Datadog.Trace.TestHelpers
             }
 
             return $"net{_major}{_minor}{_patch ?? string.Empty}";
+        }
+
+        public void DisableAutomaticInstrumentation()
+        {
+            AutomaticInstrumentationEnabled = false;
         }
 
         public void EnableWindowsNamedPipes(string tracePipeName = null, string statsPipeName = null)

--- a/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Program.cs
@@ -26,7 +26,7 @@ namespace Sandbox.AutomaticInstrumentation
             PermissionSet permSet = new PermissionSet(PermissionState.None);
             permSet.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution)); // REQUIRED to run code.
             permSet.AddPermission(new SecurityPermission(SecurityPermissionFlag.UnmanagedCode)); // REQUIRED for automatic instrumentation.
-            // permSet.AddPermission(new WebPermission(PermissionState.Unrestricted)); // REQUIRED for application to send traces to the Agent over HTTP. Also enables application to generate automatic instrumentation spans.
+            permSet.AddPermission(new WebPermission(PermissionState.Unrestricted)); // REQUIRED for application to send traces to the Agent over HTTP. Also enables application to generate automatic instrumentation spans.
 
             var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation, permSet);
 
@@ -65,6 +65,7 @@ namespace Sandbox.AutomaticInstrumentation
                 {
                     Console.WriteLine($"Failed to send request {i + 1}/{iterations}");
                     Console.WriteLine(ex);
+                    throw;
                 }
             }
         }

--- a/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Program.cs
@@ -1,0 +1,99 @@
+using Samples;
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Security;
+using System.Security.Permissions;
+using System.Text;
+
+namespace Sandbox.ManualTracing
+{
+    public static class Program
+    {
+        private const string ResponseContent = "PONG";
+        private static readonly Encoding Utf8 = Encoding.UTF8;
+
+        public static int Main(string[] args)
+        {
+            // Set up local web server
+            string port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
+            using var server = WebServer.Start(port, out var url);
+            server.RequestHandler = HandleHttpRequests;
+            Console.WriteLine();
+            Console.WriteLine($"Starting HTTP listener at {url}");
+            Console.WriteLine();
+
+            // Set the minimum permissions needed to run code in the new AppDomain
+            PermissionSet permSet = new PermissionSet(PermissionState.None);
+            permSet.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution)); // Necessary to run code.
+            permSet.AddPermission(new WebPermission(PermissionState.Unrestricted)); // Necessary to create a WebRequest object (triggers automatic instrumentation) and to emit traces.
+            // permSet.AddPermission(new FileIOPermission(PermissionState.Unrestricted)); // Necessary to access the file system.
+
+            var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation, permSet);
+
+            try
+            {
+                remote.SetData("url", url);
+                remote.DoCallBack(CreateAutomaticTraces);
+                return (int)ExitCode.Success;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"We have encountered an exception, the smoke test fails: {ex.Message}");
+                Console.Error.WriteLine(ex);
+                return (int)ExitCode.UnknownError;
+            }
+            finally
+            {
+                AppDomain.Unload(remote);
+            }
+        }
+
+        public static void CreateAutomaticTraces()
+        {
+            var url = AppDomain.CurrentDomain.GetData("url") as string;
+            var iterations = 5;
+            for (int i = 0; i < iterations; i++)
+            {
+                // Create separate request objects since .NET Core asserts only one response per request
+                HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(url);
+                request.GetResponse().Close();
+                Console.WriteLine($"Received {i + 1}/{iterations} response for request.GetResponse()");
+            }
+        }
+
+        private static void HandleHttpRequests(HttpListenerContext context)
+        {
+            Console.WriteLine("[HttpListener] received request");
+
+            // read request content and headers
+            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+            {
+                string requestContent = reader.ReadToEnd();
+                Console.WriteLine($"[HttpListener] request content: {requestContent}");
+
+                foreach (string headerName in context.Request.Headers)
+                {
+                    string headerValue = context.Request.Headers[headerName];
+                    Console.WriteLine($"[HttpListener] request header: {headerName}={headerValue}");
+                }
+            }
+
+            // write response content
+            byte[] responseBytes = Utf8.GetBytes(ResponseContent);
+            context.Response.ContentEncoding = Utf8;
+            context.Response.ContentLength64 = responseBytes.Length;
+            context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+
+            // we must close the response
+            context.Response.Close();
+        }
+    }
+
+    enum ExitCode : int
+    {
+        Success = 0,
+        UnknownError = -10
+    }
+}

--- a/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Properties/launchSettings.json
@@ -3,7 +3,7 @@
     "Sandbox.AutomaticInstrumentation": {
       "commandName": "Project",
       "environmentVariables": {
-        "COR_ENABLE_PROFILING": "0",
+        "COR_ENABLE_PROFILING": "1",
         "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
 

--- a/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "Sandbox.AutomaticInstrumentation": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "0",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)tracer\\bin\\tracer-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer\\bin\\tracer-home",
+        "DD_VERSION": "1.0.0"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Sandbox.AutomaticInstrumentation.csproj
+++ b/tracer/test/test-applications/regression/Sandbox.AutomaticInstrumentation/Sandbox.AutomaticInstrumentation.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net461</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
@@ -21,9 +21,8 @@ namespace Sandbox.ManualTracing
         {
             // Set the minimum permissions needed to run code in the new AppDomain
             PermissionSet permSet = new PermissionSet(PermissionState.None);
-            permSet.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution)); // Necessary to run code.
-            // permSet.AddPermission(new WebPermission(PermissionState.Unrestricted)); // Necessary to emit traces. If commented out, the Tracer will not send Traces but it should not crash.
-            // permSet.AddPermission(new FileIOPermission(PermissionState.Unrestricted)); // Necessary to access the file system.
+            permSet.AddPermission(new SecurityPermission(SecurityPermissionFlag.Execution)); // REQUIRED to run code.
+            // permSet.AddPermission(new WebPermission(PermissionState.Unrestricted)); // REQUIRED for application to send traces to the Agent over HTTP.
 
             var remote = AppDomain.CreateDomain("Remote", null, AppDomain.CurrentDomain.SetupInformation, permSet);
 
@@ -69,7 +68,7 @@ namespace Sandbox.ManualTracing
             }
 
             // Sleep so we add more time for Tracer threads to operate in the background
-            Thread.Sleep(5000);
+            Thread.Sleep(2000);
         }
     }
 

--- a/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
@@ -49,7 +49,8 @@ namespace Sandbox.ManualTracing
             // which would require an additional permission to be added
             var configurationSource = new NameValueConfigurationSource(new NameValueCollection()
             {
-                { "DD_RUNTIME_METRICS_ENABLED", "1" }
+                // TODO: Enable AppSec somehow. There is currently no way to enable it inside a sandboxed environment where environment variables and files cannot be accessed
+                { "DD_RUNTIME_METRICS_ENABLED", "1" },
             });
 
             var tracerSettings = new TracerSettings(configurationSource);

--- a/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
@@ -56,24 +56,20 @@ namespace Sandbox.ManualTracing
             var tracerSettings = new TracerSettings(configurationSource);
             Tracer.Configure(tracerSettings);
 
-            for (int i = 0; i < 5; i++)
-            {
-                EmitCustomSpans();
-                Thread.Sleep(2000);
-            }
-        }
-
-        private static void EmitCustomSpans()
-        {
             using (Tracer.Instance.StartActive("custom-span"))
             {
-                Thread.Sleep(1500);
+                // Simulate some work
+                Thread.Sleep(500);
 
                 using (Tracer.Instance.StartActive("inner-span"))
                 {
-                    Thread.Sleep(1500);
+                    // Simulate some work
+                    Thread.Sleep(500);
                 }
             }
+
+            // Sleep so we add more time for Tracer threads to operate in the background
+            Thread.Sleep(5000);
         }
     }
 

--- a/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.ManualTracing/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -10,6 +11,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace;
+using Datadog.Trace.Configuration;
 
 namespace Sandbox.ManualTracing
 {
@@ -27,7 +29,7 @@ namespace Sandbox.ManualTracing
 
             try
             {
-                remote.DoCallBack(RunWebRequestSync);
+                remote.DoCallBack(CreateManualTraces);
                 return (int)ExitCode.Success;
             }
             catch (Exception ex)
@@ -42,8 +44,18 @@ namespace Sandbox.ManualTracing
             }
         }
 
-        public static void RunWebRequestSync()
+        public static void CreateManualTraces()
         {
+            // Create a configuration source so we can enable runtime metrics without relying on environment variables,
+            // which would require an additional permission to be added
+            var configurationSource = new NameValueConfigurationSource(new NameValueCollection()
+            {
+                { "DD_RUNTIME_METRICS_ENABLED", "1" }
+            });
+
+            var tracerSettings = new TracerSettings(configurationSource);
+            Tracer.Configure(tracerSettings);
+
             for (int i = 0; i < 5; i++)
             {
                 EmitCustomSpans();


### PR DESCRIPTION
We previously had a regression test called `Sandbox.ManualTracing` to make sure that a simple usage of custom instrumentation did not cause issues due to code permissions. This PR adds the correct test category to make sure it runs in CI.

This PR also adds a `Sandbox.AutomaticInstrumentation` to run automatic instrumentation in a similar partial trust scenario. However, this application is expected to fail so we expect a failure in its test runs.