### PR TITLE
Setup Github Actions for the profiler CI

### DIFF
--- a/.github/scripts/package_and_deploy.sh
+++ b/.github/scripts/package_and_deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+
+ddprof_deploy_folder=$1
+commit_sha=$2
+commit_author=$3
+
+
+profiler_version=v1.0.0_$(date -u +%G%m%d%H%M%S)
+
+## Create master.index.txt file
+cat <<- EOF > master.index.txt
+master
+${commit_sha}
+datadog-dotnet-profiler-apm-${profiler_version}-*
+${commit_author}
+EOF
+
+## Create package
+package_name="datadog-dotnet-profiler-apm-${profiler_version}-full"
+compressed_package_name="${package_name}.zip"
+echo "Creating ${compressed_package_name}..."
+mv ${ddprof_deploy_folder} ${package_name}  || (echo "Failed to move ${ddprof_deploy_folder} to ${package_name}." && exit 1)
+zip -r ${compressed_package_name} ${package_name} || (echo "Failed to compress ${package_name}." && exit 1)
+
+## Deploy on AWS
+echo "Copying ${compressed_package_name} to S3"
+aws s3 cp ${compressed_package_name} s3://datadog-reliability-env/dotnet-profiler/${compressed_package_name} || (echo "Failed to copy ${compressed_package_name} to S3." && exit 1)
+
+echo "Copying master.index.txt to S3"
+aws s3 cp master.index.txt s3://datadog-reliability-env/dotnet-profiler/master.index.txt || (echo "Failed to copy master.index.txt to S3." && exit 1)

--- a/.github/scripts/run-managed-unit-tests.sh
+++ b/.github/scripts/run-managed-unit-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+base_dir=$1
+configuration=$2
+
+for i in $(find $base_dir -name "*.Tests.csproj")
+do
+	dotnet test -c $configuration $i
+done

--- a/.github/scripts/run-native-unit-tests.sh
+++ b/.github/scripts/run-native-unit-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+
+base_dir=$1
+configuration=$2
+platform=$3
+
+for i in $(find $base_dir -name "*.Tests.vcxproj")
+do
+	project_name=$(basename $i ".vcxproj")
+	./_build/bin/${configuration}-${platform}/test/${project_name}/${project_name}.exe
+done

--- a/.github/workflows/profiler-pipeline.yml
+++ b/.github/workflows/profiler-pipeline.yml
@@ -1,0 +1,468 @@
+name: profiler pipeline
+
+on:
+  push:
+    branches:
+      - master
+      - profiler-vnext
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - master
+      - profiler-vnext
+
+    paths_ignore:
+      - 'tracer/**'
+
+  workflow_dispatch:
+
+env:
+  APPLICATION_RUN_TIMEOUT_IN_SECONDS: 10
+  DD_PROFILING_UPLOAD_PERIOD: 3
+  DD_TRACE_DEBUG: 1
+
+jobs:
+
+  build_linux_release_x64:
+     name: Build Linux Release x64
+     runs-on: ubuntu-18.04
+
+     steps:
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Build Managed Loader
+       run: dotnet build -c Release shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader.csproj
+
+     - name: Build Managed Profiler Engine
+       run: dotnet build -c Release profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
+
+     - name: Build Native Profiler Engine and Tests
+       run: |
+         CXX=clang++ CC=clang cmake -S dd-trace-dotnet -B _build/cmake
+         cd _build/cmake
+         make
+
+     - name: Run Managed Unit tests
+       shell: bash
+       run: ./.github/scripts/run-managed-unit-tests.sh profiler/test Release
+
+     - name: Run Native Unit tests
+       shell: bash
+       run: |
+         cd _build/cmake
+         ctest
+
+     - name: Publish artifact
+       uses: actions/upload-artifact@v2
+       with:
+         if-no-files-found: error
+         name: DDProf-Deploy.Linux.Release.x64
+         path: _build/DDProf-Deploy
+         retention-days: 7
+
+  test_linux_profiler_x64:
+     name: STests Linux x64
+     runs-on: ubuntu-latest
+     needs: build_linux_release_x64
+
+     steps:
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Download profiler artifact
+       uses: actions/download-artifact@v2
+       with:
+         name: DDProf-Deploy.Linux.Release.x64
+         path: DDProf-Deploy
+
+     - name: Build sample applications
+       run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
+
+     - name: Prepare environment to run the application
+       run: |
+         # download and setup dotnet-dump
+         mkdir tools
+         curl -o tools/dotnet-dump -L https://aka.ms/dotnet-dump/linux-x64
+         chmod +x tools/dotnet-dump
+
+         echo "$(realpath .)/tools" >> $GITHUB_PATH
+
+         #
+         # set profiler deployment and test output dir folder path for the test
+         #
+         echo "DD_TESTING_PROFILER_FOLDER=$(realpath .)/DDProf-Deploy" >> $GITHUB_ENV
+         # create
+         tests_output_dir=$(realpath .)/tests_output
+         mkdir $tests_output_dir
+         echo "DD_TESTING_OUPUT_DIR=$tests_output_dir" >> $GITHUB_ENV
+
+     - name: Run Integration tests
+       env:
+         DD_API_KEY: ${{ secrets.DD_API_KEY }}
+       run: |
+         cd profiler/test/Datadog.Profiler.IntegrationTests &&
+         LD_PRELOAD=${DD_TESTING_PROFILER_FOLDER}/Datadog.Linux.ApiWrapper.x64.so dotnet test -c Release -p:Platform=x64 --logger "trx" -- RunConfiguration.TreatNoTestsAsError=true
+
+     - name: Generate tests report
+       uses: dorny/test-reporter@v1
+       if: ${{ always() }}
+       with:
+         name: STests Linux x64 report
+         path: 'profiler/test/Datadog.Profiler.IntegrationTests/TestResults/*.trx'
+         reporter: 'dotnet-trx'
+         working-directory: 'dd-trace-dotnet'
+
+     - name: Publish Tests result, Logs and PProf files
+       uses: actions/upload-artifact@v2
+       if: ${{ always() }}
+       with:
+         if-no-files-found: error
+         name: Tests_result_logs_and_pprofs_files.Linux.Release.x64
+         path: |
+           ${{ env.DD_TESTING_OUPUT_DIR }}
+         retention-days: 7
+
+  benchmark_linux_x64:
+     name: BMmark Linux x64
+     runs-on: ubuntu-latest
+     needs: build_linux_release_x64
+     strategy:
+       fail-fast: false
+       matrix:
+         framework: [netcoreapp31, net50]
+
+     services:
+      dd-agent:
+        image: datadog/agent:latest
+        ports:
+        - 8126:8126
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_INSIDE_CI: true
+          DD_HOSTNAME: "dd-profiler-dotnet"
+          DD_SERVICE: "dd-profiler-dotnet"
+
+     steps:
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Download profiler artifact
+       uses: actions/download-artifact@v2
+       with:
+         name: DDProf-Deploy.Linux.Release.x64
+         path: DDProf-Deploy
+
+     - name: Setup Go 1.16.8
+       uses: actions/setup-go@v2
+       with:
+         go-version: '1.16.8'
+
+     - name: Prepare environment to run the application
+       run: |
+         #
+         # set profiler deployment and test output dir folder path for the test
+         #
+         go_tool_dir=$(realpath .)/tools
+         mkdir $go_tool_dir
+         echo "GOPATH=$go_tool_dir" >> $GITHUB_ENV
+
+     - name: Install timeit
+       run: go install github.com/tonyredondo/timeit@latest
+
+     - name: Build sample applications
+       run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
+
+     - name: Execute PiComputation benchmark
+       run: |
+         cd dd-trace-dotnet/build
+         ./run.sh ${{ matrix.framework }}
+     - name: Wait 20 seconds to agent flush before finishing pipeline
+       run: sleep 20
+
+  build_windows:
+     name: Build Windows
+     runs-on: windows-2019
+
+     strategy:
+       fail-fast: false
+       matrix:
+         platform: [x64,x86]
+         configuration: [Release,Debug]
+
+     steps:
+
+     - name: Support longpaths
+       run: git config --system core.longpaths true
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Build Managed Loader
+       run: dotnet build -c ${{matrix.configuration}} shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader.csproj
+
+     - name: Build Managed Profiler Engine
+       run: dotnet build -c ${{matrix.configuration}} profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
+
+     - name: Add MSBuild to PATH
+       uses: microsoft/setup-msbuild@v1.0.2
+
+     - name: Build Native profiler and tests
+       run: msbuild /property:Configuration=${{matrix.configuration}} /property:Platform=${{matrix.platform}}  profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.WithTests.proj
+
+     - name: Run Managed Unit tests
+       shell: bash
+       run: ./.github/scripts/run-managed-unit-tests.sh profiler/test ${{matrix.configuration}}
+
+     - name: Run Native Unit tests
+       shell: bash
+       run: ./.github/scripts/run-native-unit-tests.sh profiler/test ${{matrix.configuration}} ${{matrix.platform}}
+
+     - name: Publish artifact
+       uses: actions/upload-artifact@v2
+       with:
+         if-no-files-found: error
+         name: DDProf-Deploy.Windows.${{matrix.configuration}}.${{matrix.platform}}
+         path: _build/DDProf-Deploy
+         retention-days: 7
+
+  test_windows_profiler:
+     name: STests Windows
+     runs-on: windows-2019
+     needs: build_windows
+     strategy:
+       fail-fast: false
+       matrix:
+         platform: [x64,x86]
+         configuration: [Release,Debug]
+
+     steps:
+
+     - name: Support longpaths
+       run: git config --system core.longpaths true
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Download profiler artifact
+       uses: actions/download-artifact@v2
+       with:
+         name: DDProf-Deploy.Windows.${{matrix.configuration}}.${{matrix.platform}}
+         path: DDProf-Deploy
+
+     - name: Build sample applications
+       run: dotnet build -c ${{matrix.configuration}} profiler/src/Demos/Datadog.Demos.sln -p:Platform=${{matrix.platform}}
+
+     - name: Prepare environment to run the application
+       shell: pwsh
+       run: |
+         # Donwload Procdump and add it to PATH environment variable
+         curl.exe --output Procdump.zip --url https://download.sysinternals.com/files/Procdump.zip
+         7z x Procdump.zip -oProcdump
+         echo "$(Join-Path -Path $(Resolve-Path .) -ChildPath Procdump)" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
+         #
+         # set profiler deployment and test output dir folder path for the test
+         #
+         echo "DD_TESTING_PROFILER_FOLDER=$(Join-Path -Path $(Resolve-Path .) -ChildPath DDProf-Deploy)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+         echo "DD_TESTING_OUPUT_DIR=$(Join-Path -Path $(Resolve-Path .) -ChildPath tests_output)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+     - name: Run Integration tests
+       shell: cmd
+       env:
+         DD_API_KEY: ${{ secrets.DD_API_KEY }}
+       run: >
+         cd profiler/test/Datadog.Profiler.IntegrationTests &&
+         dotnet test -c ${{matrix.configuration}} -p:Platform=${{matrix.platform}}  --logger "trx" -- RunConfiguration.TreatNoTestsAsError=true
+
+     - name: Generate tests report
+       uses: dorny/test-reporter@v1
+       if: ${{ always() }}
+       with:
+         name: STests Windows (${{ matrix.platform }}, ${{ matrix.configuration }}) report
+         path: 'profiler/test/Datadog.Profiler.IntegrationTests/TestResults/*.trx'
+         reporter: 'dotnet-trx'
+         working-directory: 'dd-trace-dotnet'
+
+     - name: Publish Test results, Logs and PProf files
+       uses: actions/upload-artifact@v2
+       if: ${{ always() }}
+       with:
+         if-no-files-found: error
+         name: Tests_result_logs_and_pprofs_files.Windows.${{matrix.configuration}}.${{matrix.platform}}
+         path: |
+           ${{ env.DD_TESTING_OUPUT_DIR }}
+         retention-days: 7
+
+  benchmark_windows_x64:
+     name: BMmark Windows x64
+     runs-on: windows-2019
+     needs: build_windows
+
+     strategy:
+       fail-fast: false
+       matrix:
+         framework: [net45, netcoreapp31, net50]
+
+     steps:
+
+     - name: Install Datadog agent
+       continue-on-error: false
+       shell: pwsh
+       run: |
+         curl.exe --output datadog-agent-7-latest.amd64.msi --url https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
+         Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY=${{ secrets.DD_API_KEY }} SITE="datadoghq.com"'
+       env:
+         DD_INSIDE_CI: true
+         DD_HOSTNAME: "dd-profiler-dotnet"
+         DD_SERVICE: "dd-profiler-dotnet"
+
+     - name: Support longpaths
+       run: git config --system core.longpaths true
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Download profiler artifact
+       uses: actions/download-artifact@v2
+       with:
+         name: DDProf-Deploy.Windows.Release.x64
+         path: DDProf-Deploy
+
+     - name: Setup Go 1.16.8
+       uses: actions/setup-go@v2
+       with:
+         go-version: '1.16.8'
+
+     - name: Prepare environment to run the application
+       shell: pwsh
+       run: |
+         $tools_dir=(Join-Path -Path $(Resolve-Path .) -ChildPath tools)
+         mkdir $tools_dir
+         echo "GOPATH=$tools_dir" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+     - name: Install timeit
+       run: go install github.com/tonyredondo/timeit@latest
+
+     - name: Build sample applications
+       run: dotnet build -c Release profiler/src/Demos/Datadog.Demos.sln -p:Platform=x64
+
+     - name: Execute PiComputation benchmark
+       run: |
+         cd dd-continuous-profiler-dotnet\build
+         .\run.cmd ${{ matrix.framework }}
+
+     - name: Wait 20 seconds to agent flush before finishing pipeline
+       run: Start-Sleep -s 20
+
+  deploy_windows_profiler:
+     name: Deploying Windows Profiler to AWS S3 bucket
+     needs: test_windows_profiler
+     runs-on: ubuntu-latest
+     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+
+     steps:
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Download profiler artifact (x64/Release)
+       uses: actions/download-artifact@v2
+       with:
+         name: DDProf-Deploy.Windows.Release.x64
+         path: DDProf-Deploy
+
+     - name: Download profiler artifact (x86/Release)
+       uses: actions/download-artifact@v2
+       with:
+         name: DDProf-Deploy.Windows.Release.x86
+         path: DDProf-Deploy
+
+     - name: Configure AWS Credentials
+       uses: aws-actions/configure-aws-credentials@v1
+       with:
+         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+         aws-region: ${{ secrets.AWS_REGION }}
+
+     - name: Package and deploy artifacts to S3
+       run: ./.github/scripts/package_and_deploy.sh "DDProf-Deploy" ${GITHUB_SHA} ${GITHUB_ACTOR}
+
+  build_windows_asan_release:
+     name: Build Windows ASAN
+
+     runs-on: windows-2019
+
+     strategy:
+       fail-fast: false
+       matrix:
+         platform: [x64,x86]
+         configuration: [Release]
+
+     steps:
+
+     - name: Install Datadog agent
+       continue-on-error: false
+       shell: pwsh
+       run: |
+         curl.exe --output datadog-agent-7-latest.amd64.msi --url https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
+         Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY=${{ secrets.DD_API_KEY }} SITE="datadoghq.com"'
+       env:
+         DD_INSIDE_CI: true
+         DD_HOSTNAME: "dd-profiler-dotnet"
+         DD_SERVICE: "dd-profiler-dotnet"
+
+     - name: Support longpaths
+       run: git config --system core.longpaths true
+
+     - name: Clone dd-trace-dotnet repository
+       uses: actions/checkout@v2
+
+     - name: Build Managed Loader
+       run: dotnet build -c ${{matrix.configuration}} shared/src/managed-lib/ManagedLoader/Datadog.AutoInstrumentation.ManagedLoader.csproj
+
+     - name: Build Managed Profiler Engine
+       run: dotnet build -c ${{matrix.configuration}} profiler/src/ProfilerEngine/Datadog.Profiler.Managed/Datadog.Profiler.Managed.csproj
+
+     - name: Add MSBuild to PATH
+       uses: microsoft/setup-msbuild@v1.0.2
+
+     - name: Build Native profiler and tests
+       run: msbuild -target:BuildCppWithAsan -p:Configuration=${{matrix.configuration}} -p:Platform=${{matrix.platform}}  profiler\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Datadog.Profiler.Native.Windows.WithTests.proj
+     
+     - name: Build sample applications
+       run: dotnet build -c ${{matrix.configuration}} profiler/src/Demos/Datadog.Demos.sln -p:Platform=${{matrix.platform}}
+
+     - name: Prepare environment to run the application
+       shell: pwsh
+       run: |
+         #
+         # set profiler deployment and test output dir folder path for the test
+         #
+         $tests_output=$(Join-Path -Path $(Resolve-Path .) -ChildPath tests_output)
+         echo "DD_TESTING_OUPUT_DIR=$tests_output" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+         echo "DD_TRACE_DEBUG=1" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+         echo "DD_PROFILING_LOG_DIR=$(Join-Path -Path $tests_output -ChildPath logs)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+         echo "DD_PROFILING_OUTPUT_DIR=$(Join-Path -Path $tests_output -ChildPath pprofs)" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+     - name: Run Computer01 for 2min
+       shell: cmd
+       run: >
+         cd _build\DDProf-Deploy &&
+         DDProf-SetEnv.bat &&
+         cd ..\..\_build\bin\Release-${{ matrix.platform }}\src\Demos\Computer01\net45 &&
+         Datadog.Demos.Computer01.exe --scenario 1 --timeout 120
+
+     - name: Publish Test results, Logs and PProf files
+       uses: actions/upload-artifact@v2
+       if: ${{ always() }}
+       with:
+         if-no-files-found: error
+         name: Asan_Tests_result_logs_and_pprofs_files.Windows.${{matrix.configuration}}.${{matrix.platform}}
+         path: |
+           ${{ env.DD_TESTING_OUPUT_DIR }}
+         retention-days: 1

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.3.11" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageReference Include="NuGet.CommandLine" Version="5.8.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Configure Github Actions so the profiler CI can run.

The goal of this PR is also to make sure that:
- PRs on tracer-only are not blocked by the profiler CI
- PRs on profiler-only are not blocked by the tracer cCI (AzOp)
- Profiler and Tracer pipelines run if there changes in both cases
- No pipeline run if not needed

@DataDog/apm-dotnet