### PR TITLE
clean up `StartSpan()` and `StartActive()` overloads in `Tracer`

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -174,7 +174,13 @@ namespace Datadog.Trace.MSBuild
 
                 string projectName = Path.GetFileName(e.ProjectFile);
 
-                Span projectSpan = _tracer.StartSpan(BuildTags.BuildOperationName, parent: parentSpan.Context, serviceName: projectName);
+                Span projectSpan = _tracer.StartSpan(BuildTags.BuildOperationName, parent: parentSpan.Context);
+
+                if (projectName != null)
+                {
+                    projectSpan.ServiceName = projectName;
+                }
+
                 projectSpan.ResourceName = projectName;
                 projectSpan.SetTraceSamplingPriority(SamplingPriorityValues.AutoKeep);
                 projectSpan.Type = SpanTypes.Build;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.MsTestV2
             string testSuite = testMethodInfo.TestClassName;
             string testName = testMethodInfo.TestMethodName;
 
-            Scope scope = Tracer.Instance.StartActiveInternal("mstest.test", serviceName: Tracer.Instance.DefaultServiceName);
+            Scope scope = Tracer.Instance.StartActiveInternal("mstest.test");
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
             string skipReason = null;
 
-            Scope scope = Tracer.Instance.StartActiveInternal("nunit.test", serviceName: Tracer.Instance.DefaultServiceName);
+            Scope scope = Tracer.Instance.StartActiveInternal("nunit.test");
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.XUnit
 
             string testFramework = "xUnit";
 
-            Scope scope = Tracer.Instance.StartActiveInternal("xunit.test", serviceName: Tracer.Instance.DefaultServiceName);
+            Scope scope = Tracer.Instance.StartActiveInternal("xunit.test");
             Span span = scope.Span;
 
             span.Type = SpanTypes.Test;

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler
     {
         public int? GetSamplingPriority()
         {
-            return (int?)Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext?.SamplingPriority;
+            return Tracer.Instance.InternalActiveScope?.Span.Context?.TraceContext?.SamplingPriority;
         }
 
         public void SetSamplingPriority(int? samplingPriority)

--- a/tracer/src/Datadog.Trace/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/SpanContextPropagator.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace
                 setter(carrier, HttpHeaderNames.Origin, context.Origin);
             }
 
-            var samplingPriority = (int?)(context.TraceContext?.SamplingPriority ?? context.SamplingPriority);
+            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
 
             if (samplingPriority != null)
             {

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -291,7 +291,7 @@ namespace Datadog.Trace
                 parent = SpanContext.None;
             }
 
-            var span = StartSpan(operationName, parent, startTime);
+            var span = StartSpan(operationName, tags: null, parent, serviceName: null, startTime);
 
             if (serviceName != null)
             {
@@ -332,18 +332,6 @@ namespace Datadog.Trace
             return TracerManager.ScopeManager.Activate(span, finishOnClose);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="ISpan"/> with the specified parameters.
-        /// </summary>
-        /// <param name="operationName">The span's operation name</param>
-        /// <param name="parent">The span's parent</param>
-        /// <param name="startTime">An explicit start time for that span</param>
-        /// <returns>The newly created span</returns>
-        internal Span StartSpan(string operationName, ISpanContext parent = null, DateTimeOffset? startTime = null)
-        {
-            return StartSpan(operationName, tags: null, parent, serviceName: null, startTime);
-        }
-
         internal SpanContext CreateSpanContext(ISpanContext parent = null, string serviceName = null, ulong? traceId = null, ulong? spanId = null)
         {
             // null parent means use the currently active span
@@ -381,7 +369,7 @@ namespace Datadog.Trace
             return TracerManager.ScopeManager.Activate(span, finishOnClose);
         }
 
-        internal Span StartSpan(string operationName, ITags tags, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, ulong? traceId = null, ulong? spanId = null, bool addToTraceContext = true)
+        internal Span StartSpan(string operationName, ITags tags = null, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, ulong? traceId = null, ulong? spanId = null, bool addToTraceContext = true)
         {
             var spanContext = CreateSpanContext(parent, serviceName, traceId, spanId);
 

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -363,7 +363,7 @@ namespace Datadog.Trace
             return spanContext;
         }
 
-        internal Scope StartActiveInternal(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool finishOnClose = true, ITags tags = null, ulong? spanId = null)
+        internal Scope StartActiveInternal(string operationName, ISpanContext parent = null, string serviceName = null, DateTimeOffset? startTime = null, bool finishOnClose = true, ITags tags = null)
         {
             var span = StartSpan(operationName, tags, parent, serviceName, startTime);
             return TracerManager.ScopeManager.Activate(span, finishOnClose);

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -258,7 +258,7 @@ namespace Datadog.Trace
         /// <returns>A scope wrapping the newly created span</returns>
         public IScope StartActive(string operationName)
         {
-            return StartActive(operationName, parent: null, startTime: null, finishOnClose: true);
+            return StartActiveInternal(operationName);
         }
 
         /// <summary>
@@ -269,21 +269,8 @@ namespace Datadog.Trace
         /// <returns>A scope wrapping the newly created span</returns>
         public IScope StartActive(string operationName, SpanCreationSettings settings)
         {
-            return StartActive(operationName, settings.Parent, settings.StartTime, finishOnClose: settings.FinishOnClose ?? true);
-        }
-
-        /// <summary>
-        /// This creates a new span with the given parameters and makes it active.
-        /// </summary>
-        /// <param name="operationName">The span's operation name</param>
-        /// <param name="parent">The span's parent</param>
-        /// <param name="startTime">An explicit start time for that span</param>
-        /// <param name="finishOnClose">If set to false, closing the returned scope will not close the enclosed span </param>
-        /// <returns>A scope wrapping the newly created span</returns>
-        internal Scope StartActive(string operationName, ISpanContext parent, DateTimeOffset? startTime = null, bool finishOnClose = true)
-        {
-            var span = StartSpan(operationName, parent, startTime);
-            return TracerManager.ScopeManager.Activate(span, finishOnClose);
+            var finishOnClose = settings.FinishOnClose ?? true;
+            return StartActiveInternal(operationName, settings.Parent, serviceName: null, settings.StartTime, finishOnClose);
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -147,13 +147,21 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TopLevelSpans()
         {
+            // local function to start active scope and set span's service name
+            Scope StartActive(string operationName, string serviceName)
+            {
+                var scope = (Scope)_tracer.StartActive(operationName);
+                scope.Span.ServiceName = serviceName;
+                return scope;
+            }
+
             var spans = new List<(Scope Scope, bool IsTopLevel)>();
 
-            spans.Add(((Scope)_tracer.StartActive("Root", serviceName: "root"), true));
-            spans.Add(((Scope)_tracer.StartActive("Child1", serviceName: "root"), false));
-            spans.Add(((Scope)_tracer.StartActive("Child2", serviceName: "child"), true));
-            spans.Add(((Scope)_tracer.StartActive("Child3", serviceName: "child"), false));
-            spans.Add(((Scope)_tracer.StartActive("Child4", serviceName: "root"), true));
+            spans.Add((StartActive(operationName: "Root", serviceName: "root"), true));
+            spans.Add((StartActive(operationName: "Child1", serviceName: "root"), false));
+            spans.Add((StartActive(operationName: "Child2", serviceName: "child"), true));
+            spans.Add((StartActive(operationName: "Child3", serviceName: "child"), false));
+            spans.Add((StartActive(operationName: "Child4", serviceName: "root"), true));
 
             foreach (var (scope, expectedResult) in spans)
             {

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -237,7 +237,7 @@ namespace Datadog.Trace.Tests
         {
             var firstSpan = _tracer.StartSpan("First");
             _tracer.ActivateSpan(firstSpan);
-            var secondSpan = _tracer.StartSpan("Second", SpanContext.None);
+            var secondSpan = _tracer.StartSpan("Second", parent: SpanContext.None);
 
             Assert.True(secondSpan.IsRootSpan);
         }

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Tests
         public void StartActive_IgnoreActiveScope_RootSpan()
         {
             var firstScope = _tracer.StartActive("First");
-            var secondScope = (Scope)_tracer.StartActive("Second", ignoreActiveScope: true);
+            var secondScope = (Scope)_tracer.StartActive("Second", new SpanCreationSettings { Parent = SpanContext.None });
             var secondSpan = secondScope.Span;
 
             Assert.True(secondSpan.IsRootSpan);
@@ -237,7 +237,7 @@ namespace Datadog.Trace.Tests
         {
             var firstSpan = _tracer.StartSpan("First");
             _tracer.ActivateSpan(firstSpan);
-            var secondSpan = _tracer.StartSpan("Second", ignoreActiveScope: true);
+            var secondSpan = _tracer.StartSpan("Second", SpanContext.None);
 
             Assert.True(secondSpan.IsRootSpan);
         }


### PR DESCRIPTION
Clean up several `Tracer.StartSpan()` and `Tracer.StartActive()` overloads after #2131.
- remove unused (or easily refactored) `serviceName` parameters
- remove unused `ignoreActiveScope` parameters
- consolidate some overloads

Bonus: remove leftover `int` casts for sampling priority after #2372.