### PR TITLE
Bind the agent in the CLI tests

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessHelper.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.TestHelpers
             return _outputTask.Task.Wait(timeout) && _errorTask.Task.Wait(timeout);
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (!Process.HasExited)
             {


### PR DESCRIPTION
Actually bind the agent in the CLI tests, to avoid having connection errors in the logs.