### PR TITLE
improvements in `SpanContextPropagatorTests`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
@@ -96,7 +96,8 @@ namespace Datadog.Trace.Tests
                            TraceId = TraceId,
                            SpanId = SpanId,
                            Origin = Origin,
-                           SamplingPriority = SamplingPriority
+                           SamplingPriority = SamplingPriority,
+                           DatadogTags = DatadogTags,
                        });
         }
 
@@ -119,7 +120,8 @@ namespace Datadog.Trace.Tests
                            TraceId = TraceId,
                            SpanId = SpanId,
                            Origin = Origin,
-                           SamplingPriority = SamplingPriority
+                           SamplingPriority = SamplingPriority,
+                           DatadogTags = DatadogTags,
                        });
         }
 
@@ -141,7 +143,8 @@ namespace Datadog.Trace.Tests
                            TraceId = TraceId,
                            SpanId = SpanId,
                            Origin = Origin,
-                           SamplingPriority = SamplingPriority
+                           SamplingPriority = SamplingPriority,
+                           DatadogTags = DatadogTags,
                        });
         }
 
@@ -235,7 +238,8 @@ namespace Datadog.Trace.Tests
                            // SpanId has default value
                            TraceId = TraceId,
                            Origin = Origin,
-                           SamplingPriority = SamplingPriority
+                           SamplingPriority = SamplingPriority,
+                           DatadogTags = DatadogTags,
                        });
         }
 
@@ -265,7 +269,8 @@ namespace Datadog.Trace.Tests
                            TraceId = TraceId,
                            SpanId = SpanId,
                            Origin = Origin,
-                           SamplingPriority = expectedSamplingPriority
+                           SamplingPriority = expectedSamplingPriority,
+                           DatadogTags = DatadogTags,
                        });
         }
 
@@ -343,6 +348,8 @@ namespace Datadog.Trace.Tests
         public string Origin { get; set; }
 
         public int? SamplingPriority { get; set; }
+
+        public string DatadogTags { get; set; }
 
         public ISpanContext Parent { get; set; }
 

--- a/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextPropagatorTests.cs
@@ -82,10 +82,8 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void Extract_IHeadersCollection()
         {
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
             var headers = SetupMockHeadersCollection();
-            object result = SpanContextPropagator.Instance.Extract(headers.Object);
+            var result = SpanContextPropagator.Instance.Extract(headers.Object);
 
             VerifyGetCalls(headers);
 
@@ -106,10 +104,7 @@ namespace Datadog.Trace.Tests
         {
             // using IHeadersCollection for convenience, but carrier could be any type
             var headers = SetupMockHeadersCollection();
-
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
-            object result = SpanContextPropagator.Instance.Extract(headers.Object, (carrier, name) => carrier.GetValues(name));
+            var result = SpanContextPropagator.Instance.Extract(headers.Object, (carrier, name) => carrier.GetValues(name));
 
             VerifyGetCalls(headers);
 
@@ -129,10 +124,7 @@ namespace Datadog.Trace.Tests
         public void Extract_ReadOnlyDictionary()
         {
             var headers = SetupMockReadOnlyDictionary();
-
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
-            object result = SpanContextPropagator.Instance.Extract(headers.Object);
+            var result = SpanContextPropagator.Instance.Extract(headers.Object);
 
             VerifyGetCalls(headers);
 
@@ -152,10 +144,7 @@ namespace Datadog.Trace.Tests
         public void Extract_EmptyHeadersReturnsNull()
         {
             var headers = new Mock<IHeadersCollection>();
-
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
-            object result = SpanContextPropagator.Instance.Extract(headers.Object);
+            var result = SpanContextPropagator.Instance.Extract(headers.Object);
 
             result.Should().BeNull();
         }
@@ -167,10 +156,7 @@ namespace Datadog.Trace.Tests
 
             // only setup TraceId, other properties remain null/empty
             headers.Setup(h => h.GetValues(HttpHeaderNames.TraceId)).Returns(new[] { TraceId.ToString(InvariantCulture) });
-
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
-            object result = SpanContextPropagator.Instance.Extract(headers.Object);
+            var result = SpanContextPropagator.Instance.Extract(headers.Object);
 
             result.Should().BeEquivalentTo(new SpanContextMock { TraceId = TraceId });
         }
@@ -179,10 +165,7 @@ namespace Datadog.Trace.Tests
         public void SpanContextRoundTrip()
         {
             var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin);
-
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
-            object result = SpanContextPropagator.Instance.Extract(context);
+            var result = SpanContextPropagator.Instance.Extract(context);
 
             result.Should().NotBeSameAs(context);
             result.Should().BeEquivalentTo(context);
@@ -194,10 +177,8 @@ namespace Datadog.Trace.Tests
             var context = new SpanContext(TraceId, SpanId, SamplingPriority, serviceName: null, Origin);
             var headers = new NameValueHeadersCollection(new NameValueCollection());
 
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
             SpanContextPropagator.Instance.Inject(context, headers);
-            object result = SpanContextPropagator.Instance.Extract(headers);
+            var result = SpanContextPropagator.Instance.Extract(headers);
 
             result.Should().NotBeSameAs(context);
             result.Should().BeEquivalentTo(context);
@@ -227,9 +208,7 @@ namespace Datadog.Trace.Tests
             // replace ParentId setup
             headers.Setup(h => h.GetValues(HttpHeaderNames.ParentId)).Returns(new[] { spanId });
 
-            // use `object` so Should() below works correctly,
-            // otherwise it picks up the IEnumerable<KeyValuePair<string, string>> overload
-            object result = SpanContextPropagator.Instance.Extract(headers.Object);
+            var result = SpanContextPropagator.Instance.Extract(headers.Object);
 
             result.Should()
                   .BeEquivalentTo(


### PR DESCRIPTION
## Add missing `DatadogTags` property to mocks
In `SpanContextPropagatorTests`, the value of `SpanContext.DatadogTags` was not tested because the property was missing from `SpanContextMock`. This PR adds the property (which caused the tests to fail) and populates it with the correct value (so tests pass once again).

## No need to use `object` anymore to force the correct overload
Maybe this was fixed in `FlientAssertions`? We recently updated from 5.10.3 to 6.4.0, see #2386.
This code can now use `var` instead of `object` when `result` implements `IEnumerable<KeyValuePair<TKey, TValue>>`:
```
object result = ...;
result.Should().BeEquivalentTo(...);
```
