### PR TITLE
[Release] Fix the artifacts download for real?

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -819,7 +819,7 @@ partial class Build
                 throw new Exception($"Error downloading GitLab artifacts: {response.StatusCode}:{response.ReasonPhrase}");
             }
 
-            await using (var file = File.Create(destination))
+            await using (var file = File.Create(destinationFile))
             {
                 await response.Content.CopyToAsync(file);
             }


### PR DESCRIPTION
Sorry for all those back and forth. It seems that I shouldn't code anymore
I was trying to write a file to a directory. Which I assume explains why I get an `UnauthorizedAccessException` while trying to wirte the file

cf https://github.com/DataDog/dd-trace-dotnet/runs/5029260401?check_suite_focus=true#step:6:44

Changes proposed in this pull request:




@DataDog/apm-dotnet