### PR TITLE
[Releases][Artifacts] Automatic upload of MSIs and Nugets

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -72,4 +72,4 @@ jobs:
       - name: "Publish nuget packages to nuget.org"
         working-directory: ${{steps.assets.outputs.artifacts_path}}
         run: |
-          dotnet nuget push "*.{{steps.versions.outputs.full_version}}*upkg" --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "*.{{steps.versions.outputs.full_version}}*.nupkg" --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: "Download build assets from Azure Pipelines"
         id: assets
-        run: ./tracer/build.sh DownloadAzurePipelineArtifacts
+        run: ./tracer/build.sh DownloadAzurePipelineAndGitlabArtifacts
         env:
           TargetBranch: ${{ github.event.ref }}
 
@@ -66,3 +66,5 @@ jobs:
             ${{steps.assets.outputs.artifacts_path}}/*.rpm
             ${{steps.assets.outputs.artifacts_path}}/*.tar.gz
             ${{steps.assets.outputs.artifacts_path}}/*.zip
+            ${{steps.assets.outputs.gitlab_artifacts_path}}/*.msi
+            ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -68,3 +68,13 @@ jobs:
             ${{steps.assets.outputs.artifacts_path}}/*.zip
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.msi
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
+
+      - name: "Publish nuget packages to nuget.org"
+        working-directory: ${{steps.assets.outputs.artifacts_path}}
+        run: |
+          dotnet nuget push Datadog.Trace.{{steps.versions.outputs.full_version}}.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Datadog.Trace.{{steps.versions.outputs.full_version}}.snupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Datadog.OpenTracing.{{steps.versions.outputs.full_version}}.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Datadog.OpenTracing.{{steps.versions.outputs.full_version}}.snupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push Datadog.Monitoring.Distribution.{{steps.versions.outputs.full_version}}-beta01.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push dd-trace.{{steps.versions.outputs.full_version}}.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -72,9 +72,4 @@ jobs:
       - name: "Publish nuget packages to nuget.org"
         working-directory: ${{steps.assets.outputs.artifacts_path}}
         run: |
-          dotnet nuget push Datadog.Trace.{{steps.versions.outputs.full_version}}.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-          dotnet nuget push Datadog.Trace.{{steps.versions.outputs.full_version}}.snupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-          dotnet nuget push Datadog.OpenTracing.{{steps.versions.outputs.full_version}}.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-          dotnet nuget push Datadog.OpenTracing.{{steps.versions.outputs.full_version}}.snupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-          dotnet nuget push Datadog.Monitoring.Distribution.{{steps.versions.outputs.full_version}}-beta01.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
-          dotnet nuget push dd-trace.{{steps.versions.outputs.full_version}}.nupkg --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "*.{{steps.versions.outputs.full_version}}*upkg" --api-key {{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,11 +4,11 @@ stages:
   
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
-  DRIVER_S3_BUCKET: dd-windowsfilter
     
 driver_build:
   only:
     - master
+    - main
   stage: binary_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,11 @@ stages:
   
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
+  DRIVER_S3_BUCKET: dd-windowsfilter
     
 driver_build:
   only:
-    - web
+    - master
   stage: binary_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
@@ -18,7 +19,7 @@ driver_build:
     - mkdir artifacts
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
     - remove-item -recurse -force build-out\${CI_JOB_ID}
-#    - aws s3 cp --region us-east-1 --recursive --exclude "*" --include "*.msm" --include "*.msi" artifacts/ s3://$DRIVER_S3_BUCKET/builds/
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi
     - get-childitem build-out
     - get-childitem artifacts
   artifacts:

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -269,8 +269,7 @@ partial class Build
                 string line;
                 while ((line = reader.ReadLine()) != null)
                 {
-                    if (!line.StartsWith("⚠ 1. Download the NuGet packages")
-                     && !line.StartsWith("⚠ 2. Download the signed"))
+                    if (!line.StartsWith("⚠ 1. Download the NuGet packages"))
                     {
                         sb.AppendLine(line);
                     }
@@ -811,7 +810,7 @@ partial class Build
 
     static async Task DownloadGitlabArtifacts(AbsolutePath outputDirectory, string commitSha, string version)
     {
-        var awsUri = $"https://dd-windowsfilter.s3.amazonaws.com/builds/{commitSha}/";
+        var awsUri = $"https://dd-windowsfilter.s3.amazonaws.com/builds/tracer/{commitSha}/";
         var artifactsFiles= new [] 
         {
             $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi", 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -813,14 +813,14 @@ partial class Build
         var awsUri = $"https://dd-windowsfilter.s3.amazonaws.com/builds/tracer/{commitSha}/";
         var artifactsFiles= new [] 
         {
-            $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi", 
+            $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi",
             $"{awsUri}x86/en-us/datadog-dotnet-apm-{version}-x86.msi", 
             $"{awsUri}windows-native-symbols.zip"
         };
 
         foreach (var fileToDownload in artifactsFiles)
         {
-            var fileName = fileToDownload.Substring(fileToDownload.LastIndexOf('/'));
+            var fileName = fileToDownload.Substring(fileToDownload.LastIndexOf('/') + 1);
             var destination = outputDirectory / commitSha / fileName;
             EnsureExistingDirectory(destination);
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -412,7 +412,7 @@ partial class Build
 
     Target DownloadAzurePipelineAndGitlabArtifacts => _ => _
        .Unlisted()
-       .Description("Downloads the latest artifacts from Azure Devops anf Gitlab that has the provided version")
+       .Description("Downloads the latest artifacts from Azure Devops and Gitlab that has the provided version")
        .DependsOn(CreateRequiredDirectories)
        .Requires(() => AzureDevopsToken)
        .Requires(() => Version)
@@ -458,8 +458,8 @@ partial class Build
             for (var i = 0; i < maxCommitsBack; i++)
             {
                 commitSha = GitTasks.Git($"log {TargetBranch}~{i} -1 --pretty=%H")
-                                        .FirstOrDefault(x => x.Type == OutputType.Std)
-                                        .Text;
+                                    .FirstOrDefault(x => x.Type == OutputType.Std)
+                                    .Text;
 
                 Logger.Info($"Looking for builds for {commitSha}");
 
@@ -804,7 +804,7 @@ partial class Build
 
         foreach (var fileToDownload in artifactsFiles)
         {
-            var fileName = fileToDownload.Substring(fileToDownload.LastIndexOf('/') + 1);
+            var fileName = Path.GetFileName(fileToDownload);
             var destination = outputDirectory / commitSha / fileName;
             EnsureExistingDirectory(destination);
 


### PR DESCRIPTION
Signed MSIs are built on GitLab. To prevent a manual step in the release, we change things in 2 places.

- We enable Gitlab builds on master. Those build now publish the signed MSIs to S3, in folders named by commit sha, to make it easily discoverable when doing a release.
- The action creating the release, now downloads those artifacts and attach them to the release

Note that the `builds` folder in the S3 bucket already has a 30 days lifecycle rule.

Regarding nugets, I rely on dotnet nuget to push them at the end of the release.

AIT-364 AIT-366

@DataDog/apm-dotnet