### PR TITLE
Generalise `HttpClientRequestFactory`, `ApiWebRequestFactory`, and `DatadogHttpHeaderHelper`

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Agent
                 default:
 #if NETCOREAPP
                     Log.Information("Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
-                    return new HttpClientRequestFactory();
+                    return new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 #else
                     Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
                     return new ApiWebRequestFactory();

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -23,14 +23,14 @@ namespace Datadog.Trace.Agent
             {
                 case TracesTransportType.CustomTcpProvider:
                     Log.Information("Using {FactoryType} for trace transport.", nameof(TcpStreamFactory));
-                    return new HttpStreamRequestFactory(new TcpStreamFactory(settings.AgentUri.Host, settings.AgentUri.Port), new DatadogHttpClient());
+                    return new HttpStreamRequestFactory(new TcpStreamFactory(settings.AgentUri.Host, settings.AgentUri.Port), new DatadogHttpClient(new TraceAgentHttpHeaderHelper()));
                 case TracesTransportType.WindowsNamedPipe:
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
-                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), new DatadogHttpClient());
+                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), new DatadogHttpClient(new TraceAgentHttpHeaderHelper()));
                 case TracesTransportType.UnixDomainSocket:
 #if NETCOREAPP3_1_OR_GREATER
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with Unix Domain Sockets path {Path} and timeout {Timeout}ms.", nameof(UnixDomainSocketStreamFactory), settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
-                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), new DatadogHttpClient());
+                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), new DatadogHttpClient(new TraceAgentHttpHeaderHelper()));
 #else
                     Log.Error("Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.");
                     goto case TracesTransportType.Default;

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -23,14 +23,14 @@ namespace Datadog.Trace.Agent
             {
                 case TracesTransportType.CustomTcpProvider:
                     Log.Information("Using {FactoryType} for trace transport.", nameof(TcpStreamFactory));
-                    return new HttpStreamRequestFactory(new TcpStreamFactory(settings.AgentUri.Host, settings.AgentUri.Port), new DatadogHttpClient(new TraceAgentHttpHeaderHelper()));
+                    return new HttpStreamRequestFactory(new TcpStreamFactory(settings.AgentUri.Host, settings.AgentUri.Port), DatadogHttpClient.CreateTraceAgentClient());
                 case TracesTransportType.WindowsNamedPipe:
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
-                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), new DatadogHttpClient(new TraceAgentHttpHeaderHelper()));
+                    return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), DatadogHttpClient.CreateTraceAgentClient());
                 case TracesTransportType.UnixDomainSocket:
 #if NETCOREAPP3_1_OR_GREATER
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with Unix Domain Sockets path {Path} and timeout {Timeout}ms.", nameof(UnixDomainSocketStreamFactory), settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
-                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), new DatadogHttpClient(new TraceAgentHttpHeaderHelper()));
+                    return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), DatadogHttpClient.CreateTraceAgentClient());
 #else
                     Log.Error("Using Unix Domain Sockets for trace transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.");
                     goto case TracesTransportType.Default;

--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Agent
                     return new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 #else
                     Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
-                    return new ApiWebRequestFactory();
+                    return new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 #endif
             }
         }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -18,12 +18,6 @@ namespace Datadog.Trace.Agent.Transports
         public ApiWebRequest(HttpWebRequest request)
         {
             _request = request;
-
-            // Default headers
-            foreach (var pair in AgentHttpHeaderNames.DefaultHeaders)
-            {
-                _request.Headers.Add(pair.Key, pair.Value);
-            }
         }
 
         public void AddHeader(string name, string value)

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
@@ -4,12 +4,20 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Net;
 
 namespace Datadog.Trace.Agent.Transports
 {
     internal class ApiWebRequestFactory : IApiRequestFactory
     {
+        private readonly KeyValuePair<string, string>[] _defaultHeaders;
+
+        public ApiWebRequestFactory(KeyValuePair<string, string>[] defaultHeaders)
+        {
+            _defaultHeaders = defaultHeaders;
+        }
+
         public string Info(Uri endpoint)
         {
             return endpoint.ToString();
@@ -17,7 +25,14 @@ namespace Datadog.Trace.Agent.Transports
 
         public IApiRequest Create(Uri endpoint)
         {
-            return new ApiWebRequest(WebRequest.CreateHttp(endpoint));
+            var request = WebRequest.CreateHttp(endpoint);
+
+            foreach (var pair in _defaultHeaders)
+            {
+                request.Headers.Add(pair.Key, pair.Value);
+            }
+
+            return new ApiWebRequest(request);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -5,6 +5,7 @@
 
 #if NETCOREAPP
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace Datadog.Trace.Agent.Transports
@@ -13,11 +14,11 @@ namespace Datadog.Trace.Agent.Transports
     {
         private readonly HttpClient _client;
 
-        public HttpClientRequestFactory(HttpMessageHandler handler = null)
+        public HttpClientRequestFactory(KeyValuePair<string, string>[] defaultHeaders, HttpMessageHandler handler = null)
         {
             _client = handler == null ? new HttpClient() : new HttpClient(handler);
 
-            foreach (var pair in AgentHttpHeaderNames.DefaultHeaders)
+            foreach (var pair in defaultHeaders)
             {
                 _client.DefaultRequestHeaders.Add(pair.Key, pair.Value);
             }

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -26,10 +26,13 @@ namespace Datadog.Trace.HttpOverStreams
 
         private readonly HttpHeaderHelperBase _headerHelper;
 
-        public DatadogHttpClient(HttpHeaderHelperBase headerHelper)
+        private DatadogHttpClient(HttpHeaderHelperBase headerHelper)
         {
             _headerHelper = headerHelper;
         }
+
+        public static DatadogHttpClient CreateTraceAgentClient()
+            => new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
 
         public async Task<HttpResponse> SendAsync(HttpRequest request, Stream requestStream, Stream responseStream)
         {

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpClient.cs
@@ -24,9 +24,9 @@ namespace Datadog.Trace.HttpOverStreams
 
         private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<DatadogHttpClient>();
 
-        private readonly DatadogHttpHeaderHelper _headerHelper;
+        private readonly HttpHeaderHelperBase _headerHelper;
 
-        public DatadogHttpClient(DatadogHttpHeaderHelper headerHelper)
+        public DatadogHttpClient(HttpHeaderHelperBase headerHelper)
         {
             _headerHelper = headerHelper;
         }

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
@@ -27,19 +27,19 @@ namespace Datadog.Trace.HttpOverStreams
             }
         }
 
-        public static Task WriteLeadingHeaders(HttpRequest request, StreamWriter writer)
+        public static Task WriteLeadingHeaders(HttpRequest request, TextWriter writer)
         {
             var leadingHeaders =
                 $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.CrLf}Host: {request.Host}{DatadogHttpValues.CrLf}Accept-Encoding: identity{DatadogHttpValues.CrLf}Content-Length: {request.Content.Length ?? 0}{DatadogHttpValues.CrLf}{MetadataHeaders}";
             return writer.WriteAsync(leadingHeaders);
         }
 
-        public static Task WriteHeader(StreamWriter writer, HttpHeaders.HttpHeader header)
+        public static Task WriteHeader(TextWriter writer, HttpHeaders.HttpHeader header)
         {
             return writer.WriteAsync($"{header.Name}: {header.Value}{DatadogHttpValues.CrLf}");
         }
 
-        public static Task WriteEndOfHeaders(StreamWriter writer)
+        public static Task WriteEndOfHeaders(TextWriter writer)
         {
             return writer.WriteAsync($"Content-Type: application/msgpack{DatadogHttpValues.CrLf}{DatadogHttpValues.CrLf}");
         }

--- a/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/DatadogHttpHeaderHelper.cs
@@ -9,39 +9,27 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.HttpOverStreams
 {
-    internal class DatadogHttpHeaderHelper
+    internal abstract class DatadogHttpHeaderHelper
     {
-        private static string _metadataHeaders = null;
+        protected abstract string MetadataHeaders { get; }
 
-        private static string MetadataHeaders
-        {
-            get
-            {
-                if (_metadataHeaders == null)
-                {
-                    var headers = AgentHttpHeaderNames.DefaultHeaders.Select(kvp => $"{kvp.Key}: {kvp.Value}{DatadogHttpValues.CrLf}");
-                    _metadataHeaders = string.Concat(headers);
-                }
+        protected abstract string ContentType { get; }
 
-                return _metadataHeaders;
-            }
-        }
-
-        public static Task WriteLeadingHeaders(HttpRequest request, TextWriter writer)
+        public Task WriteLeadingHeaders(HttpRequest request, TextWriter writer)
         {
             var leadingHeaders =
                 $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.CrLf}Host: {request.Host}{DatadogHttpValues.CrLf}Accept-Encoding: identity{DatadogHttpValues.CrLf}Content-Length: {request.Content.Length ?? 0}{DatadogHttpValues.CrLf}{MetadataHeaders}";
             return writer.WriteAsync(leadingHeaders);
         }
 
-        public static Task WriteHeader(TextWriter writer, HttpHeaders.HttpHeader header)
+        public Task WriteHeader(TextWriter writer, HttpHeaders.HttpHeader header)
         {
             return writer.WriteAsync($"{header.Name}: {header.Value}{DatadogHttpValues.CrLf}");
         }
 
-        public static Task WriteEndOfHeaders(TextWriter writer)
+        public Task WriteEndOfHeaders(TextWriter writer)
         {
-            return writer.WriteAsync($"Content-Type: application/msgpack{DatadogHttpValues.CrLf}{DatadogHttpValues.CrLf}");
+            return writer.WriteAsync($"Content-Type: {ContentType}{DatadogHttpValues.CrLf}{DatadogHttpValues.CrLf}");
         }
     }
 }

--- a/tracer/src/Datadog.Trace/HttpOverStreams/HttpHeaderHelperBase.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/HttpHeaderHelperBase.cs
@@ -1,15 +1,14 @@
-// <copyright file="DatadogHttpHeaderHelper.cs" company="Datadog">
+// <copyright file="HttpHeaderHelperBase.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.HttpOverStreams
 {
-    internal abstract class DatadogHttpHeaderHelper
+    internal abstract class HttpHeaderHelperBase
     {
         protected abstract string MetadataHeaders { get; }
 

--- a/tracer/src/Datadog.Trace/HttpOverStreams/TraceAgentHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/TraceAgentHttpHeaderHelper.cs
@@ -1,0 +1,32 @@
+// <copyright file="TraceAgentHttpHeaderHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Linq;
+
+namespace Datadog.Trace.HttpOverStreams
+{
+    internal class TraceAgentHttpHeaderHelper : DatadogHttpHeaderHelper
+    {
+        private static string? _metadataHeaders = null;
+
+        protected override string MetadataHeaders
+        {
+            get
+            {
+                if (_metadataHeaders == null)
+                {
+                    var headers = AgentHttpHeaderNames.DefaultHeaders.Select(kvp => $"{kvp.Key}: {kvp.Value}{DatadogHttpValues.CrLf}");
+                    _metadataHeaders = string.Concat(headers);
+                }
+
+                return _metadataHeaders;
+            }
+        }
+
+        protected override string ContentType => "application/msgpack";
+    }
+}

--- a/tracer/src/Datadog.Trace/HttpOverStreams/TraceAgentHttpHeaderHelper.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/TraceAgentHttpHeaderHelper.cs
@@ -9,7 +9,7 @@ using System.Linq;
 
 namespace Datadog.Trace.HttpOverStreams
 {
-    internal class TraceAgentHttpHeaderHelper : DatadogHttpHeaderHelper
+    internal class TraceAgentHttpHeaderHelper : HttpHeaderHelperBase
     {
         private static string? _metadataHeaders = null;
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
         {
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for log submission transport.", nameof(HttpClientRequestFactory));
-            return new HttpClientRequestFactory();
+            return new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 #else
             Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
             return new ApiWebRequestFactory();

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             return new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 #else
             Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
-            return new ApiWebRequestFactory();
+            return new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 #endif
         }
     }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/LogsTransportStrategy.cs
@@ -6,6 +6,7 @@
 
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Logging.DirectSubmission.Sink;
 
 namespace Datadog.Trace.Logging.DirectSubmission
 {
@@ -17,10 +18,10 @@ namespace Datadog.Trace.Logging.DirectSubmission
         {
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for log submission transport.", nameof(HttpClientRequestFactory));
-            return new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
+            return new HttpClientRequestFactory(LogsApiHeaderNames.DefaultHeaders);
 #else
             Log.Information("Using {FactoryType} for log submission transport.", nameof(ApiWebRequestFactory));
-            return new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
+            return new ApiWebRequestFactory(LogsApiHeaderNames.DefaultHeaders);
 #endif
         }
     }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApiHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/LogsApiHeaderNames.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="LogsApiHeaderNames.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Datadog.Trace.Logging.DirectSubmission.Sink
+{
+    internal static class LogsApiHeaderNames
+    {
+        /// <summary>
+        /// Gets the default constant header that should be added to any request to the agent
+        /// </summary>
+        internal static KeyValuePair<string, string>[] DefaultHeaders { get; } =
+        {
+            new(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
+        };
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ApiWebRequestFactoryTests.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.Tests
 
             try
             {
-                var factory = new ApiWebRequestFactory();
+                var factory = new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 
                 var request = factory.Create(new Uri("http://localhost"));
 

--- a/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task DatadogHttpClient_CanParseResponse()
         {
-            var client = new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
+            var client = DatadogHttpClient.CreateTraceAgentClient();
             var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
             var htmlResponse = string.Join("\r\n", HtmlResponseLines());
             using var requestStream = new MemoryStream();
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Tests
         [InlineData(100)]
         public async Task DatadogHttpClient_WhenOnlyPartOfResponseIsAvailable_ParsesCorrectly(int bytesToRead)
         {
-            var client = new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
+            var client = DatadogHttpClient.CreateTraceAgentClient();
             var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
             var htmlResponse = string.Join("\r\n", HtmlResponseLines());
             using var requestStream = new MemoryStream();

--- a/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public async Task DatadogHttpClient_CanParseResponse()
         {
-            var client = new DatadogHttpClient();
+            var client = new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
             var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
             var htmlResponse = string.Join("\r\n", HtmlResponseLines());
             using var requestStream = new MemoryStream();
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Tests
         [InlineData(100)]
         public async Task DatadogHttpClient_WhenOnlyPartOfResponseIsAvailable_ParsesCorrectly(int bytesToRead)
         {
-            var client = new DatadogHttpClient();
+            var client = new DatadogHttpClient(new TraceAgentHttpHeaderHelper());
             var requestContent = new BufferContent(new ArraySegment<byte>(new byte[0]));
             var htmlResponse = string.Join("\r\n", HtmlResponseLines());
             using var requestStream = new MemoryStream();

--- a/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpClientRequestTests.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Tests
         {
             var handler = new CustomHandler();
 
-            var factory = new HttpClientRequestFactory(handler);
+            var factory = new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders, handler);
             var request = factory.Create(new Uri("http://localhost/"));
 
             request.AddHeader("Hello", "World");
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Tests
         {
             var handler = new CustomHandler();
 
-            var factory = new HttpClientRequestFactory(handler);
+            var factory = new HttpClientRequestFactory(AgentHttpHeaderNames.DefaultHeaders, handler);
             var request = factory.Create(new Uri("http://localhost/"));
 
             await request.PostAsync(ArraySegment<byte>.Empty, MimeTypes.MsgPack);

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/DatadogHttpHeaderHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/DatadogHttpHeaderHelperTests.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="DatadogHttpHeaderHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.HttpOverStreams.HttpContent;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.HttpOverStreams
+{
+    public class DatadogHttpHeaderHelperTests
+    {
+        [Fact]
+        public void WriteLeadingHeaders()
+        {
+            var headers = new HttpHeaders { { "x-test", "my-value" } };
+            var bytes = Encoding.UTF8.GetBytes("{}"); // length = 2
+            var content = new BufferContent(new ArraySegment<byte>(bytes));
+            var request = new HttpRequest(
+                verb: "PATCH",
+                host: "my-host.com",
+                path: "/some/path",
+                headers,
+                content);
+
+            var tracerVersion = TracerConstants.AssemblyVersion;
+            var lang = FrameworkDescription.Instance.Name;
+            var fxVersion = FrameworkDescription.Instance.ProductVersion;
+
+            var expected = "PATCH /some/path HTTP/1.1\r\nHost: my-host.com\r\nAccept-Encoding: identity\r\nContent-Length: 2\r\nDatadog-Meta-Lang: .NET\r\nDatadog-Meta-Tracer-Version: "
+                         + tracerVersion + "\r\nx-datadog-tracing-enabled: false\r\nDatadog-Meta-Lang-Interpreter: "
+                         + lang + "\r\nDatadog-Meta-Lang-Version: "
+                         + fxVersion + "\r\nDatadog-Client-Computed-Top-Level: 1\r\n";
+
+            var sb = new StringBuilder();
+            using var textWriter = new StringWriter(sb);
+            DatadogHttpHeaderHelper.WriteLeadingHeaders(request, textWriter);
+
+            sb.ToString().Should().Be(expected);
+        }
+
+        [Fact]
+        public void WriteHeader()
+        {
+            var header = new HttpHeaders.HttpHeader("my-key", "my-value");
+            var expected = "my-key: my-value\r\n";
+
+            var sb = new StringBuilder();
+            using var textWriter = new StringWriter(sb);
+            DatadogHttpHeaderHelper.WriteHeader(textWriter, header);
+
+            sb.ToString().Should().Be(expected);
+        }
+
+        [Fact]
+        public void WriteEndOfHeaders()
+        {
+            var expected = "Content-Type: application/msgpack\r\n\r\n";
+
+            var sb = new StringBuilder();
+            using var textWriter = new StringWriter(sb);
+            DatadogHttpHeaderHelper.WriteEndOfHeaders(textWriter);
+
+            sb.ToString().Should().Be(expected);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/TraceAgentHttpHeaderHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/TraceAgentHttpHeaderHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DatadogHttpHeaderHelperTests.cs" company="Datadog">
+﻿// <copyright file="TraceAgentHttpHeaderHelperTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,11 +13,12 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.HttpOverStreams
 {
-    public class DatadogHttpHeaderHelperTests
+    public class TraceAgentHttpHeaderHelperTests
     {
         [Fact]
         public void WriteLeadingHeaders()
         {
+            // Note that WriteLeadingHeaders should NOT write this header in WriteLeadingHeaders
             var headers = new HttpHeaders { { "x-test", "my-value" } };
             var bytes = Encoding.UTF8.GetBytes("{}"); // length = 2
             var content = new BufferContent(new ArraySegment<byte>(bytes));
@@ -27,6 +28,8 @@ namespace Datadog.Trace.Tests.HttpOverStreams
                 path: "/some/path",
                 headers,
                 content);
+
+            var helper = new TraceAgentHttpHeaderHelper();
 
             var tracerVersion = TracerConstants.AssemblyVersion;
             var lang = FrameworkDescription.Instance.Name;
@@ -39,7 +42,7 @@ namespace Datadog.Trace.Tests.HttpOverStreams
 
             var sb = new StringBuilder();
             using var textWriter = new StringWriter(sb);
-            DatadogHttpHeaderHelper.WriteLeadingHeaders(request, textWriter);
+            helper.WriteLeadingHeaders(request, textWriter);
 
             sb.ToString().Should().Be(expected);
         }
@@ -48,11 +51,12 @@ namespace Datadog.Trace.Tests.HttpOverStreams
         public void WriteHeader()
         {
             var header = new HttpHeaders.HttpHeader("my-key", "my-value");
+            var helper = new TraceAgentHttpHeaderHelper();
             var expected = "my-key: my-value\r\n";
 
             var sb = new StringBuilder();
             using var textWriter = new StringWriter(sb);
-            DatadogHttpHeaderHelper.WriteHeader(textWriter, header);
+            helper.WriteHeader(textWriter, header);
 
             sb.ToString().Should().Be(expected);
         }
@@ -60,11 +64,12 @@ namespace Datadog.Trace.Tests.HttpOverStreams
         [Fact]
         public void WriteEndOfHeaders()
         {
+            var helper = new TraceAgentHttpHeaderHelper();
             var expected = "Content-Type: application/msgpack\r\n\r\n";
 
             var sb = new StringBuilder();
             using var textWriter = new StringWriter(sb);
-            DatadogHttpHeaderHelper.WriteEndOfHeaders(textWriter);
+            helper.WriteEndOfHeaders(textWriter);
 
             sb.ToString().Should().Be(expected);
         }

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -59,7 +59,7 @@ namespace Benchmarks.Trace
         /// </summary>
         private class FakeApiRequestFactory : IApiRequestFactory
         {
-            private readonly IApiRequestFactory _realFactory = new ApiWebRequestFactory();
+            private readonly IApiRequestFactory _realFactory = new ApiWebRequestFactory(AgentHttpHeaderNames.DefaultHeaders);
 
             public string Info(Uri endpoint)
             {


### PR DESCRIPTION
These classes currently all assume you're sending traces to the agent, but they are more generally useful than that (e.g. we're already using `HttpClientRequestFactory` and `ApiWebRequestFactory` with direct log submission, and we want to reuse them with the Telemetry sender).

This PR:
- Allows passing in the default headers when creating the factory types.
- Adds unit tests for `DatadogHttpHeaderHelper` to ensure existing behaviour.
- Makes `DatadogHttpHeaderHelper` abstract (renamed to HttpHeaderHelperBase) and creates implementation for the existing "Trace" use-case. Separate PR to follow for telemetry use case.
- Updates DirectLogSubmission to use different headers.


@DataDog/apm-dotnet