### PR TITLE
Add profiler x64 MSI to releases

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -811,7 +811,8 @@ partial class Build
         {
             $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi",
             $"{awsUri}x86/en-us/datadog-dotnet-apm-{version}-x86.msi", 
-            $"{awsUri}windows-native-symbols.zip"
+            $"{awsUri}windows-native-symbols.zip",
+            $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64-profiler-beta.msi",
         };
 
         var destination = outputDirectory / commitSha;


### PR DESCRIPTION
Profiler MSI wasn't downloaded from AWS.
We do upload all MSIs present in the release creation action (cf this code: https://github.com/DataDog/dd-trace-dotnet/blob/master/.github/workflows/create_draft_release.yml#L71) 

@DataDog/apm-dotnet