### PR TITLE
Update FluentAssertions to 6.4.0

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/EquivalencyAssertionOptionsExtensions.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/EquivalencyAssertionOptionsExtensions.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
             {
                 ctx.Subject.Should().ContainKeys(presentTags);
                 ctx.Subject.ExceptKeys(presentTags).Should().Equal(ctx.Expectation);
-            }).When(info => info.SelectedMemberPath.EndsWith("Tags"));
+            }).When(info => info.Path.EndsWith("Tags"));
         }
 
         public static EquivalencyAssertionOptions<MockSpan> AssertMetricsMatchExcludingKeys(this EquivalencyAssertionOptions<MockSpan> options, params string[] excludedKeys)
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Helpers
             return options.Using<Dictionary<string, double>>(ctx =>
             {
                 ctx.Subject.ExceptKeys(excludedKeys).Should().Equal(ctx.Expectation);
-            }).When(info => info.SelectedMemberPath.EndsWith("Metrics"));
+            }).When(info => info.Path.EndsWith("Metrics"));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogDuckTypingTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="NLogDuckTypingTests.cs" company="Datadog">
+// <copyright file="NLogDuckTypingTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
             instance.DuckCast<ILoggingConfigurationProxy>();
             instance.TryDuckCast(out ILoggingConfigurationProxy duck).Should().BeTrue();
             duck.Should().NotBeNull();
-            duck.ConfiguredNamedTargets.Should().BeEmpty();
+            duck.ConfiguredNamedTargets.Cast<object>().Should().BeEmpty();
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
 
             instanceWithoutProperties.Properties["TestKey"] = "TestValue";
             duckWithoutProperties.HasProperties.Should().BeTrue();
-            duckWithoutProperties.Properties.Should().ContainKey("TestKey").WhichValue.Should().Be("TestValue");
+            duckWithoutProperties.Properties.Should().ContainKey("TestKey").WhoseValue.Should().Be("TestValue");
         }
 #elif NLOG_43
         [Fact]

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogDuckTypingTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SerilogDuckTypingTests.cs" company="Datadog">
+// <copyright file="SerilogDuckTypingTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
 
             instance.TryDuckCast(out ILogEvent duck).Should().BeTrue();
             var intLevel = (int)instance.Level;
-            var intLevel2 = (LogEventLevelDuck)duck.Level;
+            var intLevel2 = (int)duck.Level;
             duck.Should().NotBeNull();
             duck.Exception.Should().Be(instance.Exception);
             intLevel2.Should().Be(intLevel);
@@ -74,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
 
             config.TryDuckCast(out ILoggerConfiguration duckConfig).Should().BeTrue();
             duckConfig.Should().NotBeNull();
-            duckConfig.LogEventSinks.Should().BeEmpty();
+            duckConfig.LogEventSinks.Cast<object>().Should().BeEmpty();
 
             Type sinkType = typeof(ILogEventSink);
             var sink = new TestSerilogSink();

--- a/tracer/test/Datadog.Trace.Tests/Logging/SerilogDuckTypeTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/SerilogDuckTypeTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SerilogDuckTypeTests.cs" company="Datadog">
+// <copyright file="SerilogDuckTypeTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Tests.Logging
             var proxy = logEvent.DuckCast<LogEventProxy>();
 
             proxy.Properties.Should().NotBeNull();
-            proxy.Properties.Should().BeEmpty();
+            proxy.Properties.Count.Should().Be(0);
 
             logEvent.AddPropertyIfAbsent(new LogEventProperty("key", new ScalarValue("value")));
 

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -159,7 +159,7 @@ namespace Datadog.Trace.Tests
             // but a full flush should be triggered rather than a partial, because every span in the trace has been closed
             traceContext.CloseSpan(rootSpan);
 
-            spans.Should().NotBeNullOrEmpty("a full flush should have been triggered");
+            spans.Value.Should().NotBeNullOrEmpty("a full flush should have been triggered");
 
             rootSpan.GetMetric(Metrics.SamplingPriority).Should().Be(SamplingPriorityValues.UserKeep, "priority should be assigned to the root span");
 
@@ -205,7 +205,7 @@ namespace Datadog.Trace.Tests
                 traceContext.CloseSpan(span);
             }
 
-            spans.Should().NotBeNullOrEmpty("partial flush should have been triggered");
+            spans.Value.Should().NotBeNullOrEmpty("partial flush should have been triggered");
 
             spans.Value.Should().OnlyContain(s => (int)s.GetMetric(Metrics.SamplingPriority) == SamplingPriorityValues.UserKeep);
         }

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
This is needed for https://github.com/DataDog/dd-trace-dotnet/pull/2337, but it introduces a few extra changes (because they removed assertions on non-generic collections) so I prefer to push it as a separate PR.