### PR TITLE
Add env variable in CI builds to select a specific ref for the continuous profiler build

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -101,6 +101,7 @@ variables:
   DiffEngine_Disabled: true
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])]
   NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY: true
+  GIT_PROFILER_REF: master
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:
@@ -117,6 +118,7 @@ resources:
     type: github
     endpoint: DataDog
     name: DataDog/dd-continuous-profiler-dotnet
+    ref: $(GIT_PROFILER_REF)
 
 # Stages
 stages:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -101,7 +101,6 @@ variables:
   DiffEngine_Disabled: true
   OriginalCommitId: $[coalesce(variables['System.PullRequest.SourceCommitId'], variables['Build.SourceVersion'])]
   NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY: true
-  GIT_PROFILER_REF: master
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -199,7 +199,7 @@ stages:
       displayName: Create symlink from $(System.DefaultWorkingDirectory)\..\dd-trace-dotnet to $(System.DefaultWorkingDirectory)
 
     - powershell: |
-        Write-Host "Attempting to check out ref specified by GIT_PROFILER_REF: '${GIT_PROFILER_REF}'"
+        Write-Host "Attempting to check out ref specified by GIT_PROFILER_REF: '$(GIT_PROFILER_REF)'"
         git checkout $(GIT_PROFILER_REF)
       workingDirectory: $(System.DefaultWorkingDirectory)\..\dd-continuous-profiler-dotnet
       displayName: Checkout GIT_PROFILER_REF

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -199,8 +199,9 @@ stages:
       displayName: Create symlink from $(System.DefaultWorkingDirectory)\..\dd-trace-dotnet to $(System.DefaultWorkingDirectory)
 
     - powershell: |
-        Write-Host "Attempting to checkout git ref GIT_PROFILER_REF=$(GIT_PROFILER_REF)"
+        Write-Host "Attempting to check out ref specified by GIT_PROFILER_REF: '${GIT_PROFILER_REF}'"
         git checkout $(GIT_PROFILER_REF)
+      workingDirectory: $(System.DefaultWorkingDirectory)\..\dd-continuous-profiler-dotnet
       displayName: Checkout GIT_PROFILER_REF
 
     - powershell: |

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -118,7 +118,7 @@ resources:
     type: github
     endpoint: DataDog
     name: DataDog/dd-continuous-profiler-dotnet
-    ref: $(GIT_PROFILER_REF)
+    ref: $[variables.GIT_PROFILER_REF]
 
 # Stages
 stages:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -118,7 +118,6 @@ resources:
     type: github
     endpoint: DataDog
     name: DataDog/dd-continuous-profiler-dotnet
-    ref: $[variables.GIT_PROFILER_REF]
 
 # Stages
 stages:
@@ -199,6 +198,11 @@ stages:
     - powershell: |
         New-Item -Path $(System.DefaultWorkingDirectory)\..\dd-trace-dotnet -ItemType SymbolicLink -Value $(System.DefaultWorkingDirectory)
       displayName: Create symlink from $(System.DefaultWorkingDirectory)\..\dd-trace-dotnet to $(System.DefaultWorkingDirectory)
+
+    - powershell: |
+        Write-Host "Attempting to checkout git ref GIT_PROFILER_REF=$(GIT_PROFILER_REF)"
+        git checkout $(GIT_PROFILER_REF)
+      displayName: Checkout GIT_PROFILER_REF
 
     - powershell: |
         $sha = git rev-parse --short HEAD

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ stages:
   
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
+  GIT_PROFILER_REF: master
     
 driver_build:
   only:
@@ -13,7 +14,8 @@ driver_build:
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
-    - git clone https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/dd-continuous-profiler-dotnet.git
+    - Write-Host "Attempting to clone profiler repo with GIT_PROFILER_REF=${GIT_PROFILER_REF}"
+    - git clone -b ${GIT_PROFILER_REF} https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/dd-continuous-profiler-dotnet.git
     - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_x64:$Env:DATADOG_AGENT_WINBUILDIMAGES c:\mnt\tracer\build\_build\gitlab.bat
     - mkdir artifacts
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts


### PR DESCRIPTION
I have confirmed that it works in both Azure DevOps and GitLab pipelines. Let me know if you have feedback on the environment variable name.

Note: In the Azure DevOps build pipeline, we use a repository reference for the continuous profiler repo. The repository resource does allow us to [specify a specific ref](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#checking-out-a-specific-ref), however there are [reported issues](https://developercommunity.visualstudio.com/t/allow-variables-at-resourcesrepositoriesrepository/816606) that it cannot be set by build variables. This means we are forced to checkout the target ref in a script step.

@DataDog/apm-dotnet