### PR TITLE
Add a stage in the gitlab build for artifacts upload

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,3 +43,11 @@ publish:
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
     - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
+    - |
+      if( -not $? )
+      {
+        $msg = $Error[0].Exception.Message
+        Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
+        Write-Output "Retrying..."
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
+      }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,15 +1,16 @@
 
 stages:
-  - binary_build
+  - build
+  - publish
   
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
     
-driver_build:
+build:
   only:
     - master
     - main
-  stage: binary_build
+  stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
@@ -19,10 +20,26 @@ driver_build:
     - mkdir artifacts
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
     - remove-item -recurse -force build-out\${CI_JOB_ID}
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
     - get-childitem build-out
     - get-childitem artifacts
   artifacts:
     expire_in: 2 weeks
     paths:
     - artifacts
+
+publish:
+  only:
+    - master
+    - main
+  stage: publish
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  dependencies: 
+    - build
+  script:
+    - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
+    - $resultjson = $result | convertfrom-json
+    - $credentials = $($resultjson.Credentials)
+    - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
+    - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
+    - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"


### PR DESCRIPTION
I've done a few changes:
- Added a stage to publish artifacts
- Renamed stages
- Added credentials
- Added a retry mechanism because it failed on my first attempt with a known flaky error. The retry mechanism itself hasn't been tested, because obviously the copy didn't failed after I've implemented it.

I've finaly understood that I can test the job on a branch by removing the the `only` parameter. This one is working.



@DataDog/apm-dotnet