### PR TITLE
Display a warning when a test has been running for too long

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tests/CustomTestFramework.cs
@@ -112,6 +112,12 @@ namespace Datadog.Trace.Tests
 
                 _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"STARTED: {test}"));
 
+                using var timer = new Timer(
+                    _ => _diagnosticMessageSink.OnMessage(new DiagnosticMessage($"WARNING: {test} has been running for more than 15 minutes")),
+                    null,
+                    TimeSpan.FromMinutes(15),
+                    Timeout.InfiniteTimeSpan);
+
                 try
                 {
                     var result = await base.RunTestCaseAsync(testCase);


### PR DESCRIPTION
When a test is stuck forever, it takes a non-trivial amount of effort to parse the output of the CI to find exactly which test is still running. This PR displays a warning message after 15 minutes, so the culprit can be easily spotted.