### PR TITLE
Small tidy up of the build for serverless tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -659,8 +659,9 @@ stages:
       inputs:
         artifact: linux-tracer-home-$(baseImage)
         path: $(System.DefaultWorkingDirectory)/tracer/serverlessArtifacts
+
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests
+        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests serverless-lambda serverless-integration-trace-context-mock
         docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies
       env:
         baseImage: $(baseImage)
@@ -675,6 +676,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           framework=$(publishTargetFramework)
+          tracerhome=$(relativeTracerHome)
         dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) IntegrationTests
         projectName: ddtrace_$(Build.BuildNumber)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -655,7 +655,8 @@ stages:
         command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg tracerhome=$(relativeTracerHome) IntegrationTests serverless-lambda serverless-integration-trace-context-mock
+        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg tracerhome=$(relativeTracerHome) serverless-lambda-no-param-sync serverless-lambda-one-param-sync serverless-lambda-two-params-sync serverless-lambda-no-param-async serverless-lambda-one-param-async serverless-lambda-two-params-async serverless-integration-trace-context-mock
+        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests
         docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies
       env:
         baseImage: $(baseImage)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -654,14 +654,8 @@ stages:
         baseImage: $(baseImage)
         command: "BuildLinuxIntegrationTests --framework $(publishTargetFramework)"
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux tracer home
-      inputs:
-        artifact: linux-tracer-home-$(baseImage)
-        path: $(System.DefaultWorkingDirectory)/tracer/serverlessArtifacts
-
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) IntegrationTests serverless-lambda serverless-integration-trace-context-mock
+        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg tracerhome=$(relativeTracerHome) IntegrationTests serverless-lambda serverless-integration-trace-context-mock
         docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies
       env:
         baseImage: $(baseImage)

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@ packages/
 **/bin/
 **/obj/
 
+!tracer/src/bin/
+!tracer/test/test-applications/integrations/Samples.AWS.Lambda/bin/
 !tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/bin/
 !tracer/src/WindowsInstaller/bin/
 

--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -458,7 +458,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.LargePayload", "tracer\test\test-applications\integrations\Samples.LargePayload\Samples.LargePayload.csproj", "{C94E0739-1DA0-4657-8D53-FA4143F6FDA3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.AWS.Lambda", "tracer\test\test-applications\integrations\Samples.AWS.Lambda\Samples.AWS.Lambda.csproj", "{31D192AF-5454-4D91-97E1-889723AAD309}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.AWS.Lambda", "tracer\test\test-applications\integrations\Samples.AWS.Lambda\Samples.AWS.Lambda.csproj", "{31D192AF-5454-4D91-97E1-889723AAD309}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Console", "tracer\test\test-applications\integrations\Samples.Console\Samples.Console.csproj", "{887AC8BA-35A6-4646-BF9A-59357155805E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Tools.Runner.Tests", "tracer\test\Datadog.Trace.Tools.Runner.Tests\Datadog.Trace.Tools.Runner.Tests.csproj", "{595BB494-CD26-4A51-8E5B-009219E3F2AE}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -454,6 +454,12 @@ services:
       - kafka-zookeeper
       - aws_sqs
       - couchbase
+      - serverless-lambda-no-param-sync
+      - serverless-lambda-one-param-sync
+      - serverless-lambda-two-params-sync
+      - serverless-lambda-no-param-async
+      - serverless-lambda-one-param-async
+      - serverless-lambda-two-params-async
       - serverless-integration-trace-context-mock
 
   ExplorationTests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,11 +273,14 @@ services:
 
   serverless-lambda-no-param-sync:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.lambda.dockerfile
+      context: ./
+      dockerfile: ./tracer/build/_build/docker/serverless.lambda.dockerfile
+      args:
+        - tracerhome=/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
     depends_on:
       - serverless-integration-trace-context-mock
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNoParamSync"
+    image: dd-trace-dotnet/serverless-lambda-noparamsync
     environment:
       - DD_TRACE_AGENT_URL=http://integrationtests:5002
       - _DD_TRACE_CONTEXT_ENDPOINT=http://serverless-integration-trace-context-mock:9003
@@ -286,11 +289,14 @@ services:
 
   serverless-lambda-one-param-sync:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.lambda.dockerfile
+      context: ./
+      dockerfile: ./tracer/build/_build/docker/serverless.lambda.dockerfile
+      args:
+        - tracerhome=/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
     depends_on:
       - serverless-integration-trace-context-mock
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerOneParamSync"
+    image: dd-trace-dotnet/serverless-lambda-oneparamsync
     environment:
       - DD_TRACE_AGENT_URL=http://integrationtests:5002
       - _DD_TRACE_CONTEXT_ENDPOINT=http://serverless-integration-trace-context-mock:9003
@@ -299,11 +305,14 @@ services:
 
   serverless-lambda-two-params-sync:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.lambda.dockerfile
+      context: ./
+      dockerfile: ./tracer/build/_build/docker/serverless.lambda.dockerfile
+      args:
+        - tracerhome=/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
     depends_on:
       - serverless-integration-trace-context-mock
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerTwoParamsSync"
+    image: dd-trace-dotnet/serverless-lambda-twoparamsync
     environment:
       - DD_TRACE_AGENT_URL=http://integrationtests:5002
       - _DD_TRACE_CONTEXT_ENDPOINT=http://serverless-integration-trace-context-mock:9003
@@ -312,11 +321,14 @@ services:
 
   serverless-lambda-no-param-async:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.lambda.dockerfile
+      context: ./
+      dockerfile: ./tracer/build/_build/docker/serverless.lambda.dockerfile
+      args:
+        - tracerhome=/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
     depends_on:
       - serverless-integration-trace-context-mock
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerNoParamAsync"
+    image: dd-trace-dotnet/serverless-lambda-noparamasync
     environment:
       - DD_TRACE_AGENT_URL=http://integrationtests:5002
       - _DD_TRACE_CONTEXT_ENDPOINT=http://serverless-integration-trace-context-mock:9003
@@ -325,11 +337,14 @@ services:
 
   serverless-lambda-one-param-async:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.lambda.dockerfile
+      context: ./
+      dockerfile: ./tracer/build/_build/docker/serverless.lambda.dockerfile
+      args:
+        - tracerhome=/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
     depends_on:
       - serverless-integration-trace-context-mock
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerOneParamAsync"
+    image: dd-trace-dotnet/serverless-lambda-oneparamasync
     environment:
       - DD_TRACE_AGENT_URL=http://integrationtests:5002
       - _DD_TRACE_CONTEXT_ENDPOINT=http://serverless-integration-trace-context-mock:9003
@@ -338,11 +353,14 @@ services:
 
   serverless-lambda-two-params-async:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.lambda.dockerfile
+      context: ./
+      dockerfile: ./tracer/build/_build/docker/serverless.lambda.dockerfile
+      args:
+        - tracerhome=/${relativeTracerHome:-tracer/src/bin/windows-tracer-home}
     depends_on:
       - serverless-integration-trace-context-mock
     command: "Samples.AWS.Lambda::Samples.AWS.Lambda.Function::HandlerTwoParamsAsync"
+    image: dd-trace-dotnet/serverless-lambda-oneparamasync
     environment:
       - DD_TRACE_AGENT_URL=http://integrationtests:5002
       - _DD_TRACE_CONTEXT_ENDPOINT=http://serverless-integration-trace-context-mock:9003
@@ -351,8 +369,8 @@ services:
 
   serverless-integration-trace-context-mock:
     build:
-      context: ./tracer
-      dockerfile: build/_build/docker/serverless.tracecontextmock.dockerfile
+      context: ./tracer/build/_build
+      dockerfile: docker/serverless.tracecontextmock.dockerfile
     image: dd-trace-dotnet/serverless-trace-context-mock
     ports:
       - "9003:9003"

--- a/tracer/build/_build/docker/serverless.lambda.dockerfile
+++ b/tracer/build/_build/docker/serverless.lambda.dockerfile
@@ -1,12 +1,13 @@
 FROM public.ecr.aws/lambda/dotnet:core3.1
+ARG tracerhome
 
 # Add Tracer
-COPY ./serverlessArtifacts /opt/datadog
+COPY ./$tracerhome /opt/datadog
 
 # Add Tests
-COPY ./serverlessArtifacts/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.dll /var/task/
-COPY ./serverlessArtifacts/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.deps.json /var/task/
-COPY ./serverlessArtifacts/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.runtimeconfig.json /var/task/
+COPY ./$tracerhome/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.dll /var/task/
+COPY ./$tracerhome/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.deps.json /var/task/
+COPY ./$tracerhome/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.runtimeconfig.json /var/task/
 
 ENV DD_LOG_LEVEL="DEBUG"
 ENV DD_TRACE_ENABLED=true


### PR DESCRIPTION
The new serverless docker files were adding benign errors to the build logs, and were doing additional downloads of the tracer home directory. This tidies up the build slightly, without touching any functionality.

Includes an auto-fix for incorrect sln file configurations

@DataDog/apm-dotnet