### PR TITLE
[Build] No op pipeline should be considering PR exclusion filters

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -64,6 +64,7 @@ pr:
       - .gitlab-ci.yml
       - tracer/build/_build/Build.GitHub.cs
       - tracer/build/_build/Build.Gitlab.cs
+      - .azure-pipelines/noop-pipeline.yml
 
 schedules:
   - cron: "0 3 * * *"

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -312,7 +312,7 @@ partial class Build : NukeBuild
 
            var config = GetPipelineDefinition();
 
-           var excludePaths = config.Trigger?.Paths?.Exclude ?? Array.Empty<string>();
+           var excludePaths = config.Pr?.Paths?.Exclude ?? Array.Empty<string>();
            Logger.Info($"Found {excludePaths.Length} exclude paths");
 
            var gitChanges = GetGitChangedFiles(baseBranch);


### PR DESCRIPTION
No op pipeline runs on PRs. When evaluating whether it should run or not, it should consider PR exclusion paths only.
Currently, it does consider trigger path (thus the exclusion path for master) which leads to blocking situation because some PRs won't run the no-op nor the consolidated pipelines

Changes proposed in this pull request:




@DataDog/apm-dotnet