### PR TITLE
Re-use ultimate pipeline on forked repositories

### DIFF
--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -10,14 +10,16 @@
 
 steps:
 - script: |
-    TARGET_URL="https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=$(Build.BuildId)"
+    TARGET_URL="https://dev.azure.com/datadoghq/$(PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
     curl -X POST \
     -H "Accept: application/vnd.github.v3+json" \
     -H "Authorization: Bearer $(GITHUB_TOKEN)" \
-    https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$(OriginalCommitId) \
+    https://api.github.com/repos/DataDog/$(REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
     -d '{"state":"${{ parameters.status }}","context":"${{ parameters.checkName }}","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'
   displayName: Set GitHub Status ${{ parameters.status }}
   condition: and(succeededOrFailed(), ne(variables['Build.BuildId'], ''))
   continueOnError: true
   env:
+    PROJECT_NAME: $(AZURE_PROJECT_NAME)
     GITHUB_TOKEN: $(GITHUB_TOKEN)
+    REPOSITORY_NAME: $(GITHUB_REPOSITORY_NAME)

--- a/.azure-pipelines/steps/update-github-status.yml
+++ b/.azure-pipelines/steps/update-github-status.yml
@@ -10,16 +10,16 @@
 
 steps:
 - script: |
-    TARGET_URL="https://dev.azure.com/datadoghq/$(PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
+    TARGET_URL="https://dev.azure.com/datadoghq/$(AZURE_PROJECT_NAME)/_build/results?buildId=$(Build.BuildId)"
     curl -X POST \
     -H "Accept: application/vnd.github.v3+json" \
     -H "Authorization: Bearer $(GITHUB_TOKEN)" \
-    https://api.github.com/repos/DataDog/$(REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
+    https://api.github.com/repos/DataDog/$(GITHUB_REPOSITORY_NAME)/statuses/$(OriginalCommitId) \
     -d '{"state":"${{ parameters.status }}","context":"${{ parameters.checkName }}","description":"${{ parameters.description }}","target_url":"'"$TARGET_URL"'"}'
   displayName: Set GitHub Status ${{ parameters.status }}
   condition: and(succeededOrFailed(), ne(variables['Build.BuildId'], ''))
   continueOnError: true
   env:
-    PROJECT_NAME: $(AZURE_PROJECT_NAME)
+    AZURE_PROJECT_NAME: $(AZURE_PROJECT_NAME)
     GITHUB_TOKEN: $(GITHUB_TOKEN)
-    REPOSITORY_NAME: $(GITHUB_REPOSITORY_NAME)
+    GITHUB_REPOSITORY_NAME: $(GITHUB_REPOSITORY_NAME)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -89,6 +89,7 @@ variables:
   relativeRunnerTool: tracer/src/bin/runnerTool
   relativeRunnerStandalone: tracer/src/bin/runnerStandalone
   ddApiKey: $(DD_API_KEY)
+  isMainRepository: $[eq(variables['GITHUB_REPOSITORY_NAME'], 'dd-trace-dotnet')]
   isMainBranch: $[in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main')]
   isMainOrReleaseBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hostfix/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
@@ -947,9 +948,8 @@ stages:
         baseImage: $(baseImage)
         command: "CheckBuildLogsForErrors"
 
-
 - stage: benchmarks
-  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
   dependsOn: build_windows_tracer
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -1231,9 +1231,8 @@ stages:
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
 
-
 - stage: upload_to_s3
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
   dependsOn: [package_windows, build_linux, build_arm64]
   jobs:
   - job: s3_upload
@@ -1327,7 +1326,7 @@ stages:
         )
 
 - stage: upload_to_azure
-  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'))
+  condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), eq(variables.isMainRepository, true))
   dependsOn: [package_windows, build_linux, build_arm64, dotnet_tool]
   jobs:
     - job: upload
@@ -1435,7 +1434,7 @@ stages:
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
 
 - stage: throughput
-  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
   dependsOn: [build_linux, build_arm64, build_windows_tracer]
   pool: Throughput
   jobs:
@@ -1505,7 +1504,7 @@ stages:
         DD_ENV: CI
 
 - stage: throughput_appsec
-  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
   dependsOn: [build_linux]
   pool: Throughput-AppSec
   jobs:
@@ -1533,7 +1532,6 @@ stages:
       displayName: Crank
       env:
         DD_SERVICE: dd-trace-dotnet-appsec
-
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isScheduledBuild'], 'False'), ne(variables['isNgenTestBuild'], 'True'))
@@ -1576,7 +1574,7 @@ stages:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 - stage: execution_benchmarks
-  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'))
+  condition: and(succeeded(), ne(variables['isNgenTestBuild'], 'True'), eq(variables.isMainRepository, true))
   dependsOn: [build_windows_tracer]
   jobs:
   - template: steps/update-github-status-jobs.yml

--- a/tracer/build/_build/BenchmarkComparison/CompareBenchmarks.cs
+++ b/tracer/build/_build/BenchmarkComparison/CompareBenchmarks.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CompareBenchmarks.cs" company="Datadog">
+// <copyright file="CompareBenchmarks.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -8,9 +8,9 @@ namespace BenchmarkComparison
 {
     public static class CompareBenchmarks
     {
-        public static string GetMarkdown(string masterDir, string prDir, int prNumber, string oldCommit)
+        public static string GetMarkdown(string masterDir, string prDir, int prNumber, string oldCommit, string repositoryName)
         {
-            var oldBranchMarkdown = $"[master](https://github.com/DataDog/dd-trace-dotnet/tree/{oldCommit})";
+            var oldBranchMarkdown = $"[master](https://github.com/DataDog/${repositoryName}/tree/{oldCommit})";
             var newBranchMarkdown = $"#{prNumber}";
 
             var baseJsonResults = BenchmarkParser.ReadJsonResults(masterDir);

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -85,7 +85,7 @@ partial class Build
        .Unlisted()
        .Requires(() => GitHubRepositoryName)
        .Requires(() => GitHubToken)
-                                       .Requires(() => Version)
+       .Requires(() => Version)
        .Executes(async() =>
         {
             var client = GetGitHubClient();
@@ -301,7 +301,7 @@ partial class Build
        .Unlisted()
        .Requires(() => GitHubRepositoryName)
        .Requires(() => GitHubToken)
-                                       .Requires(() => Version)
+       .Requires(() => Version)
        .Executes(async () =>
         {
             const string fixes = "Fixes";

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -46,7 +46,7 @@ partial class Build
     readonly bool ExpectChangelogUpdate = true;
 
     [Parameter("Git repository name", Name = "GITHUB_REPOSITORY_NAME")]
-    readonly string GitHubRepositoryName;
+    readonly string GitHubRepositoryName = "dd-trace-dotnet";
 
     const string GitHubRepositoryOwner = "DataDog";
     const string AzureDevopsOrganisation = "https://dev.azure.com/datadoghq";
@@ -57,6 +57,7 @@ partial class Build
 
     Target AssignPullRequestToMilestone => _ => _
        .Unlisted()
+       .Requires(() => GitHubRepositoryName)
        .Requires(() => GitHubToken)
        .Requires(() => PullRequestNumber)
        .Executes(async() =>

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -33,8 +33,17 @@ partial class Build
     [Parameter("A GitHub token (for use in GitHub Actions)", Name = "GITHUB_TOKEN")]
     readonly string GitHubToken;
 
+    [Parameter("Git repository name", Name = "GITHUB_REPOSITORY_NAME", List = false)]
+    readonly string GitHubRepositoryName = "dd-trace-dotnet";
+
     [Parameter("An Azure Devops PAT (for use in GitHub Actions)", Name = "AZURE_DEVOPS_TOKEN")]
     readonly string AzureDevopsToken;
+
+    [Parameter("Azure Devops pipeline id", Name = "AZURE_DEVOPS_PIPELINE_ID", List = false)]
+    readonly int AzureDevopsConsolidatePipelineId = 54;
+
+    [Parameter("Azure Devops project id", Name = "AZURE_DEVOPS_PROJECT_ID", List = false)]
+    readonly Guid AzureDevopsProjectId = Guid.Parse("a51c4863-3eb4-4c5d-878a-58b41a049e4e");
 
     [Parameter("The Pull Request number for GitHub Actions")]
     readonly int? PullRequestNumber;
@@ -45,13 +54,8 @@ partial class Build
     [Parameter("Is the ChangeLog expected to change?", List = false)]
     readonly bool ExpectChangelogUpdate = true;
 
-    [Parameter("Git repository name", Name = "GITHUB_REPOSITORY_NAME")]
-    readonly string GitHubRepositoryName = "dd-trace-dotnet";
-
     const string GitHubRepositoryOwner = "DataDog";
     const string AzureDevopsOrganisation = "https://dev.azure.com/datadoghq";
-    const int AzureDevopsConsolidatePipelineId = 54;
-    static readonly Guid AzureDevopsProjectId = Guid.Parse("a51c4863-3eb4-4c5d-878a-58b41a049e4e");
 
     string FullVersion => IsPrerelease ? $"{Version}-prerelease" : Version;
 
@@ -79,8 +83,9 @@ partial class Build
 
     Target RenameVNextMilestone => _ => _
        .Unlisted()
+       .Requires(() => GitHubRepositoryName)
        .Requires(() => GitHubToken)
-       .Requires(() => Version)
+                                       .Requires(() => Version)
        .Executes(async() =>
         {
             var client = GetGitHubClient();
@@ -294,8 +299,9 @@ partial class Build
 
     Target GenerateReleaseNotes => _ => _
        .Unlisted()
+       .Requires(() => GitHubRepositoryName)
        .Requires(() => GitHubToken)
-       .Requires(() => Version)
+                                       .Requires(() => Version)
        .Executes(async () =>
         {
             const string fixes = "Fixes";
@@ -523,6 +529,7 @@ partial class Build
          .Unlisted()
          .DependsOn(CreateRequiredDirectories)
          .Requires(() => AzureDevopsToken)
+         .Requires(() => GitHubRepositoryName)
          .Requires(() => GitHubToken)
          .Executes(async () =>
           {
@@ -582,6 +589,7 @@ partial class Build
          .Unlisted()
          .DependsOn(CreateRequiredDirectories)
          .Requires(() => AzureDevopsToken)
+         .Requires(() => GitHubRepositoryName)
          .Requires(() => GitHubToken)
          .Executes(async () =>
          {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -45,8 +45,10 @@ partial class Build
     [Parameter("Is the ChangeLog expected to change?", List = false)]
     readonly bool ExpectChangelogUpdate = true;
 
+    [Parameter("Git repository name", Name = "GITHUB_REPOSITORY_NAME")]
+    readonly string GitHubRepositoryName;
+
     const string GitHubRepositoryOwner = "DataDog";
-    const string GitHubRepositoryName = "dd-trace-dotnet";
     const string AzureDevopsOrganisation = "https://dev.azure.com/datadoghq";
     const int AzureDevopsConsolidatePipelineId = 54;
     static readonly Guid AzureDevopsProjectId = Guid.Parse("a51c4863-3eb4-4c5d-878a-58b41a049e4e");
@@ -278,7 +280,7 @@ partial class Build
 
                 // Write the new entry
                 file.WriteLine();
-                file.WriteLine($"## [Release {FullVersion}](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v{FullVersion})");
+                file.WriteLine($"## [Release {FullVersion}](https://github.com/DataDog/{GitHubRepositoryName}/releases/tag/v{FullVersion})");
                 file.WriteLine();
                 file.WriteLine(releaseNotes);
                 file.WriteLine();
@@ -359,7 +361,7 @@ partial class Build
 
             if (previousRelease is not null)
             {
-                sb.AppendLine($"[Changes since {previousRelease.Name}](https://github.com/DataDog/dd-trace-dotnet/compare/v{previousRelease.Name}...v{nextVersion})")
+                sb.AppendLine($"[Changes since {previousRelease.Name}](https://github.com/DataDog/{GitHubRepositoryName}/compare/v{previousRelease.Name}...v{nextVersion})")
                   .AppendLine();
             }
 
@@ -550,8 +552,8 @@ partial class Build
               var oldReportPath = oldReportdir / oldArtifact.Name / $"summary{oldBuildId}" / "Cobertura.xml";
               var newReportPath = newReportdir / newArtifact.Name / $"summary{newBuildId}" / "Cobertura.xml";
 
-              var reportOldLink = $"{AzureDevopsOrganisation}/dd-trace-dotnet/_build/results?buildId={oldBuildId}&view=codecoverage-tab";
-              var reportNewLink = $"{AzureDevopsOrganisation}/dd-trace-dotnet/_build/results?buildId={newBuildId}&view=codecoverage-tab";
+              var reportOldLink = $"{AzureDevopsOrganisation}/${GitHubRepositoryName}/_build/results?buildId={oldBuildId}&view=codecoverage-tab";
+              var reportNewLink = $"{AzureDevopsOrganisation}/${GitHubRepositoryName}/_build/results?buildId={newBuildId}&view=codecoverage-tab";
 
               var downloadOldLink = oldArtifact.Resource.DownloadUrl;
               var downloadNewLink = newArtifact.Resource.DownloadUrl;
@@ -561,6 +563,7 @@ partial class Build
 
               var comparison = Covertura.CodeCoverage.Compare(oldReport, newReport);
               var markdown = Covertura.CodeCoverage.RenderAsMarkdown(
+                  GitHubRepositoryName,
                   comparison,
                   prNumber,
                   downloadOldLink,
@@ -601,7 +604,7 @@ partial class Build
 
              var (oldBuild, _) = await FindAndDownloadAzureArtifact(buildHttpClient, "refs/heads/master", build => "benchmarks_results", masterDir, buildReason: null);
 
-             var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion);
+             var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion, GitHubRepositoryName);
 
              await HideCommentsInPullRequest(prNumber, "## Benchmarks Report");
              await PostCommentToPullRequest(prNumber, markdown);

--- a/tracer/build/_build/Covertura/CompareReports.cs
+++ b/tracer/build/_build/Covertura/CompareReports.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CompareReports.cs" company="Datadog">
+// <copyright file="CompareReports.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -158,6 +158,7 @@ namespace Covertura
         }
 
         public static string RenderAsMarkdown(
+            string repositoryName,
             CoverturaReportComparison comparison,
             int prNumber,
             string oldDownloadLink,
@@ -167,10 +168,10 @@ namespace Covertura
             string oldCommit,
             string newCommit)
         {
-            var oldBranchMarkdown = $"[master](https://github.com/DataDog/dd-trace-dotnet/tree/{oldCommit})";
+            var oldBranchMarkdown = $"[master](https://github.com/DataDog/${repositoryName}/tree/{oldCommit})";
             var newBranchMarkdown = $"#{prNumber}";
-            var prFiles = $"https://github.com/DataDog/dd-trace-dotnet/pull/{prNumber}/files";
-            var tree = $"https://github.com/DataDog/dd-trace-dotnet/tree/{newCommit}";
+            var prFiles = $"https://github.com/DataDog/${repositoryName}/pull/{prNumber}/files";
+            var tree = $"https://github.com/DataDog/${repositoryName}/tree/{newCommit}";
             var oldReport = comparison.Old;
             var newReport = comparison.New;
 


### PR DESCRIPTION
This PR allows re-using ultimate pipeline on forked repositories.

Changes proposed in this pull request:
Convert hard coded repository name to parameter.
Skip stages, that are not relevant for forked repositories.

@DataDog/apm-dotnet