### PR TITLE
[Serverless] Fix AWS Lambda integration tests

### DIFF
--- a/tracer/build/_build/docker/serverless.lambda.dockerfile
+++ b/tracer/build/_build/docker/serverless.lambda.dockerfile
@@ -6,6 +6,7 @@ COPY ./serverlessArtifacts /opt/datadog
 # Add Tests
 COPY ./serverlessArtifacts/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.dll /var/task/
 COPY ./serverlessArtifacts/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.deps.json /var/task/
+COPY ./serverlessArtifacts/createLogPath.sh ./test/test-applications/integrations/Samples.AWS.Lambda/bin/Release/netcoreapp3.1/*.runtimeconfig.json /var/task/
 
 ENV DD_LOG_LEVEL="DEBUG"
 ENV DD_TRACE_ENABLED=true

--- a/tracer/build/_build/docker/serverless.lambda.dockerfile
+++ b/tracer/build/_build/docker/serverless.lambda.dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/dotnet:latest
+FROM public.ecr.aws/lambda/dotnet:core3.1
 
 # Add Tracer
 COPY ./serverlessArtifacts /opt/datadog


### PR DESCRIPTION
Fixes #

Fix AWS Lambda integration tests
Latest docker image was used, we need to fix the version

@DataDog/apm-dotnet