### PR TITLE
Explicitly allow public reads on objects we upload to S3 from gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --acl bucket-owner-full-control
     - |
       if( -not $? )
       {

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,5 +51,5 @@ publish:
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,12 +38,12 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants full=id="7c1bcc5bc514572e2b2be86cd8534f06d5c87e2da82a2a8ac49bf298a34e594e"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants full=id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grants full=id="7c1bcc5bc514572e2b2be86cd8534f06d5c87e2da82a2a8ac49bf298a34e594e"
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grants full=id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,18 +32,18 @@ publish:
   dependencies: 
     - build
   script:
-    - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
+    - $result =  aws sts assume-role --role-arn "arn:aws:iam::727006795293:role/build-stable-cloudfront-invalidation" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json
     - $credentials = $($resultjson.Credentials)
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
 variables:
   DATADOG_AGENT_WINBUILDIMAGES: v5996510-a9e6a7d
   GIT_PROFILER_REF: master
+  GRANT_PUBLIC_ACCESS_RIGHTS: --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
     
 build:
   only:
@@ -44,12 +45,12 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" ${GRANT_PUBLIC_ACCESS_RIGHTS}
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" ${GRANT_PUBLIC_ACCESS_RIGHTS}
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,12 +38,12 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants full=id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --acl bucket-owner-full-control --grant-read uri=http://acs.amazonaws.com/groups/global/AllUsers
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grants full=id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --acl bucket-owner-full-control --grant-read uri=http://acs.amazonaws.com/groups/global/AllUsers
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,12 +38,12 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --acl bucket-owner-full-control
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,9 @@ variables:
   GIT_PROFILER_REF: master
     
 build:
+  only:
+    - master
+    - main
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
@@ -27,6 +30,9 @@ build:
     - artifacts
 
 publish:
+  only:
+    - master
+    - main
   stage: publish
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,12 +38,12 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --acl bucket-owner-full-control --grant-read uri=http://acs.amazonaws.com/groups/global/AllUsers
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --acl bucket-owner-full-control --grant-read uri=http://acs.amazonaws.com/groups/global/AllUsers
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,18 +32,18 @@ publish:
   dependencies: 
     - build
   script:
-    - $result =  aws sts assume-role --role-arn "arn:aws:iam::727006795293:role/build-stable-cloudfront-invalidation" --role-session-name AWSCLI-Session
+    - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json
     - $credentials = $($resultjson.Credentials)
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
       }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,9 +8,6 @@ variables:
   GIT_PROFILER_REF: master
     
 build:
-  only:
-    - master
-    - main
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
@@ -30,9 +27,6 @@ build:
     - artifacts
 
 publish:
-  only:
-    - master
-    - main
   stage: publish
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,12 +38,12 @@ publish:
     - $Env:AWS_ACCESS_KEY_ID="$($credentials.AccessKeyId)"
     - $Env:AWS_SECRET_ACCESS_KEY="$($credentials.SecretAccessKey)"
     - $Env:AWS_SESSION_TOKEN="$($credentials.SessionToken)"
-    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
+    - aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants full=id="7c1bcc5bc514572e2b2be86cd8534f06d5c87e2da82a2a8ac49bf298a34e594e"
     - |
       if( -not $? )
       {
         $msg = $Error[0].Exception.Message
         Write-Output "Encountered error during while publishing to S3. Error Message is $msg."
         Write-Output "Retrying..."
-        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grant-full-control id="612548d92af7fa77f7ad7bcab230494f7310438ac6332e904a8fb2e6daa5cb23"
+        aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip"  --grants full=id="7c1bcc5bc514572e2b2be86cd8534f06d5c87e2da82a2a8ac49bf298a34e594e"
       }


### PR DESCRIPTION
So the files uploaded by gitlab weren't accessible publicly even though.
Need to make it explicit at upload



@DataDog/apm-dotnet