### PR TITLE
Remove `TraceContext.SamplingPriority` setter

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler
                 if (!addToTraceContext && span.Context.TraceContext.SamplingPriority == null)
                 {
                     // If we don't add the span to the trace context, then we need to manually call the sampler
-                    span.Context.TraceContext.SamplingPriority = tracer.TracerManager.Sampler?.GetSamplingPriority(span);
+                    span.Context.TraceContext.SetSamplingPriority(tracer.TracerManager.Sampler?.GetSamplingPriority(span));
                 }
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ExtensionMethods
 
             if (span.Context is SpanContext spanContext && spanContext.TraceContext != null)
             {
-                spanContext.TraceContext.SamplingPriority = samplingPriority;
+                spanContext.TraceContext.SetSamplingPriority(samplingPriority);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -177,7 +177,7 @@ namespace Datadog.Trace
                         Enum.IsDefined(typeof(SamplingPriority), samplingPriority))
                     {
                         // allow setting the sampling priority via a tag
-                        Context.TraceContext.SamplingPriority = samplingPriority;
+                        Context.TraceContext.SetSamplingPriority(samplingPriority);
                     }
 
                     break;
@@ -185,7 +185,7 @@ namespace Datadog.Trace
                     if (value?.ToBoolean() == true)
                     {
                         // user-friendly tag to set UserKeep priority
-                        Context.TraceContext.SamplingPriority = SamplingPriority.UserKeep;
+                        Context.TraceContext.SetSamplingPriority(SamplingPriority.UserKeep);
                     }
 
                     break;
@@ -193,7 +193,7 @@ namespace Datadog.Trace
                     if (value?.ToBoolean() == true)
                     {
                         // user-friendly tag to set UserReject priority
-                        Context.TraceContext.SamplingPriority = SamplingPriority.UserReject;
+                        Context.TraceContext.SetSamplingPriority(SamplingPriority.UserReject);
                     }
 
                     break;

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace
                 }
                 else
                 {
-                    SetSamplingPriority(span, _samplingPriority.Value);
+                    AddSamplingPriorityTags(span, _samplingPriority.Value);
                 }
             }
 
@@ -164,7 +164,7 @@ namespace Datadog.Trace
             return Elapsed + (_utcStart - date);
         }
 
-        private static void SetSamplingPriority(Span span, SamplingPriority samplingPriority)
+        private static void AddSamplingPriorityTags(Span span, SamplingPriority samplingPriority)
         {
             if (span.Tags is CommonTags tags)
             {
@@ -191,7 +191,7 @@ namespace Datadog.Trace
             // Using a for loop to avoid the boxing allocation on ArraySegment.GetEnumerator
             for (int i = 0; i < spans.Count; i++)
             {
-                SetSamplingPriority(spans.Array[i + spans.Offset], samplingPriority.Value);
+                AddSamplingPriorityTags(spans.Array[i + spans.Offset], samplingPriority.Value);
             }
         }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -36,15 +36,11 @@ namespace Datadog.Trace
         public IDatadogTracer Tracer { get; }
 
         /// <summary>
-        /// Gets or sets sampling priority.
+        /// Gets the trace's sampling priority.
         /// </summary>
         public SamplingPriority? SamplingPriority
         {
             get => _samplingPriority;
-            set
-            {
-                SetSamplingPriority(value);
-            }
         }
 
         private TimeSpan Elapsed => StopwatchHelpers.GetElapsed(Stopwatch.GetTimestamp() - _timestamp);

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -343,12 +343,17 @@ namespace Datadog.Trace
             // otherwise start a new trace context
             if (parent is SpanContext parentSpanContext)
             {
-                traceContext = parentSpanContext.TraceContext
-                    ?? new TraceContext(this) { SamplingPriority = parentSpanContext.SamplingPriority ?? DistributedTracer.Instance.GetSamplingPriority() };
+                traceContext = parentSpanContext.TraceContext;
+                if (traceContext == null)
+                {
+                    traceContext = new TraceContext(this);
+                    traceContext.SetSamplingPriority(parentSpanContext.SamplingPriority ?? DistributedTracer.Instance.GetSamplingPriority());
+                }
             }
             else
             {
-                traceContext = new TraceContext(this) { SamplingPriority = DistributedTracer.Instance.GetSamplingPriority() };
+                traceContext = new TraceContext(this);
+                traceContext.SetSamplingPriority(DistributedTracer.Instance.GetSamplingPriority());
             }
 
             var finalServiceName = serviceName ?? DefaultServiceName;

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -138,10 +138,8 @@ namespace Datadog.Trace.Tests
             tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>()))
                   .Callback<ArraySegment<Span>>(s => spans = s);
 
-            var traceContext = new TraceContext(tracer.Object)
-            {
-                SamplingPriority = SamplingPriority.UserKeep
-            };
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(SamplingPriority.UserKeep);
 
             var rootSpan = CreateSpan();
 
@@ -191,10 +189,8 @@ namespace Datadog.Trace.Tests
             tracer.Setup(t => t.Write(It.IsAny<ArraySegment<Span>>()))
                   .Callback<ArraySegment<Span>>(s => spans = s);
 
-            var traceContext = new TraceContext(tracer.Object)
-            {
-                SamplingPriority = SamplingPriority.UserKeep
-            };
+            var traceContext = new TraceContext(tracer.Object);
+            traceContext.SetSamplingPriority(SamplingPriority.UserKeep);
 
             var rootSpan = CreateSpan();
 


### PR DESCRIPTION
Currently `TraceContext` has two ways to set `SamplingPriority`:

```csharp
// property setter
public SamplingPriority? SamplingPriority { get; set; }

// method with optional `notifyDistributedTracer` parameter
public void SetSamplingPriority(SamplingPriority? samplingPriority, bool notifyDistributedTracer = true);
```

To simplify the API and avoid confusion, this PR replaces all uses of the `SamplingPriority` property setter with `SetSamplingPriority(SamplingPriority?, /* true */)` and removes the property setter. This change also makes the `notifyDistributedTracer` option more discoverable whenever someone is setting the `SamplingPriority`.

~Bonus: simplify the logic in `Tracer.CreateSpanContext()` used to (sometimes) create a `TraceContext` and (sometimes) set its `SamplingPriority`.~ (reverted)