### PR TITLE
create_draft_release GH action can't use a shallow checkout

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@v1
         with:


### PR DESCRIPTION
We have to walk the commit history to find the right build to use (if the latest commit doesn't have a build), so we need to have the history available

@DataDog/apm-dotnet