### PR TITLE
[Release] Create the right folder when downloading gitlab artifacts

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -809,7 +809,7 @@ partial class Build
         foreach (var fileToDownload in artifactsFiles)
         {
             var fileName = Path.GetFileName(fileToDownload);
-            var destinationFile = outputDirectory / commitSha / fileName;
+            var destinationFile = destination / fileName;
 
             Console.WriteLine($"Downloading {fileToDownload} to {destinationFile}...");
             var response = await client.GetAsync(fileToDownload);

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -802,14 +802,16 @@ partial class Build
             $"{awsUri}windows-native-symbols.zip"
         };
 
+        var destination = outputDirectory / commitSha;
+        EnsureExistingDirectory(destination);
+
         using var client = new HttpClient();
         foreach (var fileToDownload in artifactsFiles)
         {
             var fileName = Path.GetFileName(fileToDownload);
-            var destination = outputDirectory / commitSha / fileName;
-            EnsureExistingDirectory(destination);
+            var destinationFile = outputDirectory / commitSha / fileName;
 
-            Console.WriteLine($"Downloading {fileName} to {destination}...");
+            Console.WriteLine($"Downloading {fileToDownload} to {destinationFile}...");
             var response = await client.GetAsync(fileToDownload);
 
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
Previously, the code was creating the folder containing the file name.

@DataDog/apm-dotnet