### PR TITLE
Add retry to cosmosdb initialization

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -540,6 +540,7 @@ stages:
         Start-CosmosDbEmulator -Timeout 300
       displayName: 'Start CosmosDB Emulator'
       workingDirectory: $(Pipeline.Workspace)
+      retryCountOnTaskFailure: 5
 
     - powershell: |
         Write-Host "Initializing LocalDB"


### PR DESCRIPTION
We've had a lot of failures for cosmosdb not starting. Add some retries

@DataDog/apm-dotnet