### PR TITLE
[Release] Make Gitlab artifacts download non blocking

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -37,7 +37,7 @@ jobs:
         id: release_notes
         run: ./tracer/build.sh GenerateReleaseNotes
         env:
-          PIPELINE_ARTIFACTS_LINK: ${{steps.assets.outputs.artifacts_link}}
+          GITLAB_ARTIFACTS_DOWNLOADED: ${{steps.assets.outputs.gitlab_artifacts_downloaded}}
 
       - name: "Rename vNext milestone"
         id: rename


### PR DESCRIPTION
No need to block a release for something we can do manually.

It didn't work in the last release because of an access forbidden. Which is weird as I had done tests locally and it worked. I need to check if the folder isn't public anymore (in a meeting now, so can't MFA). 




@DataDog/apm-dotnet