### PR TITLE
Configurable timeout for the WAF

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -308,10 +308,10 @@ namespace Datadog.Trace.AppSec
             }
 
             // run the WAF and execute the results
-            using var wafResult = additiveContext.Run(args);
+            using var wafResult = additiveContext.Run(args, _settings.WafTimeoutMicroSeconds);
             if (wafResult.ReturnCode == ReturnCode.Monitor || wafResult.ReturnCode == ReturnCode.Block)
             {
-                var block = _settings.BlockingEnabled && wafResult.ReturnCode == ReturnCode.Block;
+                var block = wafResult.ReturnCode == ReturnCode.Block;
                 if (block)
                 {
                     // blocking has been removed, waiting a better implementation

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.AppSec
         public IReadOnlyList<string> ExtraHeaders { get; }
 
         /// <summary>
-        /// Gets the path to a user definted WAF Rules file.
+        /// Gets the path to a user-defined WAF Rules file.
         /// Default is null, meaning uses embedded rule set
         /// </summary>
         public string Rules { get; }

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -6,31 +6,37 @@
 using System;
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.AppSec
 {
     internal class SecuritySettings
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SecuritySettings>();
+
         public SecuritySettings(IConfigurationSource source)
         {
             // both should default to false
             Enabled = source?.GetBool(ConfigurationKeys.AppSecEnabled) ?? false;
-            BlockingEnabled = source?.GetBool(ConfigurationKeys.AppSecBlockingEnabled) ?? false;
             Rules = source?.GetString(ConfigurationKeys.AppSecRules);
             CustomIpHeader = source?.GetString(ConfigurationKeys.AppSecCustomIpHeader);
             var extraHeaders = source?.GetString(ConfigurationKeys.AppSecExtraHeaders);
             ExtraHeaders = !string.IsNullOrEmpty(extraHeaders) ? extraHeaders.Split(',') : Array.Empty<string>();
             KeepTraces = source?.GetBool(ConfigurationKeys.AppSecKeepTraces) ?? true;
-            var traceRateLimitString = source?.GetString(ConfigurationKeys.AppSecTraceRateLimit);
+
             // empty or junk values to default to 100, any number is valid, with zero or less meaning limit off
-            if (traceRateLimitString != null && int.TryParse(traceRateLimitString, out var traceRateLimit))
+            TraceRateLimit = source?.GetInt32(ConfigurationKeys.AppSecTraceRateLimit) ?? 100;
+
+            // Default timeout of 100 ms, only extreme conditions should cause timeout
+            const int defaultWafTimeout = 100_000;
+            var wafTimeout = source?.GetInt32(ConfigurationKeys.AppSecWafTimeout) ?? defaultWafTimeout;
+            if (wafTimeout <= 0)
             {
-                TraceRateLimit = traceRateLimit;
+                wafTimeout = defaultWafTimeout;
+                Log.Warning<string, int>("Ignoring '{WafTimeoutKey}'  of '{WafTimeout}' because it was zero or less", ConfigurationKeys.AppSecWafTimeout, wafTimeout);
             }
-            else
-            {
-                TraceRateLimit = 100;
-            }
+
+            WafTimeoutMicroSeconds = (ulong)wafTimeout;
         }
 
         public bool Enabled { get; set; }
@@ -42,16 +48,27 @@ namespace Datadog.Trace.AppSec
         /// </summary>
         public IReadOnlyList<string> ExtraHeaders { get; }
 
-        public bool BlockingEnabled { get; }
-
+        /// <summary>
+        /// Gets the path to a user definted WAF Rules file.
+        /// Default is null, meaning uses embedded rule set
+        /// </summary>
         public string Rules { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether traces should be mark traces with manual keep below trace rate limit
+        /// Default is true
+        /// </summary>
         public bool KeepTraces { get; }
 
         /// <summary>
         /// Gets the limit of AppSec traces sent per second with an integer value, strictly positive.
         /// </summary>
         public int TraceRateLimit { get; }
+
+        /// <summary>
+        /// Gets the limit for the amount of time the WAF will perform analysis
+        /// </summary>
+        public ulong WafTimeoutMicroSeconds { get; }
 
         public static SecuritySettings FromDefaultSources()
         {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.AppSec.Waf
             Dispose(false);
         }
 
-        public IResult Run(IDictionary<string, object> args)
+        public IResult Run(IDictionary<string, object> args, ulong timeoutMicroSeconds)
         {
             var pwArgs = encoder.Encode(args, argCache);
 
@@ -45,7 +45,7 @@ namespace Datadog.Trace.AppSec.Waf
             var rawAgs = pwArgs.RawPtr;
             DdwafResultStruct retNative = default;
 
-            var code = wafNative.Run(contextHandle, rawAgs, ref retNative, 1000000);
+            var code = wafNative.Run(contextHandle, rawAgs, ref retNative, timeoutMicroSeconds);
 
             var ret = new Result(retNative, code, wafNative);
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IContext.cs
@@ -5,12 +5,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Datadog.Trace.AppSec.Waf
 {
     internal interface IContext : IDisposable
     {
-        IResult Run(IDictionary<string, object> args);
+        IResult Run(IDictionary<string, object> args, ulong timeoutMicroSeconds);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -53,12 +53,6 @@ namespace Datadog.Trace.Configuration
         public const string AppSecEnabled = "DD_APPSEC_ENABLED";
 
         /// <summary>
-        /// Configuration key for enabling or disabling blocking in AppSec.
-        /// Default is value is false (disabled).
-        /// </summary>
-        public const string AppSecBlockingEnabled = "DD_APPSEC_BLOCKING_ENABLED";
-
-        /// <summary>
         /// Override the default rules file provided. Must be a path to a valid JSON rules file.
         /// Default is value is null (do not override).
         /// </summary>
@@ -87,6 +81,11 @@ namespace Datadog.Trace.Configuration
         /// Limits the amount of AppSec traces sent per second with an integer value, strictly positive.
         /// </summary>
         internal const string AppSecTraceRateLimit = "DD_APPSEC_TRACE_RATE_LIMIT";
+
+        /// <summary>
+        /// Limits the amount of AppSec traces sent per second with an integer value, strictly positive.
+        /// </summary>
+        internal const string AppSecWafTimeout = "DD_APPSEC_WAF_TIMEOUT";
 
         /// <summary>
         /// Configuration key for enabling or disabling the Tracer's debug mode.

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -322,9 +322,6 @@ namespace Datadog.Trace
                     writer.WritePropertyName("appsec_enabled");
                     writer.WriteValue(Security.Instance.Settings.Enabled);
 
-                    writer.WritePropertyName("appsec_blocking_enabled");
-                    writer.WriteValue(Security.Instance.Settings.BlockingEnabled);
-
                     writer.WritePropertyName("appsec_trace_rate_limit");
                     writer.WriteValue(Security.Instance.Settings.TraceRateLimit);
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -79,7 +79,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
-            SetAppSecBlockingEnabled(blockingEnabled);
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             _blockingEnabled = blockingEnabled;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -102,7 +102,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
-            SetAppSecBlockingEnabled(blockingEnabled);
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             _blockingEnabled = blockingEnabled;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             using var waf = Waf.Create();
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
-            var result = context.Run(args);
+            var result = context.Run(args, 100_000);
             result.ReturnCode.Should().Be(ReturnCode.Monitor);
             var resultData = JsonConvert.DeserializeObject<WafMatch[]>(result.Data).FirstOrDefault();
             resultData.Rule.Tags.Type.Should().Be(flow);

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -221,11 +220,6 @@ namespace Datadog.Trace.TestHelpers
             if (enableSecurity)
             {
                 environmentVariables[ConfigurationKeys.AppSecEnabled] = enableSecurity.ToString();
-            }
-
-            if (enableBlocking)
-            {
-                environmentVariables[ConfigurationKeys.AppSecBlockingEnabled] = enableBlocking.ToString();
             }
 
             if (!string.IsNullOrEmpty(externalRulesFile))

--- a/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TestHelper.cs
@@ -348,11 +348,6 @@ namespace Datadog.Trace.TestHelpers
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecEnabled, security ? "true" : "false");
         }
 
-        protected void SetAppSecBlockingEnabled(bool appSecBlockingEnabled)
-        {
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSecBlockingEnabled, appSecBlockingEnabled ? "true" : "false");
-        }
-
         protected void EnableDirectLogSubmission(int intakePort, string integrationName, string host = "integration_tests")
         {
             SetEnvironmentVariable(ConfigurationKeys.DirectLogSubmission.Host, host);


### PR DESCRIPTION
This allows users to configure a timeout for the WAF. This feature requested by some clients and is a safety mechanism added to stop the WAF consuming too much CPU.

I also removed the config relating to blocking as it's unlike to be used, as blocking is like to have a different configuration mechanism.



@DataDog/apm-dotnet