### PR TITLE
Don't log to Console.WriteLine

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/StartupLogger.cs
@@ -37,8 +37,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                         // ignore
                     }
                 }
-
-                Console.Error.WriteLine(message, args);
             }
             catch
             {


### PR DESCRIPTION
Just ran into this while testing something unrelated. Not sure exactly why it happened, but we shouldn't write to the console unprovoked, as it could break people's logs etc. Especially when we're running in CI etc, and people may be grepping logs for other things

@DataDog/apm-dotnet