### PR TITLE
Add warning when attempting to use UDS on < .NET Core 3.1

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Agent/TracesTransportStrategy.cs
@@ -27,10 +27,13 @@ namespace Datadog.Trace.Agent
                 case TracesTransportType.WindowsNamedPipe:
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with pipe name {PipeName} and timeout {Timeout}ms.", nameof(NamedPipeClientStreamFactory), settings.TracesPipeName, settings.TracesPipeTimeoutMs);
                     return new HttpStreamRequestFactory(new NamedPipeClientStreamFactory(settings.TracesPipeName, settings.TracesPipeTimeoutMs), new DatadogHttpClient());
-#if NETCOREAPP3_1_OR_GREATER
                 case TracesTransportType.UnixDomainSocket:
+#if NETCOREAPP3_1_OR_GREATER
                     Log.Information<string, string, int>("Using {FactoryType} for trace transport, with UDS path {Path} and timeout {Timeout}ms.", nameof(UnixDomainSocketStreamFactory), settings.TracesUnixDomainSocketPath, settings.TracesPipeTimeoutMs);
                     return new HttpStreamRequestFactory(new UnixDomainSocketStreamFactory(settings.TracesUnixDomainSocketPath), new DatadogHttpClient());
+#else
+                    Log.Error("Using UDS for trace transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.");
+                    goto case TracesTransportType.Default;
 #endif
                 case TracesTransportType.Default:
                 default:


### PR DESCRIPTION
This currently isn't supported, and we silently use the default config instead, which is very unlikely to work, depending how the customer has configured their settings. This PR does the minimum required: log an error.

I also tried to remove settings that users shouldn't be able to set from `ExporterSettings` on unsupported frameworks, but that got messy fast. That's mostly due to the way we set a bunch of properties in the `ExporterSettings` constructor.

IMO (and we've discussed this before I believe) we should remove the 1-1 mapping from some settings to config keys in `ExporterSettings`, and should move the "calculation" to `ImmutableExporterSettings`, but that's a lot more work, and is a breaking change in terms of behaviour (and some APIs, though only for customers who were using it incorrectly anyway)

@DataDog/apm-dotnet